### PR TITLE
Show weekly rehearsal count on members dashboard

### DIFF
--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 
+import { endOfWeek, startOfWeek } from "date-fns";
+
 import { requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
@@ -18,17 +20,17 @@ export async function GET() {
     }
 
     const now = new Date();
-    const startOfDay = new Date(now);
-    startOfDay.setHours(0, 0, 0, 0);
-    const endOfDay = new Date(now);
-    endOfDay.setHours(23, 59, 59, 999);
+    const startOfCurrentWeek = startOfWeek(now, { weekStartsOn: 1 });
+    startOfCurrentWeek.setHours(0, 0, 0, 0);
+    const endOfCurrentWeek = endOfWeek(now, { weekStartsOn: 1 });
+    endOfCurrentWeek.setHours(23, 59, 59, 999);
     const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
     const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
     endOfMonth.setHours(23, 59, 59, 999);
 
     const [
       totalMembers,
-      todayRehearsals,
+      rehearsalsThisWeek,
       unreadNotifications,
       recentNotifications,
       recentRehearsals,
@@ -39,8 +41,8 @@ export async function GET() {
       prisma.rehearsal.count({
         where: {
           start: {
-            gte: startOfDay,
-            lte: endOfDay,
+            gte: startOfCurrentWeek,
+            lte: endOfCurrentWeek,
           },
         },
       }),
@@ -112,7 +114,7 @@ export async function GET() {
     return NextResponse.json({
       stats: {
         totalMembers,
-        todayRehearsals,
+        rehearsalsThisWeek,
         unreadNotifications,
         totalRehearsalsThisMonth,
       },

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -32,20 +32,20 @@ interface RecentActivity {
 interface DashboardStats {
   totalOnline: number;
   totalMembers: number;
-  todayRehearsals: number;
+  rehearsalsThisWeek: number;
   unreadNotifications: number;
 }
 
 const INITIAL_STATS: DashboardStats = {
   totalOnline: 0,
   totalMembers: 0,
-  todayRehearsals: 0,
+  rehearsalsThisWeek: 0,
   unreadNotifications: 0,
 };
 
 type OverviewStatsPayload = {
   totalMembers?: unknown;
-  todayRehearsals?: unknown;
+  rehearsalsThisWeek?: unknown;
   unreadNotifications?: unknown;
 };
 
@@ -143,10 +143,10 @@ export function MembersDashboard() {
               typeof statsPayload.totalMembers === "number"
                 ? statsPayload.totalMembers
                 : prev.totalMembers,
-            todayRehearsals:
-              typeof statsPayload.todayRehearsals === "number"
-                ? statsPayload.todayRehearsals
-                : prev.todayRehearsals,
+            rehearsalsThisWeek:
+              typeof statsPayload.rehearsalsThisWeek === "number"
+                ? statsPayload.rehearsalsThisWeek
+                : prev.rehearsalsThisWeek,
             unreadNotifications:
               typeof statsPayload.unreadNotifications === "number"
                 ? statsPayload.unreadNotifications
@@ -335,12 +335,12 @@ export function MembersDashboard() {
 
           <Card className="h-full">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Heutige Proben</CardTitle>
+              <CardTitle className="text-sm font-medium">Proben diese Woche</CardTitle>
               <Calendar className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{stats.todayRehearsals}</div>
-              <p className="text-xs text-muted-foreground">Termine zwischen 00:00 und 23:59 Uhr</p>
+              <div className="text-2xl font-bold">{stats.rehearsalsThisWeek}</div>
+              <p className="text-xs text-muted-foreground">Termine der laufenden Kalenderwoche</p>
             </CardContent>
           </Card>
 


### PR DESCRIPTION
## Summary
- count rehearsals for the current calendar week in the dashboard overview API
- surface the new weekly rehearsal total in the members dashboard statistics card

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ccf91535a8832dadc7bfe9a416523e