### PR TITLE
Add member profile management

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -1,0 +1,76 @@
+import { notFound } from "next/navigation";
+import { PageHeader } from "@/components/members/page-header";
+import { ProfileForm } from "@/components/members/profile-form";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { ROLE_BADGE_VARIANTS, ROLE_LABELS, sortRoles, type Role } from "@/lib/roles";
+
+export default async function ProfilePage() {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    notFound();
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      name: true,
+      email: true,
+      role: true,
+      roles: { select: { role: true } },
+    },
+  });
+
+  if (!user) {
+    notFound();
+  }
+
+  const roles = sortRoles([user.role as Role, ...user.roles.map((r) => r.role as Role)]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Mein Profil"
+        description="Pflege deine Kontaktdaten und behalte den Überblick über deine Berechtigungsrollen."
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.65fr)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Rollen & Berechtigungen</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-foreground/80">
+            <p>
+              Deine Rollen bestimmen, welche Bereiche im Mitgliederportal sichtbar sind und welche Aktionen du ausführen
+              darfst. Für weitere Rechte wende dich bitte an die Administration.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {roles.length > 0 ? (
+                roles.map((role) => (
+                  <Badge key={role} className={ROLE_BADGE_VARIANTS[role]}>
+                    {ROLE_LABELS[role] ?? role}
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-foreground/70">Derzeit sind keine Rollen hinterlegt.</span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Profildaten</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ProfileForm initialName={user.name} initialEmail={user.email} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/rbac";
+import { prisma } from "@/lib/prisma";
+import { hashPassword } from "@/lib/password";
+import { sortRoles, type Role } from "@/lib/roles";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function GET() {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      roles: { select: { role: true } },
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "Benutzer nicht gefunden" }, { status: 404 });
+  }
+
+  const roles = sortRoles([user.role as Role, ...user.roles.map((r) => r.role as Role)]);
+
+  return NextResponse.json({
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    roles,
+  });
+}
+
+export async function PUT(request: NextRequest) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const rawBody = await request.json().catch(() => null);
+
+  if (!rawBody || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const body = rawBody as Record<string, unknown>;
+  const updates: Record<string, unknown> = {};
+
+  if ("name" in body) {
+    const name = body.name;
+    if (typeof name === "string") {
+      updates.name = name.trim() || null;
+    } else if (name === null) {
+      updates.name = null;
+    } else {
+      return NextResponse.json({ error: "Ungültiger Name" }, { status: 400 });
+    }
+  }
+
+  if ("email" in body) {
+    const emailValue = body.email;
+    if (typeof emailValue !== "string") {
+      return NextResponse.json({ error: "Ungültige E-Mail-Adresse" }, { status: 400 });
+    }
+    const email = emailValue.trim().toLowerCase();
+    if (!email || !EMAIL_REGEX.test(email)) {
+      return NextResponse.json({ error: "Ungültige E-Mail-Adresse" }, { status: 400 });
+    }
+    updates.email = email;
+  }
+
+  if ("password" in body) {
+    const passwordValue = body.password;
+    if (typeof passwordValue !== "string" || passwordValue.length < 6) {
+      return NextResponse.json({ error: "Passwort muss mindestens 6 Zeichen haben" }, { status: 400 });
+    }
+    updates.passwordHash = await hashPassword(passwordValue);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "Keine Änderungen übermittelt" }, { status: 400 });
+  }
+
+  try {
+    const updated = await prisma.user.update({
+      where: { id: userId },
+      data: updates,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        roles: { select: { role: true } },
+      },
+    });
+
+    const roles = sortRoles([updated.role as Role, ...updated.roles.map((r) => r.role as Role)]);
+
+    return NextResponse.json({
+      ok: true,
+      user: {
+        id: updated.id,
+        name: updated.name,
+        email: updated.email,
+        roles,
+      },
+    });
+  } catch (error: unknown) {
+    const code = extractErrorCode(error);
+    if (code === "P2002") {
+      return NextResponse.json({ error: "Diese E-Mail wird bereits verwendet" }, { status: 409 });
+    }
+
+    if (code === "P2025") {
+      return NextResponse.json({ error: "Benutzer nicht gefunden" }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: "Aktualisierung fehlgeschlagen" }, { status: 500 });
+  }
+}
+
+function extractErrorCode(error: unknown): string | undefined {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string") {
+      return code;
+    }
+  }
+  return undefined;
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -7,6 +7,7 @@ type Item = { href: string; label: string; roles?: Role[] };
 
 const baseItems: Item[] = [
   { href: "/mitglieder", label: "Übersicht" },
+  { href: "/mitglieder/profil", label: "Profil" },
   { href: "/mitglieder/dashboard", label: "Dashboard" },
   { href: "/mitglieder/sperrliste", label: "Sperrliste" },
   { href: "/mitglieder/probenplanung", label: "Probenplanung", roles: ["board", "admin", "tech"] },

--- a/src/components/members/profile-form.tsx
+++ b/src/components/members/profile-form.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+interface ProfileFormProps {
+  initialName?: string | null;
+  initialEmail?: string | null;
+}
+
+export function ProfileForm({ initialName, initialEmail }: ProfileFormProps) {
+  const { update } = useSession();
+  const [baseline, setBaseline] = useState({
+    name: initialName ?? "",
+    email: initialEmail ?? "",
+  });
+  const [name, setName] = useState(baseline.name);
+  const [email, setEmail] = useState(baseline.email);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setName(baseline.name);
+    setEmail(baseline.email);
+    setPassword("");
+    setConfirmPassword("");
+    setError(null);
+    setSuccess(null);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const trimmedEmail = email.trim().toLowerCase();
+    if (!trimmedEmail) {
+      setError("E-Mail darf nicht leer sein");
+      return;
+    }
+
+    if (password && password.length < 6) {
+      setError("Passwort muss mindestens 6 Zeichen haben");
+      return;
+    }
+
+    if (password && password !== confirmPassword) {
+      setError("Passwörter stimmen nicht überein");
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      email: trimmedEmail,
+      name: name.trim() || null,
+    };
+
+    if (password) {
+      payload.password = password;
+    }
+
+    setSaving(true);
+
+    try {
+      const response = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Aktualisierung fehlgeschlagen");
+      }
+
+      const updatedName = (data?.user?.name as string | null | undefined) ?? null;
+      const updatedEmail = (data?.user?.email as string | null | undefined) ?? null;
+
+      setBaseline({
+        name: updatedName ?? "",
+        email: updatedEmail ?? "",
+      });
+      setName(updatedName ?? "");
+      setEmail(updatedEmail ?? "");
+      setPassword("");
+      setConfirmPassword("");
+      setSuccess("Profil wurde erfolgreich aktualisiert");
+      toast.success("Profil wurde aktualisiert");
+
+      // Aktualisiere die Session-Daten, damit Navigationskomponenten sofort aktualisiert werden.
+      try {
+        await update({
+          user: {
+            name: updatedName ?? null,
+            email: updatedEmail ?? null,
+          },
+        });
+      } catch (sessionError) {
+        console.error("[Profil] Session konnte nicht aktualisiert werden", sessionError);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Aktualisierung fehlgeschlagen";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-foreground/90" htmlFor="profile-name">
+          Name
+        </label>
+        <Input
+          id="profile-name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="Vorname Nachname"
+          autoComplete="name"
+        />
+        <p className="text-xs text-foreground/70">
+          Der Name wird in internen Übersichten und im Mitgliederbereich angezeigt.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium text-foreground/90" htmlFor="profile-email">
+          E-Mail-Adresse
+        </label>
+        <Input
+          id="profile-email"
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          autoComplete="email"
+          required
+        />
+        <p className="text-xs text-foreground/70">
+          Diese E-Mail dient sowohl zur Anmeldung als auch für Benachrichtigungen.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-foreground/90" htmlFor="profile-password">
+            Neues Passwort
+          </label>
+          <Input
+            id="profile-password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="Optional – mindestens 6 Zeichen"
+            autoComplete="new-password"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-foreground/90" htmlFor="profile-password-confirm">
+            Passwort bestätigen
+          </label>
+          <Input
+            id="profile-password-confirm"
+            type="password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            placeholder="Nur wenn du das Passwort änderst"
+            autoComplete="new-password"
+          />
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {success && <p className="text-sm text-emerald-600">{success}</p>}
+
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        <Button type="button" variant="outline" onClick={resetForm} disabled={saving}>
+          Zurücksetzen
+        </Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? "Speichern…" : "Änderungen speichern"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -118,11 +118,11 @@ export function UserNav({ className }: { className?: string }) {
             </Link>
             <Link
               role="menuitem"
-              href="/profil"
+              href="/mitglieder/profil"
               className="block px-3 py-2 text-sm hover:bg-accent/30 focus:bg-accent/30 focus:outline-none"
               onClick={() => setOpen(false)}
             >
-              Profil (bald)
+              Profil
             </Link>
             <button
               role="menuitem"


### PR DESCRIPTION
## Summary
- add a dedicated member profile page that shows active roles and hosts the profile form
- expose a /api/profile endpoint so members can read and update their own details
- introduce a reusable ProfileForm client component and wire navigation/auth to surface the new page

## Testing
- pnpm lint *(fails: repository already contains numerous eslint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9e4694fc832d8fcbc10d3ea8fdb7