### PR TITLE
Allow discarding rehearsal drafts from planning overview

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/discard-draft-button.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/discard-draft-button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { discardRehearsalDraftAction } from "./actions";
+
+type DiscardDraftButtonProps = {
+  id: string;
+  title?: string | null;
+};
+
+export function DiscardDraftButton({ id, title }: DiscardDraftButtonProps) {
+  const router = useRouter();
+  const [isDiscarding, startDiscard] = useTransition();
+
+  const handleDiscard = () => {
+    const normalizedTitle = title?.trim();
+    const confirmationMessage = normalizedTitle
+      ? `Möchtest du den Entwurf "${normalizedTitle}" wirklich verwerfen? Diese Aktion kann nicht rückgängig gemacht werden.`
+      : "Möchtest du diesen Entwurf wirklich verwerfen? Diese Aktion kann nicht rückgängig gemacht werden.";
+
+    if (!confirm(confirmationMessage)) {
+      return;
+    }
+
+    startDiscard(() => {
+      discardRehearsalDraftAction({ id })
+        .then((result) => {
+          if (result?.success) {
+            toast.success("Entwurf verworfen.");
+            router.refresh();
+          } else {
+            toast.error(result?.error ?? "Der Entwurf konnte nicht verworfen werden.");
+          }
+        })
+        .catch(() => {
+          toast.error("Der Entwurf konnte nicht verworfen werden.");
+        });
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDiscard}
+      disabled={isDiscarding}
+      className="rounded text-xs font-medium text-destructive underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {isDiscarding ? "Verwerfe Entwurf…" : "Entwurf verwerfen"}
+    </button>
+  );
+}

--- a/src/app/(members)/mitglieder/probenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/page.tsx
@@ -9,6 +9,7 @@ import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CreateRehearsalButton } from "./create-rehearsal-button";
+import { DiscardDraftButton } from "./discard-draft-button";
 import {
   RehearsalCalendar,
   type CalendarBlockedDay,
@@ -160,12 +161,15 @@ export default async function ProbenplanungPage() {
                       Zuletzt bearbeitet {formatDistanceToNow(draft.updatedAt, { locale: de, addSuffix: true })}
                     </span>
                   </div>
-                  <Link
-                    href={`/mitglieder/probenplanung/proben/${draft.id}`}
-                    className="text-xs font-medium text-primary hover:underline"
-                  >
-                    Entwurf öffnen
-                  </Link>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Link
+                      href={`/mitglieder/probenplanung/proben/${draft.id}`}
+                      className="text-xs font-medium text-primary hover:underline"
+                    >
+                      Entwurf öffnen
+                    </Link>
+                    <DiscardDraftButton id={draft.id} title={draft.title} />
+                  </div>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- add a discard button to each draft in the planning overview
- reuse the existing server action with confirmation, toast feedback, and refresh

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd10626a00832d8dfe2808dba234fb