### PR TITLE
Add production management permissions and schema

### DIFF
--- a/prisma/migrations/20250919193418_production_management/migration.sql
+++ b/prisma/migrations/20250919193418_production_management/migration.sql
@@ -1,0 +1,173 @@
+-- CreateEnum
+CREATE TYPE "public"."DepartmentMembershipRole" AS ENUM ('lead', 'member', 'deputy', 'guest');
+
+-- CreateEnum
+CREATE TYPE "public"."CharacterCastingType" AS ENUM ('primary', 'alternate', 'cover', 'cameo');
+
+-- CreateEnum
+CREATE TYPE "public"."BreakdownStatus" AS ENUM ('planned', 'in_progress', 'blocked', 'ready', 'done');
+
+-- CreateTable
+CREATE TABLE "public"."Department" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "color" TEXT,
+    "isCore" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Department_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."DepartmentMembership" (
+    "id" TEXT NOT NULL,
+    "departmentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "public"."DepartmentMembershipRole" NOT NULL DEFAULT 'member',
+    "title" TEXT,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DepartmentMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Character" (
+    "id" TEXT NOT NULL,
+    "showId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "shortName" TEXT,
+    "description" TEXT,
+    "notes" TEXT,
+    "color" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Character_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."CharacterCasting" (
+    "id" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" "public"."CharacterCastingType" NOT NULL DEFAULT 'primary',
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CharacterCasting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Scene" (
+    "id" TEXT NOT NULL,
+    "showId" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL DEFAULT 0,
+    "identifier" TEXT,
+    "title" TEXT,
+    "slug" TEXT,
+    "summary" TEXT,
+    "location" TEXT,
+    "timeOfDay" TEXT,
+    "durationMinutes" INTEGER,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Scene_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SceneCharacter" (
+    "id" TEXT NOT NULL,
+    "sceneId" TEXT NOT NULL,
+    "characterId" TEXT NOT NULL,
+    "isFeatured" BOOLEAN NOT NULL DEFAULT false,
+    "note" TEXT,
+    "order" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "SceneCharacter_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SceneBreakdownItem" (
+    "id" TEXT NOT NULL,
+    "sceneId" TEXT NOT NULL,
+    "departmentId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "public"."BreakdownStatus" NOT NULL DEFAULT 'planned',
+    "neededBy" TIMESTAMP(3),
+    "note" TEXT,
+    "assignedToId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SceneBreakdownItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Department_slug_key" ON "public"."Department"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DepartmentMembership_departmentId_userId_key" ON "public"."DepartmentMembership"("departmentId", "userId");
+
+-- CreateIndex
+CREATE INDEX "Character_showId_order_idx" ON "public"."Character"("showId", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CharacterCasting_characterId_userId_type_key" ON "public"."CharacterCasting"("characterId", "userId", "type");
+
+-- CreateIndex
+CREATE INDEX "Scene_showId_sequence_idx" ON "public"."Scene"("showId", "sequence");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Scene_showId_slug_key" ON "public"."Scene"("showId", "slug");
+
+-- CreateIndex
+CREATE INDEX "SceneCharacter_characterId_idx" ON "public"."SceneCharacter"("characterId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SceneCharacter_sceneId_characterId_key" ON "public"."SceneCharacter"("sceneId", "characterId");
+
+-- CreateIndex
+CREATE INDEX "SceneBreakdownItem_sceneId_departmentId_idx" ON "public"."SceneBreakdownItem"("sceneId", "departmentId");
+
+-- AddForeignKey
+ALTER TABLE "public"."DepartmentMembership" ADD CONSTRAINT "DepartmentMembership_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "public"."Department"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."DepartmentMembership" ADD CONSTRAINT "DepartmentMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Character" ADD CONSTRAINT "Character_showId_fkey" FOREIGN KEY ("showId") REFERENCES "public"."Show"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."CharacterCasting" ADD CONSTRAINT "CharacterCasting_characterId_fkey" FOREIGN KEY ("characterId") REFERENCES "public"."Character"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."CharacterCasting" ADD CONSTRAINT "CharacterCasting_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Scene" ADD CONSTRAINT "Scene_showId_fkey" FOREIGN KEY ("showId") REFERENCES "public"."Show"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SceneCharacter" ADD CONSTRAINT "SceneCharacter_sceneId_fkey" FOREIGN KEY ("sceneId") REFERENCES "public"."Scene"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SceneCharacter" ADD CONSTRAINT "SceneCharacter_characterId_fkey" FOREIGN KEY ("characterId") REFERENCES "public"."Character"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SceneBreakdownItem" ADD CONSTRAINT "SceneBreakdownItem_sceneId_fkey" FOREIGN KEY ("sceneId") REFERENCES "public"."Scene"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SceneBreakdownItem" ADD CONSTRAINT "SceneBreakdownItem_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "public"."Department"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SceneBreakdownItem" ADD CONSTRAINT "SceneBreakdownItem_assignedToId_fkey" FOREIGN KEY ("assignedToId") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,28 @@ enum Role {
   admin
 }
 
+enum DepartmentMembershipRole {
+  lead
+  member
+  deputy
+  guest
+}
+
+enum CharacterCastingType {
+  primary
+  alternate
+  cover
+  cameo
+}
+
+enum BreakdownStatus {
+  planned
+  in_progress
+  blocked
+  ready
+  done
+}
+
 enum AvatarSource {
   GRAVATAR
   UPLOAD
@@ -167,6 +189,9 @@ model User {
   rehearsalInvites       RehearsalInvitee[]
   photoConsent           PhotoConsent?
   approvedPhotoConsents  PhotoConsent[] @relation("PhotoConsentApprover")
+  departmentMemberships  DepartmentMembership[]
+  characterCastings      CharacterCasting[]
+  breakdownAssignments   SceneBreakdownItem[] @relation("BreakdownAssignee")
 }
 
 model Account {
@@ -218,6 +243,123 @@ model Show {
   finance    FinanceEntry[]
   guesses    Guess[]
   proposals  RehearsalProposal[]
+  characters Character[]
+  scenes     Scene[]
+}
+
+model Department {
+  id          String   @id @default(cuid())
+  slug        String   @unique
+  name        String
+  description String?
+  color       String?
+  isCore      Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  memberships DepartmentMembership[]
+  breakdownItems SceneBreakdownItem[]
+}
+
+model DepartmentMembership {
+  id           String                  @id @default(cuid())
+  departmentId String
+  userId       String
+  role         DepartmentMembershipRole @default(member)
+  title        String?
+  note         String?
+  createdAt    DateTime                @default(now())
+  updatedAt    DateTime                @updatedAt
+  department   Department              @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  user         User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([departmentId, userId], name: "departmentId_userId")
+}
+
+model Character {
+  id             String            @id @default(cuid())
+  showId         String
+  name           String
+  shortName      String?
+  description    String?
+  notes          String?
+  color          String?
+  order          Int               @default(0)
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+  show           Show              @relation(fields: [showId], references: [id], onDelete: Cascade)
+  castings       CharacterCasting[]
+  sceneAppearances SceneCharacter[]
+
+  @@index([showId, order])
+}
+
+model CharacterCasting {
+  id          String               @id @default(cuid())
+  characterId String
+  userId      String
+  type        CharacterCastingType @default(primary)
+  notes       String?
+  createdAt   DateTime             @default(now())
+  updatedAt   DateTime             @updatedAt
+  character   Character            @relation(fields: [characterId], references: [id], onDelete: Cascade)
+  user        User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([characterId, userId, type], name: "characterId_userId_type")
+}
+
+model Scene {
+  id              String   @id @default(cuid())
+  showId          String
+  sequence        Int      @default(0)
+  identifier      String?
+  title           String?
+  slug            String?
+  summary         String?
+  location        String?
+  timeOfDay       String?
+  durationMinutes Int?
+  notes           String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  show            Show     @relation(fields: [showId], references: [id], onDelete: Cascade)
+  characters      SceneCharacter[]
+  breakdownItems  SceneBreakdownItem[]
+
+  @@unique([showId, slug], name: "showId_slug")
+  @@index([showId, sequence])
+}
+
+model SceneCharacter {
+  id          String   @id @default(cuid())
+  sceneId     String
+  characterId String
+  isFeatured  Boolean  @default(false)
+  note        String?
+  order       Int      @default(0)
+  scene       Scene    @relation(fields: [sceneId], references: [id], onDelete: Cascade)
+  character   Character @relation(fields: [characterId], references: [id], onDelete: Cascade)
+
+  @@unique([sceneId, characterId], name: "sceneId_characterId")
+  @@index([characterId])
+}
+
+model SceneBreakdownItem {
+  id            String          @id @default(cuid())
+  sceneId       String
+  departmentId  String
+  title         String
+  description   String?
+  status        BreakdownStatus @default(planned)
+  neededBy      DateTime?
+  note          String?
+  assignedToId  String?
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+  scene         Scene           @relation(fields: [sceneId], references: [id], onDelete: Cascade)
+  department    Department      @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  assignedTo    User?           @relation("BreakdownAssignee", fields: [assignedToId], references: [id], onDelete: SetNull)
+
+  @@index([sceneId, departmentId])
 }
 
 model Clue {

--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -1,0 +1,805 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { CharacterCastingType, BreakdownStatus } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+import {
+  createCharacterAction,
+  updateCharacterAction,
+  deleteCharacterAction,
+  assignCharacterCastingAction,
+  updateCharacterCastingAction,
+  removeCharacterCastingAction,
+  createSceneAction,
+  updateSceneAction,
+  deleteSceneAction,
+  addSceneCharacterAction,
+  removeSceneCharacterAction,
+  createBreakdownItemAction,
+  updateBreakdownItemAction,
+  removeBreakdownItemAction,
+} from "../actions";
+
+const CASTING_LABELS: Record<CharacterCastingType, string> = {
+  primary: "Primär",
+  alternate: "Alternate",
+  cover: "Cover",
+  cameo: "Cameo",
+};
+
+const CASTING_ORDER: CharacterCastingType[] = [
+  CharacterCastingType.primary,
+  CharacterCastingType.alternate,
+  CharacterCastingType.cover,
+  CharacterCastingType.cameo,
+];
+
+const STATUS_LABELS: Record<BreakdownStatus, string> = {
+  planned: "Geplant",
+  in_progress: "In Arbeit",
+  blocked: "Blockiert",
+  ready: "Bereit",
+  done: "Erledigt",
+};
+
+const selectSmallClassName =
+  "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+function formatUserName(user: { name: string | null; email: string | null }) {
+  if (user.name && user.name.trim()) return user.name;
+  if (user.email) return user.email;
+  return "Unbekannt";
+}
+
+export default async function ProduktionDetailPage({ params }: { params: { showId: string } }) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.produktionen");
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-border/70 bg-background/60 p-6 text-sm text-muted-foreground">
+        Du hast keinen Zugriff auf diese Produktion.
+      </div>
+    );
+  }
+
+  const [show, departments, users] = await Promise.all([
+    prisma.show.findUnique({
+      where: { id: params.showId },
+      select: {
+        id: true,
+        title: true,
+        year: true,
+        synopsis: true,
+        characters: {
+          orderBy: { order: "asc" },
+          select: {
+            id: true,
+            name: true,
+            shortName: true,
+            description: true,
+            notes: true,
+            color: true,
+            order: true,
+            castings: {
+              select: {
+                id: true,
+                type: true,
+                notes: true,
+                user: { select: { id: true, name: true, email: true } },
+              },
+            },
+          },
+        },
+        scenes: {
+          orderBy: { sequence: "asc" },
+          select: {
+            id: true,
+            identifier: true,
+            title: true,
+            summary: true,
+            location: true,
+            timeOfDay: true,
+            notes: true,
+            sequence: true,
+            durationMinutes: true,
+            slug: true,
+            characters: {
+              orderBy: { order: "asc" },
+              select: {
+                id: true,
+                isFeatured: true,
+                order: true,
+                character: { select: { id: true, name: true, shortName: true, color: true } },
+              },
+            },
+            breakdownItems: {
+              orderBy: { createdAt: "asc" },
+              select: {
+                id: true,
+                title: true,
+                description: true,
+                note: true,
+                status: true,
+                neededBy: true,
+                department: { select: { id: true, name: true, slug: true, color: true } },
+                assignedToId: true,
+                assignedTo: { select: { id: true, name: true, email: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.department.findMany({ orderBy: { name: "asc" }, select: { id: true, name: true, slug: true, color: true } }),
+    prisma.user.findMany({
+      orderBy: [
+        { name: "asc" },
+        { email: "asc" },
+      ],
+      select: { id: true, name: true, email: true },
+    }),
+  ]);
+
+  if (!show) {
+    notFound();
+  }
+
+  const showPath = `/mitglieder/produktionen/${show.id}`;
+  const statusOptions = Object.values(BreakdownStatus);
+
+  return (
+    <div className="space-y-12">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Produktion {show.year}</p>
+          <h1 className="text-2xl font-semibold">{show.title ?? `Produktion ${show.year}`}</h1>
+          {show.synopsis ? (
+            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{show.synopsis}</p>
+          ) : null}
+        </div>
+        <Button asChild variant="ghost">
+          <Link href="/mitglieder/produktionen">Zur Übersicht</Link>
+        </Button>
+      </div>
+
+      <section className="space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold">Figuren &amp; Besetzungen</h2>
+          <p className="text-sm text-muted-foreground">
+            Lege neue Rollen an, pflege Beschreibungen und ordne Ensemble-Mitglieder mit Primär-, Alternate- oder Cover-Funktionen zu.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border/70 bg-background/60 p-6">
+          <h3 className="text-lg font-medium">Neue Rolle anlegen</h3>
+          <form action={createCharacterAction} method="post" className="mt-4 grid gap-4 md:grid-cols-2">
+            <input type="hidden" name="showId" value={show.id} />
+            <input type="hidden" name="redirectPath" value={showPath} />
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Name</label>
+              <Input name="name" placeholder="z.B. Protagonist" minLength={2} maxLength={120} required />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Kurzname</label>
+              <Input name="shortName" placeholder="Kurzlabel" maxLength={40} />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Beschreibung</label>
+              <Textarea name="description" rows={2} maxLength={500} placeholder="Charakterbeschreibung" />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Farbe</label>
+              <input
+                type="color"
+                name="color"
+                defaultValue="#7c3aed"
+                className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Sortierung</label>
+              <Input type="number" name="order" min={0} max={9999} placeholder="0" />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Notiz</label>
+              <Textarea name="notes" rows={2} maxLength={500} placeholder="interne Notiz" />
+            </div>
+            <div className="md:col-span-2">
+              <Button type="submit">Rolle speichern</Button>
+            </div>
+          </form>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-2">
+          {show.characters.map((character) => {
+            const sortedCastings = [...character.castings].sort((a, b) => {
+              const orderA = CASTING_ORDER.indexOf(a.type);
+              const orderB = CASTING_ORDER.indexOf(b.type);
+              return orderA - orderB;
+            });
+            return (
+              <div key={character.id} className="flex flex-col gap-4 rounded-lg border border-border/70 bg-background/60 p-6">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-lg font-semibold">{character.name}</h3>
+                    {character.shortName ? (
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">{character.shortName}</p>
+                    ) : null}
+                    {character.description ? (
+                      <p className="mt-2 text-sm text-muted-foreground">{character.description}</p>
+                    ) : null}
+                    {character.notes ? (
+                      <p className="mt-1 text-xs text-muted-foreground">Notiz: {character.notes}</p>
+                    ) : null}
+                  </div>
+                  <form action={deleteCharacterAction} method="post">
+                    <input type="hidden" name="characterId" value={character.id} />
+                    <input type="hidden" name="redirectPath" value={showPath} />
+                    <Button type="submit" variant="ghost" size="sm">
+                      Entfernen
+                    </Button>
+                  </form>
+                </div>
+
+                <form
+                  action={updateCharacterAction}
+                  method="post"
+                  className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
+                >
+                  <input type="hidden" name="characterId" value={character.id} />
+                  <input type="hidden" name="redirectPath" value={showPath} />
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
+                      <Input name="name" defaultValue={character.name} minLength={2} maxLength={120} required />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Kurzname</label>
+                      <Input name="shortName" defaultValue={character.shortName ?? ""} maxLength={40} />
+                    </div>
+                    <div className="space-y-1 md:col-span-2">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Beschreibung
+                      </label>
+                      <Textarea name="description" rows={2} maxLength={500} defaultValue={character.description ?? ""} />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Sortierung</label>
+                      <Input type="number" name="order" defaultValue={character.order ?? 0} min={0} max={9999} />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Farbe</label>
+                      <input
+                        type="color"
+                        name="color"
+                        defaultValue={character.color ?? "#7c3aed"}
+                        className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+                      />
+                    </div>
+                    <div className="space-y-1 md:col-span-2">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+                      <Textarea name="notes" rows={2} maxLength={500} defaultValue={character.notes ?? ""} />
+                    </div>
+                  </div>
+                  <div className="flex justify-end">
+                    <Button type="submit" variant="outline" size="sm">
+                      Rolle aktualisieren
+                    </Button>
+                  </div>
+                </form>
+
+                <div className="space-y-3">
+                  <h4 className="text-sm font-semibold">Besetzung</h4>
+                  <div className="space-y-3">
+                    {sortedCastings.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">Noch keine Besetzung zugeordnet.</p>
+                    ) : (
+                      sortedCastings.map((casting) => (
+                        <div
+                          key={casting.id}
+                          className="rounded-md border border-border/60 bg-background/80 p-3 text-sm"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div>
+                              <p className="font-medium">{formatUserName(casting.user)}</p>
+                              <p className="text-xs text-muted-foreground">{CASTING_LABELS[casting.type]}</p>
+                              {casting.notes ? (
+                                <p className="text-xs text-muted-foreground">Notiz: {casting.notes}</p>
+                              ) : null}
+                            </div>
+                            <form action={removeCharacterCastingAction} method="post">
+                              <input type="hidden" name="castingId" value={casting.id} />
+                              <input type="hidden" name="redirectPath" value={showPath} />
+                              <Button type="submit" variant="ghost" size="sm">
+                                Entfernen
+                              </Button>
+                            </form>
+                          </div>
+                          <form
+                            action={updateCharacterCastingAction}
+                            method="post"
+                            className="mt-3 grid gap-2 md:grid-cols-3"
+                          >
+                            <input type="hidden" name="castingId" value={casting.id} />
+                            <input type="hidden" name="redirectPath" value={showPath} />
+                            <div className="space-y-1">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Besetzungsart
+                              </label>
+                              <select name="type" defaultValue={casting.type} className={selectSmallClassName}>
+                                {CASTING_ORDER.map((type) => (
+                                  <option key={type} value={type}>
+                                    {CASTING_LABELS[type]}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                            <div className="space-y-1 md:col-span-2">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+                              <Input name="notes" defaultValue={casting.notes ?? ""} maxLength={200} />
+                            </div>
+                            <div className="md:col-span-3 flex justify-end">
+                              <Button type="submit" variant="outline" size="sm">
+                                Speichern
+                              </Button>
+                            </div>
+                          </form>
+                        </div>
+                      ))
+                    )}
+                  </div>
+
+                  <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-3">
+                    <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Mitglied zuordnen
+                    </h5>
+                    <form className="mt-2 grid gap-2 md:grid-cols-4" action={assignCharacterCastingAction} method="post">
+                      <input type="hidden" name="characterId" value={character.id} />
+                      <input type="hidden" name="redirectPath" value={showPath} />
+                      <div className="space-y-1 md:col-span-2">
+                        <label className="text-xs font-medium text-muted-foreground">Mitglied</label>
+                        <select name="userId" className={selectSmallClassName} required>
+                          <option value="">Mitglied auswählen</option>
+                          {users.map((user) => (
+                            <option key={user.id} value={user.id}>
+                              {formatUserName(user)}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium text-muted-foreground">Besetzungsart</label>
+                        <select
+                          name="type"
+                          className={selectSmallClassName}
+                          defaultValue={CharacterCastingType.primary}
+                        >
+                          {CASTING_ORDER.map((type) => (
+                            <option key={type} value={type}>
+                              {CASTING_LABELS[type]}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium text-muted-foreground">Notiz</label>
+                        <Input name="notes" maxLength={200} placeholder="optional" />
+                      </div>
+                      <div className="md:col-span-4 flex justify-end">
+                        <Button type="submit" size="sm">
+                          Mitglied besetzen
+                        </Button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold">Szenen &amp; Breakdowns</h2>
+          <p className="text-sm text-muted-foreground">
+            Pflege Szeneninformationen, setze Rollenauftritte und dokumentiere Aufgaben für Gewerke mit Status und Zuständigkeiten.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border/70 bg-background/60 p-6">
+          <h3 className="text-lg font-medium">Neue Szene anlegen</h3>
+          <form action={createSceneAction} method="post" className="mt-4 grid gap-4 md:grid-cols-3">
+            <input type="hidden" name="showId" value={show.id} />
+            <input type="hidden" name="redirectPath" value={showPath} />
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Nummer</label>
+              <Input name="identifier" maxLength={40} placeholder="z.B. 1" />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Titel</label>
+              <Input name="title" maxLength={160} placeholder="z.B. Ankunft im Park" />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Ort</label>
+              <Input name="location" maxLength={120} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Tageszeit</label>
+              <Input name="timeOfDay" maxLength={60} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Slug</label>
+              <Input name="slug" maxLength={80} placeholder="szene-1" />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Reihenfolge</label>
+              <Input type="number" name="sequence" min={0} max={9999} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Dauer (Minuten)</label>
+              <Input type="number" name="duration" min={0} max={600} />
+            </div>
+            <div className="space-y-1 md:col-span-3">
+              <label className="text-sm font-medium">Zusammenfassung</label>
+              <Textarea name="summary" rows={2} maxLength={600} />
+            </div>
+            <div className="space-y-1 md:col-span-3">
+              <label className="text-sm font-medium">Notizen</label>
+              <Textarea name="notes" rows={2} maxLength={400} />
+            </div>
+            <div className="md:col-span-3">
+              <Button type="submit">Szene speichern</Button>
+            </div>
+          </form>
+        </div>
+
+        <div className="space-y-6">
+          {show.scenes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Noch keine Szenen erfasst.</p>
+          ) : (
+            show.scenes.map((scene) => {
+              const assignedCharacterIds = new Set(scene.characters.map((entry) => entry.character.id));
+              const availableCharacters = show.characters.filter((character) => !assignedCharacterIds.has(character.id));
+              return (
+                <div key={scene.id} className="flex flex-col gap-5 rounded-lg border border-border/70 bg-background/60 p-6">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs uppercase tracking-wide text-muted-foreground">Szene {scene.identifier ?? "?"}</span>
+                        <span className="text-sm text-muted-foreground">#{scene.sequence ?? 0}</span>
+                      </div>
+                      <h3 className="text-lg font-semibold">{scene.title ?? "(ohne Titel)"}</h3>
+                      {scene.summary ? (
+                        <p className="mt-1 text-sm text-muted-foreground">{scene.summary}</p>
+                      ) : null}
+                      <div className="mt-1 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                        {scene.location ? <span>Ort: {scene.location}</span> : null}
+                        {scene.timeOfDay ? <span>Tageszeit: {scene.timeOfDay}</span> : null}
+                        {scene.durationMinutes ? <span>Dauer: {scene.durationMinutes} min</span> : null}
+                      </div>
+                    </div>
+                    <form action={deleteSceneAction} method="post">
+                      <input type="hidden" name="sceneId" value={scene.id} />
+                      <input type="hidden" name="redirectPath" value={showPath} />
+                      <Button type="submit" variant="ghost" size="sm">
+                        Entfernen
+                      </Button>
+                    </form>
+                  </div>
+
+                  <form
+                    action={updateSceneAction}
+                    method="post"
+                    className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
+                  >
+                    <input type="hidden" name="sceneId" value={scene.id} />
+                    <input type="hidden" name="redirectPath" value={showPath} />
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Nummer</label>
+                        <Input name="identifier" defaultValue={scene.identifier ?? ""} maxLength={40} />
+                      </div>
+                      <div className="space-y-1 md:col-span-2">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Titel</label>
+                        <Input name="title" defaultValue={scene.title ?? ""} maxLength={160} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Slug</label>
+                        <Input name="slug" defaultValue={scene.slug ?? ""} maxLength={80} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Ort</label>
+                        <Input name="location" defaultValue={scene.location ?? ""} maxLength={120} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Tageszeit</label>
+                        <Input name="timeOfDay" defaultValue={scene.timeOfDay ?? ""} maxLength={60} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Reihenfolge</label>
+                        <Input
+                          type="number"
+                          name="sequence"
+                          defaultValue={scene.sequence ?? 0}
+                          min={0}
+                          max={9999}
+                        />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Dauer (Minuten)</label>
+                        <Input
+                          type="number"
+                          name="duration"
+                          defaultValue={scene.durationMinutes ?? ""}
+                          min={0}
+                          max={600}
+                        />
+                      </div>
+                      <div className="space-y-1 md:col-span-3">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Zusammenfassung</label>
+                        <Textarea name="summary" rows={2} maxLength={600} defaultValue={scene.summary ?? ""} />
+                      </div>
+                      <div className="space-y-1 md:col-span-3">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notizen</label>
+                        <Textarea name="notes" rows={2} maxLength={400} defaultValue={scene.notes ?? ""} />
+                      </div>
+                    </div>
+                    <div className="flex justify-end">
+                      <Button type="submit" variant="outline" size="sm">
+                        Szene aktualisieren
+                      </Button>
+                    </div>
+                  </form>
+
+                  <div className="space-y-3">
+                    <h4 className="text-sm font-semibold">Rolleneinsatz</h4>
+                    {scene.characters.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">Keine Figuren in dieser Szene.</p>
+                    ) : (
+                      <div className="flex flex-wrap gap-2">
+                        {scene.characters.map((entry) => (
+                          <form
+                            key={entry.id}
+                            action={removeSceneCharacterAction}
+                            method="post"
+                            className="flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1"
+                          >
+                            <input type="hidden" name="assignmentId" value={entry.id} />
+                            <input type="hidden" name="redirectPath" value={showPath} />
+                            <span className="text-sm font-medium">{entry.character.name}</span>
+                            <Button type="submit" variant="ghost" size="sm">
+                              ×
+                            </Button>
+                          </form>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-3">
+                      <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Figur hinzufügen
+                      </h5>
+                      <form className="mt-2 grid gap-2 md:grid-cols-4" action={addSceneCharacterAction} method="post">
+                        <input type="hidden" name="sceneId" value={scene.id} />
+                        <input type="hidden" name="redirectPath" value={showPath} />
+                        <div className="space-y-1 md:col-span-2">
+                          <label className="text-xs font-medium text-muted-foreground">Figur</label>
+                          <select name="characterId" className={selectSmallClassName} required>
+                            <option value="">Figur auswählen</option>
+                            {availableCharacters.map((characterOption) => (
+                              <option key={characterOption.id} value={characterOption.id}>
+                                {characterOption.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <label className="text-xs font-medium text-muted-foreground">Sortierung</label>
+                          <Input type="number" name="order" min={0} max={9999} />
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <input type="checkbox" name="isFeatured" className="h-4 w-4 rounded border-border" />
+                          <span className="text-xs text-muted-foreground">Hervorgehoben</span>
+                        </div>
+                        <div className="md:col-span-4 flex justify-end">
+                          <Button type="submit" size="sm">
+                            Figur zuordnen
+                          </Button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    <h4 className="text-sm font-semibold">Breakdown</h4>
+                    <div className="space-y-3">
+                      {scene.breakdownItems.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">Noch keine Aufgaben hinterlegt.</p>
+                      ) : (
+                        scene.breakdownItems.map((item) => (
+                          <div key={item.id} className="rounded-md border border-border/60 bg-background/80 p-4 text-sm">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div>
+                                <p className="font-medium">{item.title}</p>
+                                <p className="text-xs text-muted-foreground">
+                                  {item.department.name} · Status: {STATUS_LABELS[item.status]}
+                                </p>
+                                {item.assignedTo ? (
+                                  <p className="text-xs text-muted-foreground">
+                                    Zuständig: {formatUserName(item.assignedTo)}
+                                  </p>
+                                ) : null}
+                              </div>
+                              <form action={removeBreakdownItemAction} method="post">
+                                <input type="hidden" name="itemId" value={item.id} />
+                                <input type="hidden" name="redirectPath" value={showPath} />
+                                <Button type="submit" variant="ghost" size="sm">
+                                  Entfernen
+                                </Button>
+                              </form>
+                            </div>
+                            {item.description ? (
+                              <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
+                            ) : null}
+                            {item.note ? (
+                              <p className="text-xs text-muted-foreground">Notiz: {item.note}</p>
+                            ) : null}
+                            {item.neededBy ? (
+                              <p className="text-xs text-muted-foreground">
+                                Benötigt bis: {item.neededBy.toISOString().slice(0, 10)}
+                              </p>
+                            ) : null}
+                            <form
+                              action={updateBreakdownItemAction}
+                              method="post"
+                              className="mt-3 grid gap-2 md:grid-cols-4"
+                            >
+                              <input type="hidden" name="itemId" value={item.id} />
+                              <input type="hidden" name="redirectPath" value={showPath} />
+                              <div className="space-y-1 md:col-span-2">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Titel
+                                </label>
+                                <Input name="title" defaultValue={item.title} maxLength={160} />
+                              </div>
+                              <div className="space-y-1">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Status
+                                </label>
+                                <select name="status" defaultValue={item.status} className={selectSmallClassName}>
+                                  {statusOptions.map((status) => (
+                                    <option key={status} value={status}>
+                                      {STATUS_LABELS[status]}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                              <div className="space-y-1">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Benötigt bis
+                                </label>
+                                <Input
+                                  type="date"
+                                  name="neededBy"
+                                  defaultValue={item.neededBy ? item.neededBy.toISOString().slice(0, 10) : ""}
+                                />
+                              </div>
+                              <div className="space-y-1 md:col-span-4">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Beschreibung
+                                </label>
+                                <Textarea name="description" rows={2} maxLength={600} defaultValue={item.description ?? ""} />
+                              </div>
+                              <div className="space-y-1 md:col-span-2">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Notiz
+                                </label>
+                                <Input name="note" defaultValue={item.note ?? ""} maxLength={300} />
+                              </div>
+                              <div className="space-y-1 md:col-span-2">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Zuständig
+                                </label>
+                                <select
+                                  name="assignedToId"
+                                  defaultValue={item.assignedToId ?? ""}
+                                  className={selectSmallClassName}
+                                >
+                                  <option value="">(keine Zuordnung)</option>
+                                  {users.map((user) => (
+                                    <option key={user.id} value={user.id}>
+                                      {formatUserName(user)}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                              <div className="md:col-span-4 flex justify-end">
+                                <Button type="submit" variant="outline" size="sm">
+                                  Speichern
+                                </Button>
+                              </div>
+                            </form>
+                          </div>
+                        ))
+                      )}
+                    </div>
+
+                    <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-3">
+                      <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Breakdown-Eintrag hinzufügen
+                      </h5>
+                      <form className="mt-2 grid gap-2 md:grid-cols-4" action={createBreakdownItemAction} method="post">
+                        <input type="hidden" name="sceneId" value={scene.id} />
+                        <input type="hidden" name="redirectPath" value={showPath} />
+                        <div className="space-y-1 md:col-span-2">
+                          <label className="text-xs font-medium text-muted-foreground">Gewerk</label>
+                          <select name="departmentId" className={selectSmallClassName} required>
+                            <option value="">Gewerk auswählen</option>
+                            {departments.map((departmentOption) => (
+                              <option key={departmentOption.id} value={departmentOption.id}>
+                                {departmentOption.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <label className="text-xs font-medium text-muted-foreground">Status</label>
+                          <select name="status" className={selectSmallClassName} defaultValue={BreakdownStatus.planned}>
+                            {statusOptions.map((status) => (
+                              <option key={status} value={status}>
+                                {STATUS_LABELS[status]}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <label className="text-xs font-medium text-muted-foreground">Benötigt bis</label>
+                          <Input type="date" name="neededBy" />
+                        </div>
+                        <div className="space-y-1 md:col-span-4">
+                          <label className="text-xs font-medium text-muted-foreground">Titel</label>
+                          <Input name="title" maxLength={160} required placeholder="Aufgabe" />
+                        </div>
+                        <div className="space-y-1 md:col-span-4">
+                          <label className="text-xs font-medium text-muted-foreground">Beschreibung</label>
+                          <Textarea name="description" rows={2} maxLength={600} placeholder="Details zur Aufgabe" />
+                        </div>
+                        <div className="space-y-1 md:col-span-2">
+                          <label className="text-xs font-medium text-muted-foreground">Zuständig</label>
+                          <select name="assignedToId" className={selectSmallClassName}>
+                            <option value="">(optional)</option>
+                            {users.map((user) => (
+                              <option key={user.id} value={user.id}>
+                                {formatUserName(user)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1 md:col-span-4">
+                          <label className="text-xs font-medium text-muted-foreground">Notiz</label>
+                          <Input name="note" maxLength={300} placeholder="interne Notiz" />
+                        </div>
+                        <div className="md:col-span-4 flex justify-end">
+                          <Button type="submit" size="sm">
+                            Breakdown speichern
+                          </Button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -1,0 +1,930 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import {
+  Prisma,
+  DepartmentMembershipRole,
+  CharacterCastingType,
+  BreakdownStatus,
+} from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+
+type ActionResult = { success: true } | { error: string };
+
+type ReadOptions = {
+  minLength?: number;
+  maxLength?: number;
+  label?: string;
+};
+
+function isString(value: FormDataEntryValue | null | undefined): value is string {
+  return typeof value === "string";
+}
+
+function readOptionalString(formData: FormData, key: string, options?: ReadOptions): string | undefined {
+  const raw = formData.get(key);
+  if (!isString(raw)) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (options?.minLength && trimmed.length < options.minLength) {
+    throw new Error(
+      `${options?.label ?? key} muss mindestens ${options.minLength} Zeichen enthalten.`,
+    );
+  }
+  if (options?.maxLength && trimmed.length > options.maxLength) {
+    throw new Error(
+      `${options?.label ?? key} darf höchstens ${options.maxLength} Zeichen enthalten.`,
+    );
+  }
+  return trimmed;
+}
+
+function readString(formData: FormData, key: string, options?: ReadOptions): string {
+  const value = readOptionalString(formData, key, options);
+  if (value === undefined) {
+    throw new Error(`${options?.label ?? key} ist erforderlich.`);
+  }
+  return value;
+}
+
+function readOptionalInt(
+  formData: FormData,
+  key: string,
+  options?: { label?: string; min?: number; max?: number },
+): number | undefined {
+  const raw = readOptionalString(formData, key, { label: options?.label });
+  if (raw === undefined) return undefined;
+  const value = Number.parseInt(raw, 10);
+  if (Number.isNaN(value)) {
+    throw new Error(`${options?.label ?? key} muss eine Zahl sein.`);
+  }
+  if (options?.min !== undefined && value < options.min) {
+    throw new Error(`${options?.label ?? key} muss mindestens ${options.min} sein.`);
+  }
+  if (options?.max !== undefined && value > options.max) {
+    throw new Error(`${options?.label ?? key} darf höchstens ${options.max} sein.`);
+  }
+  return value;
+}
+
+function parseEnumValue<T extends Record<string, string>>(
+  enumeration: T,
+  raw: FormDataEntryValue | null | undefined,
+  label: string,
+  options?: { optional?: boolean },
+): T[keyof T] | undefined {
+  if (!isString(raw) || !raw.trim()) {
+    if (options?.optional) return undefined;
+    throw new Error(`${label} ist erforderlich.`);
+  }
+  const normalized = raw.trim();
+  const values = Object.values(enumeration) as string[];
+  if (!values.includes(normalized)) {
+    throw new Error(`${label} ist ungültig.`);
+  }
+  return normalized as T[keyof T];
+}
+
+function parseCheckbox(value: FormDataEntryValue | null | undefined) {
+  if (!isString(value)) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "on" || normalized === "true" || normalized === "1";
+}
+
+function parseColor(raw?: string) {
+  if (!raw) return undefined;
+  const value = raw.trim();
+  if (!value) return undefined;
+  if (!/^#(?:[0-9a-fA-F]{6})$/.test(value)) {
+    throw new Error("Farbwert muss im Format #RRGGBB angegeben werden.");
+  }
+  return value.toLowerCase();
+}
+
+function parseOptionalDate(formData: FormData, key: string, label: string) {
+  const raw = readOptionalString(formData, key, { label });
+  if (!raw) return undefined;
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${label} enthält kein gültiges Datum.`);
+  }
+  return date;
+}
+
+function slugify(value: string) {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/--+/g, "-")
+    .slice(0, 60);
+}
+
+async function ensureUniqueDepartmentSlug(base: string, excludeId?: string) {
+  const normalized = base || `gewerk-${Math.random().toString(36).slice(2, 8)}`;
+  let candidate = normalized;
+  let counter = 2;
+  while (true) {
+    const existing = await prisma.department.findFirst({
+      where: {
+        slug: candidate,
+        ...(excludeId ? { id: { not: excludeId } } : {}),
+      },
+      select: { id: true },
+    });
+    if (!existing) return candidate;
+    candidate = `${normalized}-${counter++}`;
+  }
+}
+
+async function ensureUniqueSceneSlug(showId: string, base: string, excludeId?: string) {
+  const normalized = base || `scene-${Math.random().toString(36).slice(2, 8)}`;
+  let candidate = normalized;
+  let counter = 2;
+  while (true) {
+    const existing = await prisma.scene.findFirst({
+      where: {
+        showId,
+        slug: candidate,
+        ...(excludeId ? { id: { not: excludeId } } : {}),
+      },
+      select: { id: true },
+    });
+    if (!existing) return candidate;
+    candidate = `${normalized}-${counter++}`;
+  }
+}
+
+function parseRedirectPath(formData: FormData) {
+  const raw = formData.get("redirectPath");
+  if (!isString(raw)) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed || !trimmed.startsWith("/")) return undefined;
+  return trimmed;
+}
+
+async function ensureProductionManager() {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+  if (!userId) {
+    return { ok: false as const, error: "Keine Berechtigung." };
+  }
+  const allowed = await hasPermission(session.user, "mitglieder.produktionen");
+  if (!allowed) {
+    return { ok: false as const, error: "Keine Berechtigung." };
+  }
+  return { ok: true as const, userId };
+}
+
+function revalidateDepartments(redirectPath?: string) {
+  revalidatePath("/mitglieder/produktionen");
+  if (redirectPath && redirectPath !== "/mitglieder/produktionen") {
+    revalidatePath(redirectPath);
+  }
+}
+
+function revalidateShow(showId: string, redirectPath?: string, includeList = false) {
+  const target = `/mitglieder/produktionen/${showId}`;
+  if (includeList) {
+    revalidatePath("/mitglieder/produktionen");
+  }
+  revalidatePath(target);
+  if (redirectPath && redirectPath !== target && redirectPath !== "/mitglieder/produktionen") {
+    revalidatePath(redirectPath);
+  }
+}
+
+export async function createDepartmentAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const name = readString(formData, "name", { label: "Name", minLength: 2, maxLength: 80 });
+    const slugInput = readOptionalString(formData, "slug", { label: "Slug", maxLength: 80 });
+    if (slugInput && !/^[a-z0-9-]+$/i.test(slugInput)) {
+      throw new Error("Slug darf nur Buchstaben, Zahlen und Bindestriche enthalten.");
+    }
+    const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 2000 });
+    const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
+    const baseSlug = slugify(slugInput ?? name);
+    const slug = await ensureUniqueDepartmentSlug(baseSlug);
+
+    await prisma.department.create({
+      data: {
+        name,
+        slug,
+        description: description ?? null,
+        color: color ?? null,
+      },
+    });
+
+    revalidateDepartments(redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("createDepartmentAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Gewerk konnte nicht angelegt werden.",
+    };
+  }
+}
+
+export async function updateDepartmentAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const id = readString(formData, "id", { label: "Gewerk" });
+    const department = await prisma.department.findUnique({ where: { id } });
+    if (!department) {
+      return { error: "Gewerk wurde nicht gefunden." };
+    }
+    const name = readString(formData, "name", { label: "Name", minLength: 2, maxLength: 80 });
+    const slugInput = readOptionalString(formData, "slug", { label: "Slug", maxLength: 80 });
+    if (slugInput && !/^[a-z0-9-]+$/i.test(slugInput)) {
+      throw new Error("Slug darf nur Buchstaben, Zahlen und Bindestriche enthalten.");
+    }
+    const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 2000 });
+    const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
+
+    let slug = department.slug;
+    if (slugInput) {
+      const baseSlug = slugify(slugInput);
+      slug = await ensureUniqueDepartmentSlug(baseSlug, department.id);
+    }
+
+    await prisma.department.update({
+      where: { id },
+      data: {
+        name,
+        slug,
+        description: description ?? null,
+        color: color ?? null,
+      },
+    });
+
+    revalidateDepartments(redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("updateDepartmentAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Gewerk konnte nicht aktualisiert werden.",
+    };
+  }
+}
+
+export async function deleteDepartmentAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const id = readString(formData, "id", { label: "Gewerk" });
+    await prisma.department.delete({ where: { id } });
+    revalidateDepartments(redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("deleteDepartmentAction", error);
+    return {
+      error: error instanceof Error
+        ? error.message
+        : "Gewerk konnte nicht gelöscht werden (ggf. bereits verwendet).",
+    };
+  }
+}
+
+export async function addDepartmentMemberAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const departmentId = readString(formData, "departmentId", { label: "Gewerk" });
+    const userId = readString(formData, "userId", { label: "Mitglied" });
+    const role =
+      parseEnumValue(DepartmentMembershipRole, formData.get("role"), "Funktion", { optional: true }) ??
+      DepartmentMembershipRole.member;
+    const titleValue = readOptionalString(formData, "title", { label: "Bezeichnung", maxLength: 120 });
+    const noteValue = readOptionalString(formData, "note", { label: "Notiz", maxLength: 200 });
+
+    const [department, user] = await Promise.all([
+      prisma.department.findUnique({ where: { id: departmentId } }),
+      prisma.user.findUnique({ where: { id: userId } }),
+    ]);
+    if (!department) return { error: "Gewerk wurde nicht gefunden." };
+    if (!user) return { error: "Mitglied wurde nicht gefunden." };
+
+    await prisma.departmentMembership.upsert({
+      where: { departmentId_userId: { departmentId, userId } },
+      update: {
+        role,
+        title: titleValue ?? null,
+        note: noteValue ?? null,
+      },
+      create: {
+        departmentId,
+        userId,
+        role,
+        title: titleValue ?? null,
+        note: noteValue ?? null,
+      },
+    });
+
+    revalidateDepartments(redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("addDepartmentMemberAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Mitglied konnte nicht hinzugefügt werden.",
+    };
+  }
+}
+
+export async function updateDepartmentMemberAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const membershipId = readString(formData, "membershipId", { label: "Mitgliedschaft" });
+    const membership = await prisma.departmentMembership.findUnique({
+      where: { id: membershipId },
+    });
+    if (!membership) {
+      return { error: "Mitgliedschaft wurde nicht gefunden." };
+    }
+
+    const role =
+      parseEnumValue(DepartmentMembershipRole, formData.get("role"), "Funktion", { optional: true }) ??
+      membership.role;
+    const titleValue = readOptionalString(formData, "title", { label: "Bezeichnung", maxLength: 120 });
+    const noteValue = readOptionalString(formData, "note", { label: "Notiz", maxLength: 200 });
+
+    await prisma.departmentMembership.update({
+      where: { id: membershipId },
+      data: {
+        role,
+        title: titleValue ?? null,
+        note: noteValue ?? null,
+      },
+    });
+
+    revalidateDepartments(redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("updateDepartmentMemberAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Mitglied konnte nicht aktualisiert werden.",
+    };
+  }
+}
+
+export async function removeDepartmentMemberAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const membershipId = readString(formData, "membershipId", { label: "Mitgliedschaft" });
+    await prisma.departmentMembership.delete({ where: { id: membershipId } });
+    revalidateDepartments(redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("removeDepartmentMemberAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Mitglied konnte nicht entfernt werden.",
+    };
+  }
+}
+
+export async function createCharacterAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const showId = readString(formData, "showId", { label: "Produktion" });
+    const show = await prisma.show.findUnique({ where: { id: showId }, select: { id: true } });
+    if (!show) return { error: "Produktion wurde nicht gefunden." };
+
+    const name = readString(formData, "name", { label: "Name", minLength: 2, maxLength: 120 });
+    const shortName = readOptionalString(formData, "shortName", { label: "Kurzname", maxLength: 40 });
+    const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 500 });
+    const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 500 });
+    const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
+    const orderValue = readOptionalInt(formData, "order", { label: "Sortierung", min: 0, max: 9999 });
+    const order =
+      orderValue ?? (await prisma.character.count({ where: { showId } })) ?? 0;
+
+    await prisma.character.create({
+      data: {
+        showId,
+        name,
+        shortName: shortName ?? null,
+        description: description ?? null,
+        notes: notes ?? null,
+        color: color ?? null,
+        order,
+      },
+    });
+
+    revalidateShow(showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("createCharacterAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Rolle konnte nicht angelegt werden.",
+    };
+  }
+}
+
+export async function updateCharacterAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const characterId = readString(formData, "characterId", { label: "Rolle" });
+    const character = await prisma.character.findUnique({
+      where: { id: characterId },
+      select: { showId: true },
+    });
+    if (!character) return { error: "Rolle wurde nicht gefunden." };
+
+    const name = readString(formData, "name", { label: "Name", minLength: 2, maxLength: 120 });
+    const shortName = readOptionalString(formData, "shortName", { label: "Kurzname", maxLength: 40 });
+    const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 500 });
+    const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 500 });
+    const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
+    const orderValue = readOptionalInt(formData, "order", { label: "Sortierung", min: 0, max: 9999 });
+
+    await prisma.character.update({
+      where: { id: characterId },
+      data: {
+        name,
+        shortName: shortName ?? null,
+        description: description ?? null,
+        notes: notes ?? null,
+        color: color ?? null,
+        ...(orderValue !== undefined ? { order: orderValue } : {}),
+      },
+    });
+
+    revalidateShow(character.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("updateCharacterAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Rolle konnte nicht aktualisiert werden.",
+    };
+  }
+}
+
+export async function deleteCharacterAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const characterId = readString(formData, "characterId", { label: "Rolle" });
+    const character = await prisma.character.findUnique({
+      where: { id: characterId },
+      select: { showId: true },
+    });
+    if (!character) return { error: "Rolle wurde nicht gefunden." };
+
+    await prisma.character.delete({ where: { id: characterId } });
+    revalidateShow(character.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("deleteCharacterAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Rolle konnte nicht entfernt werden.",
+    };
+  }
+}
+
+export async function assignCharacterCastingAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const characterId = readString(formData, "characterId", { label: "Rolle" });
+    const userId = readString(formData, "userId", { label: "Mitglied" });
+    const character = await prisma.character.findUnique({
+      where: { id: characterId },
+      select: { showId: true },
+    });
+    if (!character) return { error: "Rolle wurde nicht gefunden." };
+    const user = await prisma.user.findUnique({ where: { id: userId }, select: { id: true } });
+    if (!user) return { error: "Mitglied wurde nicht gefunden." };
+
+    const type =
+      parseEnumValue(CharacterCastingType, formData.get("type"), "Besetzungsart", { optional: true }) ??
+      CharacterCastingType.primary;
+    const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 200 });
+
+    await prisma.characterCasting.upsert({
+      where: {
+        characterId_userId_type: {
+          characterId,
+          userId,
+          type,
+        },
+      },
+      update: { notes: notes ?? null },
+      create: {
+        characterId,
+        userId,
+        type,
+        notes: notes ?? null,
+      },
+    });
+
+    revalidateShow(character.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("assignCharacterCastingAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Besetzung konnte nicht gespeichert werden.",
+    };
+  }
+}
+
+export async function updateCharacterCastingAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const castingId = readString(formData, "castingId", { label: "Besetzung" });
+    const casting = await prisma.characterCasting.findUnique({
+      where: { id: castingId },
+      select: {
+        id: true,
+        type: true,
+        character: { select: { showId: true } },
+      },
+    });
+    if (!casting) return { error: "Besetzung wurde nicht gefunden." };
+
+    const type =
+      parseEnumValue(CharacterCastingType, formData.get("type"), "Besetzungsart", { optional: true }) ??
+      casting.type;
+    const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 200 });
+
+    try {
+      await prisma.characterCasting.update({
+        where: { id: castingId },
+        data: {
+          type,
+          notes: notes ?? null,
+        },
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        return {
+          error: "Diese Besetzung existiert bereits in der gewählten Besetzungsart.",
+        };
+      }
+      throw error;
+    }
+
+    revalidateShow(casting.character.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("updateCharacterCastingAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Besetzung konnte nicht aktualisiert werden.",
+    };
+  }
+}
+
+export async function removeCharacterCastingAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const castingId = readString(formData, "castingId", { label: "Besetzung" });
+    const casting = await prisma.characterCasting.findUnique({
+      where: { id: castingId },
+      select: { character: { select: { showId: true } } },
+    });
+    if (!casting) return { error: "Besetzung wurde nicht gefunden." };
+
+    await prisma.characterCasting.delete({ where: { id: castingId } });
+    revalidateShow(casting.character.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("removeCharacterCastingAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Besetzung konnte nicht entfernt werden.",
+    };
+  }
+}
+
+export async function createSceneAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const showId = readString(formData, "showId", { label: "Produktion" });
+    const show = await prisma.show.findUnique({ where: { id: showId }, select: { id: true } });
+    if (!show) return { error: "Produktion wurde nicht gefunden." };
+
+    const identifier = readOptionalString(formData, "identifier", { label: "Nummer", maxLength: 40 });
+    const title = readOptionalString(formData, "title", { label: "Titel", maxLength: 160 });
+    const summary = readOptionalString(formData, "summary", { label: "Zusammenfassung", maxLength: 600 });
+    const location = readOptionalString(formData, "location", { label: "Ort", maxLength: 120 });
+    const timeOfDay = readOptionalString(formData, "timeOfDay", { label: "Tageszeit", maxLength: 60 });
+    const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 400 });
+    const sequenceValue = readOptionalInt(formData, "sequence", { label: "Reihenfolge", min: 0, max: 9999 });
+    const duration = readOptionalInt(formData, "duration", { label: "Dauer", min: 0, max: 600 });
+    const slugInput = readOptionalString(formData, "slug", { label: "Slug", maxLength: 80 });
+    if (slugInput && !/^[a-z0-9-]+$/i.test(slugInput)) {
+      throw new Error("Slug darf nur Buchstaben, Zahlen und Bindestriche enthalten.");
+    }
+
+    const baseSlugSource = slugInput ?? identifier ?? title ?? `szene-${Date.now()}`;
+    const baseSlug = slugify(baseSlugSource);
+    const slug = await ensureUniqueSceneSlug(showId, baseSlug);
+    const sequence =
+      sequenceValue ?? (await prisma.scene.count({ where: { showId } })) ?? 0;
+
+    await prisma.scene.create({
+      data: {
+        showId,
+        identifier: identifier ?? null,
+        title: title ?? null,
+        summary: summary ?? null,
+        location: location ?? null,
+        timeOfDay: timeOfDay ?? null,
+        notes: notes ?? null,
+        sequence,
+        durationMinutes: duration ?? null,
+        slug,
+      },
+    });
+
+    revalidateShow(showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("createSceneAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Szene konnte nicht angelegt werden.",
+    };
+  }
+}
+
+export async function updateSceneAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const sceneId = readString(formData, "sceneId", { label: "Szene" });
+    const scene = await prisma.scene.findUnique({
+      where: { id: sceneId },
+      select: { showId: true, slug: true },
+    });
+    if (!scene) return { error: "Szene wurde nicht gefunden." };
+
+    const identifier = readOptionalString(formData, "identifier", { label: "Nummer", maxLength: 40 });
+    const title = readOptionalString(formData, "title", { label: "Titel", maxLength: 160 });
+    const summary = readOptionalString(formData, "summary", { label: "Zusammenfassung", maxLength: 600 });
+    const location = readOptionalString(formData, "location", { label: "Ort", maxLength: 120 });
+    const timeOfDay = readOptionalString(formData, "timeOfDay", { label: "Tageszeit", maxLength: 60 });
+    const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 400 });
+    const sequenceValue = readOptionalInt(formData, "sequence", { label: "Reihenfolge", min: 0, max: 9999 });
+    const duration = readOptionalInt(formData, "duration", { label: "Dauer", min: 0, max: 600 });
+    const slugInput = readOptionalString(formData, "slug", { label: "Slug", maxLength: 80 });
+    if (slugInput && !/^[a-z0-9-]+$/i.test(slugInput)) {
+      throw new Error("Slug darf nur Buchstaben, Zahlen und Bindestriche enthalten.");
+    }
+
+    let slug = scene.slug;
+    if (slugInput) {
+      const baseSlug = slugify(slugInput);
+      slug = await ensureUniqueSceneSlug(scene.showId, baseSlug, sceneId);
+    }
+
+    await prisma.scene.update({
+      where: { id: sceneId },
+      data: {
+        identifier: identifier ?? null,
+        title: title ?? null,
+        summary: summary ?? null,
+        location: location ?? null,
+        timeOfDay: timeOfDay ?? null,
+        notes: notes ?? null,
+        ...(sequenceValue !== undefined ? { sequence: sequenceValue } : {}),
+        durationMinutes: duration ?? null,
+        slug,
+      },
+    });
+
+    revalidateShow(scene.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("updateSceneAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Szene konnte nicht aktualisiert werden.",
+    };
+  }
+}
+
+export async function deleteSceneAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const sceneId = readString(formData, "sceneId", { label: "Szene" });
+    const scene = await prisma.scene.findUnique({
+      where: { id: sceneId },
+      select: { showId: true },
+    });
+    if (!scene) return { error: "Szene wurde nicht gefunden." };
+
+    await prisma.scene.delete({ where: { id: sceneId } });
+    revalidateShow(scene.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("deleteSceneAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Szene konnte nicht entfernt werden.",
+    };
+  }
+}
+
+export async function addSceneCharacterAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const sceneId = readString(formData, "sceneId", { label: "Szene" });
+    const characterId = readString(formData, "characterId", { label: "Rolle" });
+
+    const [scene, character] = await Promise.all([
+      prisma.scene.findUnique({ where: { id: sceneId }, select: { showId: true } }),
+      prisma.character.findUnique({ where: { id: characterId }, select: { showId: true } }),
+    ]);
+    if (!scene) return { error: "Szene wurde nicht gefunden." };
+    if (!character) return { error: "Rolle wurde nicht gefunden." };
+    if (scene.showId !== character.showId) {
+      return { error: "Die Figur gehört nicht zur ausgewählten Produktion." };
+    }
+
+    const orderValue = readOptionalInt(formData, "order", { label: "Sortierung", min: 0, max: 9999 });
+    const isFeatured = parseCheckbox(formData.get("isFeatured"));
+
+    await prisma.sceneCharacter.upsert({
+      where: { sceneId_characterId: { sceneId, characterId } },
+      update: {
+        order: orderValue ?? 0,
+        isFeatured,
+      },
+      create: {
+        sceneId,
+        characterId,
+        order: orderValue ?? 0,
+        isFeatured,
+      },
+    });
+
+    revalidateShow(scene.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("addSceneCharacterAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Figur konnte nicht hinzugefügt werden.",
+    };
+  }
+}
+
+export async function removeSceneCharacterAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const assignmentId = readString(formData, "assignmentId", { label: "Zuordnung" });
+    const assignment = await prisma.sceneCharacter.findUnique({
+      where: { id: assignmentId },
+      select: { scene: { select: { showId: true } } },
+    });
+    if (!assignment) return { error: "Zuordnung wurde nicht gefunden." };
+
+    await prisma.sceneCharacter.delete({ where: { id: assignmentId } });
+    revalidateShow(assignment.scene.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("removeSceneCharacterAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Zuordnung konnte nicht entfernt werden.",
+    };
+  }
+}
+
+export async function createBreakdownItemAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const sceneId = readString(formData, "sceneId", { label: "Szene" });
+    const departmentId = readString(formData, "departmentId", { label: "Gewerk" });
+    const title = readString(formData, "title", { label: "Titel", minLength: 2, maxLength: 160 });
+    const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 600 });
+    const note = readOptionalString(formData, "note", { label: "Notiz", maxLength: 300 });
+    const status =
+      parseEnumValue(BreakdownStatus, formData.get("status"), "Status", { optional: true }) ??
+      BreakdownStatus.planned;
+    const neededBy = parseOptionalDate(formData, "neededBy", "Benötigt bis");
+    const assignedToId = readOptionalString(formData, "assignedToId", { label: "Zuständig" });
+
+    const scene = await prisma.scene.findUnique({ where: { id: sceneId }, select: { showId: true } });
+    if (!scene) return { error: "Szene wurde nicht gefunden." };
+    const department = await prisma.department.findUnique({ where: { id: departmentId } });
+    if (!department) return { error: "Gewerk wurde nicht gefunden." };
+
+    await prisma.sceneBreakdownItem.create({
+      data: {
+        sceneId,
+        departmentId,
+        title,
+        description: description ?? null,
+        status,
+        neededBy: neededBy ?? null,
+        note: note ?? null,
+        assignedToId: assignedToId ?? null,
+      },
+    });
+
+    revalidateShow(scene.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("createBreakdownItemAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Breakdown-Eintrag konnte nicht erstellt werden.",
+    };
+  }
+}
+
+export async function updateBreakdownItemAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const itemId = readString(formData, "itemId", { label: "Breakdown" });
+    const item = await prisma.sceneBreakdownItem.findUnique({
+      where: { id: itemId },
+      select: { scene: { select: { showId: true } } },
+    });
+    if (!item) return { error: "Breakdown-Eintrag wurde nicht gefunden." };
+
+    const title = readString(formData, "title", { label: "Titel", minLength: 2, maxLength: 160 });
+    const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 600 });
+    const note = readOptionalString(formData, "note", { label: "Notiz", maxLength: 300 });
+    const status =
+      parseEnumValue(BreakdownStatus, formData.get("status"), "Status", { optional: true }) ??
+      BreakdownStatus.planned;
+    const neededBy = parseOptionalDate(formData, "neededBy", "Benötigt bis");
+    const assignedToId = readOptionalString(formData, "assignedToId", { label: "Zuständig" });
+
+    await prisma.sceneBreakdownItem.update({
+      where: { id: itemId },
+      data: {
+        title,
+        description: description ?? null,
+        status,
+        neededBy: neededBy ?? null,
+        note: note ?? null,
+        assignedToId: assignedToId ?? null,
+      },
+    });
+
+    revalidateShow(item.scene.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("updateBreakdownItemAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Breakdown-Eintrag konnte nicht aktualisiert werden.",
+    };
+  }
+}
+
+export async function removeBreakdownItemAction(formData: FormData): Promise<ActionResult> {
+  const auth = await ensureProductionManager();
+  if (!auth.ok) return { error: auth.error };
+  const redirectPath = parseRedirectPath(formData);
+  try {
+    const itemId = readString(formData, "itemId", { label: "Breakdown" });
+    const item = await prisma.sceneBreakdownItem.findUnique({
+      where: { id: itemId },
+      select: { scene: { select: { showId: true } } },
+    });
+    if (!item) return { error: "Breakdown-Eintrag wurde nicht gefunden." };
+
+    await prisma.sceneBreakdownItem.delete({ where: { id: itemId } });
+    revalidateShow(item.scene.showId, redirectPath);
+    return { success: true };
+  } catch (error) {
+    console.error("removeBreakdownItemAction", error);
+    return {
+      error: error instanceof Error ? error.message : "Breakdown-Eintrag konnte nicht entfernt werden.",
+    };
+  }
+}

--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -1,0 +1,345 @@
+import Link from "next/link";
+import { DepartmentMembershipRole } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+import {
+  createDepartmentAction,
+  updateDepartmentAction,
+  deleteDepartmentAction,
+  addDepartmentMemberAction,
+  updateDepartmentMemberAction,
+  removeDepartmentMemberAction,
+} from "./actions";
+
+const ROLE_LABELS: Record<DepartmentMembershipRole, string> = {
+  lead: "Leitung",
+  member: "Mitglied",
+  deputy: "Vertretung",
+  guest: "Gast",
+};
+
+function formatUserName(user: { name: string | null; email: string | null }) {
+  if (user.name && user.name.trim()) return user.name;
+  if (user.email) return user.email;
+  return "Unbekannt";
+}
+
+const selectClassName =
+  "h-10 w-full rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+export default async function ProduktionenPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.produktionen");
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-border/70 bg-background/60 p-6 text-sm text-muted-foreground">
+        Du hast keinen Zugriff auf die Produktionsplanung.
+      </div>
+    );
+  }
+
+  const [departments, users, shows] = await Promise.all([
+    prisma.department.findMany({
+      orderBy: { name: "asc" },
+      include: {
+        memberships: {
+          include: {
+            user: { select: { id: true, name: true, email: true } },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    }),
+    prisma.user.findMany({
+      orderBy: [
+        { name: "asc" },
+        { email: "asc" },
+      ],
+      select: { id: true, name: true, email: true },
+    }),
+    prisma.show.findMany({ orderBy: { year: "desc" }, select: { id: true, year: true, title: true } }),
+  ]);
+
+  return (
+    <div className="space-y-12">
+      <div>
+        <h1 className="text-2xl font-semibold">Produktionsplanung</h1>
+        <p className="text-sm text-muted-foreground">
+          Verwalte Gewerke, Zuständigkeiten und wähle eine Produktion für Rollen-, Szenen- und Breakdown-Details aus.
+        </p>
+      </div>
+
+      <section className="space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold">Gewerke &amp; Zuständigkeiten</h2>
+          <p className="text-sm text-muted-foreground">
+            Lege neue Gewerke an, pflege Farben und Beschreibungen und ordne Teammitglieder mit klaren Verantwortlichkeiten zu.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border/70 bg-background/60 p-6">
+          <h3 className="text-lg font-medium">Neues Gewerk anlegen</h3>
+          <form action={createDepartmentAction} className="mt-4 grid gap-4 md:grid-cols-2" method="post">
+            <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Name</label>
+              <Input name="name" placeholder="z.B. Maske" required minLength={2} maxLength={80} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Slug (optional)</label>
+              <Input name="slug" placeholder="maske" maxLength={80} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Farbe</label>
+              <input
+                type="color"
+                name="color"
+                defaultValue="#9333ea"
+                className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+              />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Beschreibung</label>
+              <Textarea name="description" rows={2} maxLength={2000} placeholder="Kurzbeschreibung für das Gewerk" />
+            </div>
+            <div className="md:col-span-2">
+              <Button type="submit">Gewerk speichern</Button>
+            </div>
+          </form>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          {departments.map((department) => {
+            const memberIds = new Set(department.memberships.map((membership) => membership.user.id));
+            const availableUsers = users.filter((user) => !memberIds.has(user.id));
+            return (
+              <div key={department.id} className="flex flex-col gap-4 rounded-lg border border-border/70 bg-background/60 p-6">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="inline-block h-3 w-3 rounded-full border border-border/80"
+                        style={{ backgroundColor: department.color ?? "#94a3b8" }}
+                      />
+                      <h3 className="text-lg font-semibold">{department.name}</h3>
+                    </div>
+                    {department.description ? (
+                      <p className="mt-1 text-sm text-muted-foreground">{department.description}</p>
+                    ) : null}
+                  </div>
+                  <form action={deleteDepartmentAction} method="post">
+                    <input type="hidden" name="id" value={department.id} />
+                    <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
+                    <Button type="submit" variant="ghost" size="sm">
+                      Entfernen
+                    </Button>
+                  </form>
+                </div>
+
+                <form
+                  action={updateDepartmentAction}
+                  method="post"
+                  className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
+                >
+                  <input type="hidden" name="id" value={department.id} />
+                  <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
+                      <Input name="name" defaultValue={department.name} minLength={2} maxLength={80} required />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Slug</label>
+                      <Input name="slug" defaultValue={department.slug} maxLength={80} />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Farbe</label>
+                      <input
+                        type="color"
+                        name="color"
+                        defaultValue={department.color ?? "#94a3b8"}
+                        className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+                      />
+                    </div>
+                    <div className="space-y-1 md:col-span-2">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Beschreibung
+                      </label>
+                      <Textarea
+                        name="description"
+                        rows={2}
+                        maxLength={2000}
+                        defaultValue={department.description ?? ""}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex justify-end">
+                    <Button type="submit" variant="outline" size="sm">
+                      Aktualisieren
+                    </Button>
+                  </div>
+                </form>
+
+                <div className="space-y-3">
+                  <h4 className="text-sm font-semibold">Mitglieder</h4>
+                  <div className="space-y-3">
+                    {department.memberships.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">Noch keine Mitglieder zugeordnet.</p>
+                    ) : (
+                      department.memberships.map((membership) => (
+                        <div
+                          key={membership.id}
+                          className="rounded-md border border-border/60 bg-background/80 p-3 text-sm"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div>
+                              <p className="font-medium">{formatUserName(membership.user)}</p>
+                              <p className="text-xs text-muted-foreground">{ROLE_LABELS[membership.role]}</p>
+                              {membership.title ? (
+                                <p className="text-xs text-muted-foreground">{membership.title}</p>
+                              ) : null}
+                              {membership.note ? (
+                                <p className="text-xs text-muted-foreground">Notiz: {membership.note}</p>
+                              ) : null}
+                            </div>
+                            <form action={removeDepartmentMemberAction} method="post">
+                              <input type="hidden" name="membershipId" value={membership.id} />
+                              <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
+                              <Button type="submit" variant="ghost" size="sm">
+                                Entfernen
+                              </Button>
+                            </form>
+                          </div>
+                          <form
+                            action={updateDepartmentMemberAction}
+                            method="post"
+                            className="mt-3 grid gap-2 md:grid-cols-3"
+                          >
+                            <input type="hidden" name="membershipId" value={membership.id} />
+                            <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
+                            <div className="space-y-1">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Funktion
+                              </label>
+                              <select
+                                name="role"
+                                defaultValue={membership.role}
+                                className={selectClassName}
+                              >
+                                {Object.values(DepartmentMembershipRole).map((role) => (
+                                  <option key={role} value={role}>
+                                    {ROLE_LABELS[role]}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                            <div className="space-y-1">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Bezeichnung
+                              </label>
+                              <Input name="title" defaultValue={membership.title ?? ""} maxLength={120} />
+                            </div>
+                            <div className="space-y-1">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Notiz
+                              </label>
+                              <Input name="note" defaultValue={membership.note ?? ""} maxLength={200} />
+                            </div>
+                            <div className="md:col-span-3 flex justify-end">
+                              <Button type="submit" variant="outline" size="sm">
+                                Speichern
+                              </Button>
+                            </div>
+                          </form>
+                        </div>
+                      ))
+                    )}
+                  </div>
+
+                  <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-3">
+                    <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Mitglied hinzufügen
+                    </h5>
+                    <form className="mt-2 grid gap-2 md:grid-cols-3" action={addDepartmentMemberAction} method="post">
+                      <input type="hidden" name="departmentId" value={department.id} />
+                      <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
+                      <div className="space-y-1 md:col-span-1">
+                        <label className="text-xs font-medium text-muted-foreground">Mitglied</label>
+                        <select name="userId" className={selectClassName} required>
+                          <option value="">Mitglied auswählen</option>
+                          {availableUsers.map((user) => (
+                            <option key={user.id} value={user.id}>
+                              {formatUserName(user)}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium text-muted-foreground">Funktion</label>
+                        <select name="role" className={selectClassName} defaultValue={DepartmentMembershipRole.member}>
+                          {Object.values(DepartmentMembershipRole).map((role) => (
+                            <option key={role} value={role}>
+                              {ROLE_LABELS[role]}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium text-muted-foreground">Bezeichnung</label>
+                        <Input name="title" maxLength={120} placeholder="z.B. Leitung" />
+                      </div>
+                      <div className="space-y-1 md:col-span-3">
+                        <label className="text-xs font-medium text-muted-foreground">Notiz</label>
+                        <Input name="note" maxLength={200} placeholder="optionale Notiz" />
+                      </div>
+                      <div className="md:col-span-3 flex justify-end">
+                        <Button type="submit" size="sm">
+                          Mitglied zuordnen
+                        </Button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">Produktionen</h2>
+          <p className="text-sm text-muted-foreground">
+            Wähle eine Produktion aus, um Rollen, Szenen und Breakdowns detailliert zu verwalten.
+          </p>
+        </div>
+        {shows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine Produktionen vorhanden.</p>
+        ) : (
+          <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            {shows.map((show) => (
+              <li key={show.id}>
+                <Link
+                  href={`/mitglieder/produktionen/${show.id}`}
+                  className="flex h-full flex-col justify-between rounded-lg border border-border/70 bg-background/60 p-4 transition hover:border-primary/60 hover:shadow-sm"
+                >
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">{show.year}</p>
+                    <h3 className="mt-1 text-lg font-semibold">{show.title ?? `Produktion ${show.year}`}</h3>
+                  </div>
+                  <span className="mt-4 text-sm font-medium text-primary">Details anzeigen</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -25,6 +25,12 @@ const groupedConfig: Group[] = [
     ],
   },
   {
+    label: "Produktion",
+    items: [
+      { href: "/mitglieder/produktionen", label: "Produktionen", permissionKey: "mitglieder.produktionen" },
+    ],
+  },
+  {
     label: "Verwaltung",
     items: [
       { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", permissionKey: "mitglieder.rollenverwaltung" },
@@ -79,6 +85,15 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
         <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <rect x="3" y="4" width="18" height="18" rx="2" />
           <path d="M16 2v4M8 2v4M3 10h18" />
+        </svg>
+      );
+    case "/mitglieder/produktionen":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 4h18v4H3z" />
+          <path d="M5 8v12h14V8" />
+          <path d="M9 12h6" />
+          <path d="M9 16h6" />
         </svg>
       );
     case "/mitglieder/mitgliederverwaltung":

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -15,6 +15,12 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     description: "Zugang zum Bereich \"Meine Proben\" mit persönlichen Terminen und Fristen.",
   },
   { key: "mitglieder.probenplanung", label: "Probenplanung verwalten" },
+  {
+    key: "mitglieder.produktionen",
+    label: "Produktionsplanung öffnen",
+    description:
+      "Bereich zur Verwaltung von Gewerken, Besetzungen, Szenen und Breakdown-Aufgaben im Produktionsmanagement.",
+  },
   { key: "mitglieder.rollenverwaltung", label: "Mitgliederverwaltung öffnen" },
   { key: "mitglieder.rechte", label: "Rechteverwaltung öffnen" },
   { key: "mitglieder.sperrliste", label: "Sperrliste pflegen" },


### PR DESCRIPTION
## Summary
- add production management member pages with CRUD actions for departments, casting, scenes and breakdowns
- extend Prisma schema, seed data and migrations with departments, characters, scenes and breakdown tasks
- register mitglieder.produktionen permission and expose productions navigation entry

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cda8c374d0832d95089e4507485c4d