### PR TITLE
Remove unsupported Prisma migrate flag

### DIFF
--- a/scripts/run-prisma-migrate.mjs
+++ b/scripts/run-prisma-migrate.mjs
@@ -42,7 +42,7 @@ if (!existsSync(prismaExecutable)) {
 
 try {
   console.log("[prisma-migrate] Ensuring database schema is up to date (prisma migrate deploy)...");
-  execFileSync(prismaExecutable, ["migrate", "deploy", "--skip-generate"], {
+  execFileSync(prismaExecutable, ["migrate", "deploy"], {
     stdio: "inherit",
     env: process.env,
   });


### PR DESCRIPTION
## Summary
- remove the deprecated `--skip-generate` flag from the Prisma migrate helper script so it works with Prisma 6.16

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cddd739ce0832db04e835aeb39ee31