### PR TITLE
Update terminology to reflect school theater

### DIFF
--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -2,12 +2,12 @@ export default function ImpressumPage() {
   return (
     <div className="container mx-auto px-6 py-8 space-y-4">
       <h1 className="font-serif text-3xl">Impressum</h1>
-      <p>Bitte Platzhalter durch echte Vereins- bzw. Anbieter-Daten ersetzen.</p>
+      <p>Bitte Platzhalter durch echte Schultheater- bzw. Anbieter-Daten ersetzen.</p>
       <div>
-        <h2 className="text-xl font-semibold">Anbieter</h2>
-        <p>Sommertheater im Schlosspark Altrossthal e.V.</p>
+        <h2 className="text-xl font-semibold">Schultheater</h2>
+        <p>Schultheater „Sommertheater im Schlosspark Altrossthal“</p>
         <p>Altrossthal 1, 01169 Dresden</p>
-        <p>Vertreten durch den Vorstand (Vorname Nachname)</p>
+        <p>Vertreten durch die Projektleitung (Vorname Nachname)</p>
       </div>
       <div>
         <h2 className="text-xl font-semibold">Kontakt</h2>
@@ -15,8 +15,9 @@ export default function ImpressumPage() {
         <p>Telefon: +49 (0) 000 000 00</p>
       </div>
       <div>
-        <h2 className="text-xl font-semibold">Register</h2>
-        <p>Amtsgericht Dresden · Registernummer VR 00000</p>
+        <h2 className="text-xl font-semibold">Schule / Träger</h2>
+        <p>Schule: Gymnasium Altrossthal (Platzhalter)</p>
+        <p>Schulträger: Landeshauptstadt Dresden (Platzhalter)</p>
       </div>
       <div>
         <h2 className="text-xl font-semibold">Haftung</h2>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <main id="main" className="pt-16 sm:pt-20 min-h-screen">{children}</main>
           <footer className="border-t bg-background/60">
             <div className="container mx-auto p-4 text-sm opacity-80">
-              © Verein Sommertheater · {" "}
+              © Schultheater „Sommertheater im Schlosspark“ · {" "}
               <Link href="/impressum" className="underline hover:no-underline">
                 Impressum
               </Link>

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -236,8 +236,8 @@ export function PhotoConsentCard() {
                 className="mt-1 h-4 w-4 rounded border-border text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               />
               <span>
-                Ich erkläre mich damit einverstanden, dass im Rahmen des Vereins Fotos von mir erstellt und für interne sowie
-                öffentliche Kommunikationszwecke genutzt werden dürfen.
+                Ich erkläre mich damit einverstanden, dass im Rahmen unseres Schultheaters Fotos von mir erstellt und für
+                interne sowie öffentliche Kommunikationszwecke genutzt werden dürfen.
               </span>
             </label>
 


### PR DESCRIPTION
## Summary
- replace remaining mentions of "Verein" with wording that reflects the Schultheater
- update the imprint placeholders to reference the school theatre structure instead of an association
- adjust the photo consent text so it refers to the school theatre context

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cdae6d9234832d89379817e526643d