### PR TITLE
Use Gravatar for avatars

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,7 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "www.dresden.de" },
       { protocol: "https", hostname: "radiodresden.de" },
       { protocol: "https", hostname: "www.felix-hitzig.de" },
+      { protocol: "https", hostname: "www.gravatar.com" },
     ],
   },
   // Next.js 15+: serverComponentsExternalPackages moved to serverExternalPackages

--- a/src/components/members/members-table.tsx
+++ b/src/components/members/members-table.tsx
@@ -6,6 +6,7 @@ import { Modal } from "@/components/ui/modal";
 import { Input } from "@/components/ui/input";
 import { ROLE_BADGE_VARIANTS, ROLE_LABELS, sortRoles, type Role } from "@/lib/roles";
 import { RoleManager } from "@/components/members/role-manager";
+import { UserAvatar } from "@/components/user-avatar";
 
 export type MembersTableUser = {
   id: string;
@@ -43,13 +44,6 @@ export function MembersTable({
     });
   }, [rows, query]);
 
-  const initials = (name?: string | null, email?: string | null) => {
-    const source = (name && name.trim()) || (email && email.split("@")[0]) || "?";
-    const parts = source.split(/\s+/).filter(Boolean);
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-  };
-
   return (
     <div className="overflow-x-auto">
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -71,9 +65,7 @@ export function MembersTable({
             <div key={u.id} className="rounded-md border bg-card p-3">
               <div className="flex items-start justify-between">
                 <div className="flex items-center gap-3">
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-sm font-semibold text-slate-700">
-                    {initials(u.name, u.email)}
-                  </div>
+                  <UserAvatar email={u.email} name={u.name} size={40} className="h-10 w-10" />
                   <div>
                     <div className="font-medium">{u.name || "—"}</div>
                     <div className="text-xs text-muted-foreground">{u.email || "—"}</div>
@@ -120,9 +112,7 @@ export function MembersTable({
               <tr key={u.id} className="border-b hover:bg-accent/10">
                 <td className="px-3 py-2 whitespace-nowrap">
                   <div className="flex items-center gap-3">
-                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-sm font-semibold text-slate-700">
-                      {initials(u.name, u.email)}
-                    </div>
+                    <UserAvatar email={u.email} name={u.name} size={32} className="h-8 w-8" />
                     <div>
                       <div className="font-medium">{u.name || "—"}</div>
                       <div className="text-xs text-muted-foreground">{u.email || "—"}</div>

--- a/src/components/members/role-manager.tsx
+++ b/src/components/members/role-manager.tsx
@@ -7,6 +7,7 @@ import { ROLE_BADGE_VARIANTS, ROLE_LABELS, sortRoles, type Role } from "@/lib/ro
 import { toast } from "sonner";
 import { UserEditModal } from "@/components/members/user-edit-modal";
 import { RolePicker } from "@/components/members/role-picker";
+import { UserAvatar } from "@/components/user-avatar";
 
 export function RoleManager({
   userId,
@@ -106,14 +107,6 @@ export function RoleManager({
     setError(null);
   };
 
-  // Helper function to generate initials
-  const getInitials = (name?: string | null, email?: string | null) => {
-    const source = (name && name.trim()) || (email && email.split("@")[0]) || "?";
-    const parts = source.split(/\s+/).filter(Boolean);
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-  };
-
   return (
     <div className="space-y-6">
       {/* User Profile Card */}
@@ -122,9 +115,7 @@ export function RoleManager({
           <div className="flex items-start justify-between">
             <div className="flex items-start gap-4">
               {/* Avatar */}
-              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted text-lg font-semibold text-muted-foreground shadow-sm">
-                {getInitials(currentName, currentEmail)}
-              </div>
+              <UserAvatar email={currentEmail} name={currentName} size={48} className="h-12 w-12 text-lg" />
               
               {/* User Info */}
               <div className="flex-1 min-w-0">

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Image from "next/image";
+import { getGravatarUrl } from "@/lib/gravatar";
+import { cn } from "@/lib/utils";
+import type { CSSProperties } from "react";
+
+export type UserAvatarProps = {
+  email?: string | null;
+  name?: string | null;
+  size?: number;
+  className?: string;
+  loading?: "eager" | "lazy";
+  style?: CSSProperties;
+};
+
+export function UserAvatar({
+  email,
+  name,
+  size = 32,
+  className,
+  loading = "lazy",
+  style,
+}: UserAvatarProps) {
+  const displaySize = Math.max(1, Math.round(size));
+  const gravatarSize = Math.max(32, Math.min(2048, displaySize * 2));
+  const src = getGravatarUrl(email, { size: gravatarSize });
+  const label = name?.trim() || email?.trim() || undefined;
+
+  return (
+    <Image
+      src={src}
+      alt={label ? `Avatar von ${label}` : "Avatar"}
+      title={label}
+      width={displaySize}
+      height={displaySize}
+      loading={loading}
+      priority={loading === "eager"}
+      sizes={`${displaySize}px`}
+      className={cn("inline-block rounded-full bg-muted object-cover", className)}
+      style={{ width: displaySize, height: displaySize, ...style }}
+    />
+  );
+}

--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { UserAvatar } from "@/components/user-avatar";
 
 export function UserNav({ className }: { className?: string }) {
   const { data: session, status } = useSession();
@@ -56,13 +57,6 @@ export function UserNav({ className }: { className?: string }) {
 
   const name = session.user.name ?? session.user.email ?? "";
   const role = session.user.role;
-  const initials = (name || "?")
-    .split(/\s|@/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((s) => s[0]?.toUpperCase())
-    .join("");
-
   async function onLogout() {
     try {
       await signOut({ callbackUrl: "/" });
@@ -82,9 +76,13 @@ export function UserNav({ className }: { className?: string }) {
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
       >
-        <span className="inline-flex h-7 w-7 select-none items-center justify-center rounded-full bg-primary/20 text-primary font-semibold">
-          {initials}
-        </span>
+        <UserAvatar
+          email={session.user.email}
+          name={session.user.name}
+          size={28}
+          className="h-7 w-7 select-none"
+          loading="eager"
+        />
         <span className="hidden sm:inline text-foreground/90">
           {name}
           {role ? ` (${role})` : ""}

--- a/src/lib/__tests__/gravatar.test.ts
+++ b/src/lib/__tests__/gravatar.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getGravatarUrl, md5 } from "@/lib/gravatar";
+
+describe("gravatar", () => {
+  it("hashes emails with md5", () => {
+    expect(md5("user@example.com")).toBe("b58996c504c5638798eb6b511e6f49af");
+  });
+
+  it("normalises email before hashing", () => {
+    const trimmed = getGravatarUrl(" USER@example.com ");
+    const direct = getGravatarUrl("user@example.com");
+    expect(trimmed).toBe(direct);
+  });
+
+  it("returns default avatar when no email is provided", () => {
+    const url = new URL(getGravatarUrl(undefined));
+    expect(url.pathname).toBe("/avatar/");
+    expect(url.searchParams.get("d")).toBe("mp");
+  });
+
+  it("applies requested size within bounds", () => {
+    const url = new URL(getGravatarUrl("user@example.com", { size: 4096 }));
+    expect(url.searchParams.get("s")).toBe("2048");
+
+    const small = new URL(getGravatarUrl("user@example.com", { size: 12 }));
+    expect(small.searchParams.get("s")).toBe("12");
+  });
+});

--- a/src/lib/gravatar.ts
+++ b/src/lib/gravatar.ts
@@ -1,0 +1,196 @@
+const DEFAULT_IMAGE = "mp";
+const DEFAULT_RATING = "g";
+const MIN_SIZE = 1;
+const MAX_SIZE = 2048;
+
+type GravatarOptions = {
+  size?: number;
+  defaultImage?: string;
+  rating?: string;
+  forceDefault?: boolean;
+};
+
+function normalizeEmail(email?: string | null): string | null {
+  if (!email) return null;
+  const trimmed = email.trim().toLowerCase();
+  return trimmed ? trimmed : null;
+}
+
+function leftRotate(value: number, amount: number): number {
+  return ((value << amount) | (value >>> (32 - amount))) >>> 0;
+}
+
+function addUnsigned(x: number, y: number): number {
+  return (x + y) >>> 0;
+}
+
+function toWordArray(input: Uint8Array): Uint32Array {
+  const length = input.length;
+  const bitLength = length * 8;
+  const paddedLength = (((bitLength + 64) >>> 9) << 4) + 16;
+  const words = new Uint32Array(paddedLength);
+
+  for (let i = 0; i < length; i += 1) {
+    words[i >> 2] |= input[i] << ((i % 4) * 8);
+  }
+
+  words[length >> 2] |= 0x80 << ((length % 4) * 8);
+  words[paddedLength - 2] = bitLength;
+  return words;
+}
+
+function round(
+  func: (b: number, c: number, d: number) => number,
+  a: number,
+  b: number,
+  c: number,
+  d: number,
+  x: number,
+  s: number,
+  t: number,
+): number {
+  const sum = addUnsigned(addUnsigned(addUnsigned(a, func(b, c, d)), x), t);
+  return addUnsigned(leftRotate(sum, s), b);
+}
+
+function md5(input: string): string {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+  const words = toWordArray(data);
+
+  let a = 0x67452301;
+  let b = 0xefcdab89;
+  let c = 0x98badcfe;
+  let d = 0x10325476;
+
+  const F = (x: number, y: number, z: number) => (x & y) | (~x & z);
+  const G = (x: number, y: number, z: number) => (x & z) | (y & ~z);
+  const H = (x: number, y: number, z: number) => x ^ y ^ z;
+  const I = (x: number, y: number, z: number) => y ^ (x | ~z);
+
+  for (let i = 0; i < words.length; i += 16) {
+    const originalA = a;
+    const originalB = b;
+    const originalC = c;
+    const originalD = d;
+
+    // Round 1
+    a = round(F, a, b, c, d, words[i + 0], 7, 0xd76aa478);
+    d = round(F, d, a, b, c, words[i + 1], 12, 0xe8c7b756);
+    c = round(F, c, d, a, b, words[i + 2], 17, 0x242070db);
+    b = round(F, b, c, d, a, words[i + 3], 22, 0xc1bdceee);
+    a = round(F, a, b, c, d, words[i + 4], 7, 0xf57c0faf);
+    d = round(F, d, a, b, c, words[i + 5], 12, 0x4787c62a);
+    c = round(F, c, d, a, b, words[i + 6], 17, 0xa8304613);
+    b = round(F, b, c, d, a, words[i + 7], 22, 0xfd469501);
+    a = round(F, a, b, c, d, words[i + 8], 7, 0x698098d8);
+    d = round(F, d, a, b, c, words[i + 9], 12, 0x8b44f7af);
+    c = round(F, c, d, a, b, words[i + 10], 17, 0xffff5bb1);
+    b = round(F, b, c, d, a, words[i + 11], 22, 0x895cd7be);
+    a = round(F, a, b, c, d, words[i + 12], 7, 0x6b901122);
+    d = round(F, d, a, b, c, words[i + 13], 12, 0xfd987193);
+    c = round(F, c, d, a, b, words[i + 14], 17, 0xa679438e);
+    b = round(F, b, c, d, a, words[i + 15], 22, 0x49b40821);
+
+    // Round 2
+    a = round(G, a, b, c, d, words[i + 1], 5, 0xf61e2562);
+    d = round(G, d, a, b, c, words[i + 6], 9, 0xc040b340);
+    c = round(G, c, d, a, b, words[i + 11], 14, 0x265e5a51);
+    b = round(G, b, c, d, a, words[i + 0], 20, 0xe9b6c7aa);
+    a = round(G, a, b, c, d, words[i + 5], 5, 0xd62f105d);
+    d = round(G, d, a, b, c, words[i + 10], 9, 0x02441453);
+    c = round(G, c, d, a, b, words[i + 15], 14, 0xd8a1e681);
+    b = round(G, b, c, d, a, words[i + 4], 20, 0xe7d3fbc8);
+    a = round(G, a, b, c, d, words[i + 9], 5, 0x21e1cde6);
+    d = round(G, d, a, b, c, words[i + 14], 9, 0xc33707d6);
+    c = round(G, c, d, a, b, words[i + 3], 14, 0xf4d50d87);
+    b = round(G, b, c, d, a, words[i + 8], 20, 0x455a14ed);
+    a = round(G, a, b, c, d, words[i + 13], 5, 0xa9e3e905);
+    d = round(G, d, a, b, c, words[i + 2], 9, 0xfcefa3f8);
+    c = round(G, c, d, a, b, words[i + 7], 14, 0x676f02d9);
+    b = round(G, b, c, d, a, words[i + 12], 20, 0x8d2a4c8a);
+
+    // Round 3
+    a = round(H, a, b, c, d, words[i + 5], 4, 0xfffa3942);
+    d = round(H, d, a, b, c, words[i + 8], 11, 0x8771f681);
+    c = round(H, c, d, a, b, words[i + 11], 16, 0x6d9d6122);
+    b = round(H, b, c, d, a, words[i + 14], 23, 0xfde5380c);
+    a = round(H, a, b, c, d, words[i + 1], 4, 0xa4beea44);
+    d = round(H, d, a, b, c, words[i + 4], 11, 0x4bdecfa9);
+    c = round(H, c, d, a, b, words[i + 7], 16, 0xf6bb4b60);
+    b = round(H, b, c, d, a, words[i + 10], 23, 0xbebfbc70);
+    a = round(H, a, b, c, d, words[i + 13], 4, 0x289b7ec6);
+    d = round(H, d, a, b, c, words[i + 0], 11, 0xeaa127fa);
+    c = round(H, c, d, a, b, words[i + 3], 16, 0xd4ef3085);
+    b = round(H, b, c, d, a, words[i + 6], 23, 0x04881d05);
+    a = round(H, a, b, c, d, words[i + 9], 4, 0xd9d4d039);
+    d = round(H, d, a, b, c, words[i + 12], 11, 0xe6db99e5);
+    c = round(H, c, d, a, b, words[i + 15], 16, 0x1fa27cf8);
+    b = round(H, b, c, d, a, words[i + 2], 23, 0xc4ac5665);
+
+    // Round 4
+    a = round(I, a, b, c, d, words[i + 0], 6, 0xf4292244);
+    d = round(I, d, a, b, c, words[i + 7], 10, 0x432aff97);
+    c = round(I, c, d, a, b, words[i + 14], 15, 0xab9423a7);
+    b = round(I, b, c, d, a, words[i + 5], 21, 0xfc93a039);
+    a = round(I, a, b, c, d, words[i + 12], 6, 0x655b59c3);
+    d = round(I, d, a, b, c, words[i + 3], 10, 0x8f0ccc92);
+    c = round(I, c, d, a, b, words[i + 10], 15, 0xffeff47d);
+    b = round(I, b, c, d, a, words[i + 1], 21, 0x85845dd1);
+    a = round(I, a, b, c, d, words[i + 8], 6, 0x6fa87e4f);
+    d = round(I, d, a, b, c, words[i + 15], 10, 0xfe2ce6e0);
+    c = round(I, c, d, a, b, words[i + 6], 15, 0xa3014314);
+    b = round(I, b, c, d, a, words[i + 13], 21, 0x4e0811a1);
+    a = round(I, a, b, c, d, words[i + 4], 6, 0xf7537e82);
+    d = round(I, d, a, b, c, words[i + 11], 10, 0xbd3af235);
+    c = round(I, c, d, a, b, words[i + 2], 15, 0x2ad7d2bb);
+    b = round(I, b, c, d, a, words[i + 9], 21, 0xeb86d391);
+
+    a = addUnsigned(a, originalA);
+    b = addUnsigned(b, originalB);
+    c = addUnsigned(c, originalC);
+    d = addUnsigned(d, originalD);
+  }
+
+  const toHex = (value: number) => {
+    let result = "";
+    for (let i = 0; i < 4; i += 1) {
+      result += ((value >>> (i * 8)) & 0xff).toString(16).padStart(2, "0");
+    }
+    return result;
+  };
+
+  return (toHex(a) + toHex(b) + toHex(c) + toHex(d)).toLowerCase();
+}
+
+function sanitizeSize(input?: number): number {
+  if (typeof input !== "number" || !Number.isFinite(input)) {
+    return 0;
+  }
+
+  return Math.round(input);
+}
+
+export function getGravatarUrl(email?: string | null, options: GravatarOptions = {}): string {
+  const normalizedEmail = normalizeEmail(email);
+  const requestedSize = sanitizeSize(options.size);
+  const size = Math.min(MAX_SIZE, Math.max(MIN_SIZE, requestedSize || 80));
+  const defaultImage = options.defaultImage ?? DEFAULT_IMAGE;
+  const rating = options.rating ?? DEFAULT_RATING;
+  const forceDefault = options.forceDefault ? "y" : undefined;
+  const hash = normalizedEmail ? md5(normalizedEmail) : "";
+
+  const params = new URLSearchParams({
+    s: String(size),
+    d: defaultImage,
+    r: rating,
+  });
+
+  if (forceDefault) {
+    params.set("f", forceDefault);
+  }
+
+  return `https://www.gravatar.com/avatar/${hash}?${params.toString()}`;
+}
+
+export { md5 };


### PR DESCRIPTION
## Summary
- add a Gravatar utility and shared UserAvatar component for rendering hashed avatar URLs
- switch the navigation and member administration views to use Gravatar-based avatars
- allow Next.js Image to load Gravatar assets and cover the helper with vitest checks

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ccf50907c0832d926578359ef4467b