### PR TITLE
Improve mobile layout and notification experience

### DIFF
--- a/src/app/chronik/page.tsx
+++ b/src/app/chronik/page.tsx
@@ -17,7 +17,7 @@ export default async function ChronikPage() {
 
   if (shows.length === 0) {
     return (
-      <div className="container mx-auto px-6 py-16">
+      <div className="container mx-auto px-4 sm:px-6 py-12 sm:py-16">
         <div className="max-w-2xl mx-auto text-center space-y-6">
           <div className="w-24 h-24 mx-auto bg-gradient-to-br from-primary/20 to-primary/10 rounded-full flex items-center justify-center">
             <svg className="w-12 h-12 text-primary/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -45,7 +45,7 @@ export default async function ChronikPage() {
   return (
     <div className="relative">
       {/* Header Section */}
-      <div className="container mx-auto px-6 py-16 text-center space-y-6">
+      <div className="container mx-auto px-4 sm:px-6 py-12 sm:py-16 text-center space-y-6">
         <h1 className="font-serif text-4xl sm:text-5xl lg:text-6xl text-white [text-shadow:_0_0_10px_rgba(0,0,0,0.9),_2px_2px_6px_rgba(0,0,0,0.8)]">
           Chronik vergangener Sommer
         </h1>

--- a/src/app/chronik/stacked.tsx
+++ b/src/app/chronik/stacked.tsx
@@ -14,11 +14,15 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
   const sorted = [...items].sort((a, b) => b.year - a.year);
 
   return (
-    <div className="space-y-12 lg:space-y-16 pb-16 container mx-auto px-6">
+    <div className="space-y-12 lg:space-y-16 pb-24 container mx-auto px-4 sm:px-6">
       {sorted.map((s, idx) => {
         const meta = (s.meta || {}) as any;
         return (
-          <section key={s.id} id={s.id} className="group relative overflow-hidden rounded-3xl border border-border/30 shadow-2xl hover:shadow-3xl transition-all duration-500 hover:scale-[1.02]">
+          <section
+            key={s.id}
+            id={s.id}
+            className="group relative overflow-hidden rounded-2xl sm:rounded-3xl border border-border/30 shadow-2xl transition-all duration-500 hover:scale-[1.02] hover:shadow-3xl"
+          >
             <div className="relative h-[60vh] sm:h-[70vh] lg:h-[75vh] xl:h-[65vh] 2xl:h-[60vh] w-full max-h-[800px]">
               {s.posterUrl && (
                 <Image
@@ -35,8 +39,8 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
               <div className="absolute inset-0 bg-[radial-gradient(ellipse_60rem_40rem_at_30%_70%,_color-mix(in_oklab,var(--primary)_12%,transparent),transparent_80%)]" />
 
               <div className="absolute inset-0 flex items-end">
-                <div className="w-full p-8">
-                  <div className="max-w-5xl mx-auto backdrop-blur-sm bg-black/20 rounded-2xl border border-white/10 p-6 lg:p-8 xl:p-10 shadow-2xl group-hover:bg-black/30 transition-all duration-500">
+                <div className="w-full p-6 sm:p-8">
+                  <div className="max-w-5xl mx-auto rounded-2xl border border-white/10 bg-black/20 p-5 sm:p-6 lg:p-8 xl:p-10 backdrop-blur-sm shadow-2xl transition-all duration-500 group-hover:bg-black/30">
                     <div className="inline-flex items-center gap-2 px-3 py-1 bg-primary/20 border border-primary/30 rounded-full text-sm text-primary font-medium">
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />

--- a/src/app/chronik/timeline.tsx
+++ b/src/app/chronik/timeline.tsx
@@ -70,24 +70,29 @@ export function ChronikTimeline({ items }: { items: ChronikItem[] }) {
     }
   };
 
+  const activeIndex = items.findIndex((item) => item.id === activeId);
+  const completion =
+    items.length > 0 && activeIndex !== -1
+      ? Math.max(8, ((items.length - activeIndex) / items.length) * 100)
+      : 100;
+
   return (
-    <div className="fixed bottom-8 left-1/2 transform -translate-x-1/2 z-40">
-      <div className="relative bg-gradient-to-r from-black/60 via-black/70 to-black/60 backdrop-blur-xl border border-white/10 rounded-2xl px-8 py-4 shadow-2xl shadow-black/50">
-        {/* Background glow */}
-        <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-primary/10 to-primary/5 rounded-2xl" />
-        
-        {/* Progress bar background */}
-        <div className="absolute top-2 left-4 right-4 h-0.5 bg-white/10 rounded-full" />
-        
-        {/* Active progress bar */}
-        <div 
-          className="absolute top-2 left-4 h-0.5 bg-gradient-to-r from-primary to-primary/60 rounded-full transition-all duration-500 ease-out"
-          style={{ 
-            width: `${Math.max(8, (items.length - items.findIndex(item => item.id === activeId)) / items.length * 100)}%` 
-          }}
-        />
-        
-        <div className="relative flex items-center gap-4 overflow-x-auto max-w-[85vw] scrollbar-hide pt-2 px-2">
+    <div className="px-4 pb-12 sm:px-0 sm:pb-0">
+      <div className="relative w-full sm:fixed sm:bottom-8 sm:left-1/2 sm:z-40 sm:w-auto sm:-translate-x-1/2 sm:transform">
+        <div className="relative overflow-hidden rounded-xl border border-white/10 bg-black/65 px-5 py-4 shadow-xl backdrop-blur-lg sm:rounded-2xl sm:px-8">
+          {/* Background glow */}
+          <div className="pointer-events-none absolute inset-0 rounded-xl bg-gradient-to-r from-primary/5 via-primary/10 to-primary/5 sm:rounded-2xl" />
+
+          {/* Progress bar background */}
+          <div className="pointer-events-none absolute top-2 left-4 right-4 h-0.5 rounded-full bg-white/10" />
+
+          {/* Active progress bar */}
+          <div
+            className="pointer-events-none absolute top-2 left-4 h-0.5 rounded-full bg-gradient-to-r from-primary to-primary/60 transition-all duration-500 ease-out"
+            style={{ width: `${completion}%` }}
+          />
+
+          <div className="relative flex items-center gap-4 overflow-x-auto px-1 pt-3 scrollbar-hide sm:max-w-[85vw]">
           {[...items].reverse().map((item, index) => {
             const isActive = activeId === item.id;
             const originalIndex = items.findIndex(i => i.id === item.id);

--- a/src/app/mystery/page.tsx
+++ b/src/app/mystery/page.tsx
@@ -18,7 +18,7 @@ export default async function MysteryPage() {
   }
 
   return (
-    <div className="container mx-auto px-6 py-8 space-y-6">
+    <div className="container mx-auto px-4 sm:px-6 py-10 space-y-6">
       <h1 className="font-serif text-3xl">Das Geheimnis</h1>
       {clues.length === 0 && <p>Die Schatten sind noch still…</p>}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,9 +11,9 @@ export default function Home() {
   return (
     <div>
       <Hero images={heroImages} />
-      <div className="container mx-auto px-6">
-        <div className="space-y-8 py-16">
-          <section className="text-center py-6">
+      <div className="container mx-auto px-4 sm:px-6">
+        <div className="space-y-8 py-12 sm:py-16">
+          <section className="text-center py-6 sm:py-8">
             <div className="mt-2 opacity-80">Ein einziges Wochenende. Ein Sommer. Ein Stück.</div>
             <div className="mt-4 text-xl">Countdown: bald verfügbar…</div>
           </section>

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
-import Link from "next/link";
 import { Bell, Check, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useNotificationRealtime } from "@/hooks/useRealtime";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 const dateTimeFormatter = new Intl.DateTimeFormat("de-DE", {
   dateStyle: "short",
@@ -28,6 +29,16 @@ type NotificationItem = {
   attendanceStatus: "yes" | "no" | null;
 };
 
+type AttendanceResponse = "yes" | "no";
+
+type NotificationRealtimeEvent = {
+  notification: {
+    id: string;
+    title: string;
+    body?: string | null;
+  };
+};
+
 export function NotificationBell({ className }: { className?: string }) {
   const { data: session, status } = useSession();
   const [open, setOpen] = useState(false);
@@ -36,41 +47,57 @@ export function NotificationBell({ className }: { className?: string }) {
   const [respondingId, setRespondingId] = useState<string | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const isMobile = useMediaQuery("(max-width: 640px)");
+  const panelId = useId();
 
-  const unreadCount = notifications.filter((item) => !item.readAt).length;
+  const unreadCount = useMemo(
+    () => notifications.reduce((count, item) => count + (item.readAt ? 0 : 1), 0),
+    [notifications],
+  );
 
   useEffect(() => {
+    if (status !== "authenticated") {
+      setOpen(false);
+      setNotifications([]);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    if (!open || isMobile) return;
+
     function onDocClick(event: MouseEvent) {
-      if (!open) return;
       const target = event.target as Node;
       if (panelRef.current?.contains(target) || buttonRef.current?.contains(target)) return;
       setOpen(false);
     }
+
     function onKey(event: KeyboardEvent) {
-      if (!open) return;
-      if (event.key === "Escape") {
-        setOpen(false);
-        buttonRef.current?.focus();
-      }
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      buttonRef.current?.focus();
     }
+
     document.addEventListener("mousedown", onDocClick);
     document.addEventListener("keydown", onKey);
     return () => {
       document.removeEventListener("mousedown", onDocClick);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open]);
+  }, [open, isMobile]);
 
   const loadNotifications = useCallback(async () => {
     if (status !== "authenticated") {
       setNotifications([]);
+      setLoading(false);
       return;
     }
 
     setLoading(true);
     try {
       const response = await fetch("/api/notifications", { cache: "no-store" });
-      if (!response.ok) throw new Error("Request failed");
+      if (!response.ok) {
+        throw new Error("Request failed");
+      }
       const data: { notifications?: NotificationItem[] } = await response.json();
       setNotifications(data.notifications ?? []);
     } catch (error) {
@@ -82,25 +109,20 @@ export function NotificationBell({ className }: { className?: string }) {
   }, [status]);
 
   useEffect(() => {
-    loadNotifications();
+    void loadNotifications();
   }, [loadNotifications]);
-
-  useNotificationRealtime((event) => {
-    toast.info(event.notification.title, {
-      description: event.notification.body ?? undefined,
-    });
-    loadNotifications();
-  });
 
   useEffect(() => {
     if (!open) return;
     const unreadIds = notifications.filter((item) => !item.readAt).map((item) => item.id);
     if (!unreadIds.length) return;
-    fetch("/api/notifications/read", {
+
+    void fetch("/api/notifications/read", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ids: unreadIds }),
     }).catch(() => null);
+
     setNotifications((prev) =>
       prev.map((item) =>
         unreadIds.includes(item.id)
@@ -110,15 +132,33 @@ export function NotificationBell({ className }: { className?: string }) {
     );
   }, [open, notifications]);
 
-  const respond = (notificationId: string, response: "yes" | "no") => {
-    setRespondingId(`${notificationId}:${response}`);
-    fetch("/api/notifications/respond", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ recipientId: notificationId, response }),
-    })
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then(() => {
+  const handleRealtimeNotification = useCallback(
+    (event: NotificationRealtimeEvent) => {
+      if (status !== "authenticated") return;
+      toast.info(event.notification.title, {
+        description: event.notification.body ?? undefined,
+      });
+      void loadNotifications();
+    },
+    [status, loadNotifications],
+  );
+
+  useNotificationRealtime(handleRealtimeNotification);
+
+  const respond = useCallback(
+    async (notificationId: string, response: AttendanceResponse) => {
+      setRespondingId(`${notificationId}:${response}`);
+      try {
+        const result = await fetch("/api/notifications/respond", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ recipientId: notificationId, response }),
+        });
+
+        if (!result.ok) {
+          throw new Error("Request failed");
+        }
+
         toast.success(response === "yes" ? "Zusage gespeichert." : "Absage gespeichert.");
         setNotifications((prev) =>
           prev.map((item) =>
@@ -127,14 +167,15 @@ export function NotificationBell({ className }: { className?: string }) {
               : item,
           ),
         );
-      })
-      .catch(() => {
+      } catch (error) {
+        console.error("[NotificationBell] respond failed", error);
         toast.error("Antwort konnte nicht gespeichert werden.");
-      })
-      .finally(() => {
+      } finally {
         setRespondingId(null);
-      });
-  };
+      }
+    },
+    [],
+  );
 
   if (status === "loading") {
     return <div className={cn(className, "h-9 w-9 animate-pulse rounded-full bg-foreground/10")} aria-hidden />;
@@ -144,15 +185,38 @@ export function NotificationBell({ className }: { className?: string }) {
     return null;
   }
 
+  const toggleOpen = () => {
+    setOpen((previous) => {
+      const next = !previous;
+      if (!previous) {
+        void loadNotifications();
+      }
+      return next;
+    });
+  };
+
+  const scrollAreaClassName = isMobile ? "max-h-[60vh]" : "max-h-[min(70vh,24rem)]";
+
+  const content = (
+    <NotificationContent
+      notifications={notifications}
+      loading={loading}
+      respondingId={respondingId}
+      onRespond={respond}
+      scrollAreaClassName={scrollAreaClassName}
+    />
+  );
+
   return (
     <div className={cn("relative", className)}>
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen((value) => !value)}
+        onClick={toggleOpen}
         className="relative inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-card/70 text-foreground/80 transition hover:bg-accent/30 focus:outline-none focus:ring-2 focus:ring-ring"
-        aria-haspopup="menu"
+        aria-haspopup="true"
         aria-expanded={open}
+        aria-controls={!isMobile && open ? panelId : undefined}
         aria-label={unreadCount ? `${unreadCount} ungelesene Benachrichtigungen` : "Benachrichtigungen"}
       >
         <Bell size={18} />
@@ -163,82 +227,156 @@ export function NotificationBell({ className }: { className?: string }) {
         )}
       </button>
 
-      {open && (
-        <div
-          ref={panelRef}
-          role="menu"
-          aria-label="Benachrichtigungen"
-          className="absolute right-0 z-50 mt-2 w-80 max-w-xs rounded-md border border-border/60 bg-card/95 p-3 text-sm shadow-lg"
+      {isMobile ? (
+        <Modal
+          open={open}
+          title="Benachrichtigungen"
+          description={loading ? "Aktualisiere…" : undefined}
+          onClose={() => setOpen(false)}
         >
-          <header className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
-            <span>Benachrichtigungen</span>
-            {loading && <span>Aktualisiere…</span>}
-          </header>
+          {content}
+        </Modal>
+      ) : (
+        open && (
+          <div
+            ref={panelRef}
+            id={panelId}
+            role="menu"
+            aria-label="Benachrichtigungen"
+            className="absolute right-0 z-50 mt-3 w-[min(20rem,calc(100vw-1.5rem))] rounded-lg border border-border/60 bg-card/95 p-4 text-sm shadow-lg backdrop-blur"
+          >
+            {content}
+          </div>
+        )
+      )}
+    </div>
+  );
+}
 
-          {notifications.length === 0 ? (
-            <p className="text-xs text-muted-foreground">Keine Benachrichtigungen vorhanden.</p>
-          ) : (
-            <ul className="space-y-3">
-              {notifications.map((item) => {
-                const startDate = item.rehearsal ? new Date(item.rehearsal.start) : null;
-                const busy = respondingId?.startsWith(`${item.id}:`) ?? false;
-                const hasResponse = item.attendanceStatus === "yes" || item.attendanceStatus === "no";
-                return (
-                  <li key={item.id} className="rounded border border-border/40 bg-background/80 p-3">
-                    <div className="flex items-start justify-between gap-2">
-                      <div>
-                        <div className="font-medium text-foreground">{item.title}</div>
-                        {item.body && (
-                          <div className="text-xs text-muted-foreground">{item.body}</div>
-                        )}
-                        {startDate && (
-                          <div className="text-xs text-muted-foreground">
-                            {dateTimeFormatter.format(startDate)}
-                          </div>
-                        )}
-                      </div>
-                      {hasResponse && (
-                        <span
-                          className={cn(
-                            "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs",
-                            item.attendanceStatus === "yes"
-                              ? "bg-emerald-500/15 text-emerald-700"
-                              : "bg-rose-500/15 text-rose-700",
-                          )}
-                        >
-                          {item.attendanceStatus === "yes" ? <Check size={12} /> : <X size={12} />}
-                          {item.attendanceStatus === "yes" ? "Zusage" : "Absage"}
-                        </span>
-                      )}
-                    </div>
-                    {!hasResponse && item.rehearsal ? (
-                      <div className="mt-3 flex gap-2">
-                        <Button
-                          type="button"
-                          size="sm"
-                          onClick={() => respond(item.id, "yes")}
-                          disabled={busy}
-                        >
-                          Zusagen
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          onClick={() => respond(item.id, "no")}
-                          disabled={busy}
-                        >
-                          Absagen
-                        </Button>
-                      </div>
-                    ) : null}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
+type NotificationContentProps = {
+  notifications: NotificationItem[];
+  loading: boolean;
+  respondingId: string | null;
+  onRespond: (notificationId: string, response: AttendanceResponse) => void;
+  scrollAreaClassName?: string;
+};
+
+function NotificationContent({
+  notifications,
+  loading,
+  respondingId,
+  onRespond,
+  scrollAreaClassName,
+}: NotificationContentProps) {
+  return (
+    <div className="space-y-3 text-sm">
+      <header className="flex items-center justify-between text-xs text-muted-foreground" aria-live="polite">
+        <span>Benachrichtigungen</span>
+        {loading && <span>Aktualisiere…</span>}
+      </header>
+      {notifications.length === 0 ? (
+        <p className="text-xs text-muted-foreground">Keine Benachrichtigungen vorhanden.</p>
+      ) : (
+        <div className={cn("space-y-3 overflow-y-auto pr-1", scrollAreaClassName)}>
+          <NotificationList notifications={notifications} respondingId={respondingId} onRespond={onRespond} />
         </div>
       )}
     </div>
+  );
+}
+
+type NotificationListProps = {
+  notifications: NotificationItem[];
+  respondingId: string | null;
+  onRespond: (notificationId: string, response: AttendanceResponse) => void;
+};
+
+function NotificationList({ notifications, respondingId, onRespond }: NotificationListProps) {
+  return (
+    <ul className="space-y-3">
+      {notifications.map((item) => (
+        <NotificationEntry
+          key={item.id}
+          item={item}
+          respondingId={respondingId}
+          onRespond={onRespond}
+        />
+      ))}
+    </ul>
+  );
+}
+
+type NotificationEntryProps = {
+  item: NotificationItem;
+  respondingId: string | null;
+  onRespond: (notificationId: string, response: AttendanceResponse) => void;
+};
+
+function NotificationEntry({ item, respondingId, onRespond }: NotificationEntryProps) {
+  const busy = respondingId?.startsWith(`${item.id}:`) ?? false;
+  const hasResponse = item.attendanceStatus === "yes" || item.attendanceStatus === "no";
+  const startDate = item.rehearsal ? new Date(item.rehearsal.start) : null;
+  const createdAt = new Date(item.createdAt);
+
+  return (
+    <li className="rounded-lg border border-border/40 bg-background/85 p-3 shadow-sm">
+      <article className="space-y-3">
+        <header className="flex items-start justify-between gap-2">
+          <div className="min-w-0 space-y-1">
+            <h3 className="text-sm font-medium text-foreground break-words">{item.title}</h3>
+            {item.body && (
+              <p className="text-xs text-muted-foreground leading-snug break-words">{item.body}</p>
+            )}
+            <div className="space-y-0.5 text-[0.7rem] text-muted-foreground">
+              <time dateTime={createdAt.toISOString()} className="block">
+                Erhalten: {dateTimeFormatter.format(createdAt)}
+              </time>
+              {startDate && (
+                <time dateTime={startDate.toISOString()} className="block">
+                  Probe: {dateTimeFormatter.format(startDate)}
+                </time>
+              )}
+            </div>
+          </div>
+          {hasResponse && (
+            <span
+              className={cn(
+                "inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[0.7rem] font-medium",
+                item.attendanceStatus === "yes"
+                  ? "bg-emerald-500/20 text-emerald-200"
+                  : "bg-rose-500/20 text-rose-200",
+              )}
+            >
+              {item.attendanceStatus === "yes" ? <Check size={12} /> : <X size={12} />}
+              {item.attendanceStatus === "yes" ? "Zusage" : "Absage"}
+            </span>
+          )}
+        </header>
+
+        {!hasResponse && item.rehearsal ? (
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              type="button"
+              size="sm"
+              className="w-full sm:w-auto"
+              disabled={busy}
+              onClick={() => onRespond(item.id, "yes")}
+            >
+              Zusagen
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full sm:w-auto"
+              disabled={busy}
+              onClick={() => onRespond(item.id, "no")}
+            >
+              Absagen
+            </Button>
+          </div>
+        ) : null}
+      </article>
+    </li>
   );
 }

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -51,10 +51,13 @@ export function SiteHeader() {
         : 'bg-gradient-to-b from-black/40 via-black/25 via-black/12 to-transparent backdrop-blur-[1px]'
     }`}>
       <div className={`${!scrolled && isHomePage ? 'h-32 bg-gradient-to-b from-transparent via-transparent to-transparent absolute inset-x-0 top-full' : ''}`} />
-      <nav aria-label="Hauptnavigation" className="container mx-auto flex items-center gap-6 p-4">
-        <Link className={`font-serif text-xl transition-all duration-300 ${
+      <nav
+        aria-label="Hauptnavigation"
+        className="container mx-auto flex flex-wrap items-center gap-3 sm:gap-4 md:gap-6 px-4 py-3 sm:px-6 sm:py-4"
+      >
+        <Link className={`font-serif text-lg sm:text-xl transition-all duration-300 ${
           scrolled || !isHomePage
-            ? 'text-primary hover:opacity-90' 
+            ? 'text-primary hover:opacity-90'
             : 'text-white hover:text-primary/90 drop-shadow-lg'
         }`} href="/">
           Sommertheater
@@ -73,32 +76,32 @@ export function SiteHeader() {
           }`} href="/chronik">Chronik</Link>
         </div>
 
-        <div className="ml-auto flex items-center gap-3">
+        <div className="ml-auto flex items-center gap-2 sm:gap-3">
           <NotificationBell />
           <UserNav className="relative" />
-        </div>
 
-        {/* Mobile menu button */}
-        <button
-          ref={btnRef}
-          type="button"
-          aria-label="Menü öffnen"
-          aria-controls="mobile-menu"
-          aria-expanded={open}
-          onClick={() => setOpen((v) => !v)}
-          className={`md:hidden ml-2 inline-flex h-9 w-9 items-center justify-center rounded-md transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-ring ${
-            scrolled || !isHomePage
-              ? 'border border-border/60 hover:bg-accent/30 text-foreground' 
-              : 'border border-white/30 hover:bg-white/20 text-white drop-shadow-lg'
-          }`}
-        >
-          <span className="sr-only">Menü</span>
-          <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="12" x2="21" y2="12" />
-            <line x1="3" y1="18" x2="21" y2="18" />
-          </svg>
-        </button>
+          {/* Mobile menu button */}
+          <button
+            ref={btnRef}
+            type="button"
+            aria-label="Menü öffnen"
+            aria-controls="mobile-menu"
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+            className={`md:hidden inline-flex h-9 w-9 items-center justify-center rounded-md transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-ring ${
+              scrolled || !isHomePage
+                ? 'border border-border/60 hover:bg-accent/30 text-foreground'
+                : 'border border-white/30 hover:bg-white/20 text-white drop-shadow-lg'
+            }`}
+          >
+            <span className="sr-only">Menü</span>
+            <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+          </button>
+        </div>
       </nav>
 
       {/* Mobile overlay panel */}
@@ -108,7 +111,7 @@ export function SiteHeader() {
           <div
             ref={panelRef}
             id="mobile-menu"
-            className="absolute right-0 top-0 h-screen w-64 bg-card/95 backdrop-blur-md border-l border-border/60 shadow-2xl p-6 flex flex-col gap-4 pt-20"
+            className="absolute right-0 top-0 h-screen w-64 max-w-[80vw] border-l border-border/60 bg-card/95 backdrop-blur-md p-6 pt-20 shadow-2xl flex flex-col gap-4"
           >
             <Link 
               onClick={() => setOpen(false)} 

--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -47,7 +47,7 @@ export function UserNav({ className }: { className?: string }) {
   if (!session?.user) {
     return (
       <div className={cn(className ?? "ml-auto")}>
-        <Button asChild variant="outline">
+        <Button asChild variant="outline" size="sm" className="px-3">
           <Link href="/login">Login</Link>
         </Button>
       </div>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Lightweight media query hook that is safe for server rendering.
+ * Returns whether the provided media query currently matches.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const mediaQueryList = window.matchMedia(query);
+    const handleChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+
+    setMatches(mediaQueryList.matches);
+
+    if ("addEventListener" in mediaQueryList) {
+      mediaQueryList.addEventListener("change", handleChange);
+      return () => mediaQueryList.removeEventListener("change", handleChange);
+    }
+
+    mediaQueryList.addListener(handleChange);
+    return () => mediaQueryList.removeListener(handleChange);
+  }, [query]);
+
+  return matches;
+}
+


### PR DESCRIPTION
## Summary
- refactor the notification bell to support a dedicated mobile modal, reuse structured list rendering, and mark items read more reliably
- add a media query hook and update the site header and login entry to improve small-screen spacing and menu alignment
- tighten container padding for key pages and adjust chronicle layouts/timeline so mobile views no longer overflow

## Testing
- pnpm lint *(fails: repository already contains numerous pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8d976630832d8c137e651c1c6cc7