### PR TITLE
feat: add rehearsal planning calendar

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/create-rehearsal-button.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/create-rehearsal-button.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
+
 import { createRehearsalAction } from "./actions";
 
 function formatDate(value: Date) {
@@ -15,22 +17,39 @@ function formatTime(value: Date) {
   return value.toISOString().slice(11, 16);
 }
 
-export function CreateRehearsalButton() {
-  const now = new Date();
-  const [open, setOpen] = useState(false);
+export interface CreateRehearsalDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialTitle?: string;
+  initialDate?: string;
+  initialTime?: string;
+  initialLocation?: string;
+  onSuccess?: () => void;
+}
+
+export function CreateRehearsalDialog({
+  open,
+  onOpenChange,
+  initialTitle,
+  initialDate,
+  initialTime,
+  initialLocation,
+  onSuccess,
+}: CreateRehearsalDialogProps) {
   const [title, setTitle] = useState("");
-  const [date, setDate] = useState(() => formatDate(now));
-  const [time, setTime] = useState(() => formatTime(now));
+  const [date, setDate] = useState(() => formatDate(new Date()));
+  const [time, setTime] = useState(() => formatTime(new Date()));
   const [location, setLocation] = useState("Noch offen");
   const [isPending, startTransition] = useTransition();
 
-  const resetState = () => {
-    setTitle("");
-    const next = new Date();
-    setDate(formatDate(next));
-    setTime(formatTime(next));
-    setLocation("Noch offen");
-  };
+  useEffect(() => {
+    if (!open) return;
+    const now = new Date();
+    setTitle(initialTitle ?? "");
+    setDate(initialDate ?? formatDate(now));
+    setTime(initialTime ?? formatTime(now));
+    setLocation(initialLocation ?? "Noch offen");
+  }, [open, initialDate, initialLocation, initialTime, initialTitle]);
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -39,8 +58,8 @@ export function CreateRehearsalButton() {
         .then((result) => {
           if (result?.success) {
             toast.success("Probe erstellt. Die Benachrichtigungen wurden versendet.");
-            resetState();
-            setOpen(false);
+            onOpenChange(false);
+            onSuccess?.();
           } else {
             toast.error(result?.error ?? "Speichern fehlgeschlagen.");
           }
@@ -52,95 +71,103 @@ export function CreateRehearsalButton() {
   };
 
   return (
+    <Modal
+      open={open}
+      onClose={() => {
+        if (!isPending) onOpenChange(false);
+      }}
+      title="Neue Probe planen"
+      description="Alle Mitglieder erhalten nach dem Speichern eine Benachrichtigung."
+    >
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="rehearsal-title">
+            Titel
+          </label>
+          <Input
+            id="rehearsal-title"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="z. B. Leseprobe im Probenraum"
+            required
+            minLength={3}
+            maxLength={120}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="rehearsal-location">
+            Ort
+          </label>
+          <Input
+            id="rehearsal-location"
+            value={location}
+            onChange={(event) => setLocation(event.target.value)}
+            placeholder="z. B. Probenraum, Bühne, Außenlocation"
+            minLength={2}
+            maxLength={120}
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="rehearsal-date">
+              Datum
+            </label>
+            <Input
+              id="rehearsal-date"
+              type="date"
+              value={date}
+              onChange={(event) => setDate(event.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="rehearsal-time">
+              Uhrzeit
+            </label>
+            <Input
+              id="rehearsal-time"
+              type="time"
+              value={time}
+              onChange={(event) => setTime(event.target.value)}
+              required
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              if (!isPending) {
+                onOpenChange(false);
+              }
+            }}
+            disabled={isPending}
+          >
+            Abbrechen
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? "Speichern..." : "Probe erstellen"}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export function CreateRehearsalButton() {
+  const [open, setOpen] = useState(false);
+
+  return (
     <>
       <Button type="button" onClick={() => setOpen(true)}>
         Neue Probe anlegen
       </Button>
 
-      <Modal
-        open={open}
-        onClose={() => {
-          if (!isPending) setOpen(false);
-        }}
-        title="Neue Probe planen"
-        description="Alle Mitglieder erhalten nach dem Speichern eine Benachrichtigung."
-      >
-        <form className="space-y-4" onSubmit={handleSubmit}>
-          <div className="space-y-2">
-            <label className="text-sm font-medium" htmlFor="rehearsal-title">
-              Titel
-            </label>
-            <Input
-              id="rehearsal-title"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="z. B. Leseprobe im Probenraum"
-              required
-              minLength={3}
-              maxLength={120}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-sm font-medium" htmlFor="rehearsal-location">
-              Ort
-            </label>
-            <Input
-              id="rehearsal-location"
-              value={location}
-              onChange={(event) => setLocation(event.target.value)}
-              placeholder="z. B. Probenraum, Bühne, Außenlocation"
-              minLength={2}
-              maxLength={120}
-            />
-          </div>
-
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="rehearsal-date">
-                Datum
-              </label>
-              <Input
-                id="rehearsal-date"
-                type="date"
-                value={date}
-                onChange={(event) => setDate(event.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="rehearsal-time">
-                Uhrzeit
-              </label>
-              <Input
-                id="rehearsal-time"
-                type="time"
-                value={time}
-                onChange={(event) => setTime(event.target.value)}
-                required
-              />
-            </div>
-          </div>
-
-          <div className="flex justify-end gap-2 pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                if (!isPending) {
-                  setOpen(false);
-                }
-              }}
-              disabled={isPending}
-            >
-              Abbrechen
-            </Button>
-            <Button type="submit" disabled={isPending}>
-              {isPending ? "Speichern..." : "Probe erstellen"}
-            </Button>
-          </div>
-        </form>
-      </Modal>
+      <CreateRehearsalDialog open={open} onOpenChange={setOpen} />
     </>
   );
 }

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { format, parseISO } from "date-fns";
+import { de } from "date-fns/locale/de";
+
+import {
+  CALENDAR_DATE_FORMAT,
+  MonthCalendar,
+  type CalendarDay,
+} from "@/components/calendar/month-calendar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import { cn } from "@/lib/utils";
+
+import { CreateRehearsalDialog } from "./create-rehearsal-button";
+
+const DEFAULT_NEW_REHEARSAL_TIME = "19:00";
+
+export type CalendarBlockedDay = {
+  id: string;
+  date: string;
+  dateKey: string;
+  reason: string | null;
+  user: { id: string; name: string | null; email: string | null };
+};
+
+export type CalendarRehearsal = {
+  id: string;
+  title: string;
+  start: string;
+  end: string | null;
+  dateKey: string;
+  location: string | null;
+};
+
+interface RehearsalCalendarProps {
+  blockedDays: CalendarBlockedDay[];
+  rehearsals: CalendarRehearsal[];
+  memberCount: number;
+}
+
+export function RehearsalCalendar({
+  blockedDays,
+  rehearsals,
+  memberCount,
+}: RehearsalCalendarProps) {
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  const [selectedDayKey, setSelectedDayKey] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createDefaults, setCreateDefaults] = useState<{
+    date: string;
+    time: string;
+  } | null>(null);
+
+  const blockedByDay = useMemo(() => {
+    const map = new Map<string, CalendarBlockedDay[]>();
+    for (const entry of blockedDays) {
+      const key = entry.dateKey;
+      const list = map.get(key) ?? [];
+      list.push(entry);
+      map.set(key, list);
+    }
+    for (const [, list] of map) {
+      list.sort((a, b) => {
+        const nameA = (a.user.name ?? a.user.email ?? "").toLowerCase();
+        const nameB = (b.user.name ?? b.user.email ?? "").toLowerCase();
+        return nameA.localeCompare(nameB);
+      });
+    }
+    return map;
+  }, [blockedDays]);
+
+  const rehearsalsByDay = useMemo(() => {
+    const map = new Map<string, CalendarRehearsal[]>();
+    for (const entry of rehearsals) {
+      const key = entry.dateKey;
+      const list = map.get(key) ?? [];
+      list.push(entry);
+      map.set(key, list);
+    }
+    for (const [, list] of map) {
+      list.sort(
+        (a, b) =>
+          parseISO(a.start).getTime() -
+          parseISO(b.start).getTime()
+      );
+    }
+    return map;
+  }, [rehearsals]);
+
+  const dayDetail = useMemo(() => {
+    if (!selectedDayKey) return null;
+    return {
+      blocked: blockedByDay.get(selectedDayKey) ?? [],
+      rehearsals: rehearsalsByDay.get(selectedDayKey) ?? [],
+    };
+  }, [blockedByDay, rehearsalsByDay, selectedDayKey]);
+
+  const handleDaySelect = (day: CalendarDay) => {
+    setSelectedDate(day.date);
+    setSelectedDayKey(day.key);
+  };
+
+  const handleModalClose = () => {
+    setSelectedDate(null);
+    setSelectedDayKey(null);
+  };
+
+  const openCreateForDay = (dayKey: string, defaultTime = DEFAULT_NEW_REHEARSAL_TIME) => {
+    setCreateDefaults({ date: dayKey, time: defaultTime });
+    setCreateOpen(true);
+  };
+
+  const handlePlanRehearsalForSelectedDay = () => {
+    if (!selectedDayKey) return;
+    const dayKey = selectedDayKey;
+    handleModalClose();
+    openCreateForDay(dayKey);
+  };
+
+  const handleCreateOpenChange = (next: boolean) => {
+    setCreateOpen(next);
+    if (!next) {
+      setCreateDefaults(null);
+    }
+  };
+
+  const handleCreateToday = () => {
+    const todayKey = format(new Date(), CALENDAR_DATE_FORMAT);
+    openCreateForDay(todayKey);
+  };
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold">Kalenderübersicht</h2>
+        <p className="text-sm text-muted-foreground">
+          Klicke auf einen Tag, um geplante Proben und Sperrungen einzusehen oder direkt eine neue Probe anzulegen.
+        </p>
+      </div>
+
+      <MonthCalendar
+        title="Monatsansicht"
+        subtitle="Blockierte Mitglieder und geplante Proben auf einen Blick"
+        className="bg-card/70"
+        headerActions={
+          <Button size="sm" variant="outline" onClick={handleCreateToday}>
+            Probe für heute planen
+          </Button>
+        }
+        renderDay={(day) => {
+          const dayBlocked = blockedByDay.get(day.key) ?? [];
+          const dayRehearsals = rehearsalsByDay.get(day.key) ?? [];
+          const blockedCount = dayBlocked.length;
+          const ratio = memberCount > 0 ? blockedCount / memberCount : 0;
+          const ariaLabelParts: string[] = [
+            format(day.date, "EEEE, d. MMMM yyyy", { locale: de }),
+          ];
+          if (memberCount > 0) {
+            ariaLabelParts.push(
+              blockedCount
+                ? `${blockedCount} von ${memberCount} Mitgliedern gesperrt`
+                : "Keine Sperrungen eingetragen"
+            );
+          } else {
+            ariaLabelParts.push(
+              blockedCount
+                ? `${blockedCount} blockierte Mitglieder`
+                : "Keine Sperrungen eingetragen"
+            );
+          }
+          ariaLabelParts.push(
+            dayRehearsals.length
+              ? `${dayRehearsals.length} ${
+                  dayRehearsals.length === 1 ? "Probe" : "Proben"
+                } geplant`
+              : "Keine Probe geplant"
+          );
+
+          return {
+            onClick: () => handleDaySelect(day),
+            className: cn(
+              dayRehearsals.length > 0 &&
+                "border-primary/60 bg-primary/5 shadow-[0_0_0_1px_rgba(129,140,248,0.25)]",
+              ratio >= 0.5 && "border-destructive/60 bg-destructive/10",
+              ratio >= 0.25 && ratio < 0.5 &&
+                "border-amber-400/50 bg-amber-100/40 dark:border-amber-400/40 dark:bg-amber-500/10"
+            ),
+            "aria-label": ariaLabelParts.join(". "),
+            content: (
+              <div className="mt-2 flex flex-1 flex-col gap-1 text-xs">
+                {dayRehearsals.length ? (
+                  <div className="space-y-1">
+                    {dayRehearsals.map((entry) => {
+                      const startDate = parseISO(entry.start);
+                      return (
+                        <div
+                          key={entry.id}
+                          className="rounded-md border border-primary/30 bg-primary/10 px-2 py-1"
+                        >
+                          <div className="flex items-center justify-between gap-2 text-[11px] font-medium text-primary">
+                            <span>{format(startDate, "HH:mm", { locale: de })}</span>
+                            {entry.location ? (
+                              <span className="truncate text-[10px] text-muted-foreground">
+                                {entry.location}
+                              </span>
+                            ) : null}
+                          </div>
+                          <div className="text-[12px] font-semibold text-foreground">
+                            {entry.title}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <span className="text-[11px] text-muted-foreground">Keine Probe geplant</span>
+                )}
+                <div className="pt-1">
+                  <Badge
+                    variant={
+                      blockedCount === 0
+                        ? "outline"
+                        : ratio >= 0.5
+                        ? "destructive"
+                        : "secondary"
+                    }
+                    className={cn(
+                      "w-full justify-start text-[11px]",
+                      blockedCount === 0 && "border-dashed text-muted-foreground"
+                    )}
+                  >
+                    {memberCount > 0
+                      ? `${blockedCount} / ${memberCount} blockiert`
+                      : `${blockedCount} blockiert`}
+                  </Badge>
+                </div>
+              </div>
+            ),
+          };
+        }}
+        additionalContent={
+          <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full bg-primary/50" />
+              <span>Mindestens eine Probe geplant</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full bg-amber-400" />
+              <span>25&nbsp;–&nbsp;49&nbsp;% blockiert</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="h-2 w-2 rounded-full bg-destructive/60" />
+              <span>Ab 50&nbsp;% blockiert</span>
+            </div>
+          </div>
+        }
+      />
+
+      <Modal
+        open={Boolean(selectedDate)}
+        onClose={handleModalClose}
+        title={
+          selectedDate
+            ? format(selectedDate, "EEEE, d. MMMM yyyy", { locale: de })
+            : ""
+        }
+        description={
+          selectedDayKey
+            ? [
+                memberCount > 0
+                  ? `${dayDetail?.blocked.length ?? 0} / ${memberCount} blockiert`
+                  : `${dayDetail?.blocked.length ?? 0} blockiert`,
+                `${dayDetail?.rehearsals.length ?? 0} ${
+                  (dayDetail?.rehearsals.length ?? 0) === 1
+                    ? "Probe"
+                    : "Proben"
+                } geplant`,
+              ].join(" · ")
+            : undefined
+        }
+      >
+        <div className="space-y-5">
+          <section className="space-y-2">
+            <header>
+              <h3 className="text-sm font-semibold">Geplante Proben</h3>
+            </header>
+            {dayDetail && dayDetail.rehearsals.length ? (
+              <ul className="space-y-2">
+                {dayDetail.rehearsals.map((entry) => {
+                  const startDate = parseISO(entry.start);
+                  const endDate = entry.end ? parseISO(entry.end) : null;
+                  return (
+                    <li
+                      key={entry.id}
+                      className="rounded-lg border border-border/60 bg-muted/40 px-3 py-2"
+                    >
+                      <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                        <span>
+                          {format(startDate, "HH:mm", { locale: de })}
+                          {endDate ? ` – ${format(endDate, "HH:mm", { locale: de })}` : ""}
+                        </span>
+                        {entry.location ? <span className="truncate">{entry.location}</span> : null}
+                      </div>
+                      <div className="text-sm font-medium text-foreground">
+                        {entry.title}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Für diesen Tag sind noch keine Proben eingeplant.
+              </p>
+            )}
+          </section>
+
+          <section className="space-y-2">
+            <header>
+              <h3 className="text-sm font-semibold">Blockierte Mitglieder</h3>
+            </header>
+            {dayDetail && dayDetail.blocked.length ? (
+              <ul className="space-y-2">
+                {dayDetail.blocked.map((entry) => {
+                  const displayName = entry.user.name ?? entry.user.email ?? "Mitglied";
+                  return (
+                    <li
+                      key={entry.id}
+                      className="rounded-lg border border-border/60 bg-background/80 px-3 py-2"
+                    >
+                      <div className="text-sm font-medium text-foreground">
+                        {displayName}
+                      </div>
+                      {entry.reason ? (
+                        <div className="text-xs text-muted-foreground">{entry.reason}</div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Es sind keine Sperrungen eingetragen.
+              </p>
+            )}
+          </section>
+
+          <div className="flex justify-end">
+            <Button onClick={handlePlanRehearsalForSelectedDay}>
+              Probe für diesen Tag planen
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <CreateRehearsalDialog
+        open={createOpen}
+        onOpenChange={handleCreateOpenChange}
+        initialDate={createDefaults?.date}
+        initialTime={createDefaults?.time}
+      />
+    </section>
+  );
+}

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
@@ -7,8 +7,8 @@ import { de } from "date-fns/locale/de";
 import { Button } from "@/components/ui/button";
 
 type UserLite = { id: string; name: string | null; email: string | null };
-type AttendanceLite = { status: string; user: UserLite };
-type RecipientLite = { user: UserLite };
+type AttendanceLite = { status: string; userId: string; user: UserLite };
+type RecipientLite = { userId: string; user: UserLite };
 type NotificationLite = { recipients: RecipientLite[] };
 
 export type RehearsalLite = {
@@ -100,10 +100,7 @@ export function RehearsalList({ initial }: { initial: RehearsalLite[] }) {
               {list.map((r) => (
                 <RehearsalCardWithActions
                   key={`${r.id}-${resetKey}`}
-                  rehearsal={{
-                    ...r,
-                    start: new Date(r.start) as any,
-                  } as any}
+                  rehearsal={r}
                   forceOpen={expandAll}
                 />
               ))}

--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -8,27 +8,20 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  addDays,
-  addMonths,
-  eachDayOfInterval,
-  endOfMonth,
-  endOfWeek,
-  format,
-  getISOWeek,
-  isSameMonth,
-  isToday,
-  parseISO,
-  startOfMonth,
-  startOfWeek,
-} from "date-fns";
+import { addDays, format, startOfMonth } from "date-fns";
 import { de } from "date-fns/locale/de";
 import { toast } from "sonner";
+import { CircleX } from "lucide-react";
+
+import {
+  MonthCalendar,
+  type CalendarDay,
+  type CalendarDayRenderResult,
+} from "@/components/calendar/month-calendar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Modal } from "@/components/ui/modal";
 import { cn } from "@/lib/utils";
-import { ChevronLeft, ChevronRight, CircleX } from "lucide-react";
 
 const DATE_FORMAT = "yyyy-MM-dd";
 
@@ -108,40 +101,6 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
       }, 800);
     }
   }, []);
-
-  const monthLabel = useMemo(
-    () => format(currentMonth, "MMMM yyyy", { locale: de }),
-    [currentMonth]
-  );
-
-  const weekDayLabels = useMemo(() => {
-    const start = startOfWeek(new Date(), { weekStartsOn: 1 });
-    return Array.from({ length: 7 }, (_, index) =>
-      format(addDays(start, index), "EEE", { locale: de })
-    );
-  }, []);
-
-  const daysInView = useMemo(() => {
-    const firstDayOfMonth = startOfMonth(currentMonth);
-    const lastDayOfMonth = endOfMonth(currentMonth);
-    const gridStart = startOfWeek(firstDayOfMonth, { weekStartsOn: 1 });
-    const gridEnd = endOfWeek(lastDayOfMonth, { weekStartsOn: 1 });
-    return eachDayOfInterval({ start: gridStart, end: gridEnd });
-  }, [currentMonth]);
-
-  const weeksInView = useMemo(() => {
-    const weeks: { weekStart: Date; weekNumber: number; days: Date[] }[] = [];
-    for (let index = 0; index < daysInView.length; index += 7) {
-      const weekDays = daysInView.slice(index, index + 7);
-      if (weekDays.length === 0) continue;
-      weeks.push({
-        weekStart: weekDays[0],
-        weekNumber: getISOWeek(weekDays[0]),
-        days: weekDays,
-      });
-    }
-    return weeks;
-  }, [daysInView]);
 
   const selectedDateKey = selectedDate ? format(selectedDate, DATE_FORMAT) : null;
   const selectedEntry = selectedDateKey ? blockedByDate.get(selectedDateKey) : undefined;
@@ -241,75 +200,212 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
     }
   };
 
-  const openDay = (day: Date) => {
+  const openDay = useCallback((day: Date) => {
     setSelectedDate(day);
     setError(null);
     setModalOpen(true);
-  };
+  }, []);
 
-  const goToday = () => {
-    const target = startOfMonth(new Date());
-    setEnterDir(target.getTime() >= currentMonth.getTime() ? "right" : "left");
-    setCurrentMonth(target);
-  };
+  const handleMonthChange = useCallback(
+    (nextMonth: Date) => {
+      setEnterDir(
+        nextMonth.getTime() >= currentMonth.getTime() ? "right" : "left"
+      );
+      setCurrentMonth(nextMonth);
+    },
+    [currentMonth]
+  );
 
-  const goPrevMonth = () => {
-    setEnterDir("left");
-    setCurrentMonth((prev) => addMonths(prev, -1));
-  };
-
-  const goNextMonth = () => {
-    setEnterDir("right");
-    setCurrentMonth((prev) => addMonths(prev, 1));
-  };
-
-  const handleDayPointerDown = (
-    event: ReactPointerEvent<HTMLButtonElement>,
-    key: string
-  ) => {
-    if (!selectionMode || event.button !== 0) {
-      return;
-    }
-    event.preventDefault();
-    pointerHandledRef.current = true;
-    const shouldSelect = !selectedDayKeys.has(key);
-    dragIntentRef.current = shouldSelect ? "select" : "deselect";
-    draggingRef.current = true;
-    updateSelection(key, shouldSelect);
-  };
-
-  const handleDayPointerEnter = (
-    event: ReactPointerEvent<HTMLButtonElement>,
-    key: string
-  ) => {
-    if (!selectionMode || !draggingRef.current) {
-      return;
-    }
-    if (event.buttons === 0) {
-      draggingRef.current = false;
-      dragIntentRef.current = null;
-      return;
-    }
-    event.preventDefault();
-    const intent = dragIntentRef.current ?? "select";
-    updateSelection(key, intent === "select");
-  };
-
-  const handleDayClick = (day: Date, key: string) => {
-    if (selectionMode) {
-      if (pointerHandledRef.current) {
-        pointerHandledRef.current = false;
+  const handleDayPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, key: string) => {
+      if (!selectionMode || event.button !== 0) {
         return;
       }
-      updateSelection(key, !selectedDayKeys.has(key));
-      return;
-    }
-    openDay(day);
-  };
+      event.preventDefault();
+      pointerHandledRef.current = true;
+      const shouldSelect = !selectedDayKeys.has(key);
+      dragIntentRef.current = shouldSelect ? "select" : "deselect";
+      draggingRef.current = true;
+      updateSelection(key, shouldSelect);
+    },
+    [selectionMode, selectedDayKeys, updateSelection]
+  );
 
-  const formatKeyForMessage = useCallback((key: string) => {
-    return format(parseISO(key), "EEEE, d. MMMM yyyy", { locale: de });
-  }, []);
+  const handleDayPointerEnter = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, key: string) => {
+      if (!selectionMode || !draggingRef.current) {
+        return;
+      }
+      if (event.buttons === 0) {
+        draggingRef.current = false;
+        dragIntentRef.current = null;
+        return;
+      }
+      event.preventDefault();
+      const intent = dragIntentRef.current ?? "select";
+      updateSelection(key, intent === "select");
+    },
+    [selectionMode, updateSelection]
+  );
+
+  const handleDayClick = useCallback(
+    (day: Date, key: string) => {
+      if (selectionMode) {
+        if (pointerHandledRef.current) {
+          pointerHandledRef.current = false;
+          return;
+        }
+        updateSelection(key, !selectedDayKeys.has(key));
+        return;
+      }
+      openDay(day);
+    },
+    [openDay, selectionMode, selectedDayKeys, updateSelection]
+  );
+
+  const renderCalendarDay = useCallback(
+    (day: CalendarDay): CalendarDayRenderResult => {
+      const entry = blockedByDate.get(day.key);
+      const isSelected = selectedDayKeys.has(day.key);
+      const wasAdded = recentlyAdded.has(day.key);
+      const wasRemoved = recentlyRemoved.has(day.key);
+
+      return {
+        onClick: () => handleDayClick(day.date, day.key),
+        onPointerDown: (event) => handleDayPointerDown(event, day.key),
+        onPointerEnter: (event) => handleDayPointerEnter(event, day.key),
+        className: cn(
+          entry && "border-destructive/50 bg-destructive/10",
+          day.isToday && !isSelected && "ring-2 ring-primary/80",
+          isSelected && "border-primary ring-2 ring-primary/60",
+          "hover:shadow-sm hover:-translate-y-[1px]",
+          wasAdded && "added-anim",
+          wasRemoved && "removed-anim"
+        ),
+        "aria-pressed": selectionMode ? isSelected : undefined,
+        "aria-label": `${format(day.date, "EEEE, d. MMMM yyyy", { locale: de })}${
+          entry
+            ? `, gesperrt${entry.reason ? `: ${entry.reason}` : ""}`
+            : ", frei"
+        }`,
+        content: entry ? (
+          <span className="mt-auto flex items-center gap-1 text-xs font-semibold text-destructive transition-opacity duration-300">
+            <CircleX className="h-4 w-4" />
+            <span className="truncate" title={entry.reason ?? undefined}>
+              {entry.reason ?? "Gesperrt"}
+            </span>
+          </span>
+        ) : (
+          <span className="mt-auto text-xs text-muted-foreground">Frei</span>
+        ),
+      };
+    },
+    [
+      blockedByDate,
+      handleDayClick,
+      handleDayPointerDown,
+      handleDayPointerEnter,
+      recentlyAdded,
+      recentlyRemoved,
+      selectedDayKeys,
+      selectionMode,
+    ]
+  );
+
+  const selectionPanel = selectionMode ? (
+    <div className="space-y-3 rounded-lg border border-dashed bg-muted/30 p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium">
+            {selectedKeys.length === 0
+              ? "Keine Tage ausgewählt."
+              : `${selectedKeys.length} ${
+                  selectedKeys.length === 1 ? "Tag" : "Tage"
+                } ausgewählt.`}
+          </p>
+          {selectedKeys.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {[
+                selectedFreeCount > 0
+                  ? `${selectedFreeCount} ${
+                      selectedFreeCount === 1 ? "Tag ist" : "Tage sind"
+                    } frei`
+                  : null,
+                selectedBlockedCount > 0
+                  ? `${selectedBlockedCount} ${
+                      selectedBlockedCount === 1
+                        ? "Tag ist gesperrt"
+                        : "Tage sind gesperrt"
+                    }`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={clearSelection}
+            disabled={bulkSubmitting || selectedKeys.length === 0}
+          >
+            Auswahl leeren
+          </Button>
+        </div>
+      </div>
+
+      {selectedFreeCount > 0 && (
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+          <div className="sm:flex-1">
+            <label
+              htmlFor="bulk-reason"
+              className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            >
+              Grund (optional)
+            </label>
+            <Input
+              id="bulk-reason"
+              value={bulkReason}
+              onChange={(event) => setBulkReason(event.target.value)}
+              placeholder="z. B. Urlaub, Familienfeier"
+              maxLength={200}
+              disabled={bulkSubmitting}
+            />
+          </div>
+          <Button
+            type="button"
+            className="sm:w-auto"
+            disabled={bulkSubmitting}
+            onClick={handleBulkCreate}
+          >
+            {selectedFreeCount > 1
+              ? `${selectedFreeCount} Tage sperren`
+              : "Tag sperren"}
+          </Button>
+        </div>
+      )}
+
+      {selectedBlockedCount > 0 && (
+        <div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={bulkSubmitting}
+            onClick={handleBulkRemove}
+          >
+            {selectedBlockedCount > 1
+              ? `${selectedBlockedCount} Sperrtermine aufheben`
+              : "Sperrtermin aufheben"}
+          </Button>
+        </div>
+      )}
+
+      {bulkError && <p className="text-sm text-destructive">{bulkError}</p>}
+    </div>
+  ) : null;
 
   const handleCreate = async () => {
     if (!selectedDateKey) return;
@@ -492,225 +588,24 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-xl border bg-card shadow-sm">
-        <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/40 px-4 py-3">
-          <div className="space-y-1">
-            <h2 className="text-xl font-semibold">{monthLabel}</h2>
-            <p className="text-sm text-muted-foreground">
-              Tippe auf einen Tag, um einen Sperrtermin hinzuzufügen oder zu bearbeiten.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={goToday}
-            >
-              Heute
-            </Button>
-            <div className="flex items-center rounded-md border">
-              <button
-                type="button"
-                onClick={goPrevMonth}
-                className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
-                aria-label="Vorheriger Monat"
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </button>
-              <button
-                type="button"
-                onClick={goNextMonth}
-                className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
-                aria-label="Nächster Monat"
-              >
-                <ChevronRight className="h-4 w-4" />
-              </button>
-            </div>
-            <Button
-              type="button"
-              variant={selectionMode ? "default" : "outline"}
-              size="sm"
-              onClick={handleToggleSelectionMode}
-            >
-              {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
-            </Button>
-          </div>
-        </div>
-        <div className="overflow-x-auto">
-          <div className="min-w-[640px] space-y-3 p-3 sm:p-4">
-            <div className="grid grid-cols-[64px_repeat(7,minmax(0,1fr))] text-center text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              <div className="py-2">KW</div>
-              {weekDayLabels.map((label) => (
-                <div key={label} className="py-2">
-                  {label}
-                </div>
-              ))}
-            </div>
-            <div
-              key={format(currentMonth, "yyyy-MM")}
-              className={cn(
-                "space-y-1.5 text-sm month-enter",
-                enterDir === "right" ? "month-from-right" : "month-from-left"
-              )}
-            >
-              {weeksInView.map((week) => (
-                <div
-                  key={week.weekStart.toISOString()}
-                  className="grid grid-cols-[64px_repeat(7,minmax(0,1fr))] gap-1.5"
-                >
-                  <div className="flex items-center justify-center rounded-lg bg-muted/40 px-2 py-2 text-xs font-semibold text-muted-foreground">
-                    KW {week.weekNumber}
-                  </div>
-                  {week.days.map((day) => {
-                    const key = format(day, DATE_FORMAT);
-                    const entry = blockedByDate.get(key);
-                    const isCurrentMonth = isSameMonth(day, currentMonth);
-                    const isCurrentDay = isToday(day);
-                    const isSelected = selectedDayKeys.has(key);
-                    const wasAdded = recentlyAdded.has(key);
-                    const wasRemoved = recentlyRemoved.has(key);
-
-                    return (
-                      <button
-                        key={key}
-                        type="button"
-                        onClick={() => handleDayClick(day, key)}
-                        onPointerDown={(event) => handleDayPointerDown(event, key)}
-                        onPointerEnter={(event) => handleDayPointerEnter(event, key)}
-                        className={cn(
-                          "block-cell relative flex min-h-[78px] flex-col overflow-hidden rounded-lg border bg-background p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:p-3",
-                          !isCurrentMonth && "text-muted-foreground/60",
-                          entry && "border-destructive/50 bg-destructive/10",
-                          isCurrentDay && !isSelected && "ring-2 ring-primary/80",
-                          isSelected && "border-primary ring-2 ring-primary/60",
-                          "hover:shadow-sm hover:translate-y-[-1px]",
-                          wasAdded && "added-anim",
-                          wasRemoved && "removed-anim"
-                        )}
-                        aria-current={isCurrentDay ? "date" : undefined}
-                        aria-pressed={selectionMode ? isSelected : undefined}
-                        aria-label={`${format(day, "EEEE, d. MMMM yyyy", { locale: de })}${
-                          entry
-                            ? `, gesperrt${entry.reason ? `: ${entry.reason}` : ""}`
-                            : ", frei"
-                        }`}
-                      >
-                        <span className="text-xs font-medium">{format(day, "d")}</span>
-                        {entry ? (
-                          <span className="mt-auto flex items-center gap-1 text-xs font-semibold text-destructive transition-opacity duration-300">
-                            <CircleX className="h-4 w-4" />
-                            <span className="truncate" title={entry.reason ?? undefined}>
-                              {entry.reason ?? "Gesperrt"}
-                            </span>
-                          </span>
-                        ) : (
-                          <span className="mt-auto text-xs text-muted-foreground">Frei</span>
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              ))}
-            </div>
-
-            {selectionMode && (
-              <div className="space-y-3 rounded-lg border border-dashed bg-muted/30 p-4">
-                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                  <div>
-                    <p className="text-sm font-medium">
-                      {selectedKeys.length === 0
-                        ? "Keine Tage ausgewählt."
-                        : `${selectedKeys.length} ${
-                            selectedKeys.length === 1 ? "Tag" : "Tage"
-                          } ausgewählt.`}
-                    </p>
-                    {selectedKeys.length > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        {[
-                          selectedFreeCount > 0
-                            ? `${selectedFreeCount} ${
-                                selectedFreeCount === 1 ? "Tag ist" : "Tage sind"
-                              } frei`
-                            : null,
-                          selectedBlockedCount > 0
-                            ? `${selectedBlockedCount} ${
-                                selectedBlockedCount === 1
-                                  ? "Tag ist gesperrt"
-                                  : "Tage sind gesperrt"
-                              }`
-                            : null,
-                        ]
-                          .filter(Boolean)
-                          .join(" · ")}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={clearSelection}
-                      disabled={bulkSubmitting || selectedKeys.length === 0}
-                    >
-                      Auswahl leeren
-                    </Button>
-                  </div>
-                </div>
-
-                {selectedFreeCount > 0 && (
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
-                    <div className="sm:flex-1">
-                      <label
-                        htmlFor="bulk-reason"
-                        className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground"
-                      >
-                        Grund (optional)
-                      </label>
-                      <Input
-                        id="bulk-reason"
-                        value={bulkReason}
-                        onChange={(event) => setBulkReason(event.target.value)}
-                        placeholder="z. B. Urlaub, Familienfeier"
-                        maxLength={200}
-                        disabled={bulkSubmitting}
-                      />
-                    </div>
-                    <Button
-                      type="button"
-                      className="sm:w-auto"
-                      disabled={bulkSubmitting}
-                      onClick={handleBulkCreate}
-                    >
-                      {selectedFreeCount > 1
-                        ? `${selectedFreeCount} Tage sperren`
-                        : "Tag sperren"}
-                    </Button>
-                  </div>
-                )}
-
-                {selectedBlockedCount > 0 && (
-                  <div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={bulkSubmitting}
-                      onClick={handleBulkRemove}
-                    >
-                      {selectedBlockedCount > 1
-                        ? `${selectedBlockedCount} Sperrtermine aufheben`
-                        : "Sperrtermin aufheben"}
-                    </Button>
-                  </div>
-                )}
-
-                {bulkError && <p className="text-sm text-destructive">{bulkError}</p>}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <MonthCalendar
+        month={currentMonth}
+        onMonthChange={handleMonthChange}
+        transitionDirection={enterDir}
+        subtitle="Tippe auf einen Tag, um einen Sperrtermin hinzuzufügen oder zu bearbeiten."
+        headerActions={
+          <Button
+            type="button"
+            variant={selectionMode ? "default" : "outline"}
+            size="sm"
+            onClick={handleToggleSelectionMode}
+          >
+            {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
+          </Button>
+        }
+        renderDay={renderCalendarDay}
+        additionalContent={selectionPanel}
+      />
 
       <Modal
         open={modalOpen && !!selectedDate}
@@ -780,31 +675,6 @@ export function BlockCalendar({ initialBlockedDays }: BlockCalendarProps) {
           </div>
         </div>
       </Modal>
-      <style jsx global>{`
-        @keyframes cellPop { 0% { transform: scale(0.96); } 100% { transform: scale(1); } }
-        @keyframes addedFlash { 0% { box-shadow: 0 0 0 0 rgba(34,197,94,.55); } 100% { box-shadow: 0 0 0 12px rgba(34,197,94,0); } }
-        @keyframes removedFlash { 0% { background-color: rgba(239,68,68,.15); } 100% { background-color: transparent; } }
-        @keyframes hoverGlow { 0% { box-shadow: 0 0 0 rgba(99,102,241,0); } 50% { box-shadow: 0 0 18px rgba(99,102,241,.35); } 100% { box-shadow: 0 0 0 rgba(99,102,241,0); } }
-        @keyframes sheenSlide { 0% { transform: translateX(-150%) skewX(-20deg);} 100% { transform: translateX(150%) skewX(-20deg);} }
-        @keyframes monthInRight { 0% { opacity: 0; transform: translateX(24px);} 100% { opacity: 1; transform: translateX(0);} }
-        @keyframes monthInLeft { 0% { opacity: 0; transform: translateX(-24px);} 100% { opacity: 1; transform: translateX(0);} }
-        .block-cell { position: relative; }
-        .block-cell.added-anim { animation: cellPop .22s ease-out, addedFlash .6s ease-out; }
-        .block-cell.removed-anim { animation: removedFlash .6s ease-out; }
-        .block-cell::before { content: ""; position:absolute; inset:-2px; border-radius: inherit; pointer-events:none; opacity:0; }
-        .block-cell::after { content:""; position:absolute; top:0; left:0; width:60%; height:100%; pointer-events:none; opacity:0; background: linear-gradient(120deg, rgba(255,255,255,0), rgba(255,255,255,.11), rgba(255,255,255,0)); transform: translateX(-150%) skewX(-20deg); }
-        .block-cell:hover { border-color: rgba(99,102,241,.45); background-image: radial-gradient(100% 60% at 50% 0%, rgba(99,102,241,.10), transparent 60%); }
-        @media (prefers-reduced-motion: no-preference) {
-          .block-cell:hover::before { opacity:1; animation: hoverGlow 1.2s ease-in-out infinite; }
-          .block-cell:hover::after { opacity:1; animation: sheenSlide 900ms ease-out; }
-        }
-        .dark .block-cell:hover { border-color: rgba(129,140,248,.55); background-image: radial-gradient(100% 60% at 50% 0%, rgba(129,140,248,.14), transparent 65%); }
-        .month-enter { will-change: transform, opacity; }
-        @media (prefers-reduced-motion: no-preference) {
-          .month-enter.month-from-right { animation: monthInRight .32s ease-out; }
-          .month-enter.month-from-left  { animation: monthInLeft  .32s ease-out; }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/app/api/permissions/roles/[id]/route.ts
+++ b/src/app/api/permissions/roles/[id]/route.ts
@@ -47,7 +47,7 @@ export async function DELETE(_request: NextRequest, { params }: { params: { id: 
   try {
     await prisma.appRole.delete({ where: { id } });
     return NextResponse.json({ ok: true });
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: "Löschen fehlgeschlagen" }, { status: 500 });
   }
 }

--- a/src/components/calendar/month-calendar.tsx
+++ b/src/components/calendar/month-calendar.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import {
+  addDays,
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  getISOWeek,
+  isSameMonth,
+  isToday,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import type { Locale } from "date-fns";
+import { de } from "date-fns/locale/de";
+import {
+  type AriaAttributes,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export const CALENDAR_DATE_FORMAT = "yyyy-MM-dd";
+
+export interface CalendarDay {
+  date: Date;
+  key: string;
+  weekNumber: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+}
+
+export interface CalendarWeek {
+  weekStart: Date;
+  weekNumber: number;
+  days: Date[];
+}
+
+export interface CalendarDayRenderResult
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+  content?: ReactNode;
+}
+
+export interface MonthCalendarProps {
+  month?: Date;
+  defaultMonth?: Date;
+  onMonthChange?: (nextMonth: Date) => void;
+  transitionDirection?: "left" | "right";
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  locale?: Locale;
+  monthLabelFormat?: string;
+  weekdayFormat?: string;
+  renderWeekdayLabel?: (date: Date, index: number) => ReactNode;
+  renderWeekNumber?: (week: CalendarWeek) => ReactNode;
+  renderDay?: (day: CalendarDay) => CalendarDayRenderResult | undefined;
+  renderDayNumber?: (day: CalendarDay) => ReactNode;
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  headerActions?: ReactNode;
+  todayLabel?: string;
+  showTodayButton?: boolean;
+  showWeekNumbers?: boolean;
+  className?: string;
+  contentClassName?: string;
+  minGridWidthClassName?: string;
+  dayClassName?: string;
+  additionalContent?: ReactNode;
+}
+
+const DEFAULT_WEEKDAY_FORMAT = "EEE";
+const DEFAULT_MONTH_LABEL_FORMAT = "MMMM yyyy";
+
+export function MonthCalendar({
+  month,
+  defaultMonth,
+  onMonthChange,
+  transitionDirection,
+  weekStartsOn = 1,
+  locale = de,
+  monthLabelFormat = DEFAULT_MONTH_LABEL_FORMAT,
+  weekdayFormat = DEFAULT_WEEKDAY_FORMAT,
+  renderWeekdayLabel,
+  renderWeekNumber,
+  renderDay,
+  renderDayNumber,
+  title,
+  subtitle,
+  headerActions,
+  todayLabel = "Heute",
+  showTodayButton = true,
+  showWeekNumbers = true,
+  className,
+  contentClassName,
+  minGridWidthClassName = "min-w-[640px]",
+  dayClassName,
+  additionalContent,
+}: MonthCalendarProps) {
+  const initialMonth = useMemo(
+    () => startOfMonth(month ?? defaultMonth ?? new Date()),
+    [defaultMonth, month]
+  );
+
+  const [internalMonth, setInternalMonth] = useState<Date>(initialMonth);
+  const [internalDirection, setInternalDirection] = useState<"left" | "right">(
+    "right"
+  );
+  const previousMonthRef = useRef<Date>(initialMonth);
+
+  useEffect(() => {
+    if (month) {
+      const normalized = startOfMonth(month);
+      if (!transitionDirection) {
+        const previous = previousMonthRef.current;
+        if (previous) {
+          setInternalDirection(
+            normalized.getTime() >= previous.getTime() ? "right" : "left"
+          );
+        }
+      }
+      previousMonthRef.current = normalized;
+    }
+  }, [month, transitionDirection]);
+
+  useEffect(() => {
+    if (!month) {
+      previousMonthRef.current = internalMonth;
+    }
+  }, [internalMonth, month]);
+
+  const displayedMonth = month ? startOfMonth(month) : internalMonth;
+  const resolvedDirection = transitionDirection ?? internalDirection;
+
+  const monthLabel = useMemo(
+    () => format(displayedMonth, monthLabelFormat, { locale }),
+    [displayedMonth, locale, monthLabelFormat]
+  );
+
+  const weekDayLabels = useMemo(() => {
+    const start = startOfWeek(displayedMonth, { weekStartsOn });
+    return Array.from({ length: 7 }, (_, index) => {
+      const date = addDays(start, index);
+      if (renderWeekdayLabel) {
+        return renderWeekdayLabel(date, index);
+      }
+      return format(date, weekdayFormat, { locale });
+    });
+  }, [displayedMonth, locale, renderWeekdayLabel, weekStartsOn, weekdayFormat]);
+
+  const daysInView = useMemo(() => {
+    const firstDayOfMonth = startOfMonth(displayedMonth);
+    const lastDayOfMonth = endOfMonth(displayedMonth);
+    const gridStart = startOfWeek(firstDayOfMonth, { weekStartsOn });
+    const gridEnd = endOfWeek(lastDayOfMonth, { weekStartsOn });
+    return eachDayOfInterval({ start: gridStart, end: gridEnd });
+  }, [displayedMonth, weekStartsOn]);
+
+  const weeksInView = useMemo<CalendarWeek[]>(() => {
+    const weeks: CalendarWeek[] = [];
+    for (let index = 0; index < daysInView.length; index += 7) {
+      const weekDays = daysInView.slice(index, index + 7);
+      if (weekDays.length === 0) continue;
+      weeks.push({
+        weekStart: weekDays[0],
+        weekNumber: getISOWeek(weekDays[0]),
+        days: weekDays,
+      });
+    }
+    return weeks;
+  }, [daysInView]);
+
+  const updateMonth = (next: Date, direction: "left" | "right") => {
+    const normalized = startOfMonth(next);
+    if (!month) {
+      setInternalMonth(normalized);
+    }
+    if (!transitionDirection) {
+      setInternalDirection(direction);
+    }
+    onMonthChange?.(normalized);
+  };
+
+  const goToday = () => {
+    const todayMonth = startOfMonth(new Date());
+    updateMonth(
+      todayMonth,
+      todayMonth.getTime() >= displayedMonth.getTime() ? "right" : "left"
+    );
+  };
+
+  const goPrevMonth = () => {
+    updateMonth(addMonths(displayedMonth, -1), "left");
+  };
+
+  const goNextMonth = () => {
+    updateMonth(addMonths(displayedMonth, 1), "right");
+  };
+
+  const headerTitle = title ?? monthLabel;
+
+  const weekdayHeaderClass = showWeekNumbers
+    ? "grid grid-cols-[64px_repeat(7,minmax(0,1fr))]"
+    : "grid grid-cols-[repeat(7,minmax(0,1fr))]";
+
+  const weekRowClass = showWeekNumbers
+    ? "grid grid-cols-[64px_repeat(7,minmax(0,1fr))] gap-1.5"
+    : "grid grid-cols-[repeat(7,minmax(0,1fr))] gap-1.5";
+
+  return (
+    <div className={cn("rounded-xl border bg-card shadow-sm", className)}>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/40 px-4 py-3">
+        <div className="space-y-1">
+          {typeof headerTitle === "string" ? (
+            <h2 className="text-xl font-semibold">{headerTitle}</h2>
+          ) : (
+            headerTitle
+          )}
+          {subtitle ? (
+            <p className="text-sm text-muted-foreground">{subtitle}</p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {showTodayButton ? (
+            <Button type="button" variant="outline" size="sm" onClick={goToday}>
+              {todayLabel}
+            </Button>
+          ) : null}
+          <div className="flex items-center rounded-md border">
+            <button
+              type="button"
+              onClick={goPrevMonth}
+              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+              aria-label="Vorheriger Monat"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={goNextMonth}
+              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+              aria-label="Nächster Monat"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+          {headerActions}
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <div
+          className={cn(
+            minGridWidthClassName,
+            "space-y-3 p-3 sm:p-4",
+            contentClassName
+          )}
+        >
+          <div
+            className={cn(
+              weekdayHeaderClass,
+              "text-center text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            )}
+          >
+            {showWeekNumbers ? <div className="py-2">KW</div> : null}
+            {weekDayLabels.map((label, index) => (
+              <div key={index} className="py-2">
+                {label}
+              </div>
+            ))}
+          </div>
+          <div
+            key={format(displayedMonth, "yyyy-MM")}
+            className={cn(
+              "space-y-1.5 text-sm calendar-month-enter",
+              resolvedDirection === "right"
+                ? "calendar-month-from-right"
+                : "calendar-month-from-left"
+            )}
+          >
+            {weeksInView.map((week) => (
+              <div key={week.weekStart.toISOString()} className={weekRowClass}>
+                {showWeekNumbers ? (
+                  <div className="flex items-center justify-center rounded-lg bg-muted/40 px-2 py-2 text-xs font-semibold text-muted-foreground">
+                    {renderWeekNumber ? renderWeekNumber(week) : <>KW {week.weekNumber}</>}
+                  </div>
+                ) : null}
+                {week.days.map((day) => {
+                  const key = format(day, CALENDAR_DATE_FORMAT);
+                  const isCurrentMonth = isSameMonth(day, displayedMonth);
+                  const dayInfo: CalendarDay = {
+                    date: day,
+                    key,
+                    weekNumber: week.weekNumber,
+                    isCurrentMonth,
+                    isToday: isToday(day),
+                  };
+                  const result = renderDay?.(dayInfo) ?? {};
+                  const {
+                    content,
+                    className: daySpecificClass,
+                    type: buttonType,
+                    ["aria-label"]: ariaLabelProp,
+                    ["aria-current"]: ariaCurrentProp,
+                    ...restButtonProps
+                  } = result;
+                  const ariaLabel =
+                    ariaLabelProp ??
+                    format(day, "EEEE, d. MMMM yyyy", { locale });
+                  const ariaCurrent = ariaCurrentProp ?? (dayInfo.isToday ? "date" : undefined);
+                  const dayNumberContent = renderDayNumber
+                    ? renderDayNumber(dayInfo)
+                    : format(day, "d", { locale });
+                  const finalClassName = cn(
+                    "calendar-cell relative flex min-h-[78px] flex-col overflow-hidden rounded-lg border bg-background p-2 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:p-3",
+                    !isCurrentMonth && "text-muted-foreground/60",
+                    dayClassName,
+                    daySpecificClass
+                  );
+                  return (
+                    <button
+                      key={key}
+                      type={buttonType ?? "button"}
+                      aria-label={ariaLabel}
+                      aria-current={ariaCurrent as AriaAttributes["aria-current"]}
+                      {...restButtonProps}
+                      className={finalClassName}
+                      data-date={key}
+                      data-today={dayInfo.isToday ? "true" : undefined}
+                      data-current-month={dayInfo.isCurrentMonth ? "true" : undefined}
+                    >
+                      <span className="text-xs font-medium">{dayNumberContent}</span>
+                      {content}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+          {additionalContent}
+        </div>
+      </div>
+      <style jsx global>{`
+        @keyframes calendarCellPop { 0% { transform: scale(0.96); } 100% { transform: scale(1); } }
+        @keyframes calendarAddedFlash { 0% { box-shadow: 0 0 0 0 rgba(34,197,94,.55); } 100% { box-shadow: 0 0 0 12px rgba(34,197,94,0); } }
+        @keyframes calendarRemovedFlash { 0% { background-color: rgba(239,68,68,.15); } 100% { background-color: transparent; } }
+        @keyframes calendarHoverGlow { 0% { box-shadow: 0 0 0 rgba(99,102,241,0); } 50% { box-shadow: 0 0 18px rgba(99,102,241,.35); } 100% { box-shadow: 0 0 0 rgba(99,102,241,0); } }
+        @keyframes calendarSheenSlide { 0% { transform: translateX(-150%) skewX(-20deg);} 100% { transform: translateX(150%) skewX(-20deg);} }
+        @keyframes calendarMonthInRight { 0% { opacity: 0; transform: translateX(24px);} 100% { opacity: 1; transform: translateX(0);} }
+        @keyframes calendarMonthInLeft { 0% { opacity: 0; transform: translateX(-24px);} 100% { opacity: 1; transform: translateX(0);} }
+        .calendar-cell { position: relative; }
+        .calendar-cell.added-anim { animation: calendarCellPop .22s ease-out, calendarAddedFlash .6s ease-out; }
+        .calendar-cell.removed-anim { animation: calendarRemovedFlash .6s ease-out; }
+        .calendar-cell::before { content: ""; position:absolute; inset:-2px; border-radius: inherit; pointer-events:none; opacity:0; }
+        .calendar-cell::after { content:""; position:absolute; top:0; left:0; width:60%; height:100%; pointer-events:none; opacity:0; background: linear-gradient(120deg, rgba(255,255,255,0), rgba(255,255,255,.11), rgba(255,255,255,0)); transform: translateX(-150%) skewX(-20deg); }
+        .calendar-cell:hover { border-color: rgba(99,102,241,.45); background-image: radial-gradient(100% 60% at 50% 0%, rgba(99,102,241,.10), transparent 60%); }
+        @media (prefers-reduced-motion: no-preference) {
+          .calendar-cell:hover::before { opacity:1; animation: calendarHoverGlow 1.2s ease-in-out infinite; }
+          .calendar-cell:hover::after { opacity:1; animation: calendarSheenSlide 900ms ease-out; }
+        }
+        .dark .calendar-cell:hover { border-color: rgba(129,140,248,.55); background-image: radial-gradient(100% 60% at 50% 0%, rgba(129,140,248,.14), transparent 65%); }
+        .calendar-month-enter { will-change: transform, opacity; }
+        @media (prefers-reduced-motion: no-preference) {
+          .calendar-month-enter.calendar-month-from-right { animation: calendarMonthInRight .32s ease-out; }
+          .calendar-month-enter.calendar-month-from-left  { animation: calendarMonthInLeft  .32s ease-out; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/members/permission-matrix.tsx
+++ b/src/components/members/permission-matrix.tsx
@@ -111,15 +111,15 @@ export function PermissionMatrix() {
       body: JSON.stringify({ name }),
     });
     if (res.ok) {
-      const data = await res.json().catch(() => ({}));
-      const updated = data?.role as Role | undefined;
+      const data = (await res.json().catch(() => ({}))) as { role?: Role };
+      const updated = data?.role;
       if (updated) {
         setRoles((prev) => prev.map((r) => (r.id === updated.id ? { ...r, name: updated.name } : r)));
       }
       closeEdit();
     } else {
-      const payload = await res.json().catch(() => ({} as any));
-      setEditError(payload?.error || "Aktualisierung fehlgeschlagen");
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+      setEditError(payload?.error ?? "Aktualisierung fehlgeschlagen");
     }
     setSaving(false);
   };
@@ -139,8 +139,8 @@ export function PermissionMatrix() {
       });
       closeEdit();
     } else {
-      const payload = await res.json().catch(() => ({} as any));
-      setEditError(payload?.error || "Löschen fehlgeschlagen");
+      const payload = (await res.json().catch(() => ({}))) as { error?: string };
+      setEditError(payload?.error ?? "Löschen fehlgeschlagen");
     }
     setDeleting(false);
   };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,14 +1,11 @@
 "use client";
-
-"use client";
-import * as React from "react";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { MoreVerticalIcon } from "./icons";
 
 interface DropdownMenuItem {
   label: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   onClick: () => void;
   variant?: "default" | "destructive";
 }
@@ -59,11 +56,11 @@ export function DropdownMenu({ items, align = "right", className = "" }: Dropdow
       setCoords({ top, left });
     };
     update();
-    const opts: AddEventListenerOptions = { passive: true, capture: true } as any;
+    const opts: AddEventListenerOptions = { passive: true, capture: true };
     window.addEventListener("scroll", update, opts);
     window.addEventListener("resize", update);
     return () => {
-      window.removeEventListener("scroll", update, opts as any);
+      window.removeEventListener("scroll", update, opts);
       window.removeEventListener("resize", update);
     };
   }, [isOpen, align]);


### PR DESCRIPTION
## Summary
- create a reusable `MonthCalendar` component with configurable rendering hooks, header actions and shared styling
- refactor the block calendar to consume the shared calendar component and feed its bulk-selection controls
- tighten rehearsal planning and permission utilities typing to satisfy lint
- introduce a rehearsal planning calendar that surfaces blocked member counts, existing rehearsals and day-specific actions
- expose a reusable creation dialog so the calendar can prefill new rehearsals and update the planning page to supply the aggregated data it needs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cbfc378f18832d842cabe3bbb80b67