### PR TITLE
Revamp onboarding wizard and surface status in dashboard

### DIFF
--- a/src/app/api/onboarding/backgrounds/route.ts
+++ b/src/app/api/onboarding/backgrounds/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const profiles = await prisma.memberOnboardingProfile.findMany({
+    select: { background: true },
+    where: { background: { not: null } },
+  });
+
+  const counts = new Map<string, { name: string; count: number }>();
+
+  for (const entry of profiles) {
+    const raw = entry.background ?? "";
+    const normalized = raw.replace(/\s+/g, " ").trim();
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    const existing = counts.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      counts.set(key, { name: normalized, count: 1 });
+    }
+  }
+
+  const backgrounds = Array.from(counts.values())
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      return a.name.localeCompare(b.name, "de");
+    })
+    .slice(0, 20);
+
+  return NextResponse.json({ backgrounds });
+}

--- a/src/app/api/onboarding/interests/route.ts
+++ b/src/app/api/onboarding/interests/route.ts
@@ -4,10 +4,18 @@ import { prisma } from "@/lib/prisma";
 
 export async function GET() {
   const interests = await prisma.interest.findMany({
-    orderBy: [{ name: "asc" }],
+    include: {
+      _count: { select: { userInterest: true } },
+    },
+    orderBy: [{ userInterest: { _count: "desc" } }, { name: "asc" }],
+    take: 50,
   });
 
   return NextResponse.json({
-    interests: interests.map((interest) => ({ id: interest.id, name: interest.name })),
+    interests: interests.map((interest) => ({
+      id: interest.id,
+      name: interest.name,
+      usage: interest._count.userInterest,
+    })),
   });
 }

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -21,7 +21,9 @@ import {
   WifiOff,
   Bell,
   CheckCircle2,
+  Sparkles,
 } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface RecentActivity {
   id: string;
@@ -37,11 +39,76 @@ interface DashboardStats {
   unreadNotifications: number;
 }
 
+type OnboardingPhotoStatus = "none" | "pending" | "approved" | "rejected";
+
+interface OnboardingDomainStats {
+  count: number;
+  averageWeight: number;
+}
+
+interface OnboardingOverview {
+  completed: boolean;
+  completedAt: Date | null;
+  focus: "acting" | "tech" | "both" | null;
+  background: string | null;
+  stats: {
+    acting: OnboardingDomainStats;
+    crew: OnboardingDomainStats;
+    interests: { count: number; top: string[] };
+    dietary: { count: number; highlights: { name: string; level: string | null }[] };
+  };
+  photoConsent: {
+    status: OnboardingPhotoStatus;
+    consentGiven: boolean;
+    hasDocument: boolean;
+    updatedAt: Date | null;
+  };
+  passwordSet: boolean;
+}
+
 const INITIAL_STATS: DashboardStats = {
   totalOnline: 0,
   totalMembers: 0,
   rehearsalsThisWeek: 0,
   unreadNotifications: 0,
+};
+
+const ONBOARDING_FOCUS_LABELS: Record<"acting" | "tech" | "both", string> = {
+  acting: "Schauspiel",
+  tech: "Gewerke",
+  both: "Schauspiel & Gewerke",
+};
+
+const ONBOARDING_FOCUS_DESCRIPTIONS: Record<"acting" | "tech" | "both", string> = {
+  acting: "Du möchtest auf der Bühne wirken und Rollen gestalten.",
+  tech: "Du möchtest hinter den Kulissen organisieren, bauen oder für Licht & Ton sorgen.",
+  both: "Du bleibst flexibel zwischen Bühne und Gewerken und entscheidest situativ.",
+};
+
+const ONBOARDING_DOMAIN_ACCENT: Record<"acting" | "crew", string> = {
+  acting: "from-violet-500/70 to-fuchsia-500/70",
+  crew: "from-cyan-500/70 to-teal-500/70",
+};
+
+const ONBOARDING_PHOTO_STATUS_LABELS: Record<OnboardingPhotoStatus, string> = {
+  none: "Ausstehend",
+  pending: "In Prüfung",
+  approved: "Freigabe erteilt",
+  rejected: "Abgelehnt",
+};
+
+const ONBOARDING_PHOTO_STATUS_CLASSES: Record<OnboardingPhotoStatus, string> = {
+  none: "border-border/60 bg-muted/40 text-muted-foreground",
+  pending: "border-amber-400/40 bg-amber-50 text-amber-700",
+  approved: "border-emerald-400/40 bg-emerald-50 text-emerald-700",
+  rejected: "border-red-400/40 bg-red-50 text-red-700",
+};
+
+const DIETARY_LEVEL_LABELS: Record<string, string> = {
+  MILD: "Leicht",
+  MODERATE: "Mittel",
+  SEVERE: "Stark",
+  LETHAL: "Kritisch",
 };
 
 type OverviewStatsPayload = {
@@ -53,6 +120,7 @@ type OverviewStatsPayload = {
 type OverviewResponse = {
   stats?: OverviewStatsPayload;
   recentActivities?: unknown;
+  onboarding?: unknown;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -105,6 +173,103 @@ function parseRecentActivities(value: unknown): RecentActivity[] {
     .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
 }
 
+const isFocusValue = (value: unknown): value is "acting" | "tech" | "both" =>
+  value === "acting" || value === "tech" || value === "both";
+
+const isPhotoStatus = (value: unknown): value is OnboardingPhotoStatus =>
+  value === "pending" || value === "approved" || value === "rejected" || value === "none";
+
+function parseIsoDate(value: unknown): Date | null {
+  if (value instanceof Date && !Number.isNaN(value.valueOf())) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.valueOf())) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function parseOnboardingOverview(value: unknown): OnboardingOverview | null {
+  if (!isRecord(value)) return null;
+
+  const completed = Boolean(value.completed);
+  const focusRaw = value.focus;
+  const focus = isFocusValue(focusRaw) ? focusRaw : null;
+  const background = typeof value.background === "string" && value.background.trim() ? value.background : null;
+  const completedAt = parseIsoDate(value.completedAt);
+
+  const statsRecord = isRecord(value.stats) ? value.stats : {};
+  const parseDomain = (entry: unknown): OnboardingDomainStats => {
+    if (!isRecord(entry)) return { count: 0, averageWeight: 0 };
+    const count = typeof entry.count === "number" && Number.isFinite(entry.count) ? entry.count : 0;
+    const averageWeight = typeof entry.averageWeight === "number" && Number.isFinite(entry.averageWeight)
+      ? entry.averageWeight
+      : 0;
+    return { count, averageWeight };
+  };
+
+  const actingStats = parseDomain(statsRecord.acting);
+  const crewStats = parseDomain(statsRecord.crew);
+
+  const interestsRecord = isRecord(statsRecord.interests) ? statsRecord.interests : {};
+  const interestCount = typeof interestsRecord.count === "number" && Number.isFinite(interestsRecord.count)
+    ? interestsRecord.count
+    : 0;
+  const interestTop = parseStringArray(interestsRecord.top);
+
+  const dietaryRecord = isRecord(statsRecord.dietary) ? statsRecord.dietary : {};
+  const dietaryCount = typeof dietaryRecord.count === "number" && Number.isFinite(dietaryRecord.count)
+    ? dietaryRecord.count
+    : 0;
+  const dietaryHighlights = Array.isArray(dietaryRecord.highlights)
+    ? dietaryRecord.highlights
+        .map((entry) => {
+          if (!isRecord(entry)) return null;
+          const name = typeof entry.name === "string" && entry.name.trim() ? entry.name : null;
+          const level = typeof entry.level === "string" && entry.level.trim() ? entry.level : null;
+          if (!name) return null;
+          return { name, level };
+        })
+        .filter((entry): entry is { name: string; level: string | null } => entry !== null)
+    : [];
+
+  const photoRecord = isRecord(value.photoConsent) ? value.photoConsent : {};
+  const statusRaw = photoRecord.status;
+  const status: OnboardingPhotoStatus = isPhotoStatus(statusRaw) ? statusRaw : "none";
+  const consentGiven = Boolean(photoRecord.consentGiven);
+  const hasDocument = Boolean(photoRecord.hasDocument);
+  const updatedAt = parseIsoDate(photoRecord.updatedAt);
+
+  const passwordSet = Boolean(value.passwordSet);
+
+  return {
+    completed,
+    completedAt,
+    focus,
+    background,
+    stats: {
+      acting: actingStats,
+      crew: crewStats,
+      interests: { count: interestCount, top: interestTop },
+      dietary: { count: dietaryCount, highlights: dietaryHighlights },
+    },
+    photoConsent: { status, consentGiven, hasDocument, updatedAt },
+    passwordSet,
+  };
+}
+
 export function MembersDashboard() {
   const { data: session } = useSession();
   const { connectionStatus } = useRealtime();
@@ -117,6 +282,8 @@ export function MembersDashboard() {
   const [stats, setStats] = useState<DashboardStats>(INITIAL_STATS);
   const [recentActivities, setRecentActivities] = useState<RecentActivity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [onboarding, setOnboarding] = useState<OnboardingOverview | null>(null);
+  const [onboardingLoaded, setOnboardingLoaded] = useState(false);
 
   useEffect(() => {
     setStats((prev) => ({ ...prev, totalOnline: liveOnline }));
@@ -156,6 +323,7 @@ export function MembersDashboard() {
           return next;
         });
 
+        setOnboarding(parseOnboardingOverview(payload?.onboarding));
         const activities = parseRecentActivities(payload?.recentActivities);
 
         setRecentActivities(activities.slice(0, 10));
@@ -164,6 +332,7 @@ export function MembersDashboard() {
       } finally {
         if (!cancelled) {
           setIsLoading(false);
+          setOnboardingLoaded(true);
         }
       }
     }
@@ -238,6 +407,194 @@ export function MembersDashboard() {
 
   const onlineList = useMemo(() => onlineUsers.slice(0, 6), [onlineUsers]);
 
+  const onboardingCard = useMemo(() => {
+    if (!onboardingLoaded) {
+      return (
+        <Card className="border border-dashed border-border/60 bg-background/80">
+          <CardContent className="p-6 text-sm text-muted-foreground">
+            Onboarding-Status wird geladen …
+          </CardContent>
+        </Card>
+      );
+    }
+
+    if (!onboarding) {
+      return (
+        <Card className="border border-dashed border-border/60 bg-background/80">
+          <CardContent className="space-y-2 p-6 text-sm text-muted-foreground">
+            <p>Noch keine Onboarding-Daten vorhanden.</p>
+            <p>Nutze den Einladungslink oder melde dich beim Team.</p>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    const focusLabel = onboarding.focus ? ONBOARDING_FOCUS_LABELS[onboarding.focus] : "Noch offen";
+    const focusDescription = onboarding.focus
+      ? ONBOARDING_FOCUS_DESCRIPTIONS[onboarding.focus]
+      : "Triff deine Wahl, sobald du soweit bist.";
+    const completedAtLabel = onboarding.completedAt
+      ? new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(onboarding.completedAt)
+      : null;
+    const statusBadge = onboarding.completed ? (
+      <Badge variant="secondary" className="bg-emerald-100 text-emerald-700">
+        Abgeschlossen
+      </Badge>
+    ) : (
+      <Badge variant="outline" className="border-amber-400/40 text-amber-700">
+        In Bearbeitung
+      </Badge>
+    );
+
+    const photoStatus = onboarding.photoConsent.status;
+    const photoBadgeClass = ONBOARDING_PHOTO_STATUS_CLASSES[photoStatus];
+    const photoLabel = ONBOARDING_PHOTO_STATUS_LABELS[photoStatus];
+    const photoText = (() => {
+      switch (photoStatus) {
+        case "approved":
+          return "Freigabe erteilt – du bist für Fotoeinsätze freigeschaltet.";
+        case "pending":
+          return "Wird geprüft – du erhältst eine Benachrichtigung nach der Freigabe.";
+        case "rejected":
+          return "Der Antrag wurde abgelehnt – bitte kontaktiere das Team bei Fragen.";
+        default:
+          return onboarding.photoConsent.consentGiven
+            ? "Einverständnis liegt vor, Dokument wird noch erwartet."
+            : "Noch keine Zustimmung erfasst.";
+      }
+    })();
+    const photoUpdatedLabel = onboarding.photoConsent.updatedAt
+      ? new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(onboarding.photoConsent.updatedAt)
+      : null;
+
+    return (
+      <Card className="border border-primary/30 bg-gradient-to-br from-primary/5 via-background to-background">
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="text-lg">Dein Onboarding</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {onboarding.completed
+                ? completedAtLabel
+                  ? `Abgeschlossen am ${completedAtLabel}.`
+                  : "Abgeschlossen."
+                : "Noch in Bearbeitung – behalte deine nächsten Schritte im Blick."}
+            </p>
+          </div>
+          {statusBadge}
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm">
+          <div className="space-y-2 rounded-xl border border-border/50 bg-background/90 p-3">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Sparkles className="h-4 w-4 text-primary" />
+              {focusLabel}
+            </div>
+            <p className="text-xs text-muted-foreground">{focusDescription}</p>
+            {onboarding.background && (
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="outline" className="border-primary/30 bg-primary/5 text-primary">
+                  {onboarding.background}
+                </Badge>
+              </div>
+            )}
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {(["acting", "crew"] as const).map((domain) => {
+              const stats = onboarding.stats[domain];
+              const averageWeight = Math.max(0, Math.min(100, Math.round(stats.averageWeight)));
+              return (
+                <div key={domain} className="space-y-2 rounded-xl border border-border/60 bg-background/85 p-3">
+                  <div className="flex items-center justify-between text-xs font-semibold uppercase text-muted-foreground">
+                    <span>{domain === "acting" ? "Schauspiel" : "Gewerke"}</span>
+                    <span>
+                      {stats.count} Bereich
+                      {stats.count === 1 ? "" : "e"}
+                    </span>
+                  </div>
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted/40">
+                    <div
+                      className={cn("h-full rounded-full bg-gradient-to-r", ONBOARDING_DOMAIN_ACCENT[domain])}
+                      style={{ width: `${averageWeight}%` }}
+                    />
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">Ø Intensität: {averageWeight}%</p>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="space-y-2 rounded-xl border border-border/60 bg-background/85 p-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold uppercase text-muted-foreground">Interessen</span>
+              <Badge variant="outline" className="border-primary/20 bg-primary/5 text-primary">
+                {onboarding.stats.interests.count}
+              </Badge>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {onboarding.stats.interests.top.length ? (
+                onboarding.stats.interests.top.map((interest) => (
+                  <Badge key={interest} variant="outline" className="border-primary/30 bg-primary/5 text-primary">
+                    {interest}
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-muted-foreground">Keine Angaben</span>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2 rounded-xl border border-border/60 bg-background/85 p-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold uppercase text-muted-foreground">Essenshinweise</span>
+              <Badge variant="outline" className="border-primary/20 bg-primary/5 text-primary">
+                {onboarding.stats.dietary.count}
+              </Badge>
+            </div>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {onboarding.stats.dietary.count && onboarding.stats.dietary.highlights.length ? (
+                onboarding.stats.dietary.highlights.map((item, index) => (
+                  <Badge
+                    key={`${item.name}-${index}`}
+                    variant="outline"
+                    className="flex items-center gap-1 border-border/50 text-foreground/80"
+                  >
+                    <span className="font-medium">{item.name}</span>
+                    {item.level ? (
+                      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                        {DIETARY_LEVEL_LABELS[item.level] ?? item.level}
+                      </span>
+                    ) : null}
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-muted-foreground">Keine Hinweise</span>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2 rounded-xl border border-border/60 bg-background/85 p-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-semibold uppercase text-muted-foreground">Fotoerlaubnis</span>
+              <Badge variant="outline" className={photoBadgeClass}>
+                {photoLabel}
+              </Badge>
+            </div>
+            <p className="text-xs text-muted-foreground">{photoText}</p>
+            {!onboarding.photoConsent.hasDocument && onboarding.photoConsent.consentGiven && (
+              <p className="text-[11px] text-amber-600">Hinweis: Dokument noch ausstehend.</p>
+            )}
+            {photoUpdatedLabel ? (
+              <p className="text-[11px] text-muted-foreground">Zuletzt aktualisiert am {photoUpdatedLabel}</p>
+            ) : null}
+            <p className="text-xs text-muted-foreground">
+              Passwort: {onboarding.passwordSet ? "gesetzt" : "wird nach Abschluss aktiviert"}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }, [onboarding, onboardingLoaded]);
+
   if (!session?.user) {
     return (
       <div className="p-6">
@@ -273,39 +630,42 @@ export function MembersDashboard() {
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.6fr)_minmax(0,0.4fr)] xl:items-stretch">
-        {/* Willkommen/Quick Actions */}
-        <Card className="h-full bg-gradient-to-br from-accent/20 to-transparent">
-          <CardContent className="flex h-full flex-col gap-4 pt-6 md:flex-row md:items-center md:justify-between xl:gap-6">
-            <div>
-              <div className="text-sm text-muted-foreground">Willkommen zurück</div>
-              <h2 className="text-xl font-semibold">
-                {session?.user?.name || session?.user?.email || "Mitglied"}
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Hier findest du aktuelle Aktivitäten und schnelle Aktionen.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {(() => {
-                const userRoles = (session?.user?.roles as string[] | undefined) ?? (session?.user?.role ? [session.user.role] : []);
-                const roleSet = new Set(userRoles);
-                const links = [
-                  { href: "/mitglieder/profil", label: "Profil öffnen" },
-                  { href: "/mitglieder/meine-proben", label: "Meine Proben" },
-                  { href: "/mitglieder/probenplanung", label: "Probenplanung", roles: ["board", "admin", "tech", "owner"] },
-                  { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", roles: ["admin", "owner"] },
-                  { href: "/mitglieder/rechte", label: "Rechteverwaltung", roles: ["admin", "owner"] },
-                ].filter((l: { href: string; label: string; roles?: string[] }) => !l.roles || l.roles.some((r) => roleSet.has(r)));
-                return links.map((l) => (
-                  <Button asChild key={l.href} variant="outline" size="sm">
-                    <Link href={l.href}>{l.label}</Link>
-                  </Button>
-                ));
-              })()}
-            </div>
-          </CardContent>
-        </Card>
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.6fr)_minmax(0,0.4fr)] xl:items-start">
+        <div className="space-y-4">
+          {onboardingCard}
+
+          <Card className="h-full bg-gradient-to-br from-accent/20 to-transparent">
+            <CardContent className="flex h-full flex-col gap-4 pt-6 md:flex-row md:items-center md:justify-between xl:gap-6">
+              <div>
+                <div className="text-sm text-muted-foreground">Willkommen zurück</div>
+                <h2 className="text-xl font-semibold">
+                  {session?.user?.name || session?.user?.email || "Mitglied"}
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Hier findest du aktuelle Aktivitäten und schnelle Aktionen.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {(() => {
+                  const userRoles = (session?.user?.roles as string[] | undefined) ?? (session?.user?.role ? [session.user.role] : []);
+                  const roleSet = new Set(userRoles);
+                  const links = [
+                    { href: "/mitglieder/profil", label: "Profil öffnen" },
+                    { href: "/mitglieder/meine-proben", label: "Meine Proben" },
+                    { href: "/mitglieder/probenplanung", label: "Probenplanung", roles: ["board", "admin", "tech", "owner"] },
+                    { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", roles: ["admin", "owner"] },
+                    { href: "/mitglieder/rechte", label: "Rechteverwaltung", roles: ["admin", "owner"] },
+                  ].filter((l: { href: string; label: string; roles?: string[] }) => !l.roles || l.roles.some((r) => roleSet.has(r)));
+                  return links.map((l) => (
+                    <Button asChild key={l.href} variant="outline" size="sm">
+                      <Link href={l.href}>{l.label}</Link>
+                    </Button>
+                  ));
+                })()}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
 
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 xl:auto-rows-fr xl:grid-cols-2">
           <Card className="h-full">


### PR DESCRIPTION
## Summary
- Overhauled the onboarding wizard with password setup, dynamic background and interest suggestions, custom crew entries, improved dietary capture, and a richer review step.
- Extended onboarding APIs to hash passwords, report interest usage, and expose background suggestions for the form.
- Added onboarding progress parsing and a status card to the members dashboard so users can track their onboarding completion.

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce04124bd8832d9475a5551a4a6334