### PR TITLE
Add calendar-based blocklist to members area

### DIFF
--- a/prisma/migrations/20260101120000_blocked_day/migration.sql
+++ b/prisma/migrations/20260101120000_blocked_day/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "public"."BlockedDay" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "BlockedDay_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BlockedDay_userId_date_key" ON "public"."BlockedDay"("userId", "date");
+
+-- AddForeignKey
+ALTER TABLE "public"."BlockedDay" ADD CONSTRAINT "BlockedDay_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,6 +149,7 @@ model User {
   roles                  UserRole[]
   approvedProposals      RehearsalProposal[] @relation("ProposalApprover")
   notifications         NotificationRecipient[]
+  blockedDays            BlockedDay[]
 }
 
 model Account {
@@ -396,6 +397,18 @@ model Availability {
   end    DateTime
   status AvailabilityStatus
   user   User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model BlockedDay {
+  id        String   @id @default(cuid())
+  userId    String
+  date      DateTime
+  reason    String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, date])
 }
 
 model Task {

--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  addDays,
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { de } from "date-fns/locale/de";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight, CircleX } from "lucide-react";
+
+const DATE_FORMAT = "yyyy-MM-dd";
+
+export type BlockedDay = {
+  id: string;
+  date: string;
+  reason: string | null;
+};
+
+interface BlockCalendarProps {
+  initialBlockedDays: BlockedDay[];
+}
+
+export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
+  const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()));
+  const [blockedDays, setBlockedDays] = useState<BlockedDay[]>(() =>
+    [...initialBlockedDays].sort((a, b) => a.date.localeCompare(b.date))
+  );
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const blockedByDate = useMemo(() => {
+    const map = new Map<string, BlockedDay>();
+    for (const entry of blockedDays) {
+      map.set(entry.date, entry);
+    }
+    return map;
+  }, [blockedDays]);
+
+  const monthLabel = useMemo(
+    () => format(currentMonth, "MMMM yyyy", { locale: de }),
+    [currentMonth]
+  );
+
+  const weekDayLabels = useMemo(() => {
+    const start = startOfWeek(new Date(), { weekStartsOn: 1 });
+    return Array.from({ length: 7 }, (_, index) =>
+      format(addDays(start, index), "EEE", { locale: de })
+    );
+  }, []);
+
+  const daysInView = useMemo(() => {
+    const firstDayOfMonth = startOfMonth(currentMonth);
+    const lastDayOfMonth = endOfMonth(currentMonth);
+    const gridStart = startOfWeek(firstDayOfMonth, { weekStartsOn: 1 });
+    const gridEnd = endOfWeek(lastDayOfMonth, { weekStartsOn: 1 });
+    return eachDayOfInterval({ start: gridStart, end: gridEnd });
+  }, [currentMonth]);
+
+  const selectedDateKey = selectedDate ? format(selectedDate, DATE_FORMAT) : null;
+  const selectedEntry = selectedDateKey ? blockedByDate.get(selectedDateKey) : undefined;
+
+  useEffect(() => {
+    if (!modalOpen) return;
+    if (selectedEntry) {
+      setReason(selectedEntry.reason ?? "");
+    } else if (selectedDate) {
+      setReason("");
+    }
+  }, [modalOpen, selectedEntry, selectedDate]);
+
+  const closeModal = () => {
+    setModalOpen(false);
+    setSelectedDate(null);
+    setReason("");
+    setError(null);
+    setSubmitting(false);
+  };
+
+  const openDay = (day: Date) => {
+    setSelectedDate(day);
+    setError(null);
+    setModalOpen(true);
+  };
+
+  const handleCreate = async () => {
+    if (!selectedDateKey) return;
+    const trimmed = reason.trim();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/block-days", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          date: selectedDateKey,
+          reason: trimmed.length > 0 ? trimmed : undefined,
+        }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error ?? "Der Sperrtermin konnte nicht gespeichert werden.");
+      }
+
+      const data = (await response.json()) as BlockedDay;
+      setBlockedDays((prev) => [...prev, data].sort((a, b) => a.date.localeCompare(b.date)));
+      toast.success("Sperrtermin eingetragen.");
+      closeModal();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!selectedEntry) return;
+    const trimmed = reason.trim();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/block-days/${selectedEntry.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: trimmed.length > 0 ? trimmed : null }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error ?? "Die Änderung konnte nicht gespeichert werden.");
+      }
+
+      const data = (await response.json()) as BlockedDay;
+      setBlockedDays((prev) => prev.map((entry) => (entry.id === data.id ? data : entry)));
+      toast.success("Sperrtermin aktualisiert.");
+      setReason(data.reason ?? "");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!selectedEntry) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/block-days/${selectedEntry.id}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error ?? "Der Sperrtermin konnte nicht entfernt werden.");
+      }
+
+      setBlockedDays((prev) => prev.filter((entry) => entry.id !== selectedEntry.id));
+      toast.success("Sperrtermin entfernt.");
+      closeModal();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold">{monthLabel}</h2>
+          <p className="text-sm text-muted-foreground">
+            Tippe auf einen Tag, um einen Sperrtermin hinzuzufügen oder zu bearbeiten.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setCurrentMonth(startOfMonth(new Date()))}
+          >
+            Heute
+          </Button>
+          <div className="flex items-center rounded-md border">
+            <button
+              type="button"
+              onClick={() => setCurrentMonth((prev) => addMonths(prev, -1))}
+              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+              aria-label="Vorheriger Monat"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setCurrentMonth((prev) => addMonths(prev, 1))}
+              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+              aria-label="Nächster Monat"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1 rounded-lg border bg-card p-2 shadow-sm">
+        <div className="grid grid-cols-7 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {weekDayLabels.map((label) => (
+            <div key={label} className="py-2">
+              {label}
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7 gap-1 text-sm">
+          {daysInView.map((day) => {
+            const key = format(day, DATE_FORMAT);
+            const entry = blockedByDate.get(key);
+            const isCurrentMonth = isSameMonth(day, currentMonth);
+            const isCurrentDay = isToday(day);
+
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => openDay(day)}
+                className={cn(
+                  "relative flex min-h-[70px] flex-col rounded-md border bg-background p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  !isCurrentMonth && "text-muted-foreground/60",
+                  entry && "border-destructive/50 bg-destructive/10",
+                  isCurrentDay && "ring-2 ring-primary/80"
+                )}
+                aria-label={`${format(day, "EEEE, d. MMMM yyyy", { locale: de })}${
+                  entry
+                    ? `, gesperrt${entry.reason ? `: ${entry.reason}` : ""}`
+                    : ", frei"
+                }`}
+              >
+                <span className="text-xs font-medium">{format(day, "d")}</span>
+                {entry ? (
+                  <span className="mt-auto flex items-center gap-1 text-xs font-semibold text-destructive">
+                    <CircleX className="h-4 w-4" />
+                    <span className="truncate" title={entry.reason ?? undefined}>
+                      {entry.reason ?? "Gesperrt"}
+                    </span>
+                  </span>
+                ) : (
+                  <span className="mt-auto text-xs text-muted-foreground">Frei</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <Modal
+        open={modalOpen && !!selectedDate}
+        onClose={closeModal}
+        title={selectedDate ? format(selectedDate, "EEEE, d. MMMM yyyy", { locale: de }) : "Sperrtermin"}
+        description={selectedEntry ? "Dieser Tag ist derzeit gesperrt." : "Trage einen Sperrtermin für diesen Tag ein."}
+      >
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="block-reason" className="block text-sm font-medium">
+              Grund (optional)
+            </label>
+            <Input
+              id="block-reason"
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder="z. B. Urlaub, Familienfeier"
+              maxLength={200}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              Die Angabe hilft der Planung, bleibt aber für andere Mitglieder kurz gehalten.
+            </p>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-between">
+            {selectedEntry ? (
+              <>
+                <Button
+                  type="button"
+                  variant="default"
+                  className="sm:flex-1"
+                  disabled={submitting}
+                  onClick={handleUpdate}
+                >
+                  Grund speichern
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="sm:flex-1"
+                  disabled={submitting}
+                  onClick={handleRemove}
+                >
+                  Sperrtermin aufheben
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                className="w-full"
+                disabled={submitting}
+                onClick={handleCreate}
+              >
+                Sperrtermin eintragen
+              </Button>
+            )}
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/sperrliste/page.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page.tsx
@@ -1,0 +1,41 @@
+import { PageHeader } from "@/components/members/page-header";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { format } from "date-fns";
+import { BlockCalendar } from "./block-calendar";
+
+type BlockedDayDTO = {
+  id: string;
+  date: string;
+  reason: string | null;
+};
+
+export default async function SperrlistePage() {
+  const session = await requireAuth();
+  const userId = (session.user as { id?: string } | undefined)?.id;
+
+  if (!userId) {
+    throw new Error("Benutzerinformationen konnten nicht geladen werden.");
+  }
+
+  const blockedDays = await prisma.blockedDay.findMany({
+    where: { userId },
+    orderBy: { date: "asc" },
+  });
+
+  const initialBlockedDays: BlockedDayDTO[] = blockedDays.map((entry) => ({
+    id: entry.id,
+    date: format(entry.date, "yyyy-MM-dd"),
+    reason: entry.reason,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Sperrliste"
+        description="Markiere Tage, an denen du nicht verfügbar bist, damit das Team die Planung im Blick behält."
+      />
+      <BlockCalendar initialBlockedDays={initialBlockedDays} />
+    </div>
+  );
+}

--- a/src/app/api/block-days/[id]/route.ts
+++ b/src/app/api/block-days/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { z } from "zod";
+import { normaliseReason, reasonSchema, toResponse } from "../utils";
+
+type SessionUser = { id?: string } | null | undefined;
+
+type RouteParams = {
+  params: {
+    id: string;
+  };
+};
+
+const updateSchema = z.object({
+  reason: reasonSchema,
+});
+
+type UpdatePayload = z.infer<typeof updateSchema>;
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const session = await requireAuth();
+  const userId = (session.user as SessionUser)?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  let payload: UpdatePayload;
+  try {
+    const json = await request.json();
+    const parsed = updateSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Ungültige Eingabe" }, { status: 400 });
+    }
+    payload = parsed.data;
+  } catch {
+    return NextResponse.json({ error: "Ungültige Eingabe" }, { status: 400 });
+  }
+
+  const existing = await prisma.blockedDay.findUnique({ where: { id: params.id } });
+
+  if (!existing || existing.userId !== userId) {
+    return NextResponse.json({ error: "Sperrtermin wurde nicht gefunden." }, { status: 404 });
+  }
+
+  const updated = await prisma.blockedDay.update({
+    where: { id: existing.id },
+    data: {
+      reason: normaliseReason(payload.reason),
+    },
+  });
+
+  return NextResponse.json(toResponse(updated));
+}
+
+export async function DELETE(_: Request, { params }: RouteParams) {
+  const session = await requireAuth();
+  const userId = (session.user as SessionUser)?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const result = await prisma.blockedDay.deleteMany({
+    where: {
+      id: params.id,
+      userId,
+    },
+  });
+
+  if (result.count === 0) {
+    return NextResponse.json({ error: "Sperrtermin wurde nicht gefunden." }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/block-days/route.ts
+++ b/src/app/api/block-days/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { z } from "zod";
+import {
+  isoDate,
+  normaliseReason,
+  toDateOnly,
+  toResponse,
+  reasonSchema,
+} from "./utils";
+
+type SessionUser = { id?: string } | null | undefined;
+
+const blockDaySchema = z.object({
+  date: z.string().regex(isoDate),
+  reason: reasonSchema,
+});
+
+type BlockDayPayload = z.infer<typeof blockDaySchema>;
+
+export async function GET() {
+  const session = await requireAuth();
+  const userId = (session.user as SessionUser)?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const entries = await prisma.blockedDay.findMany({
+    where: { userId },
+    orderBy: { date: "asc" },
+  });
+
+  return NextResponse.json(entries.map(toResponse));
+}
+
+export async function POST(request: Request) {
+  const session = await requireAuth();
+  const userId = (session.user as SessionUser)?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  let payload: BlockDayPayload;
+  try {
+    const json = await request.json();
+    const parsed = blockDaySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Ungültige Eingabe" }, { status: 400 });
+    }
+    payload = parsed.data;
+  } catch {
+    return NextResponse.json({ error: "Ungültige Eingabe" }, { status: 400 });
+  }
+
+  let blockDate: Date;
+  try {
+    blockDate = toDateOnly(payload.date);
+  } catch {
+    return NextResponse.json({ error: "Ungültiges Datum" }, { status: 400 });
+  }
+
+  try {
+    const entry = await prisma.blockedDay.create({
+      data: {
+        userId,
+        date: blockDate,
+        reason: normaliseReason(payload.reason),
+      },
+    });
+
+    return NextResponse.json(toResponse(entry));
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json(
+        { error: "Für dieses Datum existiert bereits ein Sperrtermin." },
+        { status: 409 }
+      );
+    }
+
+    console.error("[block-days:POST]", error);
+    return NextResponse.json(
+      { error: "Der Sperrtermin konnte nicht gespeichert werden." },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/block-days/utils.ts
+++ b/src/app/api/block-days/utils.ts
@@ -1,0 +1,38 @@
+import { format } from "date-fns";
+import { z } from "zod";
+
+export const isoDate = /^\d{4}-\d{2}-\d{2}$/;
+
+export const reasonSchema = z
+  .string()
+  .max(200, "Der Grund darf höchstens 200 Zeichen lang sein.")
+  .optional()
+  .nullable();
+
+export type BlockDayResponse = {
+  id: string;
+  date: string;
+  reason: string | null;
+};
+
+export function normaliseReason(input?: string | null) {
+  if (!input) return null;
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function toDateOnly(date: string) {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("Ungültiges Datum");
+  }
+  return parsed;
+}
+
+export function toResponse(entry: { id: string; date: Date; reason: string | null }): BlockDayResponse {
+  return {
+    id: entry.id,
+    date: format(entry.date, "yyyy-MM-dd"),
+    reason: entry.reason,
+  };
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -8,6 +8,7 @@ type Item = { href: string; label: string; roles?: Role[] };
 const baseItems: Item[] = [
   { href: "/mitglieder", label: "Übersicht" },
   { href: "/mitglieder/dashboard", label: "Dashboard" },
+  { href: "/mitglieder/sperrliste", label: "Sperrliste" },
   { href: "/mitglieder/probenplanung", label: "Probenplanung", roles: ["board", "admin", "tech"] },
   { href: "/mitglieder/rollenverwaltung", label: "Rollenverwaltung", roles: ["admin"] },
 ];


### PR DESCRIPTION
## Summary
- add a `BlockedDay` model and migration so members can store personal block dates
- expose CRUD endpoints for blocked days and surface the Sperrliste calendar page in the member navigation
- implement a responsive calendar UI with modal actions to add, edit, or remove block entries including optional reasons

## Testing
- pnpm prisma:generate
- pnpm lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8f01e7c4832d923cd4587427cebe