### PR TITLE
Fix runtime AllergyLevel reference in onboarding wizard

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import type { AllergyLevel, Role } from "@prisma/client";
+import { AllergyLevel, type Role } from "@prisma/client";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";


### PR DESCRIPTION
## Summary
- import the Prisma AllergyLevel enum as a runtime value so the dietary level select can render safely in the client

## Testing
- pnpm lint src/components/onboarding/onboarding-wizard.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ce00e510c8832dbdc8abe26b0d6a9b