### PR TITLE
Fix Quill formats configuration to avoid bullet registration error

### DIFF
--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -59,7 +59,7 @@ const BASE_FORMATS = [
   "bold", "italic", "underline", "strike",
   "color", "background",
   "script",
-  "list", "bullet", "indent",
+  "list", "indent",
   "align",
   "blockquote", "code-block",
   "link", "image", "video"


### PR DESCRIPTION
## Summary
- remove the obsolete `bullet` entry from the ReactQuill formats configuration because Quill 2 handles bullets through the `list` format

## Testing
- pnpm lint -- src/components/ui/rich-text-editor.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cd088dccc0832d96ebe638e0281a96