### PR TITLE
Stop autosave toast spam in rehearsal editor

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
@@ -150,9 +150,6 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
           if (result?.success) {
             setSaveStatus("saved");
             setLastSavedAt(new Date());
-            if (!isDraft) {
-              toast.success("Probe aktualisiert. Alle Teilnehmer wurden benachrichtigt.");
-            }
           } else {
             setSaveStatus("error");
             const errorMessage = isDraft


### PR DESCRIPTION
## Summary
- remove the autosave success toast for published rehearsals so editing no longer spams notifications
- keep the existing save state indicator and error toasts for failure cases

## Testing
- pnpm lint (1 existing warning in src/components/user-avatar.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68cd13cae468832dbd2b6870f4bdc187