### PR TITLE
Modernize production planning UI

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import { MembersNav } from "@/components/members-nav";
 import { requireAuth } from "@/lib/rbac";
 import { getUserPermissionKeys } from "@/lib/permissions";
+import { getActiveProduction } from "@/lib/active-production";
 
 export default async function MembersLayout({ children }: { children: React.ReactNode }) {
   const session = await requireAuth();
   const permissions = await getUserPermissionKeys(session.user);
+  const activeProduction = await getActiveProduction();
 
   return (
     <main className="w-full pb-12 pt-6 sm:pt-8">
@@ -13,7 +15,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
         className="mx-auto flex w-full max-w-screen-2xl flex-col gap-6 px-4 sm:px-6 lg:grid lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start lg:gap-10 lg:px-8 xl:grid-cols-[300px_minmax(0,1fr)] xl:gap-12 xl:px-10 2xl:grid-cols-[320px_minmax(0,1fr)] 2xl:gap-16 2xl:px-12"
       >
         <aside className="lg:sticky lg:top-28 lg:h-fit lg:self-start">
-          <MembersNav permissions={permissions} />
+          <MembersNav permissions={permissions} activeProduction={activeProduction ?? undefined} />
         </aside>
         <section className="min-w-0 space-y-8">{children}</section>
       </div>

--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -1,60 +1,19 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { CharacterCastingType, BreakdownStatus } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
+import { getActiveProductionId } from "@/lib/active-production";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
-import {
-  createCharacterAction,
-  updateCharacterAction,
-  deleteCharacterAction,
-  assignCharacterCastingAction,
-  updateCharacterCastingAction,
-  removeCharacterCastingAction,
-  createSceneAction,
-  updateSceneAction,
-  deleteSceneAction,
-  addSceneCharacterAction,
-  removeSceneCharacterAction,
-  createBreakdownItemAction,
-  updateBreakdownItemAction,
-  removeBreakdownItemAction,
-} from "../actions";
+import { setActiveProductionAction } from "../actions";
 
-const CASTING_LABELS: Record<CharacterCastingType, string> = {
-  primary: "Primär",
-  alternate: "Alternate",
-  cover: "Cover",
-  cameo: "Cameo",
-};
-
-const CASTING_ORDER: CharacterCastingType[] = [
-  CharacterCastingType.primary,
-  CharacterCastingType.alternate,
-  CharacterCastingType.cover,
-  CharacterCastingType.cameo,
-];
-
-const STATUS_LABELS: Record<BreakdownStatus, string> = {
-  planned: "Geplant",
-  in_progress: "In Arbeit",
-  blocked: "Blockiert",
-  ready: "Bereit",
-  done: "Erledigt",
-};
-
-const selectSmallClassName =
-  "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
-
-function formatUserName(user: { name: string | null; email: string | null }) {
-  if (user.name && user.name.trim()) return user.name;
-  if (user.email) return user.email;
-  return "Unbekannt";
+function formatShowTitle(show: { title: string | null; year: number }) {
+  if (show.title && show.title.trim()) return show.title;
+  return `Produktion ${show.year}`;
 }
 
 export default async function ProduktionDetailPage({ params }: { params: { showId: string } }) {
@@ -68,7 +27,7 @@ export default async function ProduktionDetailPage({ params }: { params: { showI
     );
   }
 
-  const [show, departments, users] = await Promise.all([
+  const [show, breakdownCount] = await Promise.all([
     prisma.show.findUnique({
       where: { id: params.showId },
       select: {
@@ -76,730 +35,108 @@ export default async function ProduktionDetailPage({ params }: { params: { showI
         title: true,
         year: true,
         synopsis: true,
-        characters: {
-          orderBy: { order: "asc" },
-          select: {
-            id: true,
-            name: true,
-            shortName: true,
-            description: true,
-            notes: true,
-            color: true,
-            order: true,
-            castings: {
-              select: {
-                id: true,
-                type: true,
-                notes: true,
-                user: { select: { id: true, name: true, email: true } },
-              },
-            },
-          },
-        },
-        scenes: {
-          orderBy: { sequence: "asc" },
-          select: {
-            id: true,
-            identifier: true,
-            title: true,
-            summary: true,
-            location: true,
-            timeOfDay: true,
-            notes: true,
-            sequence: true,
-            durationMinutes: true,
-            slug: true,
-            characters: {
-              orderBy: { order: "asc" },
-              select: {
-                id: true,
-                isFeatured: true,
-                order: true,
-                character: { select: { id: true, name: true, shortName: true, color: true } },
-              },
-            },
-            breakdownItems: {
-              orderBy: { createdAt: "asc" },
-              select: {
-                id: true,
-                title: true,
-                description: true,
-                note: true,
-                status: true,
-                neededBy: true,
-                department: { select: { id: true, name: true, slug: true, color: true } },
-                assignedToId: true,
-                assignedTo: { select: { id: true, name: true, email: true } },
-              },
-            },
-          },
-        },
+        _count: { characters: true, scenes: true },
       },
     }),
-    prisma.department.findMany({ orderBy: { name: "asc" }, select: { id: true, name: true, slug: true, color: true } }),
-    prisma.user.findMany({
-      orderBy: [
-        { name: "asc" },
-        { email: "asc" },
-      ],
-      select: { id: true, name: true, email: true },
-    }),
+    prisma.sceneBreakdownItem.count({ where: { scene: { showId: params.showId } } }),
   ]);
 
   if (!show) {
     notFound();
   }
 
-  const showPath = `/mitglieder/produktionen/${show.id}`;
-  const statusOptions = Object.values(BreakdownStatus);
+  const activeProductionId = getActiveProductionId();
+  const isActive = activeProductionId === show.id;
+  const title = formatShowTitle(show);
 
   return (
-    <div className="space-y-12">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">Produktion {show.year}</p>
-          <h1 className="text-2xl font-semibold">{show.title ?? `Produktion ${show.year}`}</h1>
-          {show.synopsis ? (
-            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{show.synopsis}</p>
-          ) : null}
-        </div>
-        <Button asChild variant="ghost">
-          <Link href="/mitglieder/produktionen">Zur Übersicht</Link>
-        </Button>
-      </div>
-
-      <section className="space-y-6">
-        <div>
-          <h2 className="text-xl font-semibold">Figuren &amp; Besetzungen</h2>
-          <p className="text-sm text-muted-foreground">
-            Lege neue Rollen an, pflege Beschreibungen und ordne Ensemble-Mitglieder mit Primär-, Alternate- oder Cover-Funktionen zu.
-          </p>
-        </div>
-
-        <div className="rounded-lg border border-border/70 bg-background/60 p-6">
-          <h3 className="text-lg font-medium">Neue Rolle anlegen</h3>
-          <form action={createCharacterAction} method="post" className="mt-4 grid gap-4 md:grid-cols-2">
-            <input type="hidden" name="showId" value={show.id} />
-            <input type="hidden" name="redirectPath" value={showPath} />
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Name</label>
-              <Input name="name" placeholder="z.B. Protagonist" minLength={2} maxLength={120} required />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Kurzname</label>
-              <Input name="shortName" placeholder="Kurzlabel" maxLength={40} />
-            </div>
-            <div className="space-y-1 md:col-span-2">
-              <label className="text-sm font-medium">Beschreibung</label>
-              <Textarea name="description" rows={2} maxLength={500} placeholder="Charakterbeschreibung" />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Farbe</label>
-              <input
-                type="color"
-                name="color"
-                defaultValue="#7c3aed"
-                className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Sortierung</label>
-              <Input type="number" name="order" min={0} max={9999} placeholder="0" />
-            </div>
-            <div className="space-y-1 md:col-span-2">
-              <label className="text-sm font-medium">Notiz</label>
-              <Textarea name="notes" rows={2} maxLength={500} placeholder="interne Notiz" />
-            </div>
-            <div className="md:col-span-2">
-              <Button type="submit">Rolle speichern</Button>
-            </div>
-          </form>
-        </div>
-
-        <div className="grid gap-6 xl:grid-cols-2">
-          {show.characters.map((character) => {
-            const sortedCastings = [...character.castings].sort((a, b) => {
-              const orderA = CASTING_ORDER.indexOf(a.type);
-              const orderB = CASTING_ORDER.indexOf(b.type);
-              return orderA - orderB;
-            });
-            return (
-              <div key={character.id} className="flex flex-col gap-4 rounded-lg border border-border/70 bg-background/60 p-6">
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <h3 className="text-lg font-semibold">{character.name}</h3>
-                    {character.shortName ? (
-                      <p className="text-xs uppercase tracking-wide text-muted-foreground">{character.shortName}</p>
-                    ) : null}
-                    {character.description ? (
-                      <p className="mt-2 text-sm text-muted-foreground">{character.description}</p>
-                    ) : null}
-                    {character.notes ? (
-                      <p className="mt-1 text-xs text-muted-foreground">Notiz: {character.notes}</p>
-                    ) : null}
-                  </div>
-                  <form action={deleteCharacterAction} method="post">
-                    <input type="hidden" name="characterId" value={character.id} />
-                    <input type="hidden" name="redirectPath" value={showPath} />
-                    <Button type="submit" variant="ghost" size="sm">
-                      Entfernen
-                    </Button>
-                  </form>
-                </div>
-
-                <form
-                  action={updateCharacterAction}
-                  method="post"
-                  className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
-                >
-                  <input type="hidden" name="characterId" value={character.id} />
-                  <input type="hidden" name="redirectPath" value={showPath} />
-                  <div className="grid gap-3 md:grid-cols-2">
-                    <div className="space-y-1">
-                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
-                      <Input name="name" defaultValue={character.name} minLength={2} maxLength={120} required />
-                    </div>
-                    <div className="space-y-1">
-                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Kurzname</label>
-                      <Input name="shortName" defaultValue={character.shortName ?? ""} maxLength={40} />
-                    </div>
-                    <div className="space-y-1 md:col-span-2">
-                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        Beschreibung
-                      </label>
-                      <Textarea name="description" rows={2} maxLength={500} defaultValue={character.description ?? ""} />
-                    </div>
-                    <div className="space-y-1">
-                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Sortierung</label>
-                      <Input type="number" name="order" defaultValue={character.order ?? 0} min={0} max={9999} />
-                    </div>
-                    <div className="space-y-1">
-                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Farbe</label>
-                      <input
-                        type="color"
-                        name="color"
-                        defaultValue={character.color ?? "#7c3aed"}
-                        className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
-                      />
-                    </div>
-                    <div className="space-y-1 md:col-span-2">
-                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
-                      <Textarea name="notes" rows={2} maxLength={500} defaultValue={character.notes ?? ""} />
-                    </div>
-                  </div>
-                  <div className="flex justify-end">
-                    <Button type="submit" variant="outline" size="sm">
-                      Rolle aktualisieren
-                    </Button>
-                  </div>
-                </form>
-
-                <div className="space-y-3">
-                  <h4 className="text-sm font-semibold">Besetzung</h4>
-                  <div className="space-y-3">
-                    {sortedCastings.length === 0 ? (
-                      <p className="text-sm text-muted-foreground">Noch keine Besetzung zugeordnet.</p>
-                    ) : (
-                      sortedCastings.map((casting) => (
-                        <div
-                          key={casting.id}
-                          className="rounded-md border border-border/60 bg-background/80 p-3 text-sm"
-                        >
-                          <div className="flex flex-wrap items-center justify-between gap-2">
-                            <div>
-                              <p className="font-medium">{formatUserName(casting.user)}</p>
-                              <p className="text-xs text-muted-foreground">{CASTING_LABELS[casting.type]}</p>
-                              {casting.notes ? (
-                                <p className="text-xs text-muted-foreground">Notiz: {casting.notes}</p>
-                              ) : null}
-                            </div>
-                            <form action={removeCharacterCastingAction} method="post">
-                              <input type="hidden" name="castingId" value={casting.id} />
-                              <input type="hidden" name="redirectPath" value={showPath} />
-                              <Button type="submit" variant="ghost" size="sm">
-                                Entfernen
-                              </Button>
-                            </form>
-                          </div>
-                          <form
-                            action={updateCharacterCastingAction}
-                            method="post"
-                            className="mt-3 grid gap-2 md:grid-cols-3"
-                          >
-                            <input type="hidden" name="castingId" value={casting.id} />
-                            <input type="hidden" name="redirectPath" value={showPath} />
-                            <div className="space-y-1">
-                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                Besetzungsart
-                              </label>
-                              <select name="type" defaultValue={casting.type} className={selectSmallClassName}>
-                                {CASTING_ORDER.map((type) => (
-                                  <option key={type} value={type}>
-                                    {CASTING_LABELS[type]}
-                                  </option>
-                                ))}
-                              </select>
-                            </div>
-                            <div className="space-y-1 md:col-span-2">
-                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
-                              <Input name="notes" defaultValue={casting.notes ?? ""} maxLength={200} />
-                            </div>
-                            <div className="md:col-span-3 flex justify-end">
-                              <Button type="submit" variant="outline" size="sm">
-                                Speichern
-                              </Button>
-                            </div>
-                          </form>
-                        </div>
-                      ))
-                    )}
-                  </div>
-
-                  <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-3">
-                    <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Mitglied zuordnen
-                    </h5>
-                    <form className="mt-2 grid gap-2 md:grid-cols-4" action={assignCharacterCastingAction} method="post">
-                      <input type="hidden" name="characterId" value={character.id} />
-                      <input type="hidden" name="redirectPath" value={showPath} />
-                      <div className="space-y-1 md:col-span-2">
-                        <label className="text-xs font-medium text-muted-foreground">Mitglied</label>
-                        <select name="userId" className={selectSmallClassName} required>
-                          <option value="">Mitglied auswählen</option>
-                          {users.map((user) => (
-                            <option key={user.id} value={user.id}>
-                              {formatUserName(user)}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium text-muted-foreground">Besetzungsart</label>
-                        <select
-                          name="type"
-                          className={selectSmallClassName}
-                          defaultValue={CharacterCastingType.primary}
-                        >
-                          {CASTING_ORDER.map((type) => (
-                            <option key={type} value={type}>
-                              {CASTING_LABELS[type]}
-                            </option>
-                          ))}
-                        </select>
-                      </div>
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium text-muted-foreground">Notiz</label>
-                        <Input name="notes" maxLength={200} placeholder="optional" />
-                      </div>
-                      <div className="md:col-span-4 flex justify-end">
-                        <Button type="submit" size="sm">
-                          Mitglied besetzen
-                        </Button>
-                      </div>
-                    </form>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+    <div className="space-y-10">
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Produktion {show.year}</p>
+            <h1 className="text-3xl font-semibold">{title}</h1>
+            {show.synopsis ? (
+              <p className="max-w-2xl text-sm text-muted-foreground">{show.synopsis}</p>
+            ) : null}
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
+          </Button>
         </div>
       </section>
 
-      <section className="space-y-6">
-        <div>
-          <h2 className="text-xl font-semibold">Szenen &amp; Breakdowns</h2>
+      <Card>
+        <CardHeader className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="text-lg font-semibold">Status &amp; Kennzahlen</CardTitle>
+            <Badge variant={isActive ? "default" : "outline"}>{isActive ? "Aktiv" : "Inaktiv"}</Badge>
+          </div>
           <p className="text-sm text-muted-foreground">
-            Pflege Szeneninformationen, setze Rollenauftritte und dokumentiere Aufgaben für Gewerke mit Status und Zuständigkeiten.
+            Überblick über Rollen, Szenen und Breakdown-Aufgaben dieser Produktion sowie schnelle Aktionen für die neuen Arbeitsbereiche.
           </p>
-        </div>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-lg border border-border/60 bg-background/70 p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Rollen</div>
+              <div className="mt-2 text-2xl font-semibold text-foreground">{show._count.characters}</div>
+              <p className="text-xs text-muted-foreground">Angelegte Figuren in dieser Produktion</p>
+            </div>
+            <div className="rounded-lg border border-border/60 bg-background/70 p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Szenen</div>
+              <div className="mt-2 text-2xl font-semibold text-foreground">{show._count.scenes}</div>
+              <p className="text-xs text-muted-foreground">Erfasste Szenen inklusive Reihenfolge</p>
+            </div>
+            <div className="rounded-lg border border-border/60 bg-background/70 p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Breakdowns</div>
+              <div className="mt-2 text-2xl font-semibold text-foreground">{breakdownCount}</div>
+              <p className="text-xs text-muted-foreground">Aufgaben über alle Gewerke hinweg</p>
+            </div>
+          </div>
 
-        <div className="rounded-lg border border-border/70 bg-background/60 p-6">
-          <h3 className="text-lg font-medium">Neue Szene anlegen</h3>
-          <form action={createSceneAction} method="post" className="mt-4 grid gap-4 md:grid-cols-3">
-            <input type="hidden" name="showId" value={show.id} />
-            <input type="hidden" name="redirectPath" value={showPath} />
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Nummer</label>
-              <Input name="identifier" maxLength={40} placeholder="z.B. 1" />
-            </div>
-            <div className="space-y-1 md:col-span-2">
-              <label className="text-sm font-medium">Titel</label>
-              <Input name="title" maxLength={160} placeholder="z.B. Ankunft im Park" />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Ort</label>
-              <Input name="location" maxLength={120} />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Tageszeit</label>
-              <Input name="timeOfDay" maxLength={60} />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Slug</label>
-              <Input name="slug" maxLength={80} placeholder="szene-1" />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Reihenfolge</label>
-              <Input type="number" name="sequence" min={0} max={9999} />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Dauer (Minuten)</label>
-              <Input type="number" name="duration" min={0} max={600} />
-            </div>
-            <div className="space-y-1 md:col-span-3">
-              <label className="text-sm font-medium">Zusammenfassung</label>
-              <Textarea name="summary" rows={2} maxLength={600} />
-            </div>
-            <div className="space-y-1 md:col-span-3">
-              <label className="text-sm font-medium">Notizen</label>
-              <Textarea name="notes" rows={2} maxLength={400} />
-            </div>
-            <div className="md:col-span-3">
-              <Button type="submit">Szene speichern</Button>
-            </div>
-          </form>
-        </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button asChild>
+              <Link href="/mitglieder/produktionen/besetzung">Rollen &amp; Besetzung</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/mitglieder/produktionen/szenen">Szenen &amp; Breakdowns</Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/mitglieder/produktionen/gewerke">Gewerke &amp; Teams</Link>
+            </Button>
+            {!isActive ? (
+              <form action={setActiveProductionAction} className="ml-auto flex-shrink-0">
+                <input type="hidden" name="showId" value={show.id} />
+                <input type="hidden" name="redirectPath" value={`/mitglieder/produktionen/${show.id}`} />
+                <Button type="submit" size="sm">
+                  Produktion aktiv setzen
+                </Button>
+              </form>
+            ) : null}
+          </div>
+        </CardContent>
+      </Card>
 
-        <div className="space-y-6">
-          {show.scenes.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Noch keine Szenen erfasst.</p>
-          ) : (
-            show.scenes.map((scene) => {
-              const assignedCharacterIds = new Set(scene.characters.map((entry) => entry.character.id));
-              const availableCharacters = show.characters.filter((character) => !assignedCharacterIds.has(character.id));
-              return (
-                <div key={scene.id} className="flex flex-col gap-5 rounded-lg border border-border/70 bg-background/60 p-6">
-                  <div className="flex flex-wrap items-start justify-between gap-4">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs uppercase tracking-wide text-muted-foreground">Szene {scene.identifier ?? "?"}</span>
-                        <span className="text-sm text-muted-foreground">#{scene.sequence ?? 0}</span>
-                      </div>
-                      <h3 className="text-lg font-semibold">{scene.title ?? "(ohne Titel)"}</h3>
-                      {scene.summary ? (
-                        <p className="mt-1 text-sm text-muted-foreground">{scene.summary}</p>
-                      ) : null}
-                      <div className="mt-1 flex flex-wrap gap-3 text-xs text-muted-foreground">
-                        {scene.location ? <span>Ort: {scene.location}</span> : null}
-                        {scene.timeOfDay ? <span>Tageszeit: {scene.timeOfDay}</span> : null}
-                        {scene.durationMinutes ? <span>Dauer: {scene.durationMinutes} min</span> : null}
-                      </div>
-                    </div>
-                    <form action={deleteSceneAction} method="post">
-                      <input type="hidden" name="sceneId" value={scene.id} />
-                      <input type="hidden" name="redirectPath" value={showPath} />
-                      <Button type="submit" variant="ghost" size="sm">
-                        Entfernen
-                      </Button>
-                    </form>
-                  </div>
-
-                  <form
-                    action={updateSceneAction}
-                    method="post"
-                    className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
-                  >
-                    <input type="hidden" name="sceneId" value={scene.id} />
-                    <input type="hidden" name="redirectPath" value={showPath} />
-                    <div className="grid gap-3 md:grid-cols-3">
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Nummer</label>
-                        <Input name="identifier" defaultValue={scene.identifier ?? ""} maxLength={40} />
-                      </div>
-                      <div className="space-y-1 md:col-span-2">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Titel</label>
-                        <Input name="title" defaultValue={scene.title ?? ""} maxLength={160} />
-                      </div>
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Slug</label>
-                        <Input name="slug" defaultValue={scene.slug ?? ""} maxLength={80} />
-                      </div>
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Ort</label>
-                        <Input name="location" defaultValue={scene.location ?? ""} maxLength={120} />
-                      </div>
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Tageszeit</label>
-                        <Input name="timeOfDay" defaultValue={scene.timeOfDay ?? ""} maxLength={60} />
-                      </div>
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Reihenfolge</label>
-                        <Input
-                          type="number"
-                          name="sequence"
-                          defaultValue={scene.sequence ?? 0}
-                          min={0}
-                          max={9999}
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Dauer (Minuten)</label>
-                        <Input
-                          type="number"
-                          name="duration"
-                          defaultValue={scene.durationMinutes ?? ""}
-                          min={0}
-                          max={600}
-                        />
-                      </div>
-                      <div className="space-y-1 md:col-span-3">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Zusammenfassung</label>
-                        <Textarea name="summary" rows={2} maxLength={600} defaultValue={scene.summary ?? ""} />
-                      </div>
-                      <div className="space-y-1 md:col-span-3">
-                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notizen</label>
-                        <Textarea name="notes" rows={2} maxLength={400} defaultValue={scene.notes ?? ""} />
-                      </div>
-                    </div>
-                    <div className="flex justify-end">
-                      <Button type="submit" variant="outline" size="sm">
-                        Szene aktualisieren
-                      </Button>
-                    </div>
-                  </form>
-
-                  <div className="space-y-3">
-                    <h4 className="text-sm font-semibold">Rolleneinsatz</h4>
-                    {scene.characters.length === 0 ? (
-                      <p className="text-sm text-muted-foreground">Keine Figuren in dieser Szene.</p>
-                    ) : (
-                      <div className="flex flex-wrap gap-2">
-                        {scene.characters.map((entry) => (
-                          <form
-                            key={entry.id}
-                            action={removeSceneCharacterAction}
-                            method="post"
-                            className="flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-3 py-1"
-                          >
-                            <input type="hidden" name="assignmentId" value={entry.id} />
-                            <input type="hidden" name="redirectPath" value={showPath} />
-                            <span className="text-sm font-medium">{entry.character.name}</span>
-                            <Button type="submit" variant="ghost" size="sm">
-                              ×
-                            </Button>
-                          </form>
-                        ))}
-                      </div>
-                    )}
-
-                    <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-3">
-                      <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        Figur hinzufügen
-                      </h5>
-                      <form className="mt-2 grid gap-2 md:grid-cols-4" action={addSceneCharacterAction} method="post">
-                        <input type="hidden" name="sceneId" value={scene.id} />
-                        <input type="hidden" name="redirectPath" value={showPath} />
-                        <div className="space-y-1 md:col-span-2">
-                          <label className="text-xs font-medium text-muted-foreground">Figur</label>
-                          <select name="characterId" className={selectSmallClassName} required>
-                            <option value="">Figur auswählen</option>
-                            {availableCharacters.map((characterOption) => (
-                              <option key={characterOption.id} value={characterOption.id}>
-                                {characterOption.name}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div className="space-y-1">
-                          <label className="text-xs font-medium text-muted-foreground">Sortierung</label>
-                          <Input type="number" name="order" min={0} max={9999} />
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <input type="checkbox" name="isFeatured" className="h-4 w-4 rounded border-border" />
-                          <span className="text-xs text-muted-foreground">Hervorgehoben</span>
-                        </div>
-                        <div className="md:col-span-4 flex justify-end">
-                          <Button type="submit" size="sm">
-                            Figur zuordnen
-                          </Button>
-                        </div>
-                      </form>
-                    </div>
-                  </div>
-
-                  <div className="space-y-3">
-                    <h4 className="text-sm font-semibold">Breakdown</h4>
-                    <div className="space-y-3">
-                      {scene.breakdownItems.length === 0 ? (
-                        <p className="text-sm text-muted-foreground">Noch keine Aufgaben hinterlegt.</p>
-                      ) : (
-                        scene.breakdownItems.map((item) => (
-                          <div key={item.id} className="rounded-md border border-border/60 bg-background/80 p-4 text-sm">
-                            <div className="flex flex-wrap items-center justify-between gap-2">
-                              <div>
-                                <p className="font-medium">{item.title}</p>
-                                <p className="text-xs text-muted-foreground">
-                                  {item.department.name} · Status: {STATUS_LABELS[item.status]}
-                                </p>
-                                {item.assignedTo ? (
-                                  <p className="text-xs text-muted-foreground">
-                                    Zuständig: {formatUserName(item.assignedTo)}
-                                  </p>
-                                ) : null}
-                              </div>
-                              <form action={removeBreakdownItemAction} method="post">
-                                <input type="hidden" name="itemId" value={item.id} />
-                                <input type="hidden" name="redirectPath" value={showPath} />
-                                <Button type="submit" variant="ghost" size="sm">
-                                  Entfernen
-                                </Button>
-                              </form>
-                            </div>
-                            {item.description ? (
-                              <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
-                            ) : null}
-                            {item.note ? (
-                              <p className="text-xs text-muted-foreground">Notiz: {item.note}</p>
-                            ) : null}
-                            {item.neededBy ? (
-                              <p className="text-xs text-muted-foreground">
-                                Benötigt bis: {item.neededBy.toISOString().slice(0, 10)}
-                              </p>
-                            ) : null}
-                            <form
-                              action={updateBreakdownItemAction}
-                              method="post"
-                              className="mt-3 grid gap-2 md:grid-cols-4"
-                            >
-                              <input type="hidden" name="itemId" value={item.id} />
-                              <input type="hidden" name="redirectPath" value={showPath} />
-                              <div className="space-y-1 md:col-span-2">
-                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                  Titel
-                                </label>
-                                <Input name="title" defaultValue={item.title} maxLength={160} />
-                              </div>
-                              <div className="space-y-1">
-                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                  Status
-                                </label>
-                                <select name="status" defaultValue={item.status} className={selectSmallClassName}>
-                                  {statusOptions.map((status) => (
-                                    <option key={status} value={status}>
-                                      {STATUS_LABELS[status]}
-                                    </option>
-                                  ))}
-                                </select>
-                              </div>
-                              <div className="space-y-1">
-                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                  Benötigt bis
-                                </label>
-                                <Input
-                                  type="date"
-                                  name="neededBy"
-                                  defaultValue={item.neededBy ? item.neededBy.toISOString().slice(0, 10) : ""}
-                                />
-                              </div>
-                              <div className="space-y-1 md:col-span-4">
-                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                  Beschreibung
-                                </label>
-                                <Textarea name="description" rows={2} maxLength={600} defaultValue={item.description ?? ""} />
-                              </div>
-                              <div className="space-y-1 md:col-span-2">
-                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                  Notiz
-                                </label>
-                                <Input name="note" defaultValue={item.note ?? ""} maxLength={300} />
-                              </div>
-                              <div className="space-y-1 md:col-span-2">
-                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                  Zuständig
-                                </label>
-                                <select
-                                  name="assignedToId"
-                                  defaultValue={item.assignedToId ?? ""}
-                                  className={selectSmallClassName}
-                                >
-                                  <option value="">(keine Zuordnung)</option>
-                                  {users.map((user) => (
-                                    <option key={user.id} value={user.id}>
-                                      {formatUserName(user)}
-                                    </option>
-                                  ))}
-                                </select>
-                              </div>
-                              <div className="md:col-span-4 flex justify-end">
-                                <Button type="submit" variant="outline" size="sm">
-                                  Speichern
-                                </Button>
-                              </div>
-                            </form>
-                          </div>
-                        ))
-                      )}
-                    </div>
-
-                    <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-3">
-                      <h5 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        Breakdown-Eintrag hinzufügen
-                      </h5>
-                      <form className="mt-2 grid gap-2 md:grid-cols-4" action={createBreakdownItemAction} method="post">
-                        <input type="hidden" name="sceneId" value={scene.id} />
-                        <input type="hidden" name="redirectPath" value={showPath} />
-                        <div className="space-y-1 md:col-span-2">
-                          <label className="text-xs font-medium text-muted-foreground">Gewerk</label>
-                          <select name="departmentId" className={selectSmallClassName} required>
-                            <option value="">Gewerk auswählen</option>
-                            {departments.map((departmentOption) => (
-                              <option key={departmentOption.id} value={departmentOption.id}>
-                                {departmentOption.name}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div className="space-y-1">
-                          <label className="text-xs font-medium text-muted-foreground">Status</label>
-                          <select name="status" className={selectSmallClassName} defaultValue={BreakdownStatus.planned}>
-                            {statusOptions.map((status) => (
-                              <option key={status} value={status}>
-                                {STATUS_LABELS[status]}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div className="space-y-1">
-                          <label className="text-xs font-medium text-muted-foreground">Benötigt bis</label>
-                          <Input type="date" name="neededBy" />
-                        </div>
-                        <div className="space-y-1 md:col-span-4">
-                          <label className="text-xs font-medium text-muted-foreground">Titel</label>
-                          <Input name="title" maxLength={160} required placeholder="Aufgabe" />
-                        </div>
-                        <div className="space-y-1 md:col-span-4">
-                          <label className="text-xs font-medium text-muted-foreground">Beschreibung</label>
-                          <Textarea name="description" rows={2} maxLength={600} placeholder="Details zur Aufgabe" />
-                        </div>
-                        <div className="space-y-1 md:col-span-2">
-                          <label className="text-xs font-medium text-muted-foreground">Zuständig</label>
-                          <select name="assignedToId" className={selectSmallClassName}>
-                            <option value="">(optional)</option>
-                            {users.map((user) => (
-                              <option key={user.id} value={user.id}>
-                                {formatUserName(user)}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div className="space-y-1 md:col-span-4">
-                          <label className="text-xs font-medium text-muted-foreground">Notiz</label>
-                          <Input name="note" maxLength={300} placeholder="interne Notiz" />
-                        </div>
-                        <div className="md:col-span-4 flex justify-end">
-                          <Button type="submit" size="sm">
-                            Breakdown speichern
-                          </Button>
-                        </div>
-                      </form>
-                    </div>
-                  </div>
-                </div>
-              );
-            })
-          )}
-        </div>
-      </section>
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-lg font-semibold">Nächste Schritte</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Nutze die neuen Navigationspunkte, um die Produktion in klar getrennten Arbeitsbereichen zu pflegen. Alle Änderungen aktualisieren die Statistik oben automatisch, sobald du zur Übersicht zurückkehrst.
+          </p>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-3">
+          <Button asChild size="sm" variant="outline">
+            <Link href="/mitglieder/produktionen">Zur Übersicht zurückkehren</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link href="/mitglieder/produktionen/besetzung">Zum Rollenbereich</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link href="/mitglieder/produktionen/szenen">Zum Szenenbereich</Link>
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
@@ -1,0 +1,404 @@
+import Link from "next/link";
+import { CharacterCastingType } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { getActiveProduction, getActiveProductionId } from "@/lib/active-production";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import {
+  createCharacterAction,
+  updateCharacterAction,
+  deleteCharacterAction,
+  assignCharacterCastingAction,
+  updateCharacterCastingAction,
+  removeCharacterCastingAction,
+} from "../actions";
+
+const CASTING_LABELS: Record<CharacterCastingType, string> = {
+  primary: "Primär",
+  alternate: "Alternate",
+  cover: "Cover",
+  cameo: "Cameo",
+};
+
+const CASTING_ORDER: CharacterCastingType[] = [
+  CharacterCastingType.primary,
+  CharacterCastingType.alternate,
+  CharacterCastingType.cover,
+  CharacterCastingType.cameo,
+];
+
+const selectSmallClassName =
+  "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+function formatUserName(user: { name: string | null; email: string | null }) {
+  if (user.name && user.name.trim()) return user.name;
+  if (user.email) return user.email;
+  return "Unbekannt";
+}
+
+export default async function ProduktionsBesetzungPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.produktionen");
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-border/70 bg-background/60 p-6 text-sm text-muted-foreground">
+        Du hast keinen Zugriff auf die Produktionsplanung.
+      </div>
+    );
+  }
+
+  const activeProductionId = getActiveProductionId();
+  if (!activeProductionId) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-lg font-semibold">Keine aktive Produktion ausgewählt</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Wähle in der Produktionsübersicht eine aktive Produktion aus, um Rollen und Besetzungen zu bearbeiten.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const [activeProduction, users, show] = await Promise.all([
+    getActiveProduction(),
+    prisma.user.findMany({
+      orderBy: [
+        { name: "asc" },
+        { email: "asc" },
+      ],
+      select: { id: true, name: true, email: true },
+    }),
+    prisma.show.findUnique({
+      where: { id: activeProductionId },
+      select: {
+        id: true,
+        title: true,
+        year: true,
+        synopsis: true,
+        characters: {
+          orderBy: { order: "asc" },
+          select: {
+            id: true,
+            name: true,
+            shortName: true,
+            description: true,
+            notes: true,
+            color: true,
+            order: true,
+            castings: {
+              select: {
+                id: true,
+                type: true,
+                notes: true,
+                user: { select: { id: true, name: true, email: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  if (!show) {
+    return (
+      <div className="rounded-lg border border-border/70 bg-background/60 p-6 text-sm text-muted-foreground">
+        Die aktuell ausgewählte Produktion konnte nicht gefunden werden. Bitte wähle sie erneut in der Übersicht aus.
+      </div>
+    );
+  }
+
+  const currentPath = "/mitglieder/produktionen/besetzung";
+
+  const productionTitle = activeProduction?.title && activeProduction.title.trim()
+    ? activeProduction.title
+    : `Produktion ${activeProduction?.year ?? show.year}`;
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Aktive Produktion</p>
+            <h1 className="text-3xl font-semibold">Rollen &amp; Besetzungen</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Erstelle neue Figuren, pflege Beschreibungen und ordne Ensemble-Mitglieder als Primär-, Alternate- oder Cover-Besetzung zu.
+            </p>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
+          </Button>
+        </div>
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-xl font-semibold">{productionTitle}</CardTitle>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Jahrgang {show.year}</p>
+          </CardHeader>
+          {show.synopsis ? (
+            <CardContent>
+              <p className="text-sm text-muted-foreground">{show.synopsis}</p>
+            </CardContent>
+          ) : null}
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-lg font-semibold">Neue Rolle anlegen</CardTitle>
+          <p className="text-sm text-muted-foreground">Füge Figuren hinzu und definiere Reihenfolge, Farbe sowie optionale Notizen.</p>
+        </CardHeader>
+        <CardContent>
+          <form action={createCharacterAction} method="post" className="grid gap-4 md:grid-cols-2">
+            <input type="hidden" name="showId" value={show.id} />
+            <input type="hidden" name="redirectPath" value={currentPath} />
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Name</label>
+              <Input name="name" placeholder="z.B. Protagonist" minLength={2} maxLength={120} required />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Kurzname</label>
+              <Input name="shortName" placeholder="Kurzlabel" maxLength={40} />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Beschreibung</label>
+              <Textarea name="description" rows={2} maxLength={500} placeholder="Charakterbeschreibung" />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Farbe</label>
+              <input
+                type="color"
+                name="color"
+                defaultValue="#7c3aed"
+                className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Sortierung</label>
+              <Input type="number" name="order" min={0} max={9999} placeholder="0" />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Notiz</label>
+              <Textarea name="notes" rows={2} maxLength={500} placeholder="Interne Notiz" />
+            </div>
+            <div className="md:col-span-2">
+              <Button type="submit">Rolle speichern</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        {show.characters.length === 0 ? (
+          <Card>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">Noch keine Rollen angelegt. Lege eine neue Rolle über das Formular oben an.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          show.characters.map((character) => {
+            const sortedCastings = [...character.castings].sort((a, b) => {
+              const orderA = CASTING_ORDER.indexOf(a.type);
+              const orderB = CASTING_ORDER.indexOf(b.type);
+              return orderA - orderB;
+            });
+
+            return (
+              <Card key={character.id} className="space-y-5">
+                <CardHeader className="space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <CardTitle className="text-xl font-semibold">{character.name}</CardTitle>
+                      {character.shortName ? (
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">{character.shortName}</p>
+                      ) : null}
+                      {character.description ? (
+                        <p className="text-sm text-muted-foreground">{character.description}</p>
+                      ) : null}
+                      {character.notes ? (
+                        <p className="text-xs text-muted-foreground">Notiz: {character.notes}</p>
+                      ) : null}
+                    </div>
+                    <form action={deleteCharacterAction} method="post">
+                      <input type="hidden" name="characterId" value={character.id} />
+                      <input type="hidden" name="redirectPath" value={currentPath} />
+                      <Button type="submit" variant="ghost" size="sm">
+                        Entfernen
+                      </Button>
+                    </form>
+                  </div>
+                </CardHeader>
+
+                <CardContent className="space-y-5">
+                  <form
+                    action={updateCharacterAction}
+                    method="post"
+                    className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
+                  >
+                    <input type="hidden" name="characterId" value={character.id} />
+                    <input type="hidden" name="redirectPath" value={currentPath} />
+                    <div className="grid gap-3 md:grid-cols-2">
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
+                        <Input name="name" defaultValue={character.name} minLength={2} maxLength={120} required />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Kurzname</label>
+                        <Input name="shortName" defaultValue={character.shortName ?? ""} maxLength={40} />
+                      </div>
+                      <div className="space-y-1 md:col-span-2">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Beschreibung</label>
+                        <Textarea name="description" rows={2} maxLength={500} defaultValue={character.description ?? ""} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Sortierung</label>
+                        <Input type="number" name="order" defaultValue={character.order ?? 0} min={0} max={9999} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Farbe</label>
+                        <input
+                          type="color"
+                          name="color"
+                          defaultValue={character.color ?? "#7c3aed"}
+                          className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+                        />
+                      </div>
+                      <div className="space-y-1 md:col-span-2">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+                        <Textarea name="notes" rows={2} maxLength={500} defaultValue={character.notes ?? ""} />
+                      </div>
+                    </div>
+                    <div className="flex justify-end">
+                      <Button type="submit" variant="outline" size="sm">
+                        Rolle aktualisieren
+                      </Button>
+                    </div>
+                  </form>
+
+                  <div className="space-y-3">
+                    <h3 className="text-sm font-semibold">Besetzung</h3>
+                    <div className="space-y-3">
+                      {sortedCastings.length === 0 ? (
+                        <p className="text-sm text-muted-foreground">Noch keine Besetzung zugeordnet.</p>
+                      ) : (
+                        sortedCastings.map((casting) => (
+                          <div
+                            key={casting.id}
+                            className="rounded-lg border border-border/60 bg-background/80 p-3 text-sm shadow-sm"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-3">
+                              <div>
+                                <p className="font-medium">{formatUserName(casting.user)}</p>
+                                <p className="text-xs text-muted-foreground">{CASTING_LABELS[casting.type]}</p>
+                                {casting.notes ? (
+                                  <p className="text-xs text-muted-foreground">Notiz: {casting.notes}</p>
+                                ) : null}
+                              </div>
+                              <form action={removeCharacterCastingAction} method="post">
+                                <input type="hidden" name="castingId" value={casting.id} />
+                                <input type="hidden" name="redirectPath" value={currentPath} />
+                                <Button type="submit" variant="ghost" size="sm">
+                                  Entfernen
+                                </Button>
+                              </form>
+                            </div>
+                            <form
+                              action={updateCharacterCastingAction}
+                              method="post"
+                              className="mt-3 grid gap-2 rounded-md border border-border/50 bg-background/70 p-3 md:grid-cols-3"
+                            >
+                              <input type="hidden" name="castingId" value={casting.id} />
+                              <input type="hidden" name="redirectPath" value={currentPath} />
+                              <div className="space-y-1">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                  Besetzungsart
+                                </label>
+                                <select name="type" defaultValue={casting.type} className={selectSmallClassName}>
+                                  {CASTING_ORDER.map((type) => (
+                                    <option key={type} value={type}>
+                                      {CASTING_LABELS[type]}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                              <div className="space-y-1 md:col-span-2">
+                                <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+                                <Input name="notes" defaultValue={casting.notes ?? ""} maxLength={200} />
+                              </div>
+                              <div className="md:col-span-3 flex justify-end">
+                                <Button type="submit" variant="outline" size="sm">
+                                  Änderungen speichern
+                                </Button>
+                              </div>
+                            </form>
+                          </div>
+                        ))
+                      )}
+                    </div>
+
+                    <div className="rounded-lg border border-dashed border-border/70 bg-background/50 p-4">
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Mitglied zuordnen
+                      </h4>
+                      <form className="mt-3 grid gap-2 md:grid-cols-4" action={assignCharacterCastingAction} method="post">
+                        <input type="hidden" name="characterId" value={character.id} />
+                        <input type="hidden" name="redirectPath" value={currentPath} />
+                        <div className="space-y-1 md:col-span-2">
+                          <label className="text-xs font-medium text-muted-foreground">Mitglied</label>
+                          <select name="userId" className={selectSmallClassName} required>
+                            <option value="">Mitglied auswählen</option>
+                            {users.map((user) => (
+                              <option key={user.id} value={user.id}>
+                                {formatUserName(user)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <label className="text-xs font-medium text-muted-foreground">Besetzungsart</label>
+                          <select
+                            name="type"
+                            className={selectSmallClassName}
+                            defaultValue={CharacterCastingType.primary}
+                          >
+                            {CASTING_ORDER.map((type) => (
+                              <option key={type} value={type}>
+                                {CASTING_LABELS[type]}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <label className="text-xs font-medium text-muted-foreground">Notiz</label>
+                          <Input name="notes" maxLength={200} placeholder="optional" />
+                        </div>
+                        <div className="md:col-span-4 flex justify-end">
+                          <Button type="submit" size="sm">
+                            Mitglied besetzen
+                          </Button>
+                        </div>
+                      </form>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
@@ -1,0 +1,330 @@
+import Link from "next/link";
+import { DepartmentMembershipRole } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import {
+  createDepartmentAction,
+  updateDepartmentAction,
+  deleteDepartmentAction,
+  addDepartmentMemberAction,
+  updateDepartmentMemberAction,
+  removeDepartmentMemberAction,
+} from "../actions";
+
+const ROLE_LABELS: Record<DepartmentMembershipRole, string> = {
+  lead: "Leitung",
+  member: "Mitglied",
+  deputy: "Vertretung",
+  guest: "Gast",
+};
+
+function formatUserName(user: { name: string | null; email: string | null }) {
+  if (user.name && user.name.trim()) return user.name;
+  if (user.email) return user.email;
+  return "Unbekannt";
+}
+
+const selectClassName =
+  "h-10 w-full rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+export default async function ProduktionsGewerkePage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.produktionen");
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-border/70 bg-background/60 p-6 text-sm text-muted-foreground">
+        Du hast keinen Zugriff auf die Produktionsplanung.
+      </div>
+    );
+  }
+
+  const [departments, users] = await Promise.all([
+    prisma.department.findMany({
+      orderBy: { name: "asc" },
+      include: {
+        memberships: {
+          include: {
+            user: { select: { id: true, name: true, email: true } },
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    }),
+    prisma.user.findMany({
+      orderBy: [
+        { name: "asc" },
+        { email: "asc" },
+      ],
+      select: { id: true, name: true, email: true },
+    }),
+  ]);
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Team-Workspace</p>
+            <h1 className="text-3xl font-semibold">Gewerke &amp; Zuständigkeiten</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Strukturiere dein Produktionsteam, vergib Verantwortlichkeiten und halte Kontaktdaten zentral an einem Ort fest.
+            </p>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
+          </Button>
+        </div>
+      </section>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-lg font-semibold">Neues Gewerk anlegen</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Definiere Verantwortungsbereiche mit Farben, Beschreibungen und optionalem Slug für eine bessere Orientierung.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form action={createDepartmentAction} className="grid gap-4 md:grid-cols-2" method="post">
+            <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Name</label>
+              <Input name="name" placeholder="z.B. Maske" required minLength={2} maxLength={80} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Slug (optional)</label>
+              <Input name="slug" placeholder="maske" maxLength={80} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Farbe</label>
+              <input
+                type="color"
+                name="color"
+                defaultValue="#9333ea"
+                className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+              />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Beschreibung</label>
+              <Textarea name="description" rows={2} maxLength={2000} placeholder="Kurzbeschreibung für das Gewerk" />
+            </div>
+            <div className="md:col-span-2">
+              <Button type="submit">Gewerk speichern</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        {departments.map((department) => {
+          const memberIds = new Set(department.memberships.map((membership) => membership.user.id));
+          const availableUsers = users.filter((user) => !memberIds.has(user.id));
+
+          return (
+            <Card key={department.id} className="space-y-6">
+              <CardHeader className="space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-start gap-3">
+                    <span
+                      className="mt-1 inline-block h-3 w-3 rounded-full border border-border/80"
+                      style={{ backgroundColor: department.color ?? "#94a3b8" }}
+                    />
+                    <div className="space-y-1">
+                      <CardTitle className="text-xl font-semibold">{department.name}</CardTitle>
+                      {department.description ? (
+                        <p className="text-sm text-muted-foreground">{department.description}</p>
+                      ) : null}
+                      {department.slug ? (
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">Slug: {department.slug}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                  <form action={deleteDepartmentAction} method="post">
+                    <input type="hidden" name="id" value={department.id} />
+                    <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
+                    <Button type="submit" variant="ghost" size="sm">
+                      Entfernen
+                    </Button>
+                  </form>
+                </div>
+              </CardHeader>
+
+              <CardContent className="space-y-6">
+                <form
+                  action={updateDepartmentAction}
+                  method="post"
+                  className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
+                >
+                  <input type="hidden" name="id" value={department.id} />
+                  <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
+                      <Input name="name" defaultValue={department.name} minLength={2} maxLength={80} required />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Slug</label>
+                      <Input name="slug" defaultValue={department.slug ?? ""} maxLength={80} />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Farbe</label>
+                      <input
+                        type="color"
+                        name="color"
+                        defaultValue={department.color ?? "#94a3b8"}
+                        className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+                      />
+                    </div>
+                    <div className="space-y-1 md:col-span-2">
+                      <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Beschreibung
+                      </label>
+                      <Textarea
+                        name="description"
+                        rows={2}
+                        maxLength={2000}
+                        defaultValue={department.description ?? ""}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex justify-end">
+                    <Button type="submit" variant="outline" size="sm">
+                      Gewerk aktualisieren
+                    </Button>
+                  </div>
+                </form>
+
+                <div className="space-y-4">
+                  <div>
+                    <h3 className="text-sm font-semibold">Teammitglieder</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Verknüpfe Personen mit klaren Rollen und zusätzlichen Notizen.
+                    </p>
+                  </div>
+
+                  <div className="space-y-3">
+                    {department.memberships.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">Noch keine Mitglieder zugeordnet.</p>
+                    ) : (
+                      department.memberships.map((membership) => (
+                        <div
+                          key={membership.id}
+                          className="rounded-lg border border-border/60 bg-background/80 p-3 text-sm shadow-sm"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <div>
+                              <p className="font-medium">{formatUserName(membership.user)}</p>
+                              <p className="text-xs text-muted-foreground">{ROLE_LABELS[membership.role]}</p>
+                              {membership.title ? (
+                                <p className="text-xs text-muted-foreground">{membership.title}</p>
+                              ) : null}
+                              {membership.note ? (
+                                <p className="text-xs text-muted-foreground">Notiz: {membership.note}</p>
+                              ) : null}
+                            </div>
+                            <form action={removeDepartmentMemberAction} method="post">
+                              <input type="hidden" name="membershipId" value={membership.id} />
+                              <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
+                              <Button type="submit" variant="ghost" size="sm">
+                                Entfernen
+                              </Button>
+                            </form>
+                          </div>
+                          <form
+                            action={updateDepartmentMemberAction}
+                            method="post"
+                            className="mt-3 grid gap-2 rounded-md border border-border/50 bg-background/70 p-3 md:grid-cols-3"
+                          >
+                            <input type="hidden" name="membershipId" value={membership.id} />
+                            <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
+                            <div className="space-y-1">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Funktion
+                              </label>
+                              <select name="role" defaultValue={membership.role} className={selectClassName}>
+                                {Object.values(DepartmentMembershipRole).map((role) => (
+                                  <option key={role} value={role}>
+                                    {ROLE_LABELS[role]}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                            <div className="space-y-1">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Bezeichnung
+                              </label>
+                              <Input name="title" defaultValue={membership.title ?? ""} maxLength={120} />
+                            </div>
+                            <div className="space-y-1">
+                              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+                              <Input name="note" defaultValue={membership.note ?? ""} maxLength={200} />
+                            </div>
+                            <div className="md:col-span-3 flex justify-end">
+                              <Button type="submit" variant="outline" size="sm">
+                                Änderungen speichern
+                              </Button>
+                            </div>
+                          </form>
+                        </div>
+                      ))
+                    )}
+                  </div>
+
+                  <div className="rounded-lg border border-dashed border-border/70 bg-background/50 p-4">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Mitglied hinzufügen
+                    </h4>
+                    <form className="mt-3 grid gap-3 md:grid-cols-3" action={addDepartmentMemberAction} method="post">
+                      <input type="hidden" name="departmentId" value={department.id} />
+                      <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
+                      <div className="space-y-1 md:col-span-1">
+                        <label className="text-xs font-medium text-muted-foreground">Mitglied</label>
+                        <select name="userId" className={selectClassName} required>
+                          <option value="">Mitglied auswählen</option>
+                          {availableUsers.map((user) => (
+                            <option key={user.id} value={user.id}>
+                              {formatUserName(user)}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium text-muted-foreground">Funktion</label>
+                        <select name="role" className={selectClassName} defaultValue={DepartmentMembershipRole.member}>
+                          {Object.values(DepartmentMembershipRole).map((role) => (
+                            <option key={role} value={role}>
+                              {ROLE_LABELS[role]}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium text-muted-foreground">Bezeichnung</label>
+                        <Input name="title" maxLength={120} placeholder="z.B. Leitung" />
+                      </div>
+                      <div className="space-y-1 md:col-span-3">
+                        <label className="text-xs font-medium text-muted-foreground">Notiz</label>
+                        <Input name="note" maxLength={200} placeholder="optionale Notiz" />
+                      </div>
+                      <div className="md:col-span-3 flex justify-end">
+                        <Button type="submit" size="sm">
+                          Mitglied zuordnen
+                        </Button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
@@ -1,0 +1,573 @@
+import Link from "next/link";
+import { BreakdownStatus } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { getActiveProduction, getActiveProductionId } from "@/lib/active-production";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+import {
+  createSceneAction,
+  updateSceneAction,
+  deleteSceneAction,
+  addSceneCharacterAction,
+  removeSceneCharacterAction,
+  createBreakdownItemAction,
+  updateBreakdownItemAction,
+  removeBreakdownItemAction,
+} from "../actions";
+
+const STATUS_LABELS: Record<BreakdownStatus, string> = {
+  planned: "Geplant",
+  in_progress: "In Arbeit",
+  blocked: "Blockiert",
+  ready: "Bereit",
+  done: "Erledigt",
+};
+
+const selectClassName =
+  "h-10 w-full rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const selectSmallClassName =
+  "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+function formatUserName(user: { name: string | null; email: string | null }) {
+  if (user.name && user.name.trim()) return user.name;
+  if (user.email) return user.email;
+  return "Unbekannt";
+}
+
+export default async function ProduktionsSzenenPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.produktionen");
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-border/70 bg-background/60 p-6 text-sm text-muted-foreground">
+        Du hast keinen Zugriff auf die Produktionsplanung.
+      </div>
+    );
+  }
+
+  const activeProductionId = getActiveProductionId();
+  if (!activeProductionId) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-lg font-semibold">Keine aktive Produktion ausgewählt</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Wähle in der Produktionsübersicht eine aktive Produktion aus, um Szenen und Breakdowns zu verwalten.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const [activeProduction, users, departments, show] = await Promise.all([
+    getActiveProduction(),
+    prisma.user.findMany({
+      orderBy: [
+        { name: "asc" },
+        { email: "asc" },
+      ],
+      select: { id: true, name: true, email: true },
+    }),
+    prisma.department.findMany({
+      orderBy: { name: "asc" },
+      select: { id: true, name: true, slug: true, color: true },
+    }),
+    prisma.show.findUnique({
+      where: { id: activeProductionId },
+      select: {
+        id: true,
+        title: true,
+        year: true,
+        synopsis: true,
+        characters: {
+          orderBy: { order: "asc" },
+          select: { id: true, name: true, shortName: true, color: true },
+        },
+        scenes: {
+          orderBy: { sequence: "asc" },
+          select: {
+            id: true,
+            identifier: true,
+            title: true,
+            summary: true,
+            location: true,
+            timeOfDay: true,
+            notes: true,
+            sequence: true,
+            durationMinutes: true,
+            slug: true,
+            characters: {
+              orderBy: { order: "asc" },
+              select: {
+                id: true,
+                isFeatured: true,
+                order: true,
+                character: { select: { id: true, name: true, shortName: true, color: true } },
+              },
+            },
+            breakdownItems: {
+              orderBy: { createdAt: "asc" },
+              select: {
+                id: true,
+                title: true,
+                description: true,
+                note: true,
+                status: true,
+                neededBy: true,
+                department: { select: { id: true, name: true, slug: true, color: true } },
+                assignedToId: true,
+                assignedTo: { select: { id: true, name: true, email: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  if (!show) {
+    return (
+      <div className="rounded-lg border border-border/70 bg-background/60 p-6 text-sm text-muted-foreground">
+        Die aktuell ausgewählte Produktion konnte nicht gefunden werden. Bitte wähle sie erneut in der Übersicht aus.
+      </div>
+    );
+  }
+
+  const currentPath = "/mitglieder/produktionen/szenen";
+  const statusOptions = Object.values(BreakdownStatus);
+  const productionTitle = activeProduction?.title && activeProduction.title.trim()
+    ? activeProduction.title
+    : `Produktion ${activeProduction?.year ?? show.year}`;
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Aktive Produktion</p>
+            <h1 className="text-3xl font-semibold">Szenen &amp; Breakdowns</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Plane Szenenabläufe, pflege Orte und Zeiten und behalte Aufgaben je Gewerk inklusive Status und Zuständigkeit im Blick.
+            </p>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
+          </Button>
+        </div>
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-xl font-semibold">{productionTitle}</CardTitle>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Jahrgang {show.year}</p>
+          </CardHeader>
+          {show.synopsis ? (
+            <CardContent>
+              <p className="text-sm text-muted-foreground">{show.synopsis}</p>
+            </CardContent>
+          ) : null}
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-lg font-semibold">Neue Szene anlegen</CardTitle>
+          <p className="text-sm text-muted-foreground">Erfasse Orte, Tageszeiten, Reihenfolgen und Notizen, um den Szenenplan aktuell zu halten.</p>
+        </CardHeader>
+        <CardContent>
+          <form action={createSceneAction} method="post" className="grid gap-4 md:grid-cols-3">
+            <input type="hidden" name="showId" value={show.id} />
+            <input type="hidden" name="redirectPath" value={currentPath} />
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Nummer</label>
+              <Input name="identifier" maxLength={40} placeholder="z.B. 1" />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Titel</label>
+              <Input name="title" maxLength={160} placeholder="z.B. Ankunft im Park" />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Ort</label>
+              <Input name="location" maxLength={120} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Tageszeit</label>
+              <Input name="timeOfDay" maxLength={60} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Slug</label>
+              <Input name="slug" maxLength={80} placeholder="szene-1" />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Reihenfolge</label>
+              <Input type="number" name="sequence" min={0} max={9999} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Dauer (Minuten)</label>
+              <Input type="number" name="duration" min={0} max={600} />
+            </div>
+            <div className="space-y-1 md:col-span-3">
+              <label className="text-sm font-medium">Zusammenfassung</label>
+              <Textarea name="summary" rows={2} maxLength={600} />
+            </div>
+            <div className="space-y-1 md:col-span-3">
+              <label className="text-sm font-medium">Notizen</label>
+              <Textarea name="notes" rows={2} maxLength={400} />
+            </div>
+            <div className="md:col-span-3">
+              <Button type="submit">Szene speichern</Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <section className="space-y-6">
+        {show.scenes.length === 0 ? (
+          <Card>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">Noch keine Szenen erfasst. Lege eine Szene über das Formular oben an.</p>
+            </CardContent>
+          </Card>
+        ) : (
+          show.scenes.map((scene) => {
+            const assignedCharacterIds = new Set(scene.characters.map((entry) => entry.character.id));
+            const availableCharacters = show.characters.filter((character) => !assignedCharacterIds.has(character.id));
+
+            return (
+              <Card key={scene.id} className="space-y-5">
+                <CardHeader className="space-y-3">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span className="uppercase tracking-wide">Szene {scene.identifier ?? "?"}</span>
+                        <span>#{scene.sequence ?? 0}</span>
+                      </div>
+                      <CardTitle className="text-xl font-semibold">{scene.title ?? "(ohne Titel)"}</CardTitle>
+                      {scene.summary ? (
+                        <p className="text-sm text-muted-foreground">{scene.summary}</p>
+                      ) : null}
+                      <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                        {scene.location ? <span>Ort: {scene.location}</span> : null}
+                        {scene.timeOfDay ? <span>Tageszeit: {scene.timeOfDay}</span> : null}
+                        {scene.durationMinutes ? <span>Dauer: {scene.durationMinutes} min</span> : null}
+                      </div>
+                    </div>
+                    <form action={deleteSceneAction} method="post">
+                      <input type="hidden" name="sceneId" value={scene.id} />
+                      <input type="hidden" name="redirectPath" value={currentPath} />
+                      <Button type="submit" variant="ghost" size="sm">
+                        Entfernen
+                      </Button>
+                    </form>
+                  </div>
+                </CardHeader>
+
+                <CardContent className="space-y-6">
+                  <form
+                    action={updateSceneAction}
+                    method="post"
+                    className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4"
+                  >
+                    <input type="hidden" name="sceneId" value={scene.id} />
+                    <input type="hidden" name="redirectPath" value={currentPath} />
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Nummer</label>
+                        <Input name="identifier" defaultValue={scene.identifier ?? ""} maxLength={40} />
+                      </div>
+                      <div className="space-y-1 md:col-span-2">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Titel</label>
+                        <Input name="title" defaultValue={scene.title ?? ""} maxLength={160} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Slug</label>
+                        <Input name="slug" defaultValue={scene.slug ?? ""} maxLength={80} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Ort</label>
+                        <Input name="location" defaultValue={scene.location ?? ""} maxLength={120} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Tageszeit</label>
+                        <Input name="timeOfDay" defaultValue={scene.timeOfDay ?? ""} maxLength={60} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Reihenfolge</label>
+                        <Input type="number" name="sequence" defaultValue={scene.sequence ?? 0} min={0} max={9999} />
+                      </div>
+                      <div className="space-y-1">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Dauer (Minuten)</label>
+                        <Input type="number" name="duration" defaultValue={scene.durationMinutes ?? 0} min={0} max={600} />
+                      </div>
+                      <div className="space-y-1 md:col-span-3">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Zusammenfassung</label>
+                        <Textarea name="summary" rows={2} maxLength={600} defaultValue={scene.summary ?? ""} />
+                      </div>
+                      <div className="space-y-1 md:col-span-3">
+                        <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notizen</label>
+                        <Textarea name="notes" rows={2} maxLength={400} defaultValue={scene.notes ?? ""} />
+                      </div>
+                    </div>
+                    <div className="flex justify-end">
+                      <Button type="submit" variant="outline" size="sm">
+                        Szene aktualisieren
+                      </Button>
+                    </div>
+                  </form>
+
+                  <div className="space-y-4">
+                    <div className="rounded-lg border border-border/60 bg-background/70 p-4">
+                      <h3 className="text-sm font-semibold">Mitwirkende Figuren</h3>
+                      <div className="mt-3 space-y-2">
+                        {scene.characters.length === 0 ? (
+                          <p className="text-sm text-muted-foreground">Noch keine Figuren zugeordnet.</p>
+                        ) : (
+                          scene.characters.map((entry) => (
+                            <div
+                              key={entry.id}
+                              className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/50 bg-background/80 p-3 text-sm"
+                            >
+                              <div className="flex items-center gap-2">
+                                <span
+                                  className="inline-block h-3 w-3 rounded-full border border-border/80"
+                                  style={{ backgroundColor: entry.character.color ?? "#7c3aed" }}
+                                />
+                                <div>
+                                  <p className="font-medium">{entry.character.name}</p>
+                                  {entry.character.shortName ? (
+                                    <p className="text-xs text-muted-foreground">{entry.character.shortName}</p>
+                                  ) : null}
+                                  {entry.isFeatured ? (
+                                    <p className="text-xs text-muted-foreground">Hervorgehoben</p>
+                                  ) : null}
+                                </div>
+                              </div>
+                              <form action={removeSceneCharacterAction} method="post">
+                                <input type="hidden" name="assignmentId" value={entry.id} />
+                                <input type="hidden" name="redirectPath" value={currentPath} />
+                                <Button type="submit" variant="ghost" size="sm">
+                                  Entfernen
+                                </Button>
+                              </form>
+                            </div>
+                          ))
+                        )}
+                      </div>
+
+                      <div className="mt-4 rounded-md border border-dashed border-border/60 bg-background/50 p-3">
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Figur hinzufügen</h4>
+                        <form className="mt-3 grid gap-3 md:grid-cols-3" action={addSceneCharacterAction} method="post">
+                          <input type="hidden" name="sceneId" value={scene.id} />
+                          <input type="hidden" name="redirectPath" value={currentPath} />
+                          <div className="space-y-1 md:col-span-2">
+                            <label className="text-xs font-medium text-muted-foreground">Figur</label>
+                            <select name="characterId" className={selectClassName} required>
+                              <option value="">Figur auswählen</option>
+                              {availableCharacters.map((character) => (
+                                <option key={character.id} value={character.id}>
+                                  {character.name}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div className="space-y-1">
+                            <label className="text-xs font-medium text-muted-foreground">Hervorgehoben?</label>
+                            <select name="isFeatured" className={selectClassName} defaultValue="false">
+                              <option value="false">Standard</option>
+                              <option value="true">Hervorgehoben</option>
+                            </select>
+                          </div>
+                          <div className="md:col-span-3 flex justify-end">
+                            <Button type="submit" size="sm">
+                              Figur zuordnen
+                            </Button>
+                          </div>
+                        </form>
+                      </div>
+                    </div>
+
+                    <div className="space-y-3">
+                      <h3 className="text-sm font-semibold">Breakdown-Aufgaben</h3>
+                      <div className="space-y-3">
+                        {scene.breakdownItems.length === 0 ? (
+                          <p className="text-sm text-muted-foreground">Noch keine Aufgaben hinterlegt.</p>
+                        ) : (
+                          scene.breakdownItems.map((item) => (
+                            <div
+                              key={item.id}
+                              className="rounded-lg border border-border/60 bg-background/80 p-3 text-sm shadow-sm"
+                            >
+                              <div className="flex flex-wrap items-start justify-between gap-3">
+                                <div className="space-y-1">
+                                  <p className="font-semibold">{item.title}</p>
+                                  <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                                    <span>{STATUS_LABELS[item.status]}</span>
+                                    {item.department ? <span>{item.department.name}</span> : null}
+                                    {item.assignedTo ? (
+                                      <span>Zuständig: {formatUserName(item.assignedTo)}</span>
+                                    ) : null}
+                                    {item.neededBy ? (
+                                      <span>Fällig: {item.neededBy.toISOString().slice(0, 10)}</span>
+                                    ) : null}
+                                  </div>
+                                  {item.description ? (
+                                    <p className="text-xs text-muted-foreground">{item.description}</p>
+                                  ) : null}
+                                  {item.note ? (
+                                    <p className="text-xs text-muted-foreground">Notiz: {item.note}</p>
+                                  ) : null}
+                                </div>
+                                <form action={removeBreakdownItemAction} method="post">
+                                  <input type="hidden" name="itemId" value={item.id} />
+                                  <input type="hidden" name="redirectPath" value={currentPath} />
+                                  <Button type="submit" variant="ghost" size="sm">
+                                    Entfernen
+                                  </Button>
+                                </form>
+                              </div>
+                              <form
+                                action={updateBreakdownItemAction}
+                                method="post"
+                                className="mt-3 grid gap-2 rounded-md border border-border/50 bg-background/70 p-3 md:grid-cols-4"
+                              >
+                                <input type="hidden" name="itemId" value={item.id} />
+                                <input type="hidden" name="redirectPath" value={currentPath} />
+                                <div className="space-y-1">
+                                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Gewerk</label>
+                                  <select name="departmentId" defaultValue={item.department?.id ?? ""} className={selectSmallClassName}>
+                                    <option value="">Gewerk wählen</option>
+                                    {departments.map((departmentOption) => (
+                                      <option key={departmentOption.id} value={departmentOption.id}>
+                                        {departmentOption.name}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                                <div className="space-y-1">
+                                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Status</label>
+                                  <select name="status" defaultValue={item.status} className={selectSmallClassName}>
+                                    {statusOptions.map((status) => (
+                                      <option key={status} value={status}>
+                                        {STATUS_LABELS[status]}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                                <div className="space-y-1">
+                                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Benötigt bis</label>
+                                  <Input type="date" name="neededBy" defaultValue={item.neededBy ? item.neededBy.toISOString().slice(0, 10) : ""} />
+                                </div>
+                                <div className="space-y-1 md:col-span-4">
+                                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Beschreibung</label>
+                                  <Textarea name="description" rows={2} maxLength={600} defaultValue={item.description ?? ""} />
+                                </div>
+                                <div className="space-y-1 md:col-span-2">
+                                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+                                  <Input name="note" defaultValue={item.note ?? ""} maxLength={300} />
+                                </div>
+                                <div className="space-y-1 md:col-span-2">
+                                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Zuständig</label>
+                                  <select name="assignedToId" defaultValue={item.assignedToId ?? ""} className={selectSmallClassName}>
+                                    <option value="">(keine Zuordnung)</option>
+                                    {users.map((user) => (
+                                      <option key={user.id} value={user.id}>
+                                        {formatUserName(user)}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                                <div className="md:col-span-4 flex justify-end">
+                                  <Button type="submit" variant="outline" size="sm">
+                                    Änderungen speichern
+                                  </Button>
+                                </div>
+                              </form>
+                            </div>
+                          ))
+                        )}
+                      </div>
+
+                      <div className="rounded-lg border border-dashed border-border/70 bg-background/50 p-4">
+                        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Breakdown-Eintrag hinzufügen
+                        </h4>
+                        <form className="mt-3 grid gap-2 md:grid-cols-4" action={createBreakdownItemAction} method="post">
+                          <input type="hidden" name="sceneId" value={scene.id} />
+                          <input type="hidden" name="redirectPath" value={currentPath} />
+                          <div className="space-y-1 md:col-span-2">
+                            <label className="text-xs font-medium text-muted-foreground">Gewerk</label>
+                            <select name="departmentId" className={selectSmallClassName} required>
+                              <option value="">Gewerk auswählen</option>
+                              {departments.map((departmentOption) => (
+                                <option key={departmentOption.id} value={departmentOption.id}>
+                                  {departmentOption.name}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div className="space-y-1">
+                            <label className="text-xs font-medium text-muted-foreground">Status</label>
+                            <select name="status" className={selectSmallClassName} defaultValue={BreakdownStatus.planned}>
+                              {statusOptions.map((status) => (
+                                <option key={status} value={status}>
+                                  {STATUS_LABELS[status]}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div className="space-y-1">
+                            <label className="text-xs font-medium text-muted-foreground">Benötigt bis</label>
+                            <Input type="date" name="neededBy" />
+                          </div>
+                          <div className="space-y-1 md:col-span-4">
+                            <label className="text-xs font-medium text-muted-foreground">Titel</label>
+                            <Input name="title" maxLength={160} required placeholder="Aufgabe" />
+                          </div>
+                          <div className="space-y-1 md:col-span-4">
+                            <label className="text-xs font-medium text-muted-foreground">Beschreibung</label>
+                            <Textarea name="description" rows={2} maxLength={600} placeholder="Details zur Aufgabe" />
+                          </div>
+                          <div className="space-y-1 md:col-span-2">
+                            <label className="text-xs font-medium text-muted-foreground">Zuständig</label>
+                            <select name="assignedToId" className={selectSmallClassName}>
+                              <option value="">(optional)</option>
+                              {users.map((user) => (
+                                <option key={user.id} value={user.id}>
+                                  {formatUserName(user)}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div className="space-y-1 md:col-span-4">
+                            <label className="text-xs font-medium text-muted-foreground">Notiz</label>
+                            <Input name="note" maxLength={300} placeholder="interne Notiz" />
+                          </div>
+                          <div className="md:col-span-4 flex justify-end">
+                            <Button type="submit" size="sm">
+                              Breakdown speichern
+                            </Button>
+                          </div>
+                        </form>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 
 type Item = { href: string; label: string; permissionKey?: string };
 type Group = { label: string; items: Item[] };
+type ActiveProductionNavInfo = { id: string; title: string | null; year: number };
 
 const groupedConfig: Group[] = [
   {
@@ -27,7 +28,18 @@ const groupedConfig: Group[] = [
   {
     label: "Produktion",
     items: [
-      { href: "/mitglieder/produktionen", label: "Produktionen", permissionKey: "mitglieder.produktionen" },
+      { href: "/mitglieder/produktionen", label: "Übersicht", permissionKey: "mitglieder.produktionen" },
+      { href: "/mitglieder/produktionen/gewerke", label: "Gewerke & Teams", permissionKey: "mitglieder.produktionen" },
+      {
+        href: "/mitglieder/produktionen/besetzung",
+        label: "Rollen & Besetzung",
+        permissionKey: "mitglieder.produktionen",
+      },
+      {
+        href: "/mitglieder/produktionen/szenen",
+        label: "Szenen & Breakdowns",
+        permissionKey: "mitglieder.produktionen",
+      },
     ],
   },
   {
@@ -96,6 +108,36 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
           <path d="M9 16h6" />
         </svg>
       );
+    case "/mitglieder/produktionen/gewerke":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="7" cy="7" r="2.5" />
+          <circle cx="17" cy="7" r="2.5" />
+          <circle cx="12" cy="17" r="2.5" />
+          <path d="M9.5 7h5" />
+          <path d="M9.4 8.6L12 12" />
+          <path d="M14.6 8.6 12 12" />
+          <path d="M12 14.5V12" />
+        </svg>
+      );
+    case "/mitglieder/produktionen/besetzung":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="9" cy="8" r="3" />
+          <path d="M4 20c0-3 2.239-5.5 5-5.5S14 17 14 20" />
+          <path d="M17 11a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
+          <path d="M20.5 20c0-2.485-2.015-4.5-4.5-4.5" />
+        </svg>
+      );
+    case "/mitglieder/produktionen/szenen":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 9h18v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          <path d="M3 9l2.5-5h5L8 9" />
+          <path d="M8 9l2.5-5h5L13 9" />
+          <path d="M3 13h18" />
+        </svg>
+      );
     case "/mitglieder/mitgliederverwaltung":
       return (
         <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -126,7 +168,13 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
   }
 }
 
-export function MembersNav({ permissions }: { permissions?: string[] }) {
+export function MembersNav({
+  permissions,
+  activeProduction,
+}: {
+  permissions?: string[];
+  activeProduction?: ActiveProductionNavInfo;
+}) {
   const pathname = usePathname() ?? "";
   const router = useRouter();
 
@@ -145,8 +193,40 @@ export function MembersNav({ permissions }: { permissions?: string[] }) {
   const activeItem = useMemo(() => flat.find((item) => isActive(pathname, item.href)), [flat, pathname]);
   const activeHref = activeItem?.href ?? flat[0]?.href ?? "";
 
+  const activeProductionTitle = activeProduction
+    ? activeProduction.title && activeProduction.title.trim()
+      ? activeProduction.title
+      : `Produktion ${activeProduction.year}`
+    : null;
+
   return (
     <div className="flex flex-col gap-4">
+      <div className="rounded-lg border border-border/50 bg-background/60 p-4 shadow-sm">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-foreground/50">
+              Aktive Produktion
+            </div>
+            {activeProduction && activeProductionTitle ? (
+              <>
+                <div className="mt-1 text-sm font-semibold text-foreground">{activeProductionTitle}</div>
+                <div className="text-xs text-muted-foreground">Jahrgang {activeProduction.year}</div>
+              </>
+            ) : (
+              <p className="mt-1 text-xs text-muted-foreground">
+                Noch keine Produktion ausgewählt. Wähle in der Übersicht eine aktive Produktion aus.
+              </p>
+            )}
+          </div>
+          <Link
+            href="/mitglieder/produktionen"
+            className="text-xs font-medium text-primary transition hover:text-primary/80"
+          >
+            Übersicht öffnen
+          </Link>
+        </div>
+      </div>
+
       <div className="lg:hidden">
         <label htmlFor="members-navigation" className="sr-only">
           Bereich im Mitgliederbereich wählen

--- a/src/lib/active-production.ts
+++ b/src/lib/active-production.ts
@@ -1,0 +1,34 @@
+import { cookies } from "next/headers";
+
+import { prisma } from "@/lib/prisma";
+
+export const ACTIVE_PRODUCTION_COOKIE = "active-production";
+
+export function getActiveProductionId() {
+  const store = cookies();
+  const value = store.get(ACTIVE_PRODUCTION_COOKIE)?.value;
+  return value ?? null;
+}
+
+export async function getActiveProduction() {
+  const activeProductionId = getActiveProductionId();
+  if (!activeProductionId) {
+    return null;
+  }
+
+  const show = await prisma.show.findUnique({
+    where: { id: activeProductionId },
+    select: {
+      id: true,
+      title: true,
+      year: true,
+      synopsis: true,
+    },
+  });
+
+  if (!show) {
+    return null;
+  }
+
+  return show;
+}


### PR DESCRIPTION
## Summary
- add a persisted active production helper and server actions to set or clear the active selection
- refresh the production overview with a modern layout, global status card, and quick links into the new work areas
- split production management into dedicated pages for Gewerke, Rollen & Besetzung, and Szenen & Breakdowns while updating the navigation and show detail summary

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cde2b064a8832d8413e23de75cf074