### PR TITLE
Add migration for user date of birth column

### DIFF
--- a/prisma/migrations/20260104120000_add_user_date_of_birth/migration.sql
+++ b/prisma/migrations/20260104120000_add_user_date_of_birth/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN "dateOfBirth" TIMESTAMP(3);


### PR DESCRIPTION
## Summary
- add a migration that adds the optional `dateOfBirth` column to the `User` table so the schema matches the Prisma model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdb89fa86c832db2c9e3360bbc91e8