### PR TITLE
Add GitHub Action to build and push Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ${{ coalesce(secrets.DOCKER_REGISTRY, 'ghcr.io') }}
+  IMAGE_NAME: ${{ coalesce(secrets.DOCKER_IMAGE, github.repository) }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ coalesce(secrets.DOCKER_USERNAME, github.actor) }}
+          password: ${{ coalesce(secrets.DOCKER_PASSWORD, secrets.GITHUB_TOKEN) }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- add a workflow that builds the production Docker image and pushes it to a registry
- configure registry login and tagging to support GitHub Container Registry by default or custom registries via GitHub Secrets

## Testing
- Not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cd20784828832da17425675ec89fc9