### PR TITLE
Make NEXTAUTH_URL configurable for dev proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,11 @@ services:
         condition: service_healthy
     environment:
       NODE_ENV: development
-      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
       AUTH_SECRET: dev-secret-change-me
       AUTH_DEV_NO_DB: "0" # DB-backed sessions (NextAuth Prisma Adapter)
       NEXT_PUBLIC_AUTH_DEV_NO_DB: "0" # mirror to client to avoid hydration mismatch
-      NEXT_PUBLIC_REALTIME_URL: http://localhost:4001
+      NEXT_PUBLIC_REALTIME_URL: ${NEXT_PUBLIC_REALTIME_URL:-http://localhost:4001}
       REALTIME_SERVER_URL: http://realtime:4001
       REALTIME_AUTH_TOKEN: dev-realtime-secret
       DATABASE_URL: postgresql://postgres:postgres@db:5432/theater?schema=public
@@ -57,7 +57,7 @@ services:
     environment:
       PORT: 4001
       SOCKET_PATH: /socket.io
-      CORS_ORIGIN: http://localhost:3000
+      CORS_ORIGIN: ${NEXTAUTH_URL:-http://localhost:3000}
       REALTIME_AUTH_TOKEN: dev-realtime-secret
     ports:
       - "4001:4001"

--- a/docs/dev-proxy.md
+++ b/docs/dev-proxy.md
@@ -1,0 +1,16 @@
+# Entwicklung hinter Traefik oder anderen Proxies
+
+Wenn der Entwicklungsstack über einen Reverse Proxy wie Traefik erreichbar gemacht wird (z. B. `https://theater.local`),
+werden Anmelde-Weiterleitungen standardmäßig auf `http://localhost:3000` gesetzt. Der Grund: `NEXTAUTH_URL` ist in der
+Dev-Compose-Datei auf `http://localhost:3000` voreingestellt und NextAuth verwendet diesen Wert für Callback-URLs.
+
+Damit Weiterleitungen auf die externe Domain zeigen, setze vor dem Start von `docker compose` den gewünschten Host:
+
+```bash
+export NEXTAUTH_URL="https://theater.local"
+# optional: .env Datei mit NEXTAUTH_URL=...
+```
+
+Durch die Änderung in `docker-compose.yml` wird dieser Wert jetzt durchgereicht. Der Realtime-Server übernimmt denselben
+Origin für CORS. Ohne gesetzte Variable bleibt das Standardverhalten (`http://localhost:3000`) für lokale Entwicklung
+bestehen.


### PR DESCRIPTION
## Summary
- allow overriding NEXTAUTH_URL and NEXT_PUBLIC_REALTIME_URL in the dev docker compose file so proxy domains work
- reuse the same origin for the realtime CORS setting
- document how to expose the dev stack via Traefik or another proxy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd64320e2c832d82e7f0ffc2f34e4e