### PR TITLE
Add Traefik overlays for Doco deployments

### DIFF
--- a/docker-compose.dev.traefik.yml
+++ b/docker-compose.dev.traefik.yml
@@ -1,0 +1,47 @@
+services:
+  app:
+    ports: []
+    environment:
+      NEXTAUTH_URL: https://theaterdev.beegreenx.de
+      NEXT_PUBLIC_REALTIME_URL: https://theaterdev.beegreenx.de/realtime
+    networks:
+      - default
+      - proxy
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.theater-app-dev.entrypoints: web
+      traefik.http.routers.theater-app-dev.rule: Host(`theaterdev.beegreenx.de`)
+      traefik.http.routers.theater-app-dev.middlewares: theater-app-dev-redirect
+      traefik.http.routers.theater-app-dev.service: theater-app-dev
+      traefik.http.middlewares.theater-app-dev-redirect.redirectscheme.scheme: https
+      traefik.http.routers.theater-app-dev-secure.entrypoints: websecure
+      traefik.http.routers.theater-app-dev-secure.rule: Host(`theaterdev.beegreenx.de`)
+      traefik.http.routers.theater-app-dev-secure.tls: "true"
+      traefik.http.routers.theater-app-dev-secure.tls.certresolver: myresolver
+      traefik.http.routers.theater-app-dev-secure.service: theater-app-dev
+      traefik.http.services.theater-app-dev.loadbalancer.server.port: 3000
+      traefik.docker.network: proxy
+
+  realtime:
+    ports: []
+    environment:
+      CORS_ORIGIN: https://theaterdev.beegreenx.de
+    networks:
+      - default
+      - proxy
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.theater-realtime-dev.entrypoints: websecure
+      traefik.http.routers.theater-realtime-dev.rule: Host(`theaterdev.beegreenx.de`) && PathPrefix(`/realtime`)
+      traefik.http.routers.theater-realtime-dev.tls: "true"
+      traefik.http.routers.theater-realtime-dev.tls.certresolver: myresolver
+      traefik.http.routers.theater-realtime-dev.middlewares: theater-realtime-dev-strip
+      traefik.http.routers.theater-realtime-dev.service: theater-realtime-dev
+      traefik.http.middlewares.theater-realtime-dev-strip.stripprefix.prefixes: /realtime
+      traefik.http.services.theater-realtime-dev.loadbalancer.server.port: 4001
+      traefik.http.services.theater-realtime-dev.loadbalancer.server.scheme: http
+      traefik.docker.network: proxy
+
+networks:
+  proxy:
+    external: true

--- a/docker-compose.prod.traefik.yml
+++ b/docker-compose.prod.traefik.yml
@@ -1,0 +1,47 @@
+services:
+  app:
+    ports: []
+    environment:
+      NEXTAUTH_URL: https://theaterprod.beegreenx.de
+      NEXT_PUBLIC_REALTIME_URL: https://theaterprod.beegreenx.de/realtime
+    networks:
+      - default
+      - proxy
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.theater-app-prod.entrypoints: web
+      traefik.http.routers.theater-app-prod.rule: Host(`theaterprod.beegreenx.de`)
+      traefik.http.routers.theater-app-prod.middlewares: theater-app-prod-redirect
+      traefik.http.routers.theater-app-prod.service: theater-app-prod
+      traefik.http.middlewares.theater-app-prod-redirect.redirectscheme.scheme: https
+      traefik.http.routers.theater-app-prod-secure.entrypoints: websecure
+      traefik.http.routers.theater-app-prod-secure.rule: Host(`theaterprod.beegreenx.de`)
+      traefik.http.routers.theater-app-prod-secure.tls: "true"
+      traefik.http.routers.theater-app-prod-secure.tls.certresolver: myresolver
+      traefik.http.routers.theater-app-prod-secure.service: theater-app-prod
+      traefik.http.services.theater-app-prod.loadbalancer.server.port: 3000
+      traefik.docker.network: proxy
+
+  realtime:
+    ports: []
+    environment:
+      CORS_ORIGIN: https://theaterprod.beegreenx.de
+    networks:
+      - default
+      - proxy
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.theater-realtime-prod.entrypoints: websecure
+      traefik.http.routers.theater-realtime-prod.rule: Host(`theaterprod.beegreenx.de`) && PathPrefix(`/realtime`)
+      traefik.http.routers.theater-realtime-prod.tls: "true"
+      traefik.http.routers.theater-realtime-prod.tls.certresolver: myresolver
+      traefik.http.routers.theater-realtime-prod.middlewares: theater-realtime-prod-strip
+      traefik.http.routers.theater-realtime-prod.service: theater-realtime-prod
+      traefik.http.middlewares.theater-realtime-prod-strip.stripprefix.prefixes: /realtime
+      traefik.http.services.theater-realtime-prod.loadbalancer.server.port: 4001
+      traefik.http.services.theater-realtime-prod.loadbalancer.server.scheme: http
+      traefik.docker.network: proxy
+
+networks:
+  proxy:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,21 +51,6 @@ services:
     command: >-
       sh -c "pnpm -s prisma:generate && pnpm -s prisma migrate deploy && (pnpm -s db:seed || true) && pnpm -s dev --turbo -p 3000 -H 0.0.0.0"
 
-    networks:
-      - proxy
-      - default
-    labels:
-      traefik.enable: true
-      traefik.http.routers.theater-app.entrypoints: web
-      traefik.http.routers.theater-app.rule: Host(`devtheater.beegreenx.de`)
-      traefik.http.routers.theater-app-secure.entrypoints: websecure
-      traefik.http.routers.theater-app-secure.rule: Host(`devtheater.beegreenx.de`)
-      traefik.http.routers.theater-app-secure.tls: true
-      traefik.http.routers.theater-app-secure.tls.certresolver: myresolver
-      traefik.http.routers.theater-app-secure.service: theater-app
-      traefik.http.services.theater-app.loadbalancer.server.port: 3000
-      traefik.docker.network: proxy
-
   realtime:
     build: ./realtime-server
     restart: unless-stopped
@@ -79,8 +64,3 @@ services:
 
 volumes:
   pgdata:
-
-
-networks:
-  proxy:
-    external: true

--- a/docs/doco-cd.md
+++ b/docs/doco-cd.md
@@ -1,0 +1,61 @@
+# Doco CD Deployment
+
+Dieses Repository stellt zwei getrennte Deployments für Doco bereit:
+
+- **Entwicklungs-Stack** (`theaterdev.beegreenx.de`): basiert auf dem Entwicklungs-
+  `docker-compose.yml` und wird um Traefik-spezifische Einstellungen ergänzt.
+- **Produktiv-Stack** (`theaterprod.beegreenx.de`): baut das Production-Image und
+  versieht es ebenfalls mit Traefik-Routing.
+
+Die zusätzlichen Konfigurationen liegen in separaten Compose-Dateien, so dass die
+Standardentwicklung lokal weiterhin ohne Traefik funktioniert:
+
+| Umgebung | Basis-Datei | Traefik-Overlay |
+| --- | --- | --- |
+| Entwicklung | `docker-compose.yml` | `docker-compose.dev.traefik.yml` |
+| Produktion | `docker-compose.prod.yml` | `docker-compose.prod.traefik.yml` |
+
+## Vorbereitung
+
+1. **Traefik-Netzwerk**: Die Overlays erwarten ein externes Docker-Netzwerk mit dem
+   Namen `proxy` (`docker network create proxy`).
+2. **Secrets**: Hinterlege in Doco die erforderlichen Umgebungsvariablen (z. B.
+   `AUTH_SECRET`, E-Mail-Zugangsdaten oder Production-Datenbank-URL). Für das Dev-
+   Deployment genügen die Standardwerte, für Produktion müssen echte Secrets
+   gesetzt werden.
+3. **Realtime-Endpunkt**: Beide Overlays exposen den Socket.io-Server unter dem
+   Pfad `/realtime`. Der Client nutzt `NEXT_PUBLIC_REALTIME_URL`, um denselben
+   Host zu verwenden – zusätzliche Subdomains sind nicht nötig.
+
+## Deployment-Befehle
+
+### Entwicklung (`theaterdev.beegreenx.de`)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.traefik.yml up -d
+```
+
+Traefik leitet anschließend `https://theaterdev.beegreenx.de` auf den Next.js Dev-
+Server weiter und stellt die Realtime-API unter `https://theaterdev.beegreenx.de/realtime`
+bereit.
+
+### Produktion (`theaterprod.beegreenx.de`)
+
+```bash
+docker compose -f docker-compose.prod.yml -f docker-compose.prod.traefik.yml up -d
+```
+
+Dieses Setup baut das Production-Image (Dockerfile.prod) und aktiviert ebenfalls
+TLS-Routing via Traefik. Stelle sicher, dass alle produktiven Variablen gesetzt
+sind (`AUTH_SECRET`, `REALTIME_AUTH_TOKEN`, etc.).
+
+## Lokale Entwicklung
+
+Für lokale Tests ohne Traefik genügt weiterhin:
+
+```bash
+docker compose up
+```
+
+Die zusätzlichen Dateien greifen nur, wenn sie explizit in den Compose-Befehl
+aufgenommen werden.


### PR DESCRIPTION
## Summary
- strip Traefik labels from the default development compose file so it runs without the proxy
- add dedicated dev and prod Traefik overlay compose files for Doco with host rules for theaterdev and theaterprod
- document how to combine the compose files for Doco CD deployments

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce77a9e8f0832da009567e832737eb