### PR TITLE
Implement invite-based onboarding flow

### DIFF
--- a/prisma/migrations/20260105120000_member_onboarding/migration.sql
+++ b/prisma/migrations/20260105120000_member_onboarding/migration.sql
@@ -1,0 +1,141 @@
+-- CreateEnum
+CREATE TYPE "public"."OnboardingFocus" AS ENUM ('acting', 'tech', 'both');
+
+-- CreateEnum
+CREATE TYPE "public"."RolePreferenceDomain" AS ENUM ('acting', 'crew');
+
+-- CreateTable
+CREATE TABLE "public"."MemberInvite" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "label" TEXT,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+    "maxUses" INTEGER,
+    "usageCount" INTEGER NOT NULL DEFAULT 0,
+    "roles" "public"."Role"[],
+    "isDisabled" BOOLEAN NOT NULL DEFAULT false,
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "MemberInvite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MemberInviteRedemption" (
+    "id" TEXT NOT NULL,
+    "inviteId" TEXT NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "email" TEXT,
+    "userId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "payload" JSONB,
+
+    CONSTRAINT "MemberInviteRedemption_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Interest" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" TEXT,
+
+    CONSTRAINT "Interest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."UserInterest" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "interestId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserInterest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MemberRolePreference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "domain" "public"."RolePreferenceDomain" NOT NULL,
+    "weight" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MemberRolePreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MemberOnboardingProfile" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "inviteId" TEXT,
+    "redemptionId" TEXT,
+    "focus" "public"."OnboardingFocus" NOT NULL,
+    "background" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MemberOnboardingProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberInvite_tokenHash_key" ON "public"."MemberInvite"("tokenHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberInviteRedemption_sessionToken_key" ON "public"."MemberInviteRedemption"("sessionToken");
+
+-- CreateIndex
+CREATE INDEX "MemberInviteRedemption_inviteId_idx" ON "public"."MemberInviteRedemption"("inviteId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Interest_name_key" ON "public"."Interest"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserInterest_userId_interestId_key" ON "public"."UserInterest"("userId", "interestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberRolePreference_userId_code_key" ON "public"."MemberRolePreference"("userId", "code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberOnboardingProfile_userId_key" ON "public"."MemberOnboardingProfile"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemberOnboardingProfile_redemptionId_key" ON "public"."MemberOnboardingProfile"("redemptionId");
+
+-- CreateIndex
+CREATE INDEX "MemberOnboardingProfile_inviteId_idx" ON "public"."MemberOnboardingProfile"("inviteId");
+
+-- AddForeignKey
+ALTER TABLE "public"."MemberInvite" ADD CONSTRAINT "MemberInvite_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemberInviteRedemption" ADD CONSTRAINT "MemberInviteRedemption_inviteId_fkey" FOREIGN KEY ("inviteId") REFERENCES "public"."MemberInvite"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemberInviteRedemption" ADD CONSTRAINT "MemberInviteRedemption_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Interest" ADD CONSTRAINT "Interest_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."UserInterest" ADD CONSTRAINT "UserInterest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."UserInterest" ADD CONSTRAINT "UserInterest_interestId_fkey" FOREIGN KEY ("interestId") REFERENCES "public"."Interest"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemberRolePreference" ADD CONSTRAINT "MemberRolePreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemberOnboardingProfile" ADD CONSTRAINT "MemberOnboardingProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemberOnboardingProfile" ADD CONSTRAINT "MemberOnboardingProfile_inviteId_fkey" FOREIGN KEY ("inviteId") REFERENCES "public"."MemberInvite"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemberOnboardingProfile" ADD CONSTRAINT "MemberOnboardingProfile_redemptionId_fkey" FOREIGN KEY ("redemptionId") REFERENCES "public"."MemberInviteRedemption"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,17 @@ enum AvailabilityStatus {
   available
 }
 
+enum OnboardingFocus {
+  acting
+  tech
+  both
+}
+
+enum RolePreferenceDomain {
+  acting
+  crew
+}
+
 enum RehearsalProposalStatus {
   proposed    // Automatisch vorgeschlagen
   approved    // Von der Regie freigegeben
@@ -192,6 +203,12 @@ model User {
   departmentMemberships  DepartmentMembership[]
   characterCastings      CharacterCasting[]
   breakdownAssignments   SceneBreakdownItem[] @relation("BreakdownAssignee")
+  inviteLinksCreated     MemberInvite[]       @relation("MemberInvitesCreated")
+  inviteRedemptions      MemberInviteRedemption[]
+  onboardingProfile      MemberOnboardingProfile?
+  interests              UserInterest[]
+  rolePreferences        MemberRolePreference[]
+  interestsAuthored      Interest[]             @relation("InterestCreatedBy")
 }
 
 model Account {
@@ -695,6 +712,94 @@ model PhotoConsent {
   documentData     Bytes?
   user             User                @relation(fields: [userId], references: [id], onDelete: Cascade)
   approvedBy       User?               @relation("PhotoConsentApprover", fields: [approvedById], references: [id])
+}
+
+model MemberInvite {
+  id          String   @id @default(cuid())
+  tokenHash   String   @unique
+  label       String?
+  note        String?
+  createdAt   DateTime @default(now())
+  expiresAt   DateTime?
+  maxUses     Int?
+  usageCount  Int      @default(0)
+  roles       Role[]
+  isDisabled  Boolean  @default(false)
+  createdById String
+
+  createdBy   User     @relation("MemberInvitesCreated", fields: [createdById], references: [id], onDelete: Cascade)
+  redemptions MemberInviteRedemption[]
+  onboardings MemberOnboardingProfile[]
+}
+
+model MemberInviteRedemption {
+  id           String    @id @default(cuid())
+  inviteId     String
+  sessionToken String    @unique
+  email        String?
+  userId       String?
+  createdAt    DateTime  @default(now())
+  completedAt  DateTime?
+  payload      Json?
+
+  invite   MemberInvite @relation(fields: [inviteId], references: [id], onDelete: Cascade)
+  user     User?        @relation(fields: [userId], references: [id], onDelete: SetNull)
+  profile  MemberOnboardingProfile? @relation("OnboardingProfileRedemption")
+
+  @@index([inviteId])
+}
+
+model Interest {
+  id           String          @id @default(cuid())
+  name         String          @unique
+  createdAt    DateTime        @default(now())
+  createdById  String?
+
+  createdBy    User?           @relation("InterestCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
+  userInterest UserInterest[]
+}
+
+model UserInterest {
+  id         String   @id @default(cuid())
+  userId     String
+  interestId String
+  createdAt  DateTime @default(now())
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  interest  Interest @relation(fields: [interestId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, interestId])
+}
+
+model MemberRolePreference {
+  id        String               @id @default(cuid())
+  userId    String
+  code      String
+  domain    RolePreferenceDomain
+  weight    Int
+  createdAt DateTime             @default(now())
+  updatedAt DateTime             @updatedAt
+
+  user      User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, code])
+}
+
+model MemberOnboardingProfile {
+  id           String           @id @default(cuid())
+  userId       String           @unique
+  inviteId     String?
+  redemptionId String?         @unique
+  focus        OnboardingFocus
+  background   String?
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
+
+  user       User                     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  invite     MemberInvite?            @relation(fields: [inviteId], references: [id], onDelete: SetNull)
+  redemption MemberInviteRedemption?  @relation("OnboardingProfileRedemption", fields: [redemptionId], references: [id], onDelete: SetNull)
+
+  @@index([inviteId])
 }
 
 model Announcement {

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/page.tsx
@@ -4,6 +4,7 @@ import { AddMemberModal } from "@/components/members/add-member-card";
 import { sortRoles, type Role } from "@/lib/roles";
 import { hasPermission } from "@/lib/permissions";
 import { MembersTable } from "@/components/members/members-table";
+import { MemberInviteManager } from "@/components/members/member-invite-manager";
 
 export default async function MitgliederVerwaltungPage() {
   const session = await requireAuth();
@@ -11,6 +12,9 @@ export default async function MitgliederVerwaltungPage() {
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die Mitgliederverwaltung</div>;
   }
+
+  const canManageInvites =
+    (await hasPermission(session.user, "mitglieder.einladungen")) || allowed;
 
   const [users, customRoles] = await Promise.all([
     prisma.user.findMany({
@@ -53,6 +57,8 @@ export default async function MitgliederVerwaltungPage() {
           Erstelle neue Mitgliederprofile und verwalte Rollen für bestehende Nutzer in einer Tabelle.
         </p>
       </div>
+
+      {canManageInvites && <MemberInviteManager />}
 
       <div className="flex justify-end">
         <AddMemberModal />

--- a/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
+++ b/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
@@ -1,0 +1,207 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { collectOnboardingAnalytics } from "@/lib/onboarding-analytics";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+const numberFormat = new Intl.NumberFormat("de-DE");
+const percentFormat = new Intl.NumberFormat("de-DE", { style: "percent", minimumFractionDigits: 0, maximumFractionDigits: 0 });
+
+export default async function OnboardingAnalyticsPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.onboarding.analytics");
+  if (!allowed) {
+    return <div className="text-sm text-red-600">Kein Zugriff auf die Onboarding-Analytics</div>;
+  }
+
+  const analytics = await collectOnboardingAnalytics();
+  const totalFocus = analytics.completions.total || 1;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Onboarding Analytics</h1>
+        <p className="text-sm text-muted-foreground">
+          Überblick über Einladungen, Interessen und offene Aufgaben aus dem Onboarding-Wizard.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card className="border border-border/70">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Aktive Einladungen</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{analytics.invites.active}</p>
+            <p className="text-xs text-muted-foreground">von {analytics.invites.total} insgesamt</p>
+          </CardContent>
+        </Card>
+        <Card className="border border-border/70">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Genutzte Slots</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{analytics.invites.totalUsage}</p>
+            <p className="text-xs text-muted-foreground">registrierte Abschlüsse über den Wizard</p>
+          </CardContent>
+        </Card>
+        <Card className="border border-border/70">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Offene Foto-Dokumente</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{analytics.minorsPendingDocuments}</p>
+            <p className="text-xs text-muted-foreground">Minderjährige ohne hochgeladenes Elternformular</p>
+          </CardContent>
+        </Card>
+        <Card className="border border-border/70">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">Prüfung ausstehend</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-semibold">{analytics.pendingPhotoConsents}</p>
+            <p className="text-xs text-muted-foreground">Fotoeinverständnisse im Status „Pending“</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Fokusverteilung</CardTitle>
+            <p className="text-sm text-muted-foreground">Auswahl aus dem Wizard – Schauspiel, Gewerke oder beides.</p>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 text-sm">
+              {Object.entries(analytics.completions.byFocus).map(([focus, count]) => (
+                <div key={focus} className="flex items-center justify-between rounded-md border border-border/60 px-3 py-2">
+                  <span className="font-medium capitalize">
+                    {focus === "acting" ? "Schauspiel" : focus === "tech" ? "Gewerke" : "Hybrid"}
+                  </span>
+                  <span>
+                    {numberFormat.format(count)} · {percentFormat.format(count / totalFocus)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Beliebte Interessen</CardTitle>
+            <p className="text-sm text-muted-foreground">Tags und Themen, die im Wizard angegeben wurden.</p>
+          </CardHeader>
+          <CardContent>
+            {analytics.interests.length ? (
+              <ul className="space-y-2 text-sm">
+                {analytics.interests.slice(0, 10).map((interest) => (
+                  <li key={interest.name} className="flex items-center justify-between">
+                    <span>{interest.name}</span>
+                    <Badge variant="outline">{interest.count}</Badge>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">Noch keine Interessen erfasst.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border border-border/70">
+        <CardHeader>
+          <CardTitle>Rollen- & Gewerke-Präferenzen</CardTitle>
+          <p className="text-sm text-muted-foreground">Durchschnittliche Gewichtung (0–100) der gewählten Optionen.</p>
+        </CardHeader>
+        <CardContent>
+          {analytics.rolePreferences.length ? (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[480px] text-sm">
+                <thead className="text-left text-xs uppercase text-muted-foreground">
+                  <tr className="border-b border-border/70">
+                    <th className="px-3 py-2">Bereich</th>
+                    <th className="px-3 py-2">Option</th>
+                    <th className="px-3 py-2">Ø Gewicht</th>
+                    <th className="px-3 py-2">Rückmeldungen</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {analytics.rolePreferences.slice(0, 12).map((entry) => (
+                    <tr key={`${entry.domain}-${entry.code}`} className="border-b border-border/50">
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {entry.domain === "acting" ? "Schauspiel" : "Gewerke"}
+                      </td>
+                      <td className="px-3 py-2 font-medium">{humanizePreference(entry.code)}</td>
+                      <td className="px-3 py-2">{entry.averageWeight}</td>
+                      <td className="px-3 py-2">{entry.responses}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Noch keine Präferenzdaten vorhanden.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border border-border/70">
+        <CardHeader>
+          <CardTitle>Essensunverträglichkeiten</CardTitle>
+          <p className="text-sm text-muted-foreground">Aktive Angaben aus dem Wizard für Catering und Veranstaltungen.</p>
+        </CardHeader>
+        <CardContent>
+          {analytics.dietary.length ? (
+            <div className="flex flex-wrap gap-3">
+              {analytics.dietary.map((entry) => (
+                <div key={entry.level} className="rounded-lg border border-border/60 px-3 py-2 text-sm">
+                  <p className="font-medium">{dietaryLabel(entry.level)}</p>
+                  <p className="text-xs text-muted-foreground">{numberFormat.format(entry.count)} Angaben</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Keine Unverträglichkeiten gemeldet.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function humanizePreference(code: string) {
+  switch (code) {
+    case "acting_scout":
+      return "Schnupperrolle";
+    case "acting_medium":
+      return "Mittlere Rolle";
+    case "acting_lead":
+      return "Große Rolle";
+    case "crew_stage":
+      return "Bühnenbild & Ausstattung";
+    case "crew_tech":
+      return "Licht & Ton";
+    case "crew_costume":
+      return "Kostüm & Maske";
+    case "crew_direction":
+      return "Regieassistenz & Organisation";
+    default:
+      return code;
+  }
+}
+
+function dietaryLabel(level: string) {
+  switch (level) {
+    case "MILD":
+      return "Leicht";
+    case "MODERATE":
+      return "Mittel";
+    case "SEVERE":
+      return "Stark";
+    case "LETHAL":
+      return "Kritisch";
+    default:
+      return level;
+  }
+}

--- a/src/app/api/member-invites/[id]/route.ts
+++ b/src/app/api/member-invites/[id]/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { calculateInviteStatus, describeInvite } from "@/lib/member-invites";
+
+const DATE_LIMIT_YEARS = 5;
+
+type SessionPromise = ReturnType<typeof requireAuth>;
+type SessionUser = Awaited<SessionPromise>["user"];
+
+async function canManageInvites(user: SessionUser) {
+  if (!user) return false;
+  if (await hasPermission(user, "mitglieder.einladungen")) return true;
+  return hasPermission(user, "mitglieder.rollenverwaltung");
+}
+
+function normalizeString(value: unknown, maxLength = 200) {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+function parseBoolean(value: unknown) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "off"].includes(normalized)) return false;
+  }
+  return undefined;
+}
+
+function parseMaxUses(value: unknown) {
+  if (value === null) return null;
+  if (value === undefined || value === "") return undefined;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return undefined;
+  return Math.max(Math.floor(numeric), 1);
+}
+
+function parseDate(value: unknown) {
+  if (value === null) return null;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.valueOf())) return undefined;
+  const now = new Date();
+  const limit = new Date(now);
+  limit.setFullYear(limit.getFullYear() + DATE_LIMIT_YEARS);
+  if (parsed > limit) return limit;
+  return parsed;
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const session = await requireAuth();
+  if (!(await canManageInvites(session.user))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const id = params.id;
+  if (!id) {
+    return NextResponse.json({ error: "Ungültige Einladung" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => null) as
+    | {
+        isDisabled?: unknown;
+        expiresAt?: unknown;
+        maxUses?: unknown;
+        label?: unknown;
+        note?: unknown;
+      }
+    | null;
+
+  if (!body) {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const data: Record<string, unknown> = {};
+  const disabled = parseBoolean(body.isDisabled);
+  if (disabled !== undefined) data.isDisabled = disabled;
+
+  const expiresAt = parseDate(body.expiresAt);
+  if (expiresAt !== undefined) data.expiresAt = expiresAt;
+
+  const maxUses = parseMaxUses(body.maxUses);
+  if (maxUses !== undefined) data.maxUses = maxUses;
+
+  const label = normalizeString(body.label, 120);
+  if (label !== undefined) data.label = label;
+
+  const note = normalizeString(body.note, 400);
+  if (note !== undefined) data.note = note;
+
+  try {
+    const invite = await prisma.memberInvite.update({
+      where: { id },
+      data,
+      include: {
+        redemptions: { select: { id: true, completedAt: true } },
+        createdBy: { select: { id: true, name: true, email: true } },
+      },
+    });
+
+    if (typeof maxUses === "number" && invite.usageCount > maxUses) {
+      const adjusted = await prisma.memberInvite.update({
+        where: { id },
+        data: { maxUses: invite.usageCount },
+      });
+      invite.maxUses = adjusted.maxUses;
+    }
+
+    const status = describeInvite(invite);
+    const now = new Date();
+    const statusInfo = calculateInviteStatus(invite, now);
+    const completed = invite.redemptions.filter((r) => r.completedAt).length;
+    const pending = invite.redemptions.length - completed;
+
+    return NextResponse.json({
+      ok: true,
+      invite: {
+        ...status,
+        createdAt: invite.createdAt.toISOString(),
+        expiresAt: invite.expiresAt ? invite.expiresAt.toISOString() : null,
+        remainingUses: statusInfo.remainingUses,
+        isExpired: statusInfo.isExpired,
+        isExhausted: statusInfo.isExhausted,
+        pendingSessions: pending,
+        completedSessions: completed,
+        createdBy: invite.createdBy,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+      return NextResponse.json({ error: "Einladung nicht gefunden" }, { status: 404 });
+    }
+    return NextResponse.json({ error: "Aktualisierung fehlgeschlagen" }, { status: 500 });
+  }
+}

--- a/src/app/api/member-invites/route.ts
+++ b/src/app/api/member-invites/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { describeInvite, generateInviteToken, hashInviteToken, calculateInviteStatus } from "@/lib/member-invites";
+import { sortRoles, ROLES, type Role } from "@/lib/roles";
+
+const DATE_LIMIT_YEARS = 5;
+
+type SessionPromise = ReturnType<typeof requireAuth>;
+type SessionUser = Awaited<SessionPromise>["user"];
+
+async function canManageInvites(user: SessionUser) {
+  if (!user) return false;
+  if (await hasPermission(user, "mitglieder.einladungen")) return true;
+  return hasPermission(user, "mitglieder.rollenverwaltung");
+}
+
+function parseDate(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.valueOf())) return null;
+  const now = new Date();
+  const max = new Date(now);
+  max.setFullYear(max.getFullYear() + DATE_LIMIT_YEARS);
+  if (parsed > max) return max;
+  return parsed;
+}
+
+function parseMaxUses(value: unknown) {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  const rounded = Math.max(Math.floor(numeric), 1);
+  return rounded;
+}
+
+function normalizeString(value: unknown, maxLength = 200) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+function filterRoles(value: unknown): Role[] {
+  if (!Array.isArray(value)) return ["member"];
+  const set = new Set<Role>();
+  for (const entry of value) {
+    if (typeof entry !== "string") continue;
+    if ((ROLES as readonly string[]).includes(entry)) {
+      set.add(entry as Role);
+    }
+  }
+  const result = sortRoles(set.size ? Array.from(set) : ["member"]);
+  return result.length ? result : ["member"];
+}
+
+export async function GET() {
+  const session = await requireAuth();
+  if (!(await canManageInvites(session.user))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const invites = await prisma.memberInvite.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      createdBy: { select: { id: true, name: true, email: true } },
+      redemptions: { select: { id: true, completedAt: true } },
+    },
+  });
+
+  const now = new Date();
+  const formatted = invites.map((invite) => {
+    const status = calculateInviteStatus(invite, now);
+    const completed = invite.redemptions.filter((r) => r.completedAt).length;
+    const pending = invite.redemptions.length - completed;
+    return {
+      id: invite.id,
+      label: invite.label,
+      note: invite.note,
+      createdAt: invite.createdAt.toISOString(),
+      expiresAt: invite.expiresAt ? invite.expiresAt.toISOString() : null,
+      maxUses: invite.maxUses,
+      usageCount: invite.usageCount,
+      roles: invite.roles,
+      isDisabled: invite.isDisabled,
+      createdBy: invite.createdBy,
+      remainingUses: status.remainingUses,
+      isExpired: status.isExpired,
+      isExhausted: status.isExhausted,
+      pendingSessions: pending,
+      completedSessions: completed,
+    };
+  });
+
+  return NextResponse.json({ invites: formatted });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await requireAuth();
+  if (!(await canManageInvites(session.user))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => null) as
+    | {
+        label?: unknown;
+        note?: unknown;
+        expiresAt?: unknown;
+        maxUses?: unknown;
+        roles?: unknown;
+      }
+    | null;
+
+  if (!body) {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const label = normalizeString(body.label, 120);
+  const note = normalizeString(body.note, 400);
+  const expiresAt = parseDate(body.expiresAt);
+  const maxUses = parseMaxUses(body.maxUses);
+  const roles = filterRoles(body.roles);
+
+  const token = generateInviteToken();
+  const tokenHash = hashInviteToken(token);
+
+  const createdById = session.user?.id;
+  if (!createdById) {
+    return NextResponse.json({ error: "Benutzerkontext fehlt" }, { status: 500 });
+  }
+
+  const invite = await prisma.memberInvite.create({
+    data: {
+      tokenHash,
+      label,
+      note,
+      expiresAt,
+      maxUses,
+      roles,
+      createdById,
+    },
+  });
+
+  const status = describeInvite(invite);
+
+  return NextResponse.json({
+    ok: true,
+    invite: {
+      ...status,
+      createdAt: invite.createdAt.toISOString(),
+      expiresAt: invite.expiresAt ? invite.expiresAt.toISOString() : null,
+      token,
+      inviteUrl: `/onboarding/${token}`,
+    },
+  });
+}

--- a/src/app/api/onboarding/analytics/route.ts
+++ b/src/app/api/onboarding/analytics/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+import { collectOnboardingAnalytics } from "@/lib/onboarding-analytics";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+
+export async function GET() {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.onboarding.analytics"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const data = await collectOnboardingAnalytics();
+  return NextResponse.json({ analytics: data });
+}

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -1,0 +1,310 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { isInviteUsable } from "@/lib/member-invites";
+import { sortRoles, ROLES, type Role } from "@/lib/roles";
+
+const MAX_DOCUMENT_BYTES = 8 * 1024 * 1024;
+const ALLOWED_DOCUMENT_TYPES = new Set([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/jpg",
+]);
+
+const preferenceSchema = z.object({
+  code: z.string().min(1),
+  domain: z.enum(["acting", "crew"]),
+  weight: z.number().int().min(0).max(100),
+});
+
+const dietarySchema = z.object({
+  allergen: z.string().min(2),
+  level: z.enum(["MILD", "MODERATE", "SEVERE", "LETHAL"]),
+  symptoms: z.string().optional().nullable(),
+  treatment: z.string().optional().nullable(),
+  note: z.string().optional().nullable(),
+});
+
+const payloadSchema = z.object({
+  sessionToken: z.string().min(16),
+  name: z.string().min(2),
+  email: z.string().email(),
+  background: z.string().min(2),
+  dateOfBirth: z.string().optional().nullable(),
+  focus: z.enum(["acting", "tech", "both"]),
+  preferences: z.array(preferenceSchema),
+  interests: z.array(z.string().min(1)).max(30),
+  photoConsent: z
+    .object({
+      consent: z.boolean(),
+      skipDocument: z.boolean().optional(),
+    })
+    .optional()
+    .default({ consent: true, skipDocument: false }),
+  dietary: z.array(dietarySchema).optional().default([]),
+});
+
+function sanitizeFilename(name: string | undefined | null) {
+  if (!name) return "einverstaendnis.pdf";
+  const trimmed = name.trim();
+  if (!trimmed) return "einverstaendnis.pdf";
+  return trimmed.replace(/[^\w. -]+/g, "_");
+}
+
+function calculateAge(date: Date | null | undefined) {
+  if (!date) return null;
+  const now = new Date();
+  let age = now.getFullYear() - date.getFullYear();
+  const monthDiff = now.getMonth() - date.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < date.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+function normalizeString(value: string | null | undefined) {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export async function POST(request: NextRequest) {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("multipart/form-data")) {
+    return NextResponse.json({ error: "Erwartet multipart/form-data" }, { status: 400 });
+  }
+
+  const formData = await request.formData();
+  const rawPayload = formData.get("payload");
+  const documentFile = formData.get("document");
+
+  if (typeof rawPayload !== "string") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  let payload: z.infer<typeof payloadSchema>;
+  try {
+    payload = payloadSchema.parse(JSON.parse(rawPayload));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Ungültige Eingabe";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const email = normalizeEmail(payload.email);
+  const background = payload.background.trim();
+  const focus = payload.focus;
+  const preferences = payload.preferences.filter((pref) => pref.weight > 0);
+  const interests = Array.from(
+    new Set(payload.interests.map((interest) => interest.trim()).filter((interest) => interest.length > 0)),
+  ).slice(0, 30);
+  const dietary = payload.dietary.map((entry) => ({
+    allergen: entry.allergen.trim(),
+    level: entry.level,
+    symptoms: normalizeString(entry.symptoms),
+    treatment: normalizeString(entry.treatment),
+    note: normalizeString(entry.note),
+  }));
+
+  let dateOfBirth: Date | null = null;
+  if (payload.dateOfBirth) {
+    const parsed = new Date(payload.dateOfBirth);
+    if (Number.isNaN(parsed.valueOf())) {
+      return NextResponse.json({ error: "Geburtsdatum ist ungültig" }, { status: 400 });
+    }
+    dateOfBirth = parsed;
+  }
+
+  const age = calculateAge(dateOfBirth);
+  const photoConsent = payload.photoConsent ?? { consent: true, skipDocument: false };
+  const skipDocument = Boolean(photoConsent.skipDocument);
+
+  let documentBuffer: Buffer | null = null;
+  let documentMime: string | null = null;
+  let documentName: string | null = null;
+  let documentSize: number | null = null;
+
+  if (documentFile instanceof File && documentFile.size > 0) {
+    if (documentFile.size > MAX_DOCUMENT_BYTES) {
+      return NextResponse.json({ error: "Dokument darf maximal 8 MB groß sein" }, { status: 400 });
+    }
+    const type = documentFile.type?.toLowerCase() ?? "";
+    if (type && !ALLOWED_DOCUMENT_TYPES.has(type)) {
+      return NextResponse.json({ error: "Bitte nutze PDF oder Bilddateien (JPG/PNG)" }, { status: 400 });
+    }
+    const arrayBuffer = await documentFile.arrayBuffer();
+    documentBuffer = Buffer.from(arrayBuffer);
+    documentMime = type || null;
+    documentName = sanitizeFilename(documentFile.name);
+    documentSize = documentBuffer.length;
+  }
+
+  if (age !== null && age < 18 && !skipDocument && !documentBuffer) {
+    return NextResponse.json({ error: "Bitte lade die unterschriebene Einverständniserklärung hoch oder überspringe den Upload" }, { status: 400 });
+  }
+
+  const redemption = await prisma.memberInviteRedemption.findUnique({
+    where: { sessionToken: payload.sessionToken },
+    include: { invite: true },
+  });
+
+  if (!redemption?.invite) {
+    return NextResponse.json({ error: "Einladung wurde nicht gefunden" }, { status: 404 });
+  }
+
+  if (redemption.completedAt) {
+    return NextResponse.json({ error: "Einladung wurde bereits verwendet" }, { status: 409 });
+  }
+
+  const invite = redemption.invite;
+  if (!isInviteUsable(invite)) {
+    return NextResponse.json({ error: "Dieser Einladungslink ist nicht mehr gültig" }, { status: 400 });
+  }
+
+  const existingUser = await prisma.user.findUnique({ where: { email } });
+  if (existingUser) {
+    return NextResponse.json({ error: "Für diese E-Mail existiert bereits ein Konto" }, { status: 409 });
+  }
+
+  const rolesFromInvite = invite.roles?.filter((role): role is Role => (ROLES as readonly string[]).includes(role)) ?? [];
+  const roles = sortRoles(rolesFromInvite.length ? rolesFromInvite : ["member"]);
+  const primaryRole = roles[roles.length - 1];
+
+  const storedPayload = {
+    name: payload.name,
+    email,
+    focus,
+    background,
+    dateOfBirth: dateOfBirth ? dateOfBirth.toISOString() : null,
+    preferences,
+    interests,
+    dietary,
+    photoConsent: {
+      consent: photoConsent.consent,
+      skipDocument,
+      hasDocument: Boolean(documentBuffer),
+    },
+  };
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const latestInvite = await tx.memberInvite.findUnique({ where: { id: invite.id } });
+      if (!latestInvite || !isInviteUsable(latestInvite)) {
+        throw new Error("InviteUnavailable");
+      }
+
+      const user = await tx.user.create({
+        data: {
+          email,
+          name: payload.name.trim(),
+          role: primaryRole,
+          dateOfBirth,
+          roles: { create: roles.map((role) => ({ role })) },
+        },
+        select: { id: true, email: true },
+      });
+
+      await tx.memberInvite.update({
+        where: { id: invite.id },
+        data: { usageCount: { increment: 1 } },
+      });
+
+      await tx.memberInviteRedemption.update({
+        where: { id: redemption.id },
+        data: {
+          email,
+          userId: user.id,
+          completedAt: new Date(),
+          payload: storedPayload,
+        },
+      });
+
+      await tx.memberOnboardingProfile.create({
+        data: {
+          userId: user.id,
+          inviteId: invite.id,
+          redemptionId: redemption.id,
+          focus,
+          background,
+        },
+      });
+
+      if (preferences.length) {
+        await tx.memberRolePreference.createMany({
+          data: preferences.map((pref) => ({
+            userId: user.id,
+            code: pref.code,
+            domain: pref.domain,
+            weight: pref.weight,
+          })),
+        });
+      }
+
+      if (interests.length) {
+        for (const interestName of interests) {
+          const existing = await tx.interest.findFirst({
+            where: { name: { equals: interestName, mode: "insensitive" } },
+          });
+          const interest =
+            existing ??
+            (await tx.interest.create({
+              data: { name: interestName, createdById: user.id },
+            }));
+          await tx.userInterest.create({
+            data: { userId: user.id, interestId: interest.id },
+          });
+        }
+      }
+
+      if (dietary.length) {
+        for (const entry of dietary) {
+          await tx.dietaryRestriction.create({
+            data: {
+              userId: user.id,
+              allergen: entry.allergen,
+              level: entry.level,
+              symptoms: entry.symptoms,
+              treatment: entry.treatment,
+              note: entry.note,
+            },
+          });
+        }
+      }
+
+      const shouldCreateConsent = photoConsent.consent || documentBuffer || (age !== null && age < 18);
+      if (shouldCreateConsent) {
+        await tx.photoConsent.create({
+          data: {
+            userId: user.id,
+            consentGiven: photoConsent.consent,
+            status: "pending",
+            documentName: documentName,
+            documentMime: documentMime,
+            documentSize: documentSize ?? undefined,
+            documentUploadedAt: documentBuffer ? new Date() : null,
+            documentData: documentBuffer ?? undefined,
+          },
+        });
+      }
+
+      return { userId: user.id, email: user.email };
+    });
+
+    return NextResponse.json({ ok: true, user: result });
+  } catch (error) {
+    if (error instanceof Error && error.message === "InviteUnavailable") {
+      return NextResponse.json({ error: "Einladungslink ist nicht mehr gültig" }, { status: 409 });
+    }
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json({ error: "Für diese E-Mail existiert bereits ein Konto" }, { status: 409 });
+    }
+    console.error("[onboarding.complete]", error);
+    return NextResponse.json({ error: "Registrierung fehlgeschlagen" }, { status: 500 });
+  }
+}

--- a/src/app/api/onboarding/interests/route.ts
+++ b/src/app/api/onboarding/interests/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const interests = await prisma.interest.findMany({
+    orderBy: [{ name: "asc" }],
+  });
+
+  return NextResponse.json({
+    interests: interests.map((interest) => ({ id: interest.id, name: interest.name })),
+  });
+}

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -1,0 +1,76 @@
+import { notFound } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+import { calculateInviteStatus, generateInviteToken, hashInviteToken } from "@/lib/member-invites";
+import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
+
+export const dynamic = "force-dynamic";
+
+export default async function OnboardingInvitePage({ params }: { params: { token: string } }) {
+  const rawToken = params.token;
+  if (!rawToken || typeof rawToken !== "string" || rawToken.length < 10) {
+    notFound();
+  }
+
+  const token = decodeURIComponent(rawToken.trim());
+  if (!token) {
+    notFound();
+  }
+
+  const tokenHash = hashInviteToken(token);
+  const invite = await prisma.memberInvite.findUnique({
+    where: { tokenHash },
+    include: { createdBy: { select: { name: true, email: true } } },
+  });
+
+  if (!invite) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-6 py-16 text-center">
+        <h1 className="text-3xl font-semibold">Einladung nicht gefunden</h1>
+        <p className="text-muted-foreground">
+          Dieser Einladungslink ist nicht gültig oder wurde bereits entfernt. Bitte wende dich an die Theaterleitung für einen
+          neuen Link.
+        </p>
+      </div>
+    );
+  }
+
+  const status = calculateInviteStatus(invite);
+  if (!status.isActive) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-6 py-16 text-center">
+        <h1 className="text-3xl font-semibold">Einladung nicht mehr aktiv</h1>
+        <p className="text-muted-foreground">
+          Diese Einladung kann nicht mehr verwendet werden. Sie ist entweder abgelaufen, deaktiviert oder es wurden alle Plätze
+          genutzt.
+        </p>
+      </div>
+    );
+  }
+
+  const sessionToken = generateInviteToken(32);
+  const redemption = await prisma.memberInviteRedemption.create({
+    data: {
+      inviteId: invite.id,
+      sessionToken,
+    },
+  });
+
+  return (
+    <div className="mx-auto w-full max-w-5xl py-12">
+      <OnboardingWizard
+        sessionToken={redemption.sessionToken}
+        invite={{
+          label: invite.label,
+          note: invite.note,
+          roles: invite.roles,
+          createdAt: invite.createdAt.toISOString(),
+          createdBy: invite.createdBy?.name ?? invite.createdBy?.email ?? null,
+          expiresAt: invite.expiresAt ? invite.expiresAt.toISOString() : null,
+          usageCount: invite.usageCount,
+          remainingUses: status.remainingUses,
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -46,6 +46,7 @@ const groupedConfig: Group[] = [
     label: "Verwaltung",
     items: [
       { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", permissionKey: "mitglieder.rollenverwaltung" },
+      { href: "/mitglieder/onboarding-analytics", label: "Onboarding Analytics", permissionKey: "mitglieder.onboarding.analytics" },
       { href: "/mitglieder/rechte", label: "Rechteverwaltung", permissionKey: "mitglieder.rechte" },
       { href: "/mitglieder/fotoerlaubnisse", label: "Fotoerlaubnisse", permissionKey: "mitglieder.fotoerlaubnisse" },
     ],

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -1,0 +1,378 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import type { Role } from "@prisma/client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Modal } from "@/components/ui/modal";
+import { ROLE_LABELS, ROLES, sortRoles } from "@/lib/roles";
+import { cn } from "@/lib/utils";
+
+const ASSIGNABLE_ROLES = ROLES.filter((role) => role !== "admin" && role !== "owner");
+
+const statusLabelMap = {
+  active: { label: "Aktiv", variant: "default" as const },
+  disabled: { label: "Deaktiviert", variant: "secondary" as const },
+  expired: { label: "Abgelaufen", variant: "destructive" as const },
+  exhausted: { label: "Verbraucht", variant: "outline" as const },
+};
+
+type InviteSummary = {
+  id: string;
+  label: string | null;
+  note: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+  maxUses: number | null;
+  usageCount: number;
+  roles: Role[];
+  isDisabled: boolean;
+  remainingUses: number | null;
+  isExpired: boolean;
+  isExhausted: boolean;
+  pendingSessions: number;
+  completedSessions: number;
+  createdBy: { id: string; name: string | null; email: string | null } | null;
+};
+
+type CreateInviteState = {
+  label: string;
+  note: string;
+  expiresAt: string;
+  maxUses: string;
+  roles: Role[];
+};
+
+type FreshInvite = { token: string; inviteUrl: string } | null;
+
+export function MemberInviteManager() {
+  const [invites, setInvites] = useState<InviteSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [freshInvite, setFreshInvite] = useState<FreshInvite>(null);
+  const [origin, setOrigin] = useState("");
+  const [form, setForm] = useState<CreateInviteState>({
+    label: "",
+    note: "",
+    expiresAt: "",
+    maxUses: "",
+    roles: ["member"],
+  });
+
+  const loadInvites = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch("/api/member-invites", { cache: "no-store" });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Einladungen konnten nicht geladen werden");
+      }
+      setInvites(Array.isArray(data?.invites) ? data.invites : []);
+    } catch (err) {
+      console.error("[MemberInviteManager] load", err);
+      setError("Einladungen konnten nicht geladen werden.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadInvites();
+  }, [loadInvites]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setOrigin(window.location.origin);
+    }
+  }, []);
+
+  const resetForm = () => {
+    setForm({ label: "", note: "", expiresAt: "", maxUses: "", roles: ["member"] });
+    setError(null);
+  };
+
+  const toggleRole = (role: Role) => {
+    setForm((prev) => {
+      const has = prev.roles.includes(role);
+      const nextRoles = has ? prev.roles.filter((r) => r !== role) : [...prev.roles, role];
+      const normalized = sortRoles(nextRoles.length ? nextRoles : ["member"]);
+      return { ...prev, roles: normalized };
+    });
+  };
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      const payload = {
+        label: form.label || null,
+        note: form.note || null,
+        expiresAt: form.expiresAt || null,
+        maxUses: form.maxUses ? Number(form.maxUses) : null,
+        roles: form.roles,
+      };
+      const response = await fetch("/api/member-invites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Einladung konnte nicht erstellt werden");
+      }
+      if (data?.invite?.inviteUrl) {
+        setFreshInvite({ token: data.invite.token, inviteUrl: data.invite.inviteUrl });
+        try {
+          const base = origin || (typeof window !== "undefined" ? window.location.origin : "");
+          if (base) {
+            await navigator.clipboard.writeText(base + data.invite.inviteUrl);
+            toast.success("Neuer Link kopiert.");
+          } else {
+            toast.success("Neue Einladung erstellt. Link siehe unten.");
+          }
+        } catch {
+          toast.success("Neue Einladung erstellt. Link siehe unten.");
+        }
+      }
+      resetForm();
+      setModalOpen(false);
+      await loadInvites();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Einladung konnte nicht erstellt werden";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const copyFreshInvite = async () => {
+    if (!freshInvite) return;
+    try {
+      const base = origin || (typeof window !== "undefined" ? window.location.origin : "");
+      if (!base) throw new Error("no-origin");
+      await navigator.clipboard.writeText(base + freshInvite.inviteUrl);
+      toast.success("Link kopiert");
+    } catch {
+      toast.error("Kopieren fehlgeschlagen");
+    }
+  };
+
+  const toggleInvite = async (invite: InviteSummary) => {
+    try {
+      const response = await fetch(`/api/member-invites/${invite.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isDisabled: !invite.isDisabled }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Aktion fehlgeschlagen");
+      }
+      toast.success(invite.isDisabled ? "Einladung aktiviert" : "Einladung deaktiviert");
+      await loadInvites();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Aktion fehlgeschlagen";
+      toast.error(message);
+    }
+  };
+
+  const statusForInvite = (invite: InviteSummary) => {
+    if (invite.isDisabled) return statusLabelMap.disabled;
+    if (invite.isExpired) return statusLabelMap.expired;
+    if (invite.isExhausted) return statusLabelMap.exhausted;
+    return statusLabelMap.active;
+  };
+
+  const formatDate = (iso: string | null) => {
+    if (!iso) return "–";
+    try {
+      return new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(new Date(iso));
+    } catch {
+      return iso;
+    }
+  };
+
+  const sortedInvites = useMemo(() => invites.slice().sort((a, b) => b.createdAt.localeCompare(a.createdAt)), [invites]);
+
+  return (
+    <Card className="border border-border/70">
+      <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <CardTitle className="text-xl font-semibold">Einladungslinks</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Erstelle moderne Onboarding-Links und behalte den Überblick über Status und Nutzungen.
+          </p>
+        </div>
+        <Button onClick={() => setModalOpen(true)}>Link erstellen</Button>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {freshInvite && (
+          <div className="rounded-lg border border-primary/40 bg-primary/10 p-4 text-sm text-primary">
+            <p className="font-medium">Neuer Link</p>
+            <p className="break-all text-xs">{(origin ? origin : "") + freshInvite.inviteUrl}</p>
+            <div className="mt-3 flex gap-2">
+              <Button size="sm" variant="outline" onClick={copyFreshInvite}>
+                Link kopieren
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setFreshInvite(null)}
+                className="text-primary"
+              >
+                Ausblenden
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Lade Einladungen …</p>
+          ) : sortedInvites.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Noch keine Einladungslinks vorhanden.</p>
+          ) : (
+            <div className="grid gap-4">
+              {sortedInvites.map((invite) => {
+                const status = statusForInvite(invite);
+                return (
+                  <div key={invite.id} className="rounded-lg border border-border/70 bg-background/70 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="space-y-1">
+                        <h3 className="text-sm font-semibold">
+                          {invite.label?.trim() || "Allgemeiner Link"}
+                        </h3>
+                        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                          <span>Erstellt am {formatDate(invite.createdAt)}</span>
+                          {invite.expiresAt && <span>• Gültig bis {formatDate(invite.expiresAt)}</span>}
+                          {invite.maxUses !== null && (
+                            <span>
+                              • {invite.usageCount} / {invite.maxUses} genutzt
+                            </span>
+                          )}
+                        </div>
+                        {invite.note && <p className="text-xs text-muted-foreground">{invite.note}</p>}
+                        <div className="flex flex-wrap gap-2 pt-2 text-xs">
+                          {invite.roles.map((role) => (
+                            <Badge key={role} variant="outline">
+                              {ROLE_LABELS[role] ?? role}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="flex flex-col items-end gap-2">
+                        <Badge variant={status.variant}>{status.label}</Badge>
+                        <Button size="sm" variant="outline" onClick={() => toggleInvite(invite)}>
+                          {invite.isDisabled ? "Aktivieren" : "Deaktivieren"}
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </CardContent>
+
+      <Modal
+        open={modalOpen}
+        onClose={() => {
+          if (creating) return;
+          setModalOpen(false);
+        }}
+        title="Einladung erstellen"
+        description="Lege optional Ablaufdatum oder maximale Nutzungen fest."
+      >
+        <div className="space-y-4">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium">Titel (optional)</span>
+            <Input value={form.label} onChange={(event) => setForm((prev) => ({ ...prev, label: event.target.value }))} placeholder="z.B. Sommercrew 2025" />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium">Notiz (optional)</span>
+            <Textarea
+              value={form.note}
+              onChange={(event) => setForm((prev) => ({ ...prev, note: event.target.value }))}
+              placeholder="Internes Memo für die Verwaltung"
+            />
+          </label>
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Gültig bis</span>
+              <Input
+                type="date"
+                value={form.expiresAt}
+                onChange={(event) => setForm((prev) => ({ ...prev, expiresAt: event.target.value }))}
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Max. Nutzungen</span>
+              <Input
+                type="number"
+                min={1}
+                value={form.maxUses}
+                onChange={(event) => setForm((prev) => ({ ...prev, maxUses: event.target.value }))}
+                placeholder="Unbegrenzt"
+              />
+            </label>
+          </div>
+          <div className="space-y-2">
+            <span className="text-sm font-medium">Rollen bei Erstellung</span>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {ASSIGNABLE_ROLES.map((role) => {
+                const checked = form.roles.includes(role);
+                return (
+                  <label
+                    key={role}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition",
+                      checked ? "border-primary bg-primary/10 text-primary" : "border-border hover:border-primary/60",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleRole(role)}
+                      className="h-4 w-4"
+                    />
+                    <span>{ROLE_LABELS[role] ?? role}</span>
+                  </label>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Standard ist „Mitglied“. Weitere Rollen können nach dem Onboarding vergeben werden.
+            </p>
+          </div>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (creating) return;
+                setModalOpen(false);
+                resetForm();
+              }}
+            >
+              Abbrechen
+            </Button>
+            <Button onClick={handleCreate} disabled={creating}>
+              {creating ? "Erstelle …" : "Link erzeugen"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Card>
+  );
+}

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,1100 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import type { AllergyLevel, Role } from "@prisma/client";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+const allergyLevelLabels: Record<AllergyLevel, string> = {
+  MILD: "Leicht (Unbehagen)",
+  MODERATE: "Mittel (Reaktion möglich)",
+  SEVERE: "Stark (ärztliche Hilfe)",
+  LETHAL: "Kritisch (Notfall)",
+};
+
+const actingOptions = [
+  {
+    code: "acting_scout",
+    title: "Schnupperrolle",
+    description: "Kleine Auftritte zum Reinschnuppern mit überschaubarer Textmenge.",
+  },
+  {
+    code: "acting_medium",
+    title: "Mittlere Rolle",
+    description: "Spürbar auf der Bühne, mit Verantwortung im Ensemble und regelmäßigem Proben.",
+  },
+  {
+    code: "acting_lead",
+    title: "Große Rolle",
+    description: "Haupt- oder zentrale Nebenrolle mit intensiver Vorbereitung und Bühnenpräsenz.",
+  },
+];
+
+const crewOptions = [
+  {
+    code: "crew_stage",
+    title: "Bühnenbild & Ausstattung",
+    description: "Räume entwerfen, Kulissen bauen und für beeindruckende Bilder sorgen.",
+  },
+  {
+    code: "crew_tech",
+    title: "Licht & Ton",
+    description: "Shows inszenieren mit Licht, Klang, Effekten und technischer Präzision.",
+  },
+  {
+    code: "crew_costume",
+    title: "Kostüm & Maske",
+    description: "Looks entwickeln, Nähen, Schminken und verwandeln – kreativ bis ins Detail.",
+  },
+  {
+    code: "crew_direction",
+    title: "Regieassistenz & Orga",
+    description: "Abläufe koordinieren, Proben strukturieren, Teams im Hintergrund führen.",
+  },
+];
+
+const backgroundSuggestions = ["Schule", "Berufsschule", "Universität", "Ausbildung", "Beruf"];
+
+const weightLabels: { threshold: number; label: string }[] = [
+  { threshold: 0, label: "Nur mal reinschauen" },
+  { threshold: 25, label: "Locker interessiert" },
+  { threshold: 50, label: "Motiviert" },
+  { threshold: 75, label: "Sehr engagiert" },
+  { threshold: 90, label: "Herzensprojekt" },
+];
+
+const steps = [
+  { title: "Willkommen" },
+  { title: "Profil" },
+  { title: "Fokus" },
+  { title: "Interessen" },
+  { title: "Fotos" },
+  { title: "Essen" },
+  { title: "Check" },
+];
+
+const MAX_DOCUMENT_BYTES = 8 * 1024 * 1024;
+const ALLOWED_DOCUMENT_TYPES = new Set(["application/pdf", "image/jpeg", "image/png", "image/jpg"]);
+
+type PreferenceEntry = {
+  code: string;
+  title: string;
+  description: string;
+  weight: number;
+  enabled: boolean;
+  domain: "acting" | "crew";
+};
+
+type DietaryEntry = {
+  id: string;
+  allergen: string;
+  level: AllergyLevel;
+  symptoms: string;
+  treatment: string;
+  note: string;
+};
+
+type InviteMeta = {
+  label: string | null;
+  note: string | null;
+  roles: Role[];
+  createdAt: string;
+  createdBy: string | null;
+  expiresAt: string | null;
+  usageCount: number;
+  remainingUses: number | null;
+};
+
+type OnboardingWizardProps = {
+  sessionToken: string;
+  invite: InviteMeta;
+};
+
+const initialActingPreferences: PreferenceEntry[] = actingOptions.map((option, index) => ({
+  ...option,
+  domain: "acting",
+  enabled: index === 1,
+  weight: index === 1 ? 60 : 40,
+}));
+
+const initialCrewPreferences: PreferenceEntry[] = crewOptions.map((option) => ({
+  ...option,
+  domain: "crew",
+  enabled: false,
+  weight: 50,
+}));
+
+function calculateAge(value: string | null) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return null;
+  const now = new Date();
+  let age = now.getFullYear() - parsed.getFullYear();
+  const monthDiff = now.getMonth() - parsed.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < parsed.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+function createDietaryId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 10);
+}
+
+export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps) {
+  const [step, setStep] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [documentFile, setDocumentFile] = useState<File | null>(null);
+  const [documentError, setDocumentError] = useState<string | null>(null);
+  const [availableInterests, setAvailableInterests] = useState<string[]>([]);
+  const [interestsLoading, setInterestsLoading] = useState(false);
+
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    background: "",
+    dateOfBirth: "",
+    focus: "acting" as "acting" | "tech" | "both",
+    actingPreferences: initialActingPreferences,
+    crewPreferences: initialCrewPreferences,
+    interests: [] as string[],
+    photoConsent: { consent: true, skipDocument: false },
+    dietary: [] as DietaryEntry[],
+  });
+
+  const [newInterest, setNewInterest] = useState("");
+  const [dietaryDraft, setDietaryDraft] = useState({
+    allergen: "",
+    level: "MILD" as AllergyLevel,
+    symptoms: "",
+    treatment: "",
+    note: "",
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadInterests = async () => {
+      setInterestsLoading(true);
+      try {
+        const response = await fetch("/api/onboarding/interests", { cache: "no-store" });
+        const data = await response.json().catch(() => null);
+        if (!cancelled && Array.isArray(data?.interests)) {
+          setAvailableInterests(data.interests.map((entry: { name: string }) => entry.name).filter(Boolean));
+        }
+      } catch {
+        if (!cancelled) {
+          setAvailableInterests([]);
+        }
+      } finally {
+        if (!cancelled) setInterestsLoading(false);
+      }
+    };
+    void loadInterests();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const age = useMemo(() => calculateAge(form.dateOfBirth || null), [form.dateOfBirth]);
+  const requiresDocument = age !== null && age < 18;
+
+  const availableInterestSuggestions = useMemo(() => {
+    const selected = new Set(form.interests.map((item) => item.toLowerCase()));
+    return availableInterests.filter((interest) => !selected.has(interest.toLowerCase())).slice(0, 12);
+  }, [availableInterests, form.interests]);
+
+  const addInterest = useCallback(
+    (interest: string) => {
+      const value = interest.trim();
+      if (!value) return;
+      setForm((prev) => {
+        if (prev.interests.some((entry) => entry.toLowerCase() === value.toLowerCase())) {
+          return prev;
+        }
+        return { ...prev, interests: [...prev.interests, value] };
+      });
+      setNewInterest("");
+    },
+    [setForm],
+  );
+
+  const removeInterest = useCallback((interest: string) => {
+    setForm((prev) => ({
+      ...prev,
+      interests: prev.interests.filter((entry) => entry !== interest),
+    }));
+  }, []);
+
+  const togglePreference = useCallback((domain: "acting" | "crew", code: string) => {
+    setForm((prev) => {
+      const key = domain === "acting" ? "actingPreferences" : "crewPreferences";
+      const updated = prev[key].map((pref) =>
+        pref.code === code ? { ...pref, enabled: !pref.enabled } : pref,
+      );
+      return { ...prev, [key]: updated };
+    });
+  }, []);
+
+  const updatePreferenceWeight = useCallback((domain: "acting" | "crew", code: string, weight: number) => {
+    setForm((prev) => {
+      const key = domain === "acting" ? "actingPreferences" : "crewPreferences";
+      const updated = prev[key].map((pref) =>
+        pref.code === code ? { ...pref, weight } : pref,
+      );
+      return { ...prev, [key]: updated };
+    });
+  }, []);
+
+  const preferenceSummary = useMemo(() => {
+    const buildLabel = (entry: PreferenceEntry) => {
+      const match = [...weightLabels].reverse().find((label) => entry.weight >= label.threshold);
+      return match?.label ?? "Interesse";
+    };
+    const acting = form.actingPreferences
+      .filter((pref) => pref.enabled && pref.weight > 0)
+      .map((pref) => `${pref.title} – ${buildLabel(pref)}`);
+    const crew = form.crewPreferences
+      .filter((pref) => pref.enabled && pref.weight > 0)
+      .map((pref) => `${pref.title} – ${buildLabel(pref)}`);
+    return { acting, crew };
+  }, [form.actingPreferences, form.crewPreferences]);
+
+  const handleAddDietary = () => {
+    if (!dietaryDraft.allergen.trim()) {
+      setError("Bitte gib an, was du nicht verträgst.");
+      return;
+    }
+    setForm((prev) => ({
+      ...prev,
+      dietary: [
+        ...prev.dietary,
+        {
+          id: createDietaryId(),
+          allergen: dietaryDraft.allergen.trim(),
+          level: dietaryDraft.level,
+          symptoms: dietaryDraft.symptoms.trim(),
+          treatment: dietaryDraft.treatment.trim(),
+          note: dietaryDraft.note.trim(),
+        },
+      ],
+    }));
+    setDietaryDraft({ allergen: "", level: "MILD", symptoms: "", treatment: "", note: "" });
+  };
+
+  const removeDietary = (id: string) => {
+    setForm((prev) => ({
+      ...prev,
+      dietary: prev.dietary.filter((entry) => entry.id !== id),
+    }));
+  };
+
+  const handleDocumentChange = (file: File | null) => {
+    if (!file) {
+      setDocumentFile(null);
+      setDocumentError(null);
+      return;
+    }
+    if (file.size > MAX_DOCUMENT_BYTES) {
+      setDocumentError("Dokument darf maximal 8 MB groß sein");
+      setDocumentFile(null);
+      return;
+    }
+    const type = file.type?.toLowerCase() ?? "";
+    if (type && !ALLOWED_DOCUMENT_TYPES.has(type)) {
+      setDocumentError("Bitte nutze PDF oder Bilddateien (JPG/PNG)");
+      setDocumentFile(null);
+      return;
+    }
+    setDocumentError(null);
+    setDocumentFile(file);
+  };
+
+  const goNext = () => {
+    setError(null);
+    if (step === 0) {
+      setStep(1);
+      return;
+    }
+    if (step === 1) {
+      if (!form.name.trim()) {
+        setError("Bitte gib deinen Namen ein.");
+        return;
+      }
+      if (!form.email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
+        setError("Bitte nutze eine gültige E-Mail-Adresse.");
+        return;
+      }
+      if (!form.background.trim()) {
+        setError("Wo kommst du her? Schule, Uni, Ausbildung – ein Stichwort genügt.");
+        return;
+      }
+      setStep(2);
+      return;
+    }
+    if (step === 2) {
+      const wantsActing = form.focus === "acting" || form.focus === "both";
+      const wantsCrew = form.focus === "tech" || form.focus === "both";
+      if (wantsActing && !form.actingPreferences.some((pref) => pref.enabled && pref.weight > 0)) {
+        setError("Wähle mindestens eine Option im Schauspielbereich.");
+        return;
+      }
+      if (wantsCrew && !form.crewPreferences.some((pref) => pref.enabled && pref.weight > 0)) {
+        setError("Wähle mindestens ein Gewerk aus, das dich reizt.");
+        return;
+      }
+      setStep(3);
+      return;
+    }
+    if (step === 3) {
+      setStep(4);
+      return;
+    }
+    if (step === 4) {
+      if (!form.photoConsent.consent) {
+        setError("Wir benötigen deine Zustimmung zur Fotoerlaubnis, damit du beim Theater mitmachen kannst.");
+        return;
+      }
+      if (requiresDocument && !form.photoConsent.skipDocument && !documentFile) {
+        setError("Bitte lade das unterschriebene Dokument hoch oder wähle den späteren Upload.");
+        return;
+      }
+      setStep(5);
+      return;
+    }
+    if (step === 5) {
+      setStep(6);
+      return;
+    }
+  };
+
+  const goBack = () => {
+    setError(null);
+    if (step === 0) return;
+    setStep((prev) => Math.max(0, prev - 1));
+  };
+
+  const handleSubmit = async () => {
+    setError(null);
+    if (loading) return;
+    const preferences = [
+      ...form.actingPreferences
+        .filter((pref) => pref.enabled && pref.weight > 0)
+        .map((pref) => ({ code: pref.code, domain: "acting" as const, weight: pref.weight })),
+      ...form.crewPreferences
+        .filter((pref) => pref.enabled && pref.weight > 0)
+        .map((pref) => ({ code: pref.code, domain: "crew" as const, weight: pref.weight })),
+    ];
+    if (!preferences.length) {
+      setError("Bitte markiere, wo du dich einbringen möchtest.");
+      setStep(2);
+      return;
+    }
+    setLoading(true);
+    try {
+      const payload = {
+        sessionToken,
+        name: form.name.trim(),
+        email: form.email.trim(),
+        background: form.background.trim(),
+        dateOfBirth: form.dateOfBirth ? form.dateOfBirth : null,
+        focus: form.focus,
+        preferences,
+        interests: form.interests,
+        photoConsent: {
+          consent: form.photoConsent.consent,
+          skipDocument: form.photoConsent.skipDocument,
+        },
+        dietary: form.dietary.map((entry) => ({
+          allergen: entry.allergen,
+          level: entry.level,
+          symptoms: entry.symptoms,
+          treatment: entry.treatment,
+          note: entry.note,
+        })),
+      };
+
+      const body = new FormData();
+      body.append("payload", JSON.stringify(payload));
+      if (documentFile) {
+        body.append("document", documentFile);
+      }
+
+      const response = await fetch("/api/onboarding/complete", {
+        method: "POST",
+        body,
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message = data?.error ?? "Übermittlung fehlgeschlagen";
+        setError(message);
+        if (message.toLowerCase().includes("dokument")) {
+          setStep(4);
+        }
+        return;
+      }
+      setSuccess(true);
+      toast.success("Willkommen im Ensemble! Wir melden uns bei dir.");
+    } catch (err) {
+      console.error("[onboarding.wizard]", err);
+      setError("Netzwerkfehler – bitte versuche es erneut.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const inviteCreatedAt = useMemo(() => {
+    try {
+      return new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(new Date(invite.createdAt));
+    } catch {
+      return null;
+    }
+  }, [invite.createdAt]);
+
+  const inviteExpiresAt = useMemo(() => {
+    if (!invite.expiresAt) return null;
+    try {
+      return new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(new Date(invite.expiresAt));
+    } catch {
+      return null;
+    }
+  }, [invite.expiresAt]);
+
+  return (
+    <div className="space-y-8">
+      <Card className="border border-border/70 bg-gradient-to-br from-background to-background/70">
+        <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="text-2xl font-semibold">Dein Einstieg ins Theater</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Einladung erstellt {inviteCreatedAt ? `am ${inviteCreatedAt}` : "vor Kurzem"}
+              {invite.createdBy ? ` von ${invite.createdBy}` : ""}.
+              {inviteExpiresAt ? ` Gültig bis ${inviteExpiresAt}.` : ""}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Badge variant="outline">Link-ID gesichert</Badge>
+            {invite.remainingUses !== null ? (
+              <span>{invite.remainingUses} von {invite.remainingUses + invite.usageCount} Plätzen frei</span>
+            ) : (
+              <span>Mehrfach nutzbar</span>
+            )}
+          </div>
+        </CardHeader>
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-3">
+        {steps.map((item, index) => {
+          const isActive = index === step;
+          const isComplete = index < step;
+          return (
+            <div key={item.title} className="flex items-center gap-2">
+              <div
+                className={cn(
+                  "flex h-8 w-8 items-center justify-center rounded-full border text-sm font-medium",
+                  isActive && "border-primary bg-primary text-primary-foreground",
+                  isComplete && !isActive && "border-primary bg-primary/20 text-primary",
+                  !isActive && !isComplete && "border-border text-muted-foreground",
+                )}
+              >
+                {index + 1}
+              </div>
+              <span className={cn("text-sm font-medium", isActive ? "text-foreground" : "text-muted-foreground")}>{item.title}</span>
+              {index < steps.length - 1 && <div className="h-px w-10 bg-border" aria-hidden />}
+            </div>
+          );
+        })}
+      </div>
+
+      {step === 0 && (
+        <Card className="border border-border/70 bg-background/80 shadow-xl">
+          <CardContent className="space-y-6 p-8 text-center">
+            <h2 className="text-3xl font-semibold">Willkommen im Zukunftstheater</h2>
+            <p className="text-muted-foreground">
+              Schön, dass du da bist! Nimm dir 10 Minuten Zeit, such dir einen ruhigen Ort und lass uns gemeinsam herausfinden, wie du
+              dich auf der Bühne oder hinter den Kulissen einbringen möchtest.
+            </p>
+            <Button size="lg" onClick={goNext}>
+              Los geht&apos;s
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 1 && (
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Wer bist du?</CardTitle>
+            <p className="text-sm text-muted-foreground">Wir nutzen diese Angaben, um dein Profil anzulegen und dich zu erreichen.</p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">Name</span>
+                <Input value={form.name} onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))} placeholder="Vorname Nachname" />
+              </label>
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">E-Mail</span>
+                <Input
+                  type="email"
+                  value={form.email}
+                  onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+                  placeholder="du@example.com"
+                />
+              </label>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">Geburtsdatum</span>
+                <Input
+                  type="date"
+                  value={form.dateOfBirth}
+                  onChange={(event) => setForm((prev) => ({ ...prev, dateOfBirth: event.target.value }))}
+                />
+                <span className="text-xs text-muted-foreground">Damit wissen wir, ob wir ein Eltern-Formular benötigen.</span>
+              </label>
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">Wo bist du aktuell?</span>
+                <Input
+                  value={form.background}
+                  onChange={(event) => setForm((prev) => ({ ...prev, background: event.target.value }))}
+                  placeholder="z.B. BSZ Altroßthal – Berufsschule"
+                />
+                <div className="flex flex-wrap gap-2 pt-2">
+                  {backgroundSuggestions.map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground transition hover:border-primary hover:text-primary"
+                      onClick={() => setForm((prev) => ({ ...prev, background: suggestion }))}
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
+              </label>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 2 && (
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Wohin zieht es dich?</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Wähle aus, ob du dich eher im Schauspiel, hinter den Kulissen oder in beiden Welten siehst. Danach kannst du gewichten,
+              was dich am meisten reizt.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex flex-wrap gap-3">
+              {[
+                { value: "acting", label: "Schauspiel", description: "Auf der Bühne stehen, Rollen gestalten." },
+                { value: "tech", label: "Gewerke", description: "Technik, Kostüm, Bühnenbild und Organisation." },
+                { value: "both", label: "Beides", description: "Ich möchte mich offen halten." },
+              ].map((option) => {
+                const active = form.focus === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={cn(
+                      "flex min-w-[180px] flex-1 flex-col gap-1 rounded-lg border p-4 text-left transition",
+                      active
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border text-muted-foreground hover:border-primary/70 hover:text-foreground",
+                    )}
+                    onClick={() => setForm((prev) => ({ ...prev, focus: option.value as typeof prev.focus }))}
+                  >
+                    <span className="text-sm font-semibold">{option.label}</span>
+                    <span className="text-xs">{option.description}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {(form.focus === "acting" || form.focus === "both") && (
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Schauspiel</h3>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {form.actingPreferences.map((pref) => {
+                    const active = pref.enabled;
+                    const weightLabel = [...weightLabels].reverse().find((label) => pref.weight >= label.threshold)?.label ?? "";
+                    return (
+                      <div
+                        key={pref.code}
+                        className={cn(
+                          "flex flex-col gap-4 rounded-xl border p-4 transition",
+                          active ? "border-primary bg-primary/5" : "border-border bg-background",
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <h4 className="font-medium">{pref.title}</h4>
+                            <p className="text-sm text-muted-foreground">{pref.description}</p>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant={active ? "default" : "outline"}
+                            onClick={() => togglePreference("acting", pref.code)}
+                          >
+                            {active ? "Ausgewählt" : "Wählen"}
+                          </Button>
+                        </div>
+                        {active && (
+                          <div className="space-y-2">
+                            <input
+                              type="range"
+                              min={0}
+                              max={100}
+                              step={10}
+                              value={pref.weight}
+                              onChange={(event) => updatePreferenceWeight("acting", pref.code, Number(event.target.value))}
+                              className="w-full accent-primary"
+                            />
+                            <div className="flex justify-between text-xs text-muted-foreground">
+                              <span>Intensität</span>
+                              <span>{weightLabel}</span>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+
+            {(form.focus === "tech" || form.focus === "both") && (
+              <section className="space-y-4">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Gewerke & Teams</h3>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {form.crewPreferences.map((pref) => {
+                    const active = pref.enabled;
+                    const weightLabel = [...weightLabels].reverse().find((label) => pref.weight >= label.threshold)?.label ?? "";
+                    return (
+                      <div
+                        key={pref.code}
+                        className={cn(
+                          "flex flex-col gap-4 rounded-xl border p-4 transition",
+                          active ? "border-primary bg-primary/5" : "border-border bg-background",
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <h4 className="font-medium">{pref.title}</h4>
+                            <p className="text-sm text-muted-foreground">{pref.description}</p>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant={active ? "default" : "outline"}
+                            onClick={() => togglePreference("crew", pref.code)}
+                          >
+                            {active ? "Ausgewählt" : "Wählen"}
+                          </Button>
+                        </div>
+                        {active && (
+                          <div className="space-y-2">
+                            <input
+                              type="range"
+                              min={0}
+                              max={100}
+                              step={10}
+                              value={pref.weight}
+                              onChange={(event) => updatePreferenceWeight("crew", pref.code, Number(event.target.value))}
+                              className="w-full accent-primary"
+                            />
+                            <div className="flex justify-between text-xs text-muted-foreground">
+                              <span>Intensität</span>
+                              <span>{weightLabel}</span>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 3 && (
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Was begeistert dich?</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Sammle Interessen als Schlagworte – so finden wir passende Teams, Workshops und Rollen für dich. Auch neue Ideen sind
+              willkommen.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="flex flex-wrap gap-2">
+              {form.interests.map((interest) => (
+                <span
+                  key={interest}
+                  className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-xs text-primary"
+                >
+                  {interest}
+                  <button
+                    type="button"
+                    className="rounded-full p-0.5 text-primary/70 transition hover:bg-primary/20"
+                    onClick={() => removeInterest(interest)}
+                    aria-label={`${interest} entfernen`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))}
+              {!form.interests.length && <span className="text-sm text-muted-foreground">Noch keine Interessen ausgewählt.</span>}
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <Input
+                value={newInterest}
+                onChange={(event) => setNewInterest(event.target.value)}
+                placeholder="z.B. Impro, Tanz, Requisite, Social Media …"
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    addInterest(newInterest);
+                  }
+                }}
+              />
+              <Button type="button" variant="outline" onClick={() => addInterest(newInterest)}>
+                Hinzufügen
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Beliebte Tags</p>
+              <div className="flex flex-wrap gap-2">
+                {interestsLoading && <span className="text-xs text-muted-foreground">Lade Vorschläge …</span>}
+                {!interestsLoading && availableInterestSuggestions.map((interest) => (
+                  <button
+                    key={interest}
+                    type="button"
+                    className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground transition hover:border-primary hover:text-primary"
+                    onClick={() => addInterest(interest)}
+                  >
+                    {interest}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 4 && (
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Fotoeinverständnis</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Wir dokumentieren Proben, Aufführungen und Werkstätten. Deine Zustimmung hilft uns bei Social Media, Presse und
+              Erinnerungen.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <label className="flex items-start gap-3 rounded-lg border border-border/70 p-4">
+              <input
+                type="checkbox"
+                checked={form.photoConsent.consent}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, photoConsent: { ...prev.photoConsent, consent: event.target.checked } }))
+                }
+                className="mt-1 h-4 w-4"
+              />
+              <div className="space-y-1 text-sm">
+                <p className="font-medium">Ich bin einverstanden, dass Fotos/Videos von mir für das Schultheater genutzt werden.</p>
+                <p className="text-xs text-muted-foreground">
+                  Die Zustimmung kann jederzeit im Profil angepasst werden.
+                </p>
+              </div>
+            </label>
+
+            {requiresDocument && (
+              <div className="rounded-lg border border-amber-200 bg-amber-50/70 p-4 text-sm text-amber-900">
+                <p className="font-medium">Du bist minderjährig</p>
+                <p>
+                  Bitte lade die unterschriebene Erlaubnis deiner Eltern hoch. Wenn das gerade nicht klappt, kannst du den Upload
+                  überspringen und später im Profil nachreichen.
+                </p>
+                <label className="mt-3 flex items-center gap-2 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={form.photoConsent.skipDocument}
+                    onChange={(event) =>
+                      setForm((prev) => ({
+                        ...prev,
+                        photoConsent: { ...prev.photoConsent, skipDocument: event.target.checked },
+                      }))
+                    }
+                    className="h-4 w-4"
+                  />
+                  <span>Upload später nachreichen</span>
+                </label>
+              </div>
+            )}
+
+            <div className="space-y-2 text-sm">
+              <label className="block font-medium">Eltern-Formular (PDF, JPG, PNG)</label>
+              <Input
+                type="file"
+                accept="application/pdf,image/jpeg,image/png"
+                onChange={(event) => handleDocumentChange(event.target.files?.[0] ?? null)}
+              />
+              <p className="text-xs text-muted-foreground">
+                {documentFile ? `Ausgewählt: ${documentFile.name}` : "Optional – wenn vorhanden, gleich hier hochladen."}
+              </p>
+              {documentError && <p className="text-xs text-destructive">{documentError}</p>}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 5 && (
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Essensunverträglichkeiten</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Damit wir Catering, Probenverpflegung und Team-Events sicher planen können. Alles optional – teile nur, was relevant ist.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="grid gap-4">
+              {form.dietary.map((entry) => (
+                <div key={entry.id} className="rounded-lg border border-border/70 bg-background/80 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium">{entry.allergen}</p>
+                      <p className="text-xs text-muted-foreground">{allergyLevelLabels[entry.level]}</p>
+                    </div>
+                    <Button size="sm" variant="outline" onClick={() => removeDietary(entry.id)}>
+                      Entfernen
+                    </Button>
+                  </div>
+                  {(entry.symptoms || entry.treatment || entry.note) && (
+                    <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+                      {entry.symptoms && <li>Symptome: {entry.symptoms}</li>}
+                      {entry.treatment && <li>Behandlung: {entry.treatment}</li>}
+                      {entry.note && <li>Hinweis: {entry.note}</li>}
+                    </ul>
+                  )}
+                </div>
+              ))}
+              {!form.dietary.length && <p className="text-sm text-muted-foreground">Keine Unverträglichkeiten hinterlegt.</p>}
+            </div>
+
+            <div className="space-y-3 rounded-lg border border-dashed border-border/70 p-4">
+              <p className="text-sm font-medium">Neue Unverträglichkeit hinzufügen</p>
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="space-y-1 text-sm">
+                  <span>Auslöser / Gericht</span>
+                  <Input
+                    value={dietaryDraft.allergen}
+                    onChange={(event) => setDietaryDraft((prev) => ({ ...prev, allergen: event.target.value }))}
+                    placeholder="z.B. Erdnüsse, Gluten, Vegan"
+                  />
+                </label>
+                <label className="space-y-1 text-sm">
+                  <span>Schweregrad</span>
+                  <Select
+                    value={dietaryDraft.level}
+                    onValueChange={(value: AllergyLevel) => setDietaryDraft((prev) => ({ ...prev, level: value }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Wähle den Schweregrad" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.values(AllergyLevel).map((level) => (
+                        <SelectItem key={level} value={level}>
+                          {allergyLevelLabels[level]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+              </div>
+              <div className="grid gap-3 md:grid-cols-3">
+                <Textarea
+                  value={dietaryDraft.symptoms}
+                  onChange={(event) => setDietaryDraft((prev) => ({ ...prev, symptoms: event.target.value }))}
+                  placeholder="Symptome (optional)"
+                  className="md:col-span-1"
+                />
+                <Textarea
+                  value={dietaryDraft.treatment}
+                  onChange={(event) => setDietaryDraft((prev) => ({ ...prev, treatment: event.target.value }))}
+                  placeholder="Behandlung im Notfall"
+                  className="md:col-span-1"
+                />
+                <Textarea
+                  value={dietaryDraft.note}
+                  onChange={(event) => setDietaryDraft((prev) => ({ ...prev, note: event.target.value }))}
+                  placeholder="Weitere Hinweise"
+                  className="md:col-span-1"
+                />
+              </div>
+              <Button type="button" variant="outline" onClick={handleAddDietary}>
+                Speichern
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 6 && (
+        <Card className="border border-border/70">
+          <CardHeader>
+            <CardTitle>Zusammenfassung</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Schau alles noch einmal durch. Nach dem Absenden legen wir dein Profil an und melden uns mit den nächsten Schritten.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <section className="rounded-lg border border-border/70 p-4">
+              <h3 className="text-sm font-semibold uppercase text-muted-foreground">Profil</h3>
+              <dl className="mt-3 grid gap-2 text-sm">
+                <div className="grid grid-cols-3 gap-2">
+                  <dt className="text-muted-foreground">Name</dt>
+                  <dd className="col-span-2">{form.name || "–"}</dd>
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  <dt className="text-muted-foreground">E-Mail</dt>
+                  <dd className="col-span-2">{form.email || "–"}</dd>
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  <dt className="text-muted-foreground">Geburtsdatum</dt>
+                  <dd className="col-span-2">{form.dateOfBirth || "–"}</dd>
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  <dt className="text-muted-foreground">Kontext</dt>
+                  <dd className="col-span-2">{form.background || "–"}</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="rounded-lg border border-border/70 p-4">
+              <h3 className="text-sm font-semibold uppercase text-muted-foreground">Fokus</h3>
+              <p className="text-sm font-medium">
+                {form.focus === "acting"
+                  ? "Schauspiel"
+                  : form.focus === "tech"
+                  ? "Gewerke & Teams"
+                  : "Schauspiel und Gewerke"}
+              </p>
+              <ul className="mt-3 space-y-2 text-sm">
+                {preferenceSummary.acting.map((item) => (
+                  <li key={`acting-${item}`}>🎭 {item}</li>
+                ))}
+                {preferenceSummary.crew.map((item) => (
+                  <li key={`crew-${item}`}>🔧 {item}</li>
+                ))}
+              </ul>
+            </section>
+
+            <section className="rounded-lg border border-border/70 p-4">
+              <h3 className="text-sm font-semibold uppercase text-muted-foreground">Interessen</h3>
+              <div className="flex flex-wrap gap-2">
+                {form.interests.length ? (
+                  form.interests.map((interest) => (
+                    <Badge key={interest} variant="outline">
+                      {interest}
+                    </Badge>
+                  ))
+                ) : (
+                  <span className="text-sm text-muted-foreground">Keine Angaben</span>
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-lg border border-border/70 p-4">
+              <h3 className="text-sm font-semibold uppercase text-muted-foreground">Fotoerlaubnis</h3>
+              <p className="text-sm">
+                {form.photoConsent.consent
+                  ? "Einverständnis erteilt"
+                  : "Noch keine Zustimmung erteilt"}
+                {requiresDocument && !form.photoConsent.skipDocument
+                  ? documentFile
+                    ? " – Dokument wird mitgeschickt"
+                    : " – Dokument fehlt noch"
+                  : ""}
+              </p>
+            </section>
+
+            <section className="rounded-lg border border-border/70 p-4">
+              <h3 className="text-sm font-semibold uppercase text-muted-foreground">Essensunverträglichkeiten</h3>
+              {form.dietary.length ? (
+                <ul className="mt-2 space-y-2 text-sm">
+                  {form.dietary.map((entry) => (
+                    <li key={entry.id}>
+                      <span className="font-medium">{entry.allergen}</span> – {allergyLevelLabels[entry.level]}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted-foreground">Keine Angaben</p>
+              )}
+            </section>
+
+            {success ? (
+              <div className="rounded-lg border border-emerald-300 bg-emerald-50/80 p-4 text-sm text-emerald-900">
+                <p className="font-medium">Danke, deine Angaben sind angekommen!</p>
+                <p>
+                  Wir legen jetzt dein Profil an und melden uns mit den nächsten Schritten. Du kannst dich demnächst mit deiner
+                  E-Mail auf der Mitgliederseite anmelden.
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Link href="/login">
+                    <Button>Zum Mitglieder-Login</Button>
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {error && <p className="text-sm text-destructive">{error}</p>}
+                <Button onClick={handleSubmit} disabled={loading}>
+                  {loading ? "Wird übertragen …" : "Angaben absenden"}
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {step > 0 && step < 6 && (
+        <div className="flex justify-between gap-3">
+          <Button variant="outline" onClick={goBack} disabled={loading}>
+            Zurück
+          </Button>
+          <Button onClick={goNext} disabled={loading}>
+            Weiter
+          </Button>
+        </div>
+      )}
+
+      {error && step !== 6 && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/lib/member-invites.ts
+++ b/src/lib/member-invites.ts
@@ -1,0 +1,52 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import type { MemberInvite } from "@prisma/client";
+
+const DEFAULT_TOKEN_BYTES = 24;
+
+export function generateInviteToken(byteLength: number = DEFAULT_TOKEN_BYTES) {
+  const size = Number.isFinite(byteLength) && byteLength > 0 ? Math.floor(byteLength) : DEFAULT_TOKEN_BYTES;
+  return randomBytes(size).toString("base64url");
+}
+
+export function hashInviteToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+type InviteLike = Pick<MemberInvite, "expiresAt" | "maxUses" | "usageCount" | "isDisabled">;
+
+export function calculateInviteStatus(invite: InviteLike, now: Date = new Date()) {
+  const expiresAt = invite.expiresAt ? new Date(invite.expiresAt) : null;
+  const isExpired = Boolean(expiresAt && expiresAt.getTime() <= now.getTime());
+  const isExhausted = typeof invite.maxUses === "number" && invite.maxUses > -1
+    ? invite.usageCount >= invite.maxUses
+    : false;
+  const remainingUses = typeof invite.maxUses === "number" && invite.maxUses > -1
+    ? Math.max(invite.maxUses - invite.usageCount, 0)
+    : null;
+  const isDisabled = invite.isDisabled;
+  const isActive = !isDisabled && !isExpired && !isExhausted;
+
+  return { isExpired, isExhausted, isDisabled, isActive, remainingUses };
+}
+
+export function isInviteUsable(invite: InviteLike, now: Date = new Date()) {
+  const status = calculateInviteStatus(invite, now);
+  return status.isActive;
+}
+
+export function describeInvite(invite: MemberInvite, now: Date = new Date()) {
+  const status = calculateInviteStatus(invite, now);
+  return {
+    id: invite.id,
+    label: invite.label,
+    note: invite.note,
+    createdAt: invite.createdAt,
+    expiresAt: invite.expiresAt,
+    maxUses: invite.maxUses,
+    usageCount: invite.usageCount,
+    roles: invite.roles,
+    isDisabled: invite.isDisabled,
+    ...status,
+  };
+}

--- a/src/lib/onboarding-analytics.ts
+++ b/src/lib/onboarding-analytics.ts
@@ -1,0 +1,145 @@
+import type { AllergyLevel, OnboardingFocus, RolePreferenceDomain } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { calculateInviteStatus } from "@/lib/member-invites";
+
+export type OnboardingAnalytics = {
+  invites: {
+    total: number;
+    active: number;
+    expired: number;
+    disabled: number;
+    exhausted: number;
+    totalUsage: number;
+  };
+  inviteUsage: {
+    id: string;
+    label: string | null;
+    createdAt: string;
+    usageCount: number;
+    remainingUses: number | null;
+    isActive: boolean;
+  }[];
+  completions: {
+    total: number;
+    byFocus: Record<OnboardingFocus, number>;
+  };
+  interests: { name: string; count: number }[];
+  rolePreferences: { code: string; domain: RolePreferenceDomain; averageWeight: number; responses: number }[];
+  dietary: { level: AllergyLevel; count: number }[];
+  minorsPendingDocuments: number;
+  pendingPhotoConsents: number;
+};
+
+export async function collectOnboardingAnalytics(now: Date = new Date()): Promise<OnboardingAnalytics> {
+  const [invites, profiles, rolePreferences, interestEntries, dietaryGroups, pendingPhotoConsents] = await Promise.all([
+    prisma.memberInvite.findMany({
+      include: { redemptions: { select: { id: true, completedAt: true } } },
+    }),
+    prisma.memberOnboardingProfile.findMany({ select: { focus: true } }),
+    prisma.memberRolePreference.findMany({ select: { code: true, domain: true, weight: true } }),
+    prisma.userInterest.findMany({ include: { interest: true } }),
+    prisma.dietaryRestriction.groupBy({
+      by: ["level"],
+      _count: { level: true },
+      where: { isActive: true },
+    }),
+    prisma.photoConsent.count({ where: { status: "pending" } }),
+  ]);
+
+  const inviteStats = invites.reduce(
+    (acc, invite) => {
+      const status = calculateInviteStatus(invite, now);
+      acc.total += 1;
+      acc.totalUsage += invite.usageCount;
+      if (status.isActive) acc.active += 1;
+      if (status.isExpired) acc.expired += 1;
+      if (status.isExhausted) acc.exhausted += 1;
+      if (invite.isDisabled) acc.disabled += 1;
+      return acc;
+    },
+    { total: 0, active: 0, expired: 0, disabled: 0, exhausted: 0, totalUsage: 0 },
+  );
+
+  const inviteUsage = invites
+    .map((invite) => {
+      const status = calculateInviteStatus(invite, now);
+      return {
+        id: invite.id,
+        label: invite.label,
+        createdAt: invite.createdAt.toISOString(),
+        usageCount: invite.usageCount,
+        remainingUses: status.remainingUses,
+        isActive: status.isActive,
+      };
+    })
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+
+  const focusCounts: Record<OnboardingFocus, number> = {
+    acting: 0,
+    tech: 0,
+    both: 0,
+  };
+  for (const profile of profiles) {
+    focusCounts[profile.focus] = (focusCounts[profile.focus] ?? 0) + 1;
+  }
+
+  const interestMap = new Map<string, number>();
+  for (const entry of interestEntries) {
+    const name = entry.interest?.name ?? "Sonstige";
+    interestMap.set(name, (interestMap.get(name) ?? 0) + 1);
+  }
+  const interests = Array.from(interestMap.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+  const preferenceKey = (domain: RolePreferenceDomain, code: string) => `${domain}:${code}`;
+  const prefMap = new Map<string, { domain: RolePreferenceDomain; code: string; total: number; responses: number }>();
+  for (const pref of rolePreferences) {
+    const key = preferenceKey(pref.domain, pref.code);
+    if (!prefMap.has(key)) {
+      prefMap.set(key, { domain: pref.domain, code: pref.code, total: 0, responses: 0 });
+    }
+    const bucket = prefMap.get(key)!;
+    bucket.total += pref.weight;
+    bucket.responses += 1;
+  }
+  const rolePrefStats = Array.from(prefMap.values())
+    .map((bucket) => ({
+      code: bucket.code,
+      domain: bucket.domain,
+      responses: bucket.responses,
+      averageWeight: bucket.responses ? Math.round((bucket.total / bucket.responses) * 10) / 10 : 0,
+    }))
+    .sort((a, b) => b.averageWeight - a.averageWeight || a.code.localeCompare(b.code));
+
+  const dietary = dietaryGroups
+    .map((group) => ({ level: group.level, count: group._count.level }))
+    .sort((a, b) => b.count - a.count);
+
+  const majorityFocusTotal = profiles.length;
+  const completions = {
+    total: majorityFocusTotal,
+    byFocus: focusCounts,
+  };
+
+  const minorCutoff = new Date(now);
+  minorCutoff.setFullYear(minorCutoff.getFullYear() - 18);
+  const minorsPendingDocuments = await prisma.user.count({
+    where: {
+      dateOfBirth: { gt: minorCutoff },
+      OR: [{ photoConsent: null }, { photoConsent: { documentUploadedAt: null } }],
+    },
+  });
+
+  return {
+    invites: inviteStats,
+    inviteUsage,
+    completions,
+    interests,
+    rolePreferences: rolePrefStats,
+    dietary,
+    minorsPendingDocuments,
+    pendingPhotoConsents,
+  };
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -22,12 +22,22 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
       "Bereich zur Verwaltung von Gewerken, Besetzungen, Szenen und Breakdown-Aufgaben im Produktionsmanagement.",
   },
   { key: "mitglieder.rollenverwaltung", label: "Mitgliederverwaltung öffnen" },
+  {
+    key: "mitglieder.einladungen",
+    label: "Einladungslinks verwalten",
+    description: "Mehrfach nutzbare Einladungslinks anlegen, deaktivieren und deren Status prüfen.",
+  },
   { key: "mitglieder.rechte", label: "Rechteverwaltung öffnen" },
   { key: "mitglieder.sperrliste", label: "Sperrliste pflegen" },
   {
     key: "mitglieder.fotoerlaubnisse",
     label: "Fotoerlaubnisse verwalten",
     description: "Bereich zum Prüfen und Freigeben von Fotoeinverständniserklärungen.",
+  },
+  {
+    key: "mitglieder.onboarding.analytics",
+    label: "Onboarding-Analytics öffnen",
+    description: "Statistiken zum Einladungs- und Onboarding-Prozess einsehen.",
   },
 ];
 


### PR DESCRIPTION
## Summary
- extend the Prisma schema with invite/onboarding entities and new permission keys for managing links and analytics
- add a members-area invite manager, onboarding wizard, and supporting API routes that let invitees register with interests, preferences, consents, and dietary notes
- expose an onboarding analytics dashboard that aggregates invite usage, focus distribution, interests, and outstanding follow-ups

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cdf1af6a08832d8ae1cda7ce85d2af