### PR TITLE
Secure realtime handshake and protect onboarding APIs

### DIFF
--- a/src/app/api/onboarding/backgrounds/route.ts
+++ b/src/app/api/onboarding/backgrounds/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
 
 import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
   const profiles = await prisma.memberOnboardingProfile.findMany({
     select: { background: true },
     where: { background: { not: null } },

--- a/src/app/api/onboarding/interests/route.ts
+++ b/src/app/api/onboarding/interests/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
 
 import { prisma } from "@/lib/prisma";
+import { authOptions } from "@/lib/auth";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
   const interests = await prisma.interest.findMany({
     include: {
       _count: { select: { userInterest: true } },

--- a/src/app/api/realtime/handshake/route.ts
+++ b/src/app/api/realtime/handshake/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { createHmac } from 'node:crypto';
+
+import { authOptions } from '@/lib/auth';
+
+const DEFAULT_TTL_SECONDS = 5 * 60;
+
+function getHandshakeSecret(): string | null {
+  const secret =
+    process.env.REALTIME_HANDSHAKE_SECRET ||
+    process.env.REALTIME_AUTH_TOKEN ||
+    process.env.REALTIME_SERVER_TOKEN ||
+    null;
+  return secret && secret.trim() ? secret : null;
+}
+
+function resolveTtl(): number {
+  const raw = Number(process.env.REALTIME_HANDSHAKE_TTL ?? DEFAULT_TTL_SECONDS);
+  if (Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw);
+  }
+  return DEFAULT_TTL_SECONDS;
+}
+
+function createHandshakeToken(userId: string, secret: string) {
+  const issuedAt = Date.now();
+  const ttlSeconds = resolveTtl();
+  const expiresAt = issuedAt + ttlSeconds * 1000;
+  const base = `${userId}:${issuedAt}:${expiresAt}`;
+  const signature = createHmac('sha256', secret).update(base).digest('hex');
+  const token = `${issuedAt}.${expiresAt}.${signature}`;
+  return { token, issuedAt, expiresAt };
+}
+
+export async function GET() {
+  const secret = getHandshakeSecret();
+  if (!secret) {
+    console.error('[Realtime] Handshake secret is not configured.');
+    return NextResponse.json({ error: 'Realtime server is not configured.' }, { status: 500 });
+  }
+
+  const session = await getServerSession(authOptions);
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Nicht autorisiert' }, { status: 401 });
+  }
+
+  const token = createHandshakeToken(userId, secret);
+  const payload = {
+    token: token.token,
+    issuedAt: token.issuedAt,
+    expiresAt: token.expiresAt,
+    userId,
+    userName: session.user?.name ?? null,
+  };
+
+  return NextResponse.json(payload, {
+    status: 200,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a signed realtime handshake endpoint and fetch it from the client before connecting
- harden the standalone realtime server by validating tokens, restricting room access, and requiring the admin event secret
- lock down onboarding analytics endpoints and batch-create onboarding interests/dietary data to avoid N+1 queries

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ce0fe99990832d9cdcc466a623a1a4