### PR TITLE
feat: add photo consent workflows

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model User {
   role      Role     @default(member)
   passwordHash String?
   createdAt DateTime @default(now())
+  dateOfBirth DateTime?
   avatarSource        AvatarSource @default(GRAVATAR)
   avatarImage         Bytes?
   avatarImageMime     String?
@@ -164,6 +165,8 @@ model User {
   blockedDays            BlockedDay[]
   appRoles               UserAppRole[]
   rehearsalInvites       RehearsalInvitee[]
+  photoConsent           PhotoConsent?
+  approvedPhotoConsents  PhotoConsent[] @relation("PhotoConsentApprover")
 }
 
 model Account {
@@ -525,6 +528,31 @@ model NotificationRecipient {
   user           User          @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([notificationId, userId])
+}
+
+enum PhotoConsentStatus {
+  pending
+  approved
+  rejected
+}
+
+model PhotoConsent {
+  id               String              @id @default(cuid())
+  userId           String              @unique
+  status           PhotoConsentStatus  @default(pending)
+  consentGiven     Boolean             @default(true)
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
+  approvedAt       DateTime?
+  approvedById     String?
+  rejectionReason  String?
+  documentName     String?
+  documentMime     String?
+  documentSize     Int?
+  documentUploadedAt DateTime?
+  documentData     Bytes?
+  user             User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  approvedBy       User?               @relation("PhotoConsentApprover", fields: [approvedById], references: [id])
 }
 
 model Announcement {

--- a/src/app/(members)/mitglieder/fotoerlaubnisse/page.tsx
+++ b/src/app/(members)/mitglieder/fotoerlaubnisse/page.tsx
@@ -1,0 +1,18 @@
+import { PhotoConsentAdminPanel } from "@/components/members/photo-consent-admin-panel";
+import { ensurePermissionDefinitions, hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+export default async function FotoErlaubnissePage() {
+  const session = await requireAuth();
+  await ensurePermissionDefinitions();
+  const allowed = await hasPermission(session.user, "mitglieder.fotoerlaubnisse");
+  if (!allowed) {
+    return <div className="text-sm text-red-600">Kein Zugriff auf die Verwaltung der Fotoeinverständnisse</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <PhotoConsentAdminPanel />
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -29,6 +29,7 @@ export default async function ProfilePage() {
       roles: { select: { role: true } },
       avatarSource: true,
       avatarImageUpdatedAt: true,
+      dateOfBirth: true,
     },
   });
 
@@ -80,6 +81,7 @@ export default async function ProfilePage() {
               initialEmail={user.email}
               initialAvatarSource={user.avatarSource}
               initialAvatarUpdatedAt={user.avatarImageUpdatedAt?.toISOString() ?? null}
+              initialDateOfBirth={user.dateOfBirth?.toISOString() ?? null}
             />
           </CardContent>
         </Card>

--- a/src/app/api/photo-consents/[id]/document/route.ts
+++ b/src/app/api/photo-consents/[id]/document/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+
+function sanitizeForHeader(value: string): string {
+  return value.replace(/"/g, "").replace(/\r|\n/g, "");
+}
+
+export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.fotoerlaubnisse"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const id = params.id?.trim();
+  if (!id) {
+    return NextResponse.json({ error: "Fehlende ID" }, { status: 400 });
+  }
+
+  const consent = await prisma.photoConsent.findUnique({
+    where: { id },
+    select: {
+      documentData: true,
+      documentMime: true,
+      documentName: true,
+      documentSize: true,
+    },
+  });
+
+  if (!consent || !consent.documentData) {
+    return NextResponse.json({ error: "Dokument nicht gefunden" }, { status: 404 });
+  }
+
+  const buffer = Buffer.from(consent.documentData);
+  const mime = consent.documentMime || "application/octet-stream";
+  const fileName = consent.documentName || "foto-einverstaendnis.pdf";
+  const safeFileName = sanitizeForHeader(fileName);
+  const encodedFileName = encodeURIComponent(fileName);
+
+  const response = new NextResponse(buffer, {
+    headers: {
+      "Content-Type": mime,
+      "Content-Length": consent.documentSize ? String(consent.documentSize) : String(buffer.byteLength),
+      "Content-Disposition": `attachment; filename="${safeFileName}"; filename*=UTF-8''${encodedFileName}`,
+      "Cache-Control": "no-store",
+    },
+  });
+
+  return response;
+}

--- a/src/app/api/photo-consents/admin/route.ts
+++ b/src/app/api/photo-consents/admin/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import type { PhotoConsentAdminEntry } from "@/types/photo-consent";
+
+type ConsentWithUser = {
+  id: string;
+  status: "pending" | "approved" | "rejected";
+  createdAt: Date;
+  updatedAt: Date;
+  approvedAt: Date | null;
+  rejectionReason: string | null;
+  documentUploadedAt: Date | null;
+  documentName: string | null;
+  userId: string;
+  user: { id: string; name: string | null; email: string | null; dateOfBirth: Date | null };
+  approvedBy: { id: string; name: string | null } | null;
+};
+
+function calculateAge(date: Date | null | undefined): number | null {
+  if (!date) return null;
+  const now = new Date();
+  let age = now.getFullYear() - date.getFullYear();
+  const monthDiff = now.getMonth() - date.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < date.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+function mapConsent(consent: ConsentWithUser): PhotoConsentAdminEntry {
+  const dateOfBirth = consent.user.dateOfBirth;
+  const age = calculateAge(dateOfBirth);
+  const requiresDocument = age !== null && age < 18;
+  const requiresDateOfBirth = !dateOfBirth;
+  return {
+    id: consent.id,
+    userId: consent.userId,
+    name: consent.user.name,
+    email: consent.user.email,
+    status: consent.status,
+    submittedAt: consent.createdAt.toISOString(),
+    updatedAt: consent.updatedAt.toISOString(),
+    approvedAt: consent.approvedAt ? consent.approvedAt.toISOString() : null,
+    approvedByName: consent.approvedBy?.name ?? null,
+    rejectionReason: consent.rejectionReason ?? null,
+    hasDocument: Boolean(consent.documentUploadedAt),
+    requiresDocument,
+    requiresDateOfBirth,
+    dateOfBirth: dateOfBirth ? dateOfBirth.toISOString() : null,
+    age,
+    documentName: consent.documentName ?? null,
+    documentUrl: consent.documentUploadedAt ? `/api/photo-consents/${consent.id}/document` : null,
+    documentUploadedAt: consent.documentUploadedAt ? consent.documentUploadedAt.toISOString() : null,
+  };
+}
+
+export async function GET() {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.fotoerlaubnisse"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const consents = await prisma.photoConsent.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      user: { select: { id: true, name: true, email: true, dateOfBirth: true } },
+      approvedBy: { select: { id: true, name: true } },
+    },
+  });
+
+  const entries = consents.map((consent) => mapConsent(consent as ConsentWithUser));
+  return NextResponse.json({ entries });
+}
+
+export async function PATCH(request: NextRequest) {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.fotoerlaubnisse"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const id = "id" in body ? String((body as { id?: unknown }).id ?? "").trim() : "";
+  const action = "action" in body ? String((body as { action?: unknown }).action ?? "").trim() : "";
+  const reasonRaw = "reason" in body ? (body as { reason?: unknown }).reason : undefined;
+
+  if (!id) {
+    return NextResponse.json({ error: "Fehlende ID" }, { status: 400 });
+  }
+
+  if (!["approve", "reject", "reset"].includes(action)) {
+    return NextResponse.json({ error: "Unbekannte Aktion" }, { status: 400 });
+  }
+
+  let rejectionReason: string | null = null;
+  if (action === "reject") {
+    if (typeof reasonRaw !== "string" || !reasonRaw.trim()) {
+      return NextResponse.json({ error: "Bitte gib einen Ablehnungsgrund an" }, { status: 400 });
+    }
+    rejectionReason = reasonRaw.trim();
+  }
+
+  try {
+    const updateData: Record<string, unknown> = {};
+    const now = new Date();
+
+    if (action === "approve") {
+      updateData.status = "approved";
+      updateData.approvedAt = now;
+      updateData.approvedById = session.user?.id ?? null;
+      updateData.rejectionReason = null;
+    } else if (action === "reject") {
+      updateData.status = "rejected";
+      updateData.approvedAt = null;
+      updateData.approvedById = null;
+      updateData.rejectionReason = rejectionReason;
+    } else {
+      updateData.status = "pending";
+      updateData.approvedAt = null;
+      updateData.approvedById = null;
+      updateData.rejectionReason = null;
+    }
+
+    const updated = await prisma.photoConsent.update({
+      where: { id },
+      data: updateData,
+      include: {
+        user: { select: { id: true, name: true, email: true, dateOfBirth: true } },
+        approvedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    const entry = mapConsent(updated as ConsentWithUser);
+    return NextResponse.json({ ok: true, entry });
+  } catch (error: unknown) {
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "P2025") {
+      return NextResponse.json({ error: "Eintrag nicht gefunden" }, { status: 404 });
+    }
+    console.error("[PhotoConsent] Update failed", error);
+    return NextResponse.json({ error: "Aktualisierung fehlgeschlagen" }, { status: 500 });
+  }
+}

--- a/src/app/api/photo-consents/route.ts
+++ b/src/app/api/photo-consents/route.ts
@@ -1,0 +1,262 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import type { PhotoConsentSummary } from "@/types/photo-consent";
+
+const MAX_DOCUMENT_BYTES = 8 * 1024 * 1024; // 8 MB
+const ALLOWED_DOCUMENT_TYPES = new Set([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/jpg",
+]);
+
+type ConsentRecord = {
+  id: string;
+  status: "pending" | "approved" | "rejected";
+  createdAt: Date;
+  updatedAt: Date;
+  approvedAt: Date | null;
+  rejectionReason: string | null;
+  documentUploadedAt: Date | null;
+  documentName: string | null;
+  approvedBy: { name: string | null } | null;
+};
+
+type UserRecord = {
+  dateOfBirth: Date | null;
+  photoConsent: ConsentRecord | null;
+};
+
+function calculateAge(date: Date | null | undefined): number | null {
+  if (!date) return null;
+  const now = new Date();
+  let age = now.getFullYear() - date.getFullYear();
+  const monthDiff = now.getMonth() - date.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < date.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+function buildSummary(user: UserRecord): PhotoConsentSummary {
+  const consent = user.photoConsent;
+  const dateOfBirth = user.dateOfBirth;
+  const age = calculateAge(dateOfBirth);
+  const requiresDocument = age !== null && age < 18;
+  const requiresDateOfBirth = !dateOfBirth;
+
+  const status: PhotoConsentSummary["status"] = consent?.status ?? "none";
+
+  return {
+    status,
+    requiresDocument,
+    hasDocument: Boolean(consent?.documentUploadedAt),
+    submittedAt: consent ? consent.createdAt.toISOString() : null,
+    updatedAt: consent ? consent.updatedAt.toISOString() : null,
+    approvedAt: consent?.approvedAt ? consent.approvedAt.toISOString() : null,
+    approvedByName: consent?.approvedBy?.name ?? null,
+    rejectionReason: consent?.rejectionReason ?? null,
+    requiresDateOfBirth,
+    age,
+    dateOfBirth: dateOfBirth ? dateOfBirth.toISOString() : null,
+    documentName: consent?.documentName ?? null,
+    documentUploadedAt: consent?.documentUploadedAt ? consent.documentUploadedAt.toISOString() : null,
+  };
+}
+
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return ["1", "true", "yes", "on"].includes(normalized);
+  }
+  return value === true;
+}
+
+function sanitizeFilename(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return "einverstaendnis.pdf";
+  }
+  return trimmed.replace(/[^\w. -]+/g, "_");
+}
+
+export async function GET() {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      dateOfBirth: true,
+      photoConsent: {
+        select: {
+          id: true,
+          status: true,
+          createdAt: true,
+          updatedAt: true,
+          approvedAt: true,
+          rejectionReason: true,
+          documentUploadedAt: true,
+          documentName: true,
+          approvedBy: { select: { name: true } },
+        },
+      },
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "Benutzer nicht gefunden" }, { status: 404 });
+  }
+
+  return NextResponse.json({ consent: buildSummary(user) });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const contentType = request.headers.get("content-type") ?? "";
+  let body: Record<string, unknown> | null = null;
+  let documentFile: File | null = null;
+
+  if (contentType.includes("multipart/form-data")) {
+    const formData = await request.formData();
+    const parsed: Record<string, unknown> = {};
+    formData.forEach((value, key) => {
+      if (value instanceof File) {
+        if (key === "document" && value.size > 0) {
+          documentFile = value;
+        }
+      } else {
+        parsed[key] = value;
+      }
+    });
+    body = parsed;
+  } else {
+    const json = await request.json().catch(() => null);
+    if (json && typeof json === "object") {
+      body = json as Record<string, unknown>;
+    }
+  }
+
+  if (!body) {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  if (!parseBoolean(body.confirm)) {
+    return NextResponse.json({ error: "Bitte bestätige dein Einverständnis" }, { status: 400 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      dateOfBirth: true,
+      photoConsent: {
+        select: {
+          id: true,
+          status: true,
+          documentUploadedAt: true,
+        },
+      },
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "Benutzer nicht gefunden" }, { status: 404 });
+  }
+
+  const requiresDateOfBirth = !user.dateOfBirth;
+  if (requiresDateOfBirth) {
+    return NextResponse.json(
+      { error: "Bitte hinterlege zuerst dein Geburtsdatum im Profil", requiresDateOfBirth: true },
+      { status: 400 },
+    );
+  }
+
+  const age = calculateAge(user.dateOfBirth);
+  const requiresDocument = age !== null && age < 18;
+
+  if (requiresDocument && !documentFile && !user.photoConsent?.documentUploadedAt) {
+    return NextResponse.json({ error: "Bitte lade die unterschriebene Einverständniserklärung hoch" }, { status: 400 });
+  }
+
+  let documentBuffer: Buffer | undefined;
+  let documentMime: string | undefined;
+  let documentName: string | undefined;
+  let documentSize: number | undefined;
+
+  if (documentFile) {
+    if (documentFile.size > MAX_DOCUMENT_BYTES) {
+      return NextResponse.json({ error: "Dokument darf maximal 8 MB groß sein" }, { status: 400 });
+    }
+    const mime = documentFile.type?.toLowerCase() ?? "";
+    if (mime && !ALLOWED_DOCUMENT_TYPES.has(mime)) {
+      return NextResponse.json({ error: "Erlaubt sind PDF oder Bilddateien (JPG, PNG)" }, { status: 400 });
+    }
+    const buffer = Buffer.from(await documentFile.arrayBuffer());
+    documentBuffer = buffer;
+    documentMime = mime || "application/octet-stream";
+    documentName = sanitizeFilename(documentFile.name || "einverstaendnis.pdf");
+    documentSize = documentFile.size;
+  }
+
+  const now = new Date();
+  const docData = documentBuffer
+    ? {
+        documentData: documentBuffer,
+        documentMime,
+        documentName,
+        documentSize,
+        documentUploadedAt: now,
+      }
+    : {};
+
+  const consent = await prisma.photoConsent.upsert({
+    where: { userId },
+    create: {
+      userId,
+      status: "pending",
+      consentGiven: true,
+      approvedAt: null,
+      approvedById: null,
+      rejectionReason: null,
+      ...docData,
+    },
+    update: {
+      status: "pending",
+      consentGiven: true,
+      approvedAt: null,
+      approvedById: null,
+      rejectionReason: null,
+      ...(documentBuffer ? docData : {}),
+    },
+    select: {
+      id: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+      approvedAt: true,
+      rejectionReason: true,
+      documentUploadedAt: true,
+      documentName: true,
+      approvedBy: { select: { name: true } },
+    },
+  });
+
+  const summary = buildSummary({
+    dateOfBirth: user.dateOfBirth,
+    photoConsent: consent,
+  });
+
+  return NextResponse.json({ ok: true, consent: summary });
+}

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -12,6 +12,7 @@ import { useOnlineStats } from "@/hooks/useOnlineStats";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { PhotoConsentCard } from "@/components/members/photo-consent-card";
 import {
   Users,
   Activity,
@@ -418,6 +419,8 @@ export function MembersDashboard() {
           </CardContent>
         </Card>
       </div>
+
+      <PhotoConsentCard />
     </div>
   );
 }

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -29,6 +29,7 @@ const groupedConfig: Group[] = [
     items: [
       { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", permissionKey: "mitglieder.rollenverwaltung" },
       { href: "/mitglieder/rechte", label: "Rechteverwaltung", permissionKey: "mitglieder.rechte" },
+      { href: "/mitglieder/fotoerlaubnisse", label: "Fotoerlaubnisse", permissionKey: "mitglieder.fotoerlaubnisse" },
     ],
   },
 ];
@@ -92,6 +93,13 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
       return (
         <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M12 22s8-3 8-10V5l-8-3-8 3v7c0 7 8 10 8 10Z" />
+        </svg>
+      );
+    case "/mitglieder/fotoerlaubnisse":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h3l2-3h4l2 3h3a2 2 0 0 1 2 2Z" />
+          <circle cx="12" cy="14" r="3" />
         </svg>
       );
     default:

--- a/src/components/members/photo-consent-admin-panel.tsx
+++ b/src/components/members/photo-consent-admin-panel.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { PhotoConsentAdminEntry } from "@/types/photo-consent";
+
+const statusLabels: Record<PhotoConsentAdminEntry["status"], string> = {
+  pending: "In Prüfung",
+  approved: "Freigegeben",
+  rejected: "Abgelehnt",
+};
+
+const statusVariants: Record<PhotoConsentAdminEntry["status"], "default" | "secondary" | "destructive"> = {
+  pending: "secondary",
+  approved: "default",
+  rejected: "destructive",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return null;
+  return dateFormatter.format(date);
+}
+
+export function PhotoConsentAdminPanel() {
+  const [entries, setEntries] = useState<PhotoConsentAdminEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [processing, setProcessing] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/photo-consents/admin", { cache: "no-store" });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        setError(data?.error ?? "Einträge konnten nicht geladen werden");
+        return;
+      }
+      setEntries(Array.isArray(data?.entries) ? (data.entries as PhotoConsentAdminEntry[]) : []);
+    } catch {
+      setError("Netzwerkfehler beim Laden der Einträge");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const hasEntries = entries.length > 0;
+
+  const handleAction = useCallback(
+    async (id: string, action: "approve" | "reject" | "reset") => {
+      let reason: string | undefined;
+      if (action === "reject") {
+        const entered = window.prompt("Bitte Ablehnungsgrund eingeben:");
+        if (!entered) {
+          return;
+        }
+        reason = entered.trim();
+        if (!reason) {
+          toast.error("Ablehnungsgrund darf nicht leer sein");
+          return;
+        }
+      }
+
+      setProcessing(id);
+      try {
+        const response = await fetch("/api/photo-consents/admin", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id, action, reason }),
+        });
+        const data = await response.json().catch(() => null);
+        if (!response.ok) {
+          toast.error(data?.error ?? "Aktion fehlgeschlagen");
+          return;
+        }
+        const entry = data?.entry as PhotoConsentAdminEntry | undefined;
+        if (entry) {
+          setEntries((prev) => prev.map((item) => (item.id === entry.id ? entry : item)));
+        }
+        const message =
+          action === "approve"
+            ? "Fotoeinverständnis freigegeben"
+            : action === "reject"
+            ? "Fotoeinverständnis abgelehnt"
+            : "Status zurückgesetzt";
+        toast.success(message);
+      } catch {
+        toast.error("Netzwerkfehler bei der Aktion");
+      } finally {
+        setProcessing(null);
+      }
+    },
+    [],
+  );
+
+  const summary = useMemo(() => {
+    const pending = entries.filter((entry) => entry.status === "pending").length;
+    const rejected = entries.filter((entry) => entry.status === "rejected").length;
+    const missingBirthdays = entries.filter((entry) => entry.requiresDateOfBirth).length;
+    return { pending, rejected, missingBirthdays };
+  }, [entries]);
+
+  return (
+    <Card className="border border-border/70 bg-background">
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle>Fotoeinverständnisse verwalten</CardTitle>
+          <p className="text-sm text-foreground/70">
+            Prüfe eingereichte Zustimmungen, bestätige sie oder fordere zusätzliche Unterlagen an.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-foreground/60">
+          <Badge variant="secondary">Wartend: {summary.pending}</Badge>
+          <Badge variant="outline">Fehlende Geburtsdaten: {summary.missingBirthdays}</Badge>
+          <Badge variant="destructive">Abgelehnt: {summary.rejected}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Button type="button" size="sm" variant="outline" onClick={() => void load()} disabled={loading}>
+            Aktualisieren
+          </Button>
+          {error && <span className="text-sm text-destructive">{error}</span>}
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Lade Einträge …</p>
+        ) : !hasEntries ? (
+          <p className="text-sm text-muted-foreground">Bisher liegen keine Fotoeinverständnisse vor.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-auto text-sm">
+              <thead className="bg-muted/50 text-xs uppercase tracking-wide text-foreground/60">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Mitglied</th>
+                  <th className="px-3 py-2 text-left font-medium">Status</th>
+                  <th className="px-3 py-2 text-left font-medium">Anforderungen</th>
+                  <th className="px-3 py-2 text-left font-medium">Zeitleiste</th>
+                  <th className="px-3 py-2 text-left font-medium">Aktionen</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {entries.map((entry) => {
+                  const statusLabel = statusLabels[entry.status];
+                  return (
+                    <tr key={entry.id} className="align-top">
+                      <td className="px-3 py-3">
+                        <div className="font-medium text-foreground">
+                          {entry.name ?? entry.email ?? "Unbekannt"}
+                        </div>
+                        {entry.email && <div className="text-xs text-foreground/60">{entry.email}</div>}
+                        <div className="mt-1 space-y-1 text-xs text-foreground/60">
+                          <div>
+                            Geburtsdatum: {formatDate(entry.dateOfBirth) ?? "unbekannt"}
+                            {entry.age !== null ? ` (${entry.age} Jahre)` : ""}
+                          </div>
+                          {entry.documentName && (
+                            <div>
+                              Dokument: {entry.documentName}
+                              {entry.documentUploadedAt && ` · hochgeladen ${formatDate(entry.documentUploadedAt)}`}
+                              {entry.documentUrl && (
+                                <>
+                                  {" "}
+                                  <a
+                                    className="underline"
+                                    href={entry.documentUrl}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    öffnen
+                                  </a>
+                                </>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-3 py-3">
+                        <Badge variant={statusVariants[entry.status]}>{statusLabel}</Badge>
+                      </td>
+                      <td className="px-3 py-3 text-xs text-foreground/70">
+                        <ul className="space-y-1">
+                          <li>{entry.requiresDocument ? "Minderjährig" : "Volljährig"}</li>
+                          <li>{entry.requiresDateOfBirth ? "Geburtsdatum fehlt" : "Geburtsdatum vorhanden"}</li>
+                          <li>{entry.hasDocument ? "Dokument vorhanden" : "Kein Dokument"}</li>
+                        </ul>
+                      </td>
+                      <td className="px-3 py-3 text-xs text-foreground/70">
+                        <div>Eingegangen: {formatDate(entry.submittedAt)}</div>
+                        <div>Aktualisiert: {formatDate(entry.updatedAt)}</div>
+                        {entry.approvedAt && <div>Freigabe: {formatDate(entry.approvedAt)}</div>}
+                        {entry.approvedByName && <div>Durch: {entry.approvedByName}</div>}
+                        {entry.rejectionReason && (
+                          <div className="mt-1 text-destructive">Grund: {entry.rejectionReason}</div>
+                        )}
+                      </td>
+                      <td className="px-3 py-3">
+                        <div className="flex flex-col gap-2">
+                          <Button
+                            size="sm"
+                            onClick={() => void handleAction(entry.id, "approve")}
+                            disabled={processing === entry.id}
+                          >
+                            Freigeben
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => void handleAction(entry.id, "reset")}
+                            disabled={processing === entry.id}
+                          >
+                            Zurücksetzen
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="destructive"
+                            onClick={() => void handleAction(entry.id, "reject")}
+                            disabled={processing === entry.id}
+                          >
+                            Ablehnen
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import type { ChangeEvent, FormEvent } from "react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { PhotoConsentSummary } from "@/types/photo-consent";
+
+const MAX_DOCUMENT_BYTES = 8 * 1024 * 1024;
+const ALLOWED_TYPES = new Set(["application/pdf", "image/jpeg", "image/png"]);
+
+const statusLabels: Record<PhotoConsentSummary["status"], string> = {
+  none: "Noch nicht übermittelt",
+  pending: "Wartet auf Prüfung",
+  approved: "Freigabe erteilt",
+  rejected: "Abgelehnt",
+};
+
+const statusVariants: Record<PhotoConsentSummary["status"], "default" | "secondary" | "destructive" | "outline"> = {
+  none: "outline",
+  pending: "secondary",
+  approved: "default",
+  rejected: "destructive",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+
+const EMPTY_SUMMARY: PhotoConsentSummary = {
+  status: "none",
+  requiresDocument: false,
+  hasDocument: false,
+  submittedAt: null,
+  updatedAt: null,
+  approvedAt: null,
+  approvedByName: null,
+  rejectionReason: null,
+  requiresDateOfBirth: false,
+  age: null,
+  dateOfBirth: null,
+  documentName: null,
+  documentUploadedAt: null,
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return null;
+  return dateFormatter.format(date);
+}
+
+export function PhotoConsentCard() {
+  const [summary, setSummary] = useState<PhotoConsentSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState(false);
+  const [documentFile, setDocumentFile] = useState<File | null>(null);
+  const [documentError, setDocumentError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/photo-consents", { cache: "no-store" });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message = data?.error ?? "Status konnte nicht geladen werden";
+        setError(message);
+        return;
+      }
+      setSummary(data?.consent ?? null);
+    } catch {
+      setError("Netzwerkfehler beim Laden der Fotoerlaubnis");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const requiresDocument = summary?.requiresDocument ?? false;
+  const requiresDateOfBirth = summary?.requiresDateOfBirth ?? false;
+  const status = summary?.status ?? "none";
+
+  const statusBadge = useMemo(() => {
+    return (
+      <Badge variant={statusVariants[status]} className="whitespace-nowrap">
+        {statusLabels[status]}
+      </Badge>
+    );
+  }, [status]);
+
+  const resetFileInput = () => {
+    setDocumentFile(null);
+    setDocumentError(null);
+    const input = fileInputRef.current;
+    if (input) {
+      input.value = "";
+    }
+  };
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    if (!file) {
+      resetFileInput();
+      return;
+    }
+    if (file.size > MAX_DOCUMENT_BYTES) {
+      setDocumentError("Dokument darf maximal 8 MB groß sein");
+      event.target.value = "";
+      setDocumentFile(null);
+      return;
+    }
+    const type = file.type?.toLowerCase() ?? "";
+    if (type && !ALLOWED_TYPES.has(type)) {
+      setDocumentError("Bitte nutze PDF oder Bilddateien (JPG/PNG)");
+      event.target.value = "";
+      setDocumentFile(null);
+      return;
+    }
+    setDocumentError(null);
+    setDocumentFile(file);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setDocumentError(null);
+
+    if (!confirm) {
+      setDocumentError("Bitte bestätige dein Einverständnis");
+      return;
+    }
+
+    if (requiresDocument && !documentFile && !summary?.hasDocument) {
+      setDocumentError("Bitte lade die unterschriebene Einverständniserklärung hoch");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const formData = new FormData();
+      formData.append("confirm", "1");
+      if (documentFile) {
+        formData.append("document", documentFile);
+      }
+      const response = await fetch("/api/photo-consents", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message = data?.error ?? "Übermittlung fehlgeschlagen";
+        setDocumentError(message);
+        if (data?.requiresDateOfBirth) {
+          setSummary((prev) => {
+            if (prev) {
+              return { ...prev, requiresDateOfBirth: true };
+            }
+            return { ...EMPTY_SUMMARY, requiresDateOfBirth: true };
+          });
+        }
+        return;
+      }
+      const consent: PhotoConsentSummary | null = data?.consent ?? null;
+      setSummary(consent);
+      setConfirm(false);
+      resetFileInput();
+      toast.success("Fotoeinverständnis übermittelt");
+    } catch {
+      setDocumentError("Netzwerkfehler beim Übermitteln");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card className="border border-border/60 bg-background">
+      <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <CardTitle>Fotoeinverständnis</CardTitle>
+        {statusBadge}
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <p className="text-foreground/80">
+          Wir benötigen deine Einwilligung, um Fotos von Auftritten und Proben verwenden zu dürfen. Minderjährige Mitglieder
+          benötigen zusätzlich eine unterschriebene Zustimmung der Erziehungsberechtigten.
+        </p>
+
+        {loading ? (
+          <p className="text-muted-foreground">Lade Status …</p>
+        ) : error ? (
+          <div className="space-y-3">
+            <p className="text-destructive">{error}</p>
+            <Button type="button" size="sm" variant="outline" onClick={() => void load()}>
+              Erneut versuchen
+            </Button>
+          </div>
+        ) : requiresDateOfBirth ? (
+          <div className="rounded-md border border-amber-300 bg-amber-50/60 p-3 text-amber-900">
+            Bitte hinterlege dein Geburtsdatum im <Link className="underline" href="/mitglieder/profil">Profil</Link>, damit wir
+            prüfen können, ob ein Elternformular notwendig ist.
+          </div>
+        ) : status === "approved" ? (
+          <div className="space-y-2 rounded-md border border-emerald-300 bg-emerald-50/70 p-3 text-emerald-900">
+            <p>Vielen Dank – deine Fotoeinwilligung ist freigegeben.</p>
+            <ul className="text-xs text-emerald-800">
+              <li>
+                Bestätigt am {formatDate(summary?.approvedAt) ?? "unbekannt"}
+                {summary?.approvedByName ? ` durch ${summary.approvedByName}` : ""}.
+              </li>
+              {summary?.documentUploadedAt && (
+                <li>Dokument zuletzt hochgeladen am {formatDate(summary.documentUploadedAt)}.</li>
+              )}
+            </ul>
+          </div>
+        ) : (
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            {summary?.status === "rejected" && summary.rejectionReason && (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-destructive">
+                Ablehnungsgrund: {summary.rejectionReason}
+              </div>
+            )}
+
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={confirm}
+                onChange={(event) => setConfirm(event.target.checked)}
+                className="mt-1 h-4 w-4 rounded border-border text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+              <span>
+                Ich erkläre mich damit einverstanden, dass im Rahmen des Vereins Fotos von mir erstellt und für interne sowie
+                öffentliche Kommunikationszwecke genutzt werden dürfen.
+              </span>
+            </label>
+
+            {requiresDocument && (
+              <div className="space-y-2">
+                <div className="font-medium text-foreground">Elterliche Einwilligung (PDF oder JPG/PNG)</div>
+                <Input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/pdf,image/jpeg,image/png"
+                  onChange={handleFileChange}
+                  disabled={submitting}
+                />
+                {documentFile && (
+                  <p className="text-xs text-foreground/70">Ausgewählt: {documentFile.name}</p>
+                )}
+                {summary?.hasDocument && !documentFile && (
+                  <p className="text-xs text-foreground/60">
+                    Es liegt bereits ein Dokument vor. Du kannst hier ein neues hochladen, falls eine aktualisierte Version vorliegt.
+                  </p>
+                )}
+                {documentError && <p className="text-sm text-destructive">{documentError}</p>}
+              </div>
+            )}
+
+            {!requiresDocument && documentError && <p className="text-sm text-destructive">{documentError}</p>}
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="submit"
+                disabled={
+                  submitting ||
+                  !confirm ||
+                  (requiresDocument && !documentFile && !summary?.hasDocument)
+                }
+              >
+                {submitting ? "Übermittle …" : "Einverständnis senden"}
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={() => void load()} disabled={submitting}>
+                Status aktualisieren
+              </Button>
+            </div>
+
+            <div className="text-xs text-foreground/60">
+              {summary?.submittedAt ? (
+                <>Zuletzt gesendet am {formatDate(summary.submittedAt)}.</>
+              ) : (
+                <>Noch keine Einwilligung übermittelt.</>
+              )}
+            </div>
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -18,6 +18,11 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { key: "mitglieder.rollenverwaltung", label: "Mitgliederverwaltung öffnen" },
   { key: "mitglieder.rechte", label: "Rechteverwaltung öffnen" },
   { key: "mitglieder.sperrliste", label: "Sperrliste pflegen" },
+  {
+    key: "mitglieder.fotoerlaubnisse",
+    label: "Fotoerlaubnisse verwalten",
+    description: "Bereich zum Prüfen und Freigeben von Fotoeinverständniserklärungen.",
+  },
 ];
 
 const DEFAULT_PERMISSION_KEYS = DEFAULT_PERMISSION_DEFINITIONS.map((def) => def.key);

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -11,6 +11,7 @@ declare module "next-auth" {
       roles?: Role[];
       avatarSource?: AvatarSource | null;
       avatarUpdatedAt?: string | null;
+      dateOfBirth?: string | null;
     };
   }
   interface User {
@@ -18,6 +19,7 @@ declare module "next-auth" {
     roles?: Role[];
     avatarSource?: AvatarSource | null;
     avatarUpdatedAt?: string | null;
+    dateOfBirth?: string | null;
   }
 }
 

--- a/src/types/photo-consent.ts
+++ b/src/types/photo-consent.ts
@@ -1,0 +1,38 @@
+export type PhotoConsentStatus = "none" | "pending" | "approved" | "rejected";
+
+export type PhotoConsentSummary = {
+  status: PhotoConsentStatus;
+  requiresDocument: boolean;
+  hasDocument: boolean;
+  submittedAt: string | null;
+  updatedAt: string | null;
+  approvedAt: string | null;
+  approvedByName: string | null;
+  rejectionReason: string | null;
+  requiresDateOfBirth: boolean;
+  age: number | null;
+  dateOfBirth: string | null;
+  documentName: string | null;
+  documentUploadedAt: string | null;
+};
+
+export type PhotoConsentAdminEntry = {
+  id: string;
+  userId: string;
+  name: string | null;
+  email: string | null;
+  status: Exclude<PhotoConsentStatus, "none">;
+  submittedAt: string;
+  updatedAt: string;
+  approvedAt: string | null;
+  approvedByName: string | null;
+  rejectionReason: string | null;
+  hasDocument: boolean;
+  requiresDocument: boolean;
+  requiresDateOfBirth: boolean;
+  dateOfBirth: string | null;
+  age: number | null;
+  documentName: string | null;
+  documentUrl: string | null;
+  documentUploadedAt: string | null;
+};


### PR DESCRIPTION
## Summary
- add birth date support to profiles and Prisma schema to drive photo consent rules
- expose API endpoints and dashboard UI for members to submit photo consents with optional guardian documents
- add admin page, permissions, and download endpoint to review and approve or reject photo consent submissions

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68cd63edcbe4832d9852b924ce97d5fd