### PR TITLE
Improve members layout responsiveness

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -1,17 +1,19 @@
-import { requireAuth } from "@/lib/rbac";
-import { MembersNav } from "@/components/members-nav";
 import React from "react";
+import { MembersNav } from "@/components/members-nav";
+import { requireAuth } from "@/lib/rbac";
 
 export default async function MembersLayout({ children }: { children: React.ReactNode }) {
   const session = await requireAuth();
   const roles = session.user?.roles ?? (session.user?.role ? [session.user.role] : []);
 
   return (
-    <div className="container mx-auto grid md:grid-cols-[14rem_1fr] gap-6">
-      <aside className="md:sticky md:top-28 self-start h-fit">
-        <MembersNav roles={roles} />
-      </aside>
-      <section className="space-y-6">{children}</section>
-    </div>
+    <main className="w-full pb-12 pt-6 sm:pt-8">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 sm:px-6 lg:grid lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start lg:gap-10 lg:px-8">
+        <aside className="lg:sticky lg:top-28 lg:h-fit lg:self-start">
+          <MembersNav roles={roles} />
+        </aside>
+        <section className="min-w-0 space-y-8">{children}</section>
+      </div>
+    </main>
   );
 }

--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -192,7 +192,7 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
             Tippe auf einen Tag, um einen Sperrtermin hinzuzufügen oder zu bearbeiten.
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Button
             type="button"
             variant="outline"
@@ -222,52 +222,57 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
         </div>
       </div>
 
-      <div className="space-y-1 rounded-lg border bg-card p-2 shadow-sm">
-        <div className="grid grid-cols-7 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          {weekDayLabels.map((label) => (
-            <div key={label} className="py-2">
-              {label}
+      <div className="rounded-xl border bg-card shadow-sm">
+        <div className="overflow-x-auto">
+          <div className="min-w-[560px] space-y-2 p-3 sm:p-4">
+            <div className="grid grid-cols-7 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {weekDayLabels.map((label) => (
+                <div key={label} className="py-2">
+                  {label}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-        <div className="grid grid-cols-7 gap-1 text-sm">
-          {daysInView.map((day) => {
-            const key = format(day, DATE_FORMAT);
-            const entry = blockedByDate.get(key);
-            const isCurrentMonth = isSameMonth(day, currentMonth);
-            const isCurrentDay = isToday(day);
+            <div className="grid grid-cols-7 gap-1.5 text-sm">
+              {daysInView.map((day) => {
+                const key = format(day, DATE_FORMAT);
+                const entry = blockedByDate.get(key);
+                const isCurrentMonth = isSameMonth(day, currentMonth);
+                const isCurrentDay = isToday(day);
 
-            return (
-              <button
-                key={key}
-                type="button"
-                onClick={() => openDay(day)}
-                className={cn(
-                  "relative flex min-h-[70px] flex-col rounded-md border bg-background p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  !isCurrentMonth && "text-muted-foreground/60",
-                  entry && "border-destructive/50 bg-destructive/10",
-                  isCurrentDay && "ring-2 ring-primary/80"
-                )}
-                aria-label={`${format(day, "EEEE, d. MMMM yyyy", { locale: de })}${
-                  entry
-                    ? `, gesperrt${entry.reason ? `: ${entry.reason}` : ""}`
-                    : ", frei"
-                }`}
-              >
-                <span className="text-xs font-medium">{format(day, "d")}</span>
-                {entry ? (
-                  <span className="mt-auto flex items-center gap-1 text-xs font-semibold text-destructive">
-                    <CircleX className="h-4 w-4" />
-                    <span className="truncate" title={entry.reason ?? undefined}>
-                      {entry.reason ?? "Gesperrt"}
-                    </span>
-                  </span>
-                ) : (
-                  <span className="mt-auto text-xs text-muted-foreground">Frei</span>
-                )}
-              </button>
-            );
-          })}
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => openDay(day)}
+                    className={cn(
+                      "relative flex min-h-[78px] flex-col rounded-lg border bg-background p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:p-3",
+                      !isCurrentMonth && "text-muted-foreground/60",
+                      entry && "border-destructive/50 bg-destructive/10",
+                      isCurrentDay && "ring-2 ring-primary/80"
+                    )}
+                    aria-current={isCurrentDay ? "date" : undefined}
+                    aria-label={`${format(day, "EEEE, d. MMMM yyyy", { locale: de })}${
+                      entry
+                        ? `, gesperrt${entry.reason ? `: ${entry.reason}` : ""}`
+                        : ", frei"
+                    }`}
+                  >
+                    <span className="text-xs font-medium">{format(day, "d")}</span>
+                    {entry ? (
+                      <span className="mt-auto flex items-center gap-1 text-xs font-semibold text-destructive">
+                        <CircleX className="h-4 w-4" />
+                        <span className="truncate" title={entry.reason ?? undefined}>
+                          {entry.reason ?? "Gesperrt"}
+                        </span>
+                      </span>
+                    ) : (
+                      <span className="mt-auto text-xs text-muted-foreground">Frei</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- refine the members layout with a centered max-width container, responsive padding, and sticky sidebar behaviour on larger screens
- modernize the members navigation with a role-aware desktop list and a mobile-friendly select control for easier access on phones
- rework the block calendar to be scrollable with wider tap targets and improved spacing for smaller displays

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cabefa64f0832d82789ca7be850e18