### PR TITLE
Ensure Prisma migrations run before dev/start

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node scripts/run-prisma-migrate.mjs",
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
+    "prestart": "node scripts/run-prisma-migrate.mjs",
     "postinstall": "node -e \"if(!process.env.SKIP_PRISMA_POSTINSTALL){require('child_process').execSync('pnpm prisma:generate',{stdio:'inherit'})}\"",
     "start": "next start",
     "lint": "eslint",

--- a/scripts/run-prisma-migrate.mjs
+++ b/scripts/run-prisma-migrate.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function shouldSkip() {
+  const flag = process.env.SKIP_PRISMA_MIGRATE;
+  if (!flag) return false;
+  const normalized = flag.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+if (shouldSkip()) {
+  console.log("[prisma-migrate] Skipping Prisma migrations because SKIP_PRISMA_MIGRATE is set.");
+  process.exit(0);
+}
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  console.warn("[prisma-migrate] DATABASE_URL is not set; skipping Prisma migrations.");
+  process.exit(0);
+}
+
+const prismaExecutable = join(
+  __dirname,
+  "..",
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "prisma.cmd" : "prisma",
+);
+
+if (!existsSync(prismaExecutable)) {
+  console.warn(
+    `[prisma-migrate] Prisma CLI executable not found at ${prismaExecutable}. Have you installed dependencies yet?`,
+  );
+  process.exit(0);
+}
+
+try {
+  console.log("[prisma-migrate] Ensuring database schema is up to date (prisma migrate deploy)...");
+  execFileSync(prismaExecutable, ["migrate", "deploy", "--skip-generate"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+  console.log("[prisma-migrate] Prisma migrations applied successfully.");
+} catch (error) {
+  console.error("[prisma-migrate] Failed to apply Prisma migrations.");
+  if (error instanceof Error && error.message) {
+    console.error(error.message);
+  }
+  process.exit(typeof error?.status === "number" ? error.status : 1);
+}

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -98,13 +98,15 @@ export default function UserAvatar({
     const uploadSrc = previewUrl ?? (userId ? `/api/users/${userId}/avatar${version ? `?v=${version}` : ""}` : undefined);
     if (uploadSrc) {
       return (
-        <img
+        <Image
+          unoptimized
           src={uploadSrc}
           alt={label ? `Avatar von ${label}` : "Avatar"}
           title={label}
           width={displaySize}
           height={displaySize}
           loading={loading}
+          sizes={`${displaySize}px`}
           className={cn("inline-block rounded-full border border-border bg-muted object-cover", className)}
           style={sharedStyle}
           draggable={false}


### PR DESCRIPTION
## Summary
- run a small helper before `pnpm dev`/`pnpm start` to keep the Prisma schema up to date
- add a Node script that skips gracefully when `DATABASE_URL` is missing or migrations are opted out and otherwise runs `prisma migrate deploy`
- switch the uploaded avatar rendering to `next/image` to satisfy the Next.js lint rule

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cdbea15158832d9a698aa7531fbc70