### PR TITLE
Improve Probenplanung rich text editor styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,69 +127,89 @@
 @layer components {
   /* Enhanced Rich Text Editor */
   .rich-text-editor {
-    @apply transition-shadow duration-200;
+    @apply relative overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-slate-50 via-white to-slate-100 shadow-lg transition-shadow duration-200;
   }
 
   .rich-text-editor:focus-within {
-    @apply ring-2 ring-primary/20;
+    @apply ring-2 ring-primary/25 ring-offset-2 ring-offset-white shadow-xl;
   }
 
-  /* Enhanced Toolbar */
+  /* Toolbar */
   .rich-text-editor .ql-toolbar.ql-snow {
-    @apply bg-muted/50 border-0 border-b border-border px-3 py-2 flex flex-wrap;
+    @apply flex flex-wrap items-center gap-x-4 gap-y-2 border-0 border-b border-border/60 bg-gradient-to-b from-white via-slate-50 to-slate-100 px-4 py-3 shadow-inner;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-formats {
-    @apply flex items-center gap-1 mr-3 mb-1;
+    @apply mr-4 flex items-center gap-1 pr-4 last:mr-0 last:border-r-0 last:pr-0;
+    border-right: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
   }
 
-  /* Enhanced Buttons */
+  .rich-text-editor .ql-toolbar.ql-snow .ql-formats:last-child {
+    border-right: none;
+  }
+
   .rich-text-editor .ql-toolbar.ql-snow button,
   .rich-text-editor .ql-toolbar.ql-snow .ql-picker-label {
-    @apply h-8 min-w-8 flex items-center justify-center rounded text-foreground/70 hover:text-foreground hover:bg-accent transition-colors;
-    border: none !important;
-    background: none !important;
+    @apply flex h-9 min-w-9 items-center justify-center rounded-md border border-transparent bg-white/80 px-2 text-[13px] font-medium text-foreground/70 transition-all duration-150 ease-out;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+  }
+
+  .rich-text-editor .ql-toolbar.ql-snow button:hover,
+  .rich-text-editor .ql-toolbar.ql-snow button:focus-visible,
+  .rich-text-editor .ql-toolbar.ql-snow .ql-picker-label:hover,
+  .rich-text-editor .ql-toolbar.ql-snow .ql-picker-label:focus-visible {
+    @apply border-border/70 bg-white text-foreground shadow-sm outline-none;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-picker-label {
-    @apply w-auto px-2 text-xs;
+    @apply w-auto px-3 text-[13px] font-semibold tracking-wide;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-picker {
     @apply text-xs;
   }
 
-  /* Active States */
   .rich-text-editor .ql-toolbar.ql-snow button.ql-active,
   .rich-text-editor .ql-toolbar.ql-snow .ql-picker-label.ql-active {
-    @apply bg-primary text-primary-foreground;
+    @apply border-primary bg-primary/10 text-primary shadow-sm;
   }
 
-  /* Color Picker Enhancements */
-  .rich-text-editor .ql-toolbar.ql-snow .ql-color-picker .ql-picker-options,
-  .rich-text-editor .ql-toolbar.ql-snow .ql-background .ql-picker-options {
-    @apply bg-popover border border-border rounded-md shadow-lg p-2 grid grid-cols-8 gap-1;
+  .rich-text-editor .ql-toolbar.ql-snow button svg,
+  .rich-text-editor .ql-toolbar.ql-snow .ql-picker-label svg {
+    @apply h-4 w-4;
   }
 
-  .rich-text-editor .ql-toolbar.ql-snow .ql-color-picker .ql-picker-item,
-  .rich-text-editor .ql-toolbar.ql-snow .ql-background .ql-picker-item {
-    @apply w-6 h-6 rounded border border-border hover:scale-110 transition-transform;
+  .rich-text-editor .ql-toolbar.ql-snow .ql-stroke {
+    stroke: currentColor !important;
   }
 
-  /* Standard Dropdowns */
+  .rich-text-editor .ql-toolbar.ql-snow .ql-fill {
+    fill: currentColor !important;
+  }
+
+  /* Dropdowns */
   .rich-text-editor .ql-toolbar.ql-snow .ql-picker-options {
-    @apply bg-popover border border-border rounded-md shadow-lg p-1 z-10;
+    @apply mt-2 rounded-xl border border-border bg-popover p-2 shadow-xl;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-picker-options .ql-picker-item {
-    @apply px-3 py-2 text-sm rounded hover:bg-accent transition-colors;
+    @apply rounded px-3 py-2 text-sm hover:bg-accent hover:text-foreground;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-picker-options .ql-picker-item.ql-selected {
     @apply bg-primary text-primary-foreground;
   }
 
-  /* Size Picker Specific */
+  .rich-text-editor .ql-toolbar.ql-snow .ql-color-picker .ql-picker-options,
+  .rich-text-editor .ql-toolbar.ql-snow .ql-background .ql-picker-options {
+    @apply grid grid-cols-10 gap-1 rounded-xl border border-border bg-popover p-3 shadow-2xl;
+  }
+
+  .rich-text-editor .ql-toolbar.ql-snow .ql-color-picker .ql-picker-item,
+  .rich-text-editor .ql-toolbar.ql-snow .ql-background .ql-picker-item {
+    @apply h-6 w-6 rounded border border-border transition-transform hover:scale-110;
+  }
+
   .rich-text-editor .ql-toolbar.ql-snow .ql-size .ql-picker-options .ql-picker-item {
     @apply font-medium;
   }
@@ -206,88 +226,85 @@
     @apply text-xl;
   }
 
-  /* Header Picker Specific */
   .rich-text-editor .ql-toolbar.ql-snow .ql-header .ql-picker-options .ql-picker-item[data-value="1"] {
-    @apply text-2xl font-bold;
+    @apply text-3xl font-bold;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-header .ql-picker-options .ql-picker-item[data-value="2"] {
-    @apply text-xl font-bold;
+    @apply text-2xl font-semibold;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-header .ql-picker-options .ql-picker-item[data-value="3"] {
-    @apply text-lg font-bold;
+    @apply text-xl font-semibold;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-header .ql-picker-options .ql-picker-item[data-value="4"] {
-    @apply text-base font-bold;
+    @apply text-lg font-semibold;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-header .ql-picker-options .ql-picker-item[data-value="5"] {
-    @apply text-sm font-bold;
+    @apply text-base font-semibold;
   }
 
   .rich-text-editor .ql-toolbar.ql-snow .ql-header .ql-picker-options .ql-picker-item[data-value="6"] {
-    @apply text-xs font-bold;
+    @apply text-sm font-semibold;
   }
 
-  /* Editor Container */
+  /* Editor Surface */
   .rich-text-editor .ql-container.ql-snow {
-    @apply border-0 bg-background;
+    @apply border-0 bg-slate-100/70 px-6 pb-6;
   }
 
-  /* Enhanced Editor Content */
   .rich-text-editor .ql-editor {
-    @apply min-h-[180px] px-4 py-4 text-sm text-foreground leading-relaxed;
+    @apply min-h-[260px] rounded-xl border border-border/40 bg-white px-8 py-8 text-[15px] leading-relaxed text-foreground shadow-sm;
   }
 
   .rich-text-editor .ql-editor.ql-blank::before {
-    @apply text-muted-foreground not-italic;
+    @apply text-sm text-muted-foreground not-italic;
   }
 
-  /* Enhanced Content Styling */
   .rich-text-editor .ql-editor h1 {
-    @apply text-2xl font-bold mb-4 mt-6;
+    @apply mt-8 mb-4 text-3xl font-bold;
   }
 
   .rich-text-editor .ql-editor h2 {
-    @apply text-xl font-bold mb-3 mt-5;
+    @apply mt-6 mb-3 text-2xl font-semibold;
   }
 
   .rich-text-editor .ql-editor h3 {
-    @apply text-lg font-bold mb-2 mt-4;
+    @apply mt-5 mb-3 text-xl font-semibold;
   }
 
   .rich-text-editor .ql-editor h4 {
-    @apply text-base font-bold mb-2 mt-3;
+    @apply mt-4 mb-2 text-lg font-semibold;
   }
 
   .rich-text-editor .ql-editor h5 {
-    @apply text-sm font-bold mb-1 mt-2;
+    @apply mt-3 mb-2 text-base font-semibold;
   }
 
   .rich-text-editor .ql-editor h6 {
-    @apply text-xs font-bold mb-1 mt-2;
+    @apply mt-3 mb-2 text-sm font-semibold;
   }
 
-  /* Enhanced Blockquote */
   .rich-text-editor .ql-editor blockquote {
-    @apply border-l-4 border-primary/40 pl-4 my-4 bg-muted/20 py-3 rounded-r italic text-foreground/90;
+    @apply my-5 rounded-r-xl border-l-4 border-primary/50 bg-primary/5 px-5 py-3 italic text-foreground/90;
   }
 
-  /* Code Block Styling */
   .rich-text-editor .ql-editor .ql-code-block-container {
-    @apply bg-muted/50 rounded-lg p-4 my-4 font-mono text-sm border border-border;
+    @apply my-5 rounded-xl border border-border bg-muted/50 p-4 font-mono text-sm shadow-inner;
   }
 
   .rich-text-editor .ql-editor pre.ql-syntax {
-    @apply bg-muted/50 rounded-lg p-4 my-4 font-mono text-sm border border-border overflow-x-auto;
+    @apply my-5 overflow-x-auto rounded-xl border border-border bg-muted/60 p-4 font-mono text-sm shadow-inner;
   }
 
-  /* Enhanced Lists with Indentation */
-  .rich-text-editor .ql-editor ul,
+  .rich-text-editor .ql-editor ul {
+    @apply ml-6 list-disc space-y-1;
+  }
+
   .rich-text-editor .ql-editor ol {
-    @apply ml-6 space-y-1;
+    @apply ml-6 list-decimal space-y-1;
   }
 
   .rich-text-editor .ql-editor .ql-indent-1 {
@@ -310,7 +327,6 @@
     @apply ml-24;
   }
 
-  /* Text Alignment */
   .rich-text-editor .ql-editor .ql-align-center {
     @apply text-center;
   }
@@ -323,7 +339,6 @@
     @apply text-justify;
   }
 
-  /* Font Sizes */
   .rich-text-editor .ql-editor .ql-size-small {
     @apply text-xs;
   }
@@ -333,36 +348,28 @@
   }
 
   .rich-text-editor .ql-editor .ql-size-huge {
-    @apply text-xl;
+    @apply text-2xl;
   }
 
-  /* Script (Sub/Superscript) */
-  .rich-text-editor .ql-editor sub {
-    @apply text-xs;
-  }
-
+  .rich-text-editor .ql-editor sub,
   .rich-text-editor .ql-editor sup {
     @apply text-xs;
   }
 
-  /* Enhanced Links */
   .rich-text-editor .ql-editor a {
-    @apply text-primary hover:text-primary/80 underline decoration-2 underline-offset-2 transition-colors;
+    @apply font-semibold text-primary underline decoration-2 underline-offset-4 transition-colors hover:text-primary/80;
   }
 
-  /* Images */
   .rich-text-editor .ql-editor img {
-    @apply rounded-lg shadow-sm max-w-full h-auto;
+    @apply h-auto max-w-full rounded-xl border border-border/60 shadow-lg;
   }
 
-  /* Videos */
   .rich-text-editor .ql-editor iframe {
-    @apply rounded-lg shadow-sm max-w-full;
+    @apply max-w-full rounded-xl border border-border/60 shadow-lg;
   }
 
-  /* Strike-through */
   .rich-text-editor .ql-editor s {
-    @apply line-through opacity-70;
+    @apply line-through text-foreground/70;
   }
 }
 

--- a/src/components/ui/rich-text-editor.tsx
+++ b/src/components/ui/rich-text-editor.tsx
@@ -14,15 +14,28 @@ type RichTextEditorProps = {
 };
 
 const TOOLBAR_OPTIONS = [
-  [{ header: [false, 1, 2, 3, 4, 5, 6] }],
-  [{ size: ["small", false, "large", "huge"] }],
-  ["bold", "italic", "underline", "strike"],
-  [{ color: [] }, { background: [] }],
-  [{ script: "sub" }, { script: "super" }],
-  [{ list: "ordered" }, { list: "bullet" }, { indent: "-1" }, { indent: "+1" }],
-  [{ align: [] }],
-  ["blockquote", "code-block"],
-  ["link", "image", "video"],
+  [
+    { header: [false, 1, 2, 3, 4, 5, 6] },
+    { size: ["small", false, "large", "huge"] },
+  ],
+  [
+    "bold",
+    "italic",
+    "underline",
+    "strike",
+    { color: [] },
+    { background: [] },
+  ],
+  [
+    { script: "sub" },
+    { script: "super" },
+    { list: "ordered" },
+    { list: "bullet" },
+    { indent: "-1" },
+    { indent: "+1" },
+    { align: [] },
+  ],
+  ["blockquote", "code-block", "link", "image", "video"],
   ["clean"],
 ] as const;
 
@@ -99,7 +112,7 @@ export function RichTextEditor({ value, onChange, placeholder, className }: Rich
   return (
     <div
       className={cn(
-        "rich-text-editor overflow-hidden rounded-lg border border-border bg-card shadow-sm",
+        "rich-text-editor relative overflow-hidden rounded-2xl border border-border/60 bg-muted/40 shadow-lg",
         className,
       )}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -73,5 +73,6 @@ module.exports = {
       },
     },
   },
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   plugins: [require("tailwindcss-animate")],
 }


### PR DESCRIPTION
## Summary
- reorganize the rehearsal editor toolbar configuration to present grouped Word-like controls
- refresh the Quill styles with a ribbon-inspired toolbar, document canvas, and polished typography for rehearsal notes
- annotate the Tailwind animate plugin import to avoid require-based lint noise

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd0810d1d8832d98f51b13c8c66061