### PR TITLE
feat: extract reusable month calendar

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/page.tsx
@@ -4,8 +4,6 @@ import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { CreateRehearsalButton } from "./create-rehearsal-button";
 import { RehearsalList, type RehearsalLite } from "./rehearsal-list";
-import { format } from "date-fns";
-import { de } from "date-fns/locale/de";
 export default async function ProbenplanungPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.probenplanung");
@@ -70,8 +68,17 @@ export default async function ProbenplanungPage() {
             title: r.title,
             start: r.start.toISOString(),
             location: r.location,
-            attendance: r.attendance.map((a) => ({ status: a.status, user: a.user })),
-            notifications: r.notifications.map((n) => ({ recipients: n.recipients.map((x) => ({ user: x.user })) })),
+            attendance: r.attendance.map((a) => ({
+              status: a.status,
+              userId: a.userId,
+              user: a.user,
+            })),
+            notifications: r.notifications.map((n) => ({
+              recipients: n.recipients.map((x) => ({
+                userId: x.userId,
+                user: x.user,
+              })),
+            })),
           })) as RehearsalLite[]}
         />
       ) : (

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
@@ -7,8 +7,8 @@ import { de } from "date-fns/locale/de";
 import { Button } from "@/components/ui/button";
 
 type UserLite = { id: string; name: string | null; email: string | null };
-type AttendanceLite = { status: string; user: UserLite };
-type RecipientLite = { user: UserLite };
+type AttendanceLite = { status: string; userId: string; user: UserLite };
+type RecipientLite = { userId: string; user: UserLite };
 type NotificationLite = { recipients: RecipientLite[] };
 
 export type RehearsalLite = {
@@ -100,10 +100,7 @@ export function RehearsalList({ initial }: { initial: RehearsalLite[] }) {
               {list.map((r) => (
                 <RehearsalCardWithActions
                   key={`${r.id}-${resetKey}`}
-                  rehearsal={{
-                    ...r,
-                    start: new Date(r.start) as any,
-                  } as any}
+                  rehearsal={r}
                   forceOpen={expandAll}
                 />
               ))}

--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -8,27 +8,20 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  addDays,
-  addMonths,
-  eachDayOfInterval,
-  endOfMonth,
-  endOfWeek,
-  format,
-  getISOWeek,
-  isSameMonth,
-  isToday,
-  parseISO,
-  startOfMonth,
-  startOfWeek,
-} from "date-fns";
+import { addDays, format, startOfMonth } from "date-fns";
 import { de } from "date-fns/locale/de";
 import { toast } from "sonner";
+import { CircleX } from "lucide-react";
+
+import {
+  MonthCalendar,
+  type CalendarDay,
+  type CalendarDayRenderResult,
+} from "@/components/calendar/month-calendar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { cn } from "@/lib/utils";
-import { ChevronLeft, ChevronRight, CircleX } from "lucide-react";
 
 const DATE_FORMAT = "yyyy-MM-dd";
 
@@ -108,40 +101,6 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
       }, 800);
     }
   }, []);
-
-  const monthLabel = useMemo(
-    () => format(currentMonth, "MMMM yyyy", { locale: de }),
-    [currentMonth]
-  );
-
-  const weekDayLabels = useMemo(() => {
-    const start = startOfWeek(new Date(), { weekStartsOn: 1 });
-    return Array.from({ length: 7 }, (_, index) =>
-      format(addDays(start, index), "EEE", { locale: de })
-    );
-  }, []);
-
-  const daysInView = useMemo(() => {
-    const firstDayOfMonth = startOfMonth(currentMonth);
-    const lastDayOfMonth = endOfMonth(currentMonth);
-    const gridStart = startOfWeek(firstDayOfMonth, { weekStartsOn: 1 });
-    const gridEnd = endOfWeek(lastDayOfMonth, { weekStartsOn: 1 });
-    return eachDayOfInterval({ start: gridStart, end: gridEnd });
-  }, [currentMonth]);
-
-  const weeksInView = useMemo(() => {
-    const weeks: { weekStart: Date; weekNumber: number; days: Date[] }[] = [];
-    for (let index = 0; index < daysInView.length; index += 7) {
-      const weekDays = daysInView.slice(index, index + 7);
-      if (weekDays.length === 0) continue;
-      weeks.push({
-        weekStart: weekDays[0],
-        weekNumber: getISOWeek(weekDays[0]),
-        days: weekDays,
-      });
-    }
-    return weeks;
-  }, [daysInView]);
 
   const selectedDateKey = selectedDate ? format(selectedDate, DATE_FORMAT) : null;
   const selectedEntry = selectedDateKey ? blockedByDate.get(selectedDateKey) : undefined;
@@ -241,75 +200,212 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
     }
   };
 
-  const openDay = (day: Date) => {
+  const openDay = useCallback((day: Date) => {
     setSelectedDate(day);
     setError(null);
     setModalOpen(true);
-  };
+  }, []);
 
-  const goToday = () => {
-    const target = startOfMonth(new Date());
-    setEnterDir(target.getTime() >= currentMonth.getTime() ? "right" : "left");
-    setCurrentMonth(target);
-  };
+  const handleMonthChange = useCallback(
+    (nextMonth: Date) => {
+      setEnterDir(
+        nextMonth.getTime() >= currentMonth.getTime() ? "right" : "left"
+      );
+      setCurrentMonth(nextMonth);
+    },
+    [currentMonth]
+  );
 
-  const goPrevMonth = () => {
-    setEnterDir("left");
-    setCurrentMonth((prev) => addMonths(prev, -1));
-  };
-
-  const goNextMonth = () => {
-    setEnterDir("right");
-    setCurrentMonth((prev) => addMonths(prev, 1));
-  };
-
-  const handleDayPointerDown = (
-    event: ReactPointerEvent<HTMLButtonElement>,
-    key: string
-  ) => {
-    if (!selectionMode || event.button !== 0) {
-      return;
-    }
-    event.preventDefault();
-    pointerHandledRef.current = true;
-    const shouldSelect = !selectedDayKeys.has(key);
-    dragIntentRef.current = shouldSelect ? "select" : "deselect";
-    draggingRef.current = true;
-    updateSelection(key, shouldSelect);
-  };
-
-  const handleDayPointerEnter = (
-    event: ReactPointerEvent<HTMLButtonElement>,
-    key: string
-  ) => {
-    if (!selectionMode || !draggingRef.current) {
-      return;
-    }
-    if (event.buttons === 0) {
-      draggingRef.current = false;
-      dragIntentRef.current = null;
-      return;
-    }
-    event.preventDefault();
-    const intent = dragIntentRef.current ?? "select";
-    updateSelection(key, intent === "select");
-  };
-
-  const handleDayClick = (day: Date, key: string) => {
-    if (selectionMode) {
-      if (pointerHandledRef.current) {
-        pointerHandledRef.current = false;
+  const handleDayPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, key: string) => {
+      if (!selectionMode || event.button !== 0) {
         return;
       }
-      updateSelection(key, !selectedDayKeys.has(key));
-      return;
-    }
-    openDay(day);
-  };
+      event.preventDefault();
+      pointerHandledRef.current = true;
+      const shouldSelect = !selectedDayKeys.has(key);
+      dragIntentRef.current = shouldSelect ? "select" : "deselect";
+      draggingRef.current = true;
+      updateSelection(key, shouldSelect);
+    },
+    [selectionMode, selectedDayKeys, updateSelection]
+  );
 
-  const formatKeyForMessage = useCallback((key: string) => {
-    return format(parseISO(key), "EEEE, d. MMMM yyyy", { locale: de });
-  }, []);
+  const handleDayPointerEnter = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, key: string) => {
+      if (!selectionMode || !draggingRef.current) {
+        return;
+      }
+      if (event.buttons === 0) {
+        draggingRef.current = false;
+        dragIntentRef.current = null;
+        return;
+      }
+      event.preventDefault();
+      const intent = dragIntentRef.current ?? "select";
+      updateSelection(key, intent === "select");
+    },
+    [selectionMode, updateSelection]
+  );
+
+  const handleDayClick = useCallback(
+    (day: Date, key: string) => {
+      if (selectionMode) {
+        if (pointerHandledRef.current) {
+          pointerHandledRef.current = false;
+          return;
+        }
+        updateSelection(key, !selectedDayKeys.has(key));
+        return;
+      }
+      openDay(day);
+    },
+    [openDay, selectionMode, selectedDayKeys, updateSelection]
+  );
+
+  const renderCalendarDay = useCallback(
+    (day: CalendarDay): CalendarDayRenderResult => {
+      const entry = blockedByDate.get(day.key);
+      const isSelected = selectedDayKeys.has(day.key);
+      const wasAdded = recentlyAdded.has(day.key);
+      const wasRemoved = recentlyRemoved.has(day.key);
+
+      return {
+        onClick: () => handleDayClick(day.date, day.key),
+        onPointerDown: (event) => handleDayPointerDown(event, day.key),
+        onPointerEnter: (event) => handleDayPointerEnter(event, day.key),
+        className: cn(
+          entry && "border-destructive/50 bg-destructive/10",
+          day.isToday && !isSelected && "ring-2 ring-primary/80",
+          isSelected && "border-primary ring-2 ring-primary/60",
+          "hover:shadow-sm hover:-translate-y-[1px]",
+          wasAdded && "added-anim",
+          wasRemoved && "removed-anim"
+        ),
+        "aria-pressed": selectionMode ? isSelected : undefined,
+        "aria-label": `${format(day.date, "EEEE, d. MMMM yyyy", { locale: de })}${
+          entry
+            ? `, gesperrt${entry.reason ? `: ${entry.reason}` : ""}`
+            : ", frei"
+        }`,
+        content: entry ? (
+          <span className="mt-auto flex items-center gap-1 text-xs font-semibold text-destructive transition-opacity duration-300">
+            <CircleX className="h-4 w-4" />
+            <span className="truncate" title={entry.reason ?? undefined}>
+              {entry.reason ?? "Gesperrt"}
+            </span>
+          </span>
+        ) : (
+          <span className="mt-auto text-xs text-muted-foreground">Frei</span>
+        ),
+      };
+    },
+    [
+      blockedByDate,
+      handleDayClick,
+      handleDayPointerDown,
+      handleDayPointerEnter,
+      recentlyAdded,
+      recentlyRemoved,
+      selectedDayKeys,
+      selectionMode,
+    ]
+  );
+
+  const selectionPanel = selectionMode ? (
+    <div className="space-y-3 rounded-lg border border-dashed bg-muted/30 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium">
+            {selectedKeys.length === 0
+              ? "Keine Tage ausgewählt."
+              : `${selectedKeys.length} ${
+                  selectedKeys.length === 1 ? "Tag" : "Tage"
+                } ausgewählt.`}
+          </p>
+          {selectedKeys.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {[
+                selectedFreeCount > 0
+                  ? `${selectedFreeCount} ${
+                      selectedFreeCount === 1 ? "Tag ist" : "Tage sind"
+                    } frei`
+                  : null,
+                selectedBlockedCount > 0
+                  ? `${selectedBlockedCount} ${
+                      selectedBlockedCount === 1
+                        ? "Tag ist gesperrt"
+                        : "Tage sind gesperrt"
+                    }`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={clearSelection}
+            disabled={bulkSubmitting || selectedKeys.length === 0}
+          >
+            Auswahl leeren
+          </Button>
+        </div>
+      </div>
+
+      {selectedFreeCount > 0 && (
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <div className="sm:flex-1">
+            <label
+              htmlFor="bulk-reason"
+              className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            >
+              Grund (optional)
+            </label>
+            <Input
+              id="bulk-reason"
+              value={bulkReason}
+              onChange={(event) => setBulkReason(event.target.value)}
+              placeholder="z. B. Urlaub, Familienfeier"
+              maxLength={200}
+              disabled={bulkSubmitting}
+            />
+          </div>
+          <Button
+            type="button"
+            className="sm:w-auto"
+            disabled={bulkSubmitting}
+            onClick={handleBulkCreate}
+          >
+            {selectedFreeCount > 1
+              ? `${selectedFreeCount} Tage sperren`
+              : "Tag sperren"}
+          </Button>
+        </div>
+      )}
+
+      {selectedBlockedCount > 0 && (
+        <div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={bulkSubmitting}
+            onClick={handleBulkRemove}
+          >
+            {selectedBlockedCount > 1
+              ? `${selectedBlockedCount} Sperrtermine aufheben`
+              : "Sperrtermin aufheben"}
+          </Button>
+        </div>
+      )}
+
+      {bulkError && <p className="text-sm text-destructive">{bulkError}</p>}
+    </div>
+  ) : null;
 
   const handleCreate = async () => {
     if (!selectedDateKey) return;
@@ -492,225 +588,24 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-xl border bg-card shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/40 px-4 py-3">
-          <div className="space-y-1">
-            <h2 className="text-xl font-semibold">{monthLabel}</h2>
-            <p className="text-sm text-muted-foreground">
-              Tippe auf einen Tag, um einen Sperrtermin hinzuzufügen oder zu bearbeiten.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={goToday}
-            >
-              Heute
-            </Button>
-            <div className="flex items-center rounded-md border">
-              <button
-                type="button"
-                onClick={goPrevMonth}
-                className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
-                aria-label="Vorheriger Monat"
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={goNextMonth}
-                className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
-                aria-label="Nächster Monat"
-              >
-                <ChevronRight className="h-4 w-4" />
-              </button>
-            </div>
-            <Button
-              type="button"
-              variant={selectionMode ? "default" : "outline"}
-              size="sm"
-              onClick={handleToggleSelectionMode}
-            >
-              {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
-            </Button>
-          </div>
-        </div>
-        <div className="overflow-x-auto">
-          <div className="min-w-[640px] space-y-3 p-3 sm:p-4">
-            <div className="grid grid-cols-[64px_repeat(7,minmax(0,1fr))] text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              <div className="py-2">KW</div>
-              {weekDayLabels.map((label) => (
-                <div key={label} className="py-2">
-                  {label}
-                </div>
-              ))}
-            </div>
-            <div
-              key={format(currentMonth, "yyyy-MM")}
-              className={cn(
-                "space-y-1.5 text-sm month-enter",
-                enterDir === "right" ? "month-from-right" : "month-from-left"
-              )}
-            >
-              {weeksInView.map((week) => (
-                <div
-                  key={week.weekStart.toISOString()}
-                  className="grid grid-cols-[64px_repeat(7,minmax(0,1fr))] gap-1.5"
-                >
-                  <div className="flex items-center justify-center rounded-lg bg-muted/40 px-2 py-2 text-xs font-semibold text-muted-foreground">
-                    KW {week.weekNumber}
-                  </div>
-                  {week.days.map((day) => {
-                    const key = format(day, DATE_FORMAT);
-                    const entry = blockedByDate.get(key);
-                    const isCurrentMonth = isSameMonth(day, currentMonth);
-                    const isCurrentDay = isToday(day);
-                    const isSelected = selectedDayKeys.has(key);
-                    const wasAdded = recentlyAdded.has(key);
-                    const wasRemoved = recentlyRemoved.has(key);
-
-                    return (
-                      <button
-                        key={key}
-                        type="button"
-                        onClick={() => handleDayClick(day, key)}
-                        onPointerDown={(event) => handleDayPointerDown(event, key)}
-                        onPointerEnter={(event) => handleDayPointerEnter(event, key)}
-                        className={cn(
-                          "block-cell relative flex min-h-[78px] flex-col overflow-hidden rounded-lg border bg-background p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:p-3",
-                          !isCurrentMonth && "text-muted-foreground/60",
-                          entry && "border-destructive/50 bg-destructive/10",
-                          isCurrentDay && !isSelected && "ring-2 ring-primary/80",
-                          isSelected && "border-primary ring-2 ring-primary/60",
-                          "hover:shadow-sm hover:translate-y-[-1px]",
-                          wasAdded && "added-anim",
-                          wasRemoved && "removed-anim"
-                        )}
-                        aria-current={isCurrentDay ? "date" : undefined}
-                        aria-pressed={selectionMode ? isSelected : undefined}
-                        aria-label={`${format(day, "EEEE, d. MMMM yyyy", { locale: de })}${
-                          entry
-                            ? `, gesperrt${entry.reason ? `: ${entry.reason}` : ""}`
-                            : ", frei"
-                        }`}
-                      >
-                        <span className="text-xs font-medium">{format(day, "d")}</span>
-                        {entry ? (
-                          <span className="mt-auto flex items-center gap-1 text-xs font-semibold text-destructive transition-opacity duration-300">
-                            <CircleX className="h-4 w-4" />
-                            <span className="truncate" title={entry.reason ?? undefined}>
-                              {entry.reason ?? "Gesperrt"}
-                            </span>
-                          </span>
-                        ) : (
-                          <span className="mt-auto text-xs text-muted-foreground">Frei</span>
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              ))}
-            </div>
-
-            {selectionMode && (
-              <div className="space-y-3 rounded-lg border border-dashed bg-muted/30 p-4">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="text-sm font-medium">
-                      {selectedKeys.length === 0
-                        ? "Keine Tage ausgewählt."
-                        : `${selectedKeys.length} ${
-                            selectedKeys.length === 1 ? "Tag" : "Tage"
-                          } ausgewählt.`}
-                    </p>
-                    {selectedKeys.length > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        {[
-                          selectedFreeCount > 0
-                            ? `${selectedFreeCount} ${
-                                selectedFreeCount === 1 ? "Tag ist" : "Tage sind"
-                              } frei`
-                            : null,
-                          selectedBlockedCount > 0
-                            ? `${selectedBlockedCount} ${
-                                selectedBlockedCount === 1
-                                  ? "Tag ist gesperrt"
-                                  : "Tage sind gesperrt"
-                              }`
-                            : null,
-                        ]
-                          .filter(Boolean)
-                          .join(" · ")}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={clearSelection}
-                      disabled={bulkSubmitting || selectedKeys.length === 0}
-                    >
-                      Auswahl leeren
-                    </Button>
-                  </div>
-                </div>
-
-                {selectedFreeCount > 0 && (
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-                    <div className="sm:flex-1">
-                      <label
-                        htmlFor="bulk-reason"
-                        className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground"
-                      >
-                        Grund (optional)
-                      </label>
-                      <Input
-                        id="bulk-reason"
-                        value={bulkReason}
-                        onChange={(event) => setBulkReason(event.target.value)}
-                        placeholder="z. B. Urlaub, Familienfeier"
-                        maxLength={200}
-                        disabled={bulkSubmitting}
-                      />
-                    </div>
-                    <Button
-                      type="button"
-                      className="sm:w-auto"
-                      disabled={bulkSubmitting}
-                      onClick={handleBulkCreate}
-                    >
-                      {selectedFreeCount > 1
-                        ? `${selectedFreeCount} Tage sperren`
-                        : "Tag sperren"}
-                    </Button>
-                  </div>
-                )}
-
-                {selectedBlockedCount > 0 && (
-                  <div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={bulkSubmitting}
-                      onClick={handleBulkRemove}
-                    >
-                      {selectedBlockedCount > 1
-                        ? `${selectedBlockedCount} Sperrtermine aufheben`
-                        : "Sperrtermin aufheben"}
-                    </Button>
-                  </div>
-                )}
-
-                {bulkError && <p className="text-sm text-destructive">{bulkError}</p>}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <MonthCalendar
+        month={currentMonth}
+        onMonthChange={handleMonthChange}
+        transitionDirection={enterDir}
+        subtitle="Tippe auf einen Tag, um einen Sperrtermin hinzuzufügen oder zu bearbeiten."
+        headerActions={
+          <Button
+            type="button"
+            variant={selectionMode ? "default" : "outline"}
+            size="sm"
+            onClick={handleToggleSelectionMode}
+          >
+            {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
+          </Button>
+        }
+        renderDay={renderCalendarDay}
+        additionalContent={selectionPanel}
+      />
 
       <Modal
         open={modalOpen && !!selectedDate}
@@ -780,31 +675,6 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
           </div>
         </div>
       </Modal>
-      <style jsx global>{`
-        @keyframes cellPop { 0% { transform: scale(0.96); } 100% { transform: scale(1); } }
-        @keyframes addedFlash { 0% { box-shadow: 0 0 0 0 rgba(34,197,94,.55); } 100% { box-shadow: 0 0 0 12px rgba(34,197,94,0); } }
-        @keyframes removedFlash { 0% { background-color: rgba(239,68,68,.15); } 100% { background-color: transparent; } }
-        @keyframes hoverGlow { 0% { box-shadow: 0 0 0 rgba(99,102,241,0); } 50% { box-shadow: 0 0 18px rgba(99,102,241,.35); } 100% { box-shadow: 0 0 0 rgba(99,102,241,0); } }
-        @keyframes sheenSlide { 0% { transform: translateX(-150%) skewX(-20deg);} 100% { transform: translateX(150%) skewX(-20deg);} }
-        @keyframes monthInRight { 0% { opacity: 0; transform: translateX(24px);} 100% { opacity: 1; transform: translateX(0);} }
-        @keyframes monthInLeft { 0% { opacity: 0; transform: translateX(-24px);} 100% { opacity: 1; transform: translateX(0);} }
-        .block-cell { position: relative; }
-        .block-cell.added-anim { animation: cellPop .22s ease-out, addedFlash .6s ease-out; }
-        .block-cell.removed-anim { animation: removedFlash .6s ease-out; }
-        .block-cell::before { content: ""; position:absolute; inset:-2px; border-radius: inherit; pointer-events:none; opacity:0; }
-        .block-cell::after { content:""; position:absolute; top:0; left:0; width:60%; height:100%; pointer-events:none; opacity:0; background: linear-gradient(120deg, rgba(255,255,255,0), rgba(255,255,255,.11), rgba(255,255,255,0)); transform: translateX(-150%) skewX(-20deg); }
-        .block-cell:hover { border-color: rgba(99,102,241,.45); background-image: radial-gradient(100% 60% at 50% 0%, rgba(99,102,241,.10), transparent 60%); }
-        @media (prefers-reduced-motion: no-preference) {
-          .block-cell:hover::before { opacity:1; animation: hoverGlow 1.2s ease-in-out infinite; }
-          .block-cell:hover::after { opacity:1; animation: sheenSlide 900ms ease-out; }
-        }
-        .dark .block-cell:hover { border-color: rgba(129,140,248,.55); background-image: radial-gradient(100% 60% at 50% 0%, rgba(129,140,248,.14), transparent 65%); }
-        .month-enter { will-change: transform, opacity; }
-        @media (prefers-reduced-motion: no-preference) {
-          .month-enter.month-from-right { animation: monthInRight .32s ease-out; }
-          .month-enter.month-from-left  { animation: monthInLeft  .32s ease-out; }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/app/api/permissions/roles/[id]/route.ts
+++ b/src/app/api/permissions/roles/[id]/route.ts
@@ -47,7 +47,7 @@ export async function DELETE(_request: NextRequest, { params }: { params: { id: 
   try {
     await prisma.appRole.delete({ where: { id } });
     return NextResponse.json({ ok: true });
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: "Löschen fehlgeschlagen" }, { status: 500 });
   }
 }

--- a/src/components/calendar/month-calendar.tsx
+++ b/src/components/calendar/month-calendar.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import {
+  addDays,
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  getISOWeek,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import type { Locale } from "date-fns";
+import { de } from "date-fns/locale/de";
+import {
+  type AriaAttributes,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export const CALENDAR_DATE_FORMAT = "yyyy-MM-dd";
+
+export interface CalendarDay {
+  date: Date;
+  key: string;
+  weekNumber: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+}
+
+export interface CalendarWeek {
+  weekStart: Date;
+  weekNumber: number;
+  days: Date[];
+}
+
+export interface CalendarDayRenderResult
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+  content?: ReactNode;
+}
+
+export interface MonthCalendarProps {
+  month?: Date;
+  defaultMonth?: Date;
+  onMonthChange?: (nextMonth: Date) => void;
+  transitionDirection?: "left" | "right";
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  locale?: Locale;
+  monthLabelFormat?: string;
+  weekdayFormat?: string;
+  renderWeekdayLabel?: (date: Date, index: number) => ReactNode;
+  renderWeekNumber?: (week: CalendarWeek) => ReactNode;
+  renderDay?: (day: CalendarDay) => CalendarDayRenderResult | undefined;
+  renderDayNumber?: (day: CalendarDay) => ReactNode;
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  headerActions?: ReactNode;
+  todayLabel?: string;
+  showTodayButton?: boolean;
+  showWeekNumbers?: boolean;
+  className?: string;
+  contentClassName?: string;
+  minGridWidthClassName?: string;
+  dayClassName?: string;
+  additionalContent?: ReactNode;
+}
+
+const DEFAULT_WEEKDAY_FORMAT = "EEE";
+const DEFAULT_MONTH_LABEL_FORMAT = "MMMM yyyy";
+
+export function MonthCalendar({
+  month,
+  defaultMonth,
+  onMonthChange,
+  transitionDirection,
+  weekStartsOn = 1,
+  locale = de,
+  monthLabelFormat = DEFAULT_MONTH_LABEL_FORMAT,
+  weekdayFormat = DEFAULT_WEEKDAY_FORMAT,
+  renderWeekdayLabel,
+  renderWeekNumber,
+  renderDay,
+  renderDayNumber,
+  title,
+  subtitle,
+  headerActions,
+  todayLabel = "Heute",
+  showTodayButton = true,
+  showWeekNumbers = true,
+  className,
+  contentClassName,
+  minGridWidthClassName = "min-w-[640px]",
+  dayClassName,
+  additionalContent,
+}: MonthCalendarProps) {
+  const initialMonth = useMemo(
+    () => startOfMonth(month ?? defaultMonth ?? new Date()),
+    [defaultMonth, month]
+  );
+
+  const [internalMonth, setInternalMonth] = useState<Date>(initialMonth);
+  const [internalDirection, setInternalDirection] = useState<"left" | "right">(
+    "right"
+  );
+  const previousMonthRef = useRef<Date>(initialMonth);
+
+  useEffect(() => {
+    if (month) {
+      const normalized = startOfMonth(month);
+      if (!transitionDirection) {
+        const previous = previousMonthRef.current;
+        if (previous) {
+          setInternalDirection(
+            normalized.getTime() >= previous.getTime() ? "right" : "left"
+          );
+        }
+      }
+      previousMonthRef.current = normalized;
+    }
+  }, [month, transitionDirection]);
+
+  useEffect(() => {
+    if (!month) {
+      previousMonthRef.current = internalMonth;
+    }
+  }, [internalMonth, month]);
+
+  const displayedMonth = month ? startOfMonth(month) : internalMonth;
+  const resolvedDirection = transitionDirection ?? internalDirection;
+
+  const monthLabel = useMemo(
+    () => format(displayedMonth, monthLabelFormat, { locale }),
+    [displayedMonth, locale, monthLabelFormat]
+  );
+
+  const weekDayLabels = useMemo(() => {
+    const start = startOfWeek(displayedMonth, { weekStartsOn });
+    return Array.from({ length: 7 }, (_, index) => {
+      const date = addDays(start, index);
+      if (renderWeekdayLabel) {
+        return renderWeekdayLabel(date, index);
+      }
+      return format(date, weekdayFormat, { locale });
+    });
+  }, [displayedMonth, locale, renderWeekdayLabel, weekStartsOn, weekdayFormat]);
+
+  const daysInView = useMemo(() => {
+    const firstDayOfMonth = startOfMonth(displayedMonth);
+    const lastDayOfMonth = endOfMonth(displayedMonth);
+    const gridStart = startOfWeek(firstDayOfMonth, { weekStartsOn });
+    const gridEnd = endOfWeek(lastDayOfMonth, { weekStartsOn });
+    return eachDayOfInterval({ start: gridStart, end: gridEnd });
+  }, [displayedMonth, weekStartsOn]);
+
+  const weeksInView = useMemo<CalendarWeek[]>(() => {
+    const weeks: CalendarWeek[] = [];
+    for (let index = 0; index < daysInView.length; index += 7) {
+      const weekDays = daysInView.slice(index, index + 7);
+      if (weekDays.length === 0) continue;
+      weeks.push({
+        weekStart: weekDays[0],
+        weekNumber: getISOWeek(weekDays[0]),
+        days: weekDays,
+      });
+    }
+    return weeks;
+  }, [daysInView]);
+
+  const updateMonth = (next: Date, direction: "left" | "right") => {
+    const normalized = startOfMonth(next);
+    if (!month) {
+      setInternalMonth(normalized);
+    }
+    if (!transitionDirection) {
+      setInternalDirection(direction);
+    }
+    onMonthChange?.(normalized);
+  };
+
+  const goToday = () => {
+    const todayMonth = startOfMonth(new Date());
+    updateMonth(
+      todayMonth,
+      todayMonth.getTime() >= displayedMonth.getTime() ? "right" : "left"
+    );
+  };
+
+  const goPrevMonth = () => {
+    updateMonth(addMonths(displayedMonth, -1), "left");
+  };
+
+  const goNextMonth = () => {
+    updateMonth(addMonths(displayedMonth, 1), "right");
+  };
+
+  const headerTitle = title ?? monthLabel;
+
+  const weekdayHeaderClass = showWeekNumbers
+    ? "grid grid-cols-[64px_repeat(7,minmax(0,1fr))]"
+    : "grid grid-cols-[repeat(7,minmax(0,1fr))]";
+
+  const weekRowClass = showWeekNumbers
+    ? "grid grid-cols-[64px_repeat(7,minmax(0,1fr))] gap-1.5"
+    : "grid grid-cols-[repeat(7,minmax(0,1fr))] gap-1.5";
+
+  return (
+    <div className={cn("rounded-xl border bg-card shadow-sm", className)}>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/40 px-4 py-3">
+        <div className="space-y-1">
+          {typeof headerTitle === "string" ? (
+            <h2 className="text-xl font-semibold">{headerTitle}</h2>
+          ) : (
+            headerTitle
+          )}
+          {subtitle ? (
+            <p className="text-sm text-muted-foreground">{subtitle}</p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {showTodayButton ? (
+            <Button type="button" variant="outline" size="sm" onClick={goToday}>
+              {todayLabel}
+            </Button>
+          ) : null}
+          <div className="flex items-center rounded-md border">
+            <button
+              type="button"
+              onClick={goPrevMonth}
+              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+              aria-label="Vorheriger Monat"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={goNextMonth}
+              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+              aria-label="Nächster Monat"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+          {headerActions}
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <div
+          className={cn(
+            minGridWidthClassName,
+            "space-y-3 p-3 sm:p-4",
+            contentClassName
+          )}
+        >
+          <div
+            className={cn(
+              weekdayHeaderClass,
+              "text-center text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            )}
+          >
+            {showWeekNumbers ? <div className="py-2">KW</div> : null}
+            {weekDayLabels.map((label, index) => (
+              <div key={index} className="py-2">
+                {label}
+              </div>
+            ))}
+          </div>
+          <div
+            key={format(displayedMonth, "yyyy-MM")}
+            className={cn(
+              "space-y-1.5 text-sm calendar-month-enter",
+              resolvedDirection === "right"
+                ? "calendar-month-from-right"
+                : "calendar-month-from-left"
+            )}
+          >
+            {weeksInView.map((week) => (
+              <div key={week.weekStart.toISOString()} className={weekRowClass}>
+                {showWeekNumbers ? (
+                  <div className="flex items-center justify-center rounded-lg bg-muted/40 px-2 py-2 text-xs font-semibold text-muted-foreground">
+                    {renderWeekNumber ? renderWeekNumber(week) : <>KW {week.weekNumber}</>}
+                  </div>
+                ) : null}
+                {week.days.map((day) => {
+                  const key = format(day, CALENDAR_DATE_FORMAT);
+                  const isCurrentMonth = isSameMonth(day, displayedMonth);
+                  const dayInfo: CalendarDay = {
+                    date: day,
+                    key,
+                    weekNumber: week.weekNumber,
+                    isCurrentMonth,
+                    isToday: isToday(day),
+                  };
+                  const result = renderDay?.(dayInfo) ?? {};
+                  const {
+                    content,
+                    className: daySpecificClass,
+                    type: buttonType,
+                    ["aria-label"]: ariaLabelProp,
+                    ["aria-current"]: ariaCurrentProp,
+                    ...restButtonProps
+                  } = result;
+                  const ariaLabel =
+                    ariaLabelProp ??
+                    format(day, "EEEE, d. MMMM yyyy", { locale });
+                  const ariaCurrent = ariaCurrentProp ?? (dayInfo.isToday ? "date" : undefined);
+                  const dayNumberContent = renderDayNumber
+                    ? renderDayNumber(dayInfo)
+                    : format(day, "d", { locale });
+                  const finalClassName = cn(
+                    "calendar-cell relative flex min-h-[78px] flex-col overflow-hidden rounded-lg border bg-background p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:p-3",
+                    !isCurrentMonth && "text-muted-foreground/60",
+                    dayClassName,
+                    daySpecificClass
+                  );
+                  return (
+                    <button
+                      key={key}
+                      type={buttonType ?? "button"}
+                      aria-label={ariaLabel}
+                      aria-current={ariaCurrent as AriaAttributes["aria-current"]}
+                      {...restButtonProps}
+                      className={finalClassName}
+                      data-date={key}
+                      data-today={dayInfo.isToday ? "true" : undefined}
+                      data-current-month={dayInfo.isCurrentMonth ? "true" : undefined}
+                    >
+                      <span className="text-xs font-medium">{dayNumberContent}</span>
+                      {content}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+          {additionalContent}
+        </div>
+      </div>
+      <style jsx global>{`
+        @keyframes calendarCellPop { 0% { transform: scale(0.96); } 100% { transform: scale(1); } }
+        @keyframes calendarAddedFlash { 0% { box-shadow: 0 0 0 0 rgba(34,197,94,.55); } 100% { box-shadow: 0 0 0 12px rgba(34,197,94,0); } }
+        @keyframes calendarRemovedFlash { 0% { background-color: rgba(239,68,68,.15); } 100% { background-color: transparent; } }
+        @keyframes calendarHoverGlow { 0% { box-shadow: 0 0 0 rgba(99,102,241,0); } 50% { box-shadow: 0 0 18px rgba(99,102,241,.35); } 100% { box-shadow: 0 0 0 rgba(99,102,241,0); } }
+        @keyframes calendarSheenSlide { 0% { transform: translateX(-150%) skewX(-20deg);} 100% { transform: translateX(150%) skewX(-20deg);} }
+        @keyframes calendarMonthInRight { 0% { opacity: 0; transform: translateX(24px);} 100% { opacity: 1; transform: translateX(0);} }
+        @keyframes calendarMonthInLeft { 0% { opacity: 0; transform: translateX(-24px);} 100% { opacity: 1; transform: translateX(0);} }
+        .calendar-cell { position: relative; }
+        .calendar-cell.added-anim { animation: calendarCellPop .22s ease-out, calendarAddedFlash .6s ease-out; }
+        .calendar-cell.removed-anim { animation: calendarRemovedFlash .6s ease-out; }
+        .calendar-cell::before { content: ""; position:absolute; inset:-2px; border-radius: inherit; pointer-events:none; opacity:0; }
+        .calendar-cell::after { content:""; position:absolute; top:0; left:0; width:60%; height:100%; pointer-events:none; opacity:0; background: linear-gradient(120deg, rgba(255,255,255,0), rgba(255,255,255,.11), rgba(255,255,255,0)); transform: translateX(-150%) skewX(-20deg); }
+        .calendar-cell:hover { border-color: rgba(99,102,241,.45); background-image: radial-gradient(100% 60% at 50% 0%, rgba(99,102,241,.10), transparent 60%); }
+        @media (prefers-reduced-motion: no-preference) {
+          .calendar-cell:hover::before { opacity:1; animation: calendarHoverGlow 1.2s ease-in-out infinite; }
+          .calendar-cell:hover::after { opacity:1; animation: calendarSheenSlide 900ms ease-out; }
+        }
+        .dark .calendar-cell:hover { border-color: rgba(129,140,248,.55); background-image: radial-gradient(100% 60% at 50% 0%, rgba(129,140,248,.14), transparent 65%); }
+        .calendar-month-enter { will-change: transform, opacity; }
+        @media (prefers-reduced-motion: no-preference) {
+          .calendar-month-enter.calendar-month-from-right { animation: calendarMonthInRight .32s ease-out; }
+          .calendar-month-enter.calendar-month-from-left  { animation: calendarMonthInLeft  .32s ease-out; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/members/permission-matrix.tsx
+++ b/src/components/members/permission-matrix.tsx
@@ -111,15 +111,15 @@ export function PermissionMatrix() {
       body: JSON.stringify({ name }),
     });
     if (res.ok) {
-      const data = await res.json().catch(() => ({}));
-      const updated = data?.role as Role | undefined;
+      const data = (await res.json().catch(() => ({}))) as { role?: Role };
+      const updated = data?.role;
       if (updated) {
         setRoles((prev) => prev.map((r) => (r.id === updated.id ? { ...r, name: updated.name } : r)));
       }
       closeEdit();
     } else {
-      const payload = await res.json().catch(() => ({} as any));
-      setEditError(payload?.error || "Aktualisierung fehlgeschlagen");
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+      setEditError(payload?.error ?? "Aktualisierung fehlgeschlagen");
     }
     setSaving(false);
   };
@@ -139,8 +139,8 @@ export function PermissionMatrix() {
       });
       closeEdit();
     } else {
-      const payload = await res.json().catch(() => ({} as any));
-      setEditError(payload?.error || "Löschen fehlgeschlagen");
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+      setEditError(payload?.error ?? "Löschen fehlgeschlagen");
     }
     setDeleting(false);
   };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,14 +1,11 @@
 "use client";
-
-"use client";
-import * as React from "react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { MoreVerticalIcon } from "./icons";
 
 interface DropdownMenuItem {
   label: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   onClick: () => void;
   variant?: "default" | "destructive";
 }
@@ -59,11 +56,11 @@ export function DropdownMenu({ items, align = "right", className = "" }: Dropdow
       setCoords({ top, left });
     };
     update();
-    const opts: AddEventListenerOptions = { passive: true, capture: true } as any;
+    const opts: AddEventListenerOptions = { passive: true, capture: true };
     window.addEventListener("scroll", update, opts);
     window.addEventListener("resize", update);
     return () => {
-      window.removeEventListener("scroll", update, opts as any);
+      window.removeEventListener("scroll", update, opts);
       window.removeEventListener("resize", update);
     };
   }, [isOpen, align]);


### PR DESCRIPTION
## Summary
- create a reusable `MonthCalendar` component with configurable rendering hooks, header actions and shared styling
- refactor the block calendar to consume the shared calendar component and feed its bulk-selection controls
- tighten rehearsal planning and permission utilities typing to satisfy lint

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfc378f18832d842cabe3bbb80b67