### PR TITLE
Show detailed rehearsal update notifications

### DIFF
--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -392,7 +392,9 @@ function NotificationEntry({ item, respondingId, onRespond }: NotificationEntryP
               )}
             </h3>
             {item.body && (
-              <p className="text-xs text-muted-foreground leading-snug break-words">{item.body}</p>
+              <p className="text-xs text-muted-foreground leading-snug break-words whitespace-pre-line">
+                {item.body}
+              </p>
             )}
             <div className="space-y-0.5 text-[0.7rem] text-muted-foreground">
               <time dateTime={createdAt.toISOString()} className="block">


### PR DESCRIPTION
## Summary
- enrich rehearsal update notifications with the exact field changes (title, time, location, deadline, description)
- render notification bodies with preserved line breaks for clearer change listings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd16025ef4832d8cbcd064d55a9fcc