### PR TITLE
Add Docker deployment stack and build pipeline updates

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,14 +29,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}   # z.B. dein Docker Hub Username
           password: ${{ secrets.DOCKER_PAT }}        # Docker Hub Access Token (kein GitHub PAT!)
 
-      - name: Extract Docker metadata
-        id: meta
+      - name: Extract Docker metadata (dev)
+        id: meta-dev
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=dev
-            type=sha
+            type=sha,prefix=dev-
 
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v5
@@ -44,7 +44,25 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-dev.outputs.tags }}
+          labels: ${{ steps.meta-dev.outputs.labels }}
           build-args: |
             NODE_ENV=development
+
+      - name: Extract Docker metadata (prod)
+        id: meta-prod
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=prod
+            type=sha,prefix=prod-
+
+      - name: Build and push prod Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta-prod.outputs.tags }}
+          labels: ${{ steps.meta-prod.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+**/node_modules/
 /.pnp
 .pnp.*
 .yarn/*
@@ -26,6 +27,9 @@
 # misc
 .DS_Store
 *.pem
+
+# runtime caches
+v8-compile-cache-*
 
 # debug
 npm-debug.log*

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,63 @@
+# Docker Compose stack for manual deployments using prebuilt images from Docker Hub
+# Images are expected at limitlessgreen/theater_website with tags like `dev` or `prod`.
+services:
+  app:
+    image: "${THEATER_WEBSITE_IMAGE:-limitlessgreen/theater_website}:${THEATER_WEBSITE_TAG:-prod}"
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      realtime:
+        condition: service_started
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+      NEXTAUTH_URL: ${NEXTAUTH_URL:-https://example.com}
+      AUTH_SECRET: ${AUTH_SECRET}
+      DATABASE_URL: ${DATABASE_URL:-postgresql://postgres:postgres@db:5432/theater?schema=public}
+      EMAIL_SERVER: ${EMAIL_SERVER:-smtp://user:pass@smtp.example.com:587}
+      EMAIL_FROM: ${EMAIL_FROM:-noreply@example.com}
+      REALTIME_SERVER_URL: http://realtime:4001
+      REALTIME_AUTH_TOKEN: ${REALTIME_AUTH_TOKEN:-change-me}
+      NEXT_PUBLIC_REALTIME_URL: ${NEXT_PUBLIC_REALTIME_URL:-https://example.com/realtime}
+      NEXT_PUBLIC_REALTIME_PATH: ${NEXT_PUBLIC_REALTIME_PATH:-/socket.io}
+    ports:
+      - "${APP_PORT:-3000}:3000"
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
+      com.centurylinklabs.watchtower.scope: "theater-website"
+
+  realtime:
+    build: ./realtime-server
+    restart: unless-stopped
+    environment:
+      PORT: 4001
+      SOCKET_PATH: ${NEXT_PUBLIC_REALTIME_PATH:-/socket.io}
+      CORS_ORIGIN: ${REALTIME_CORS_ORIGIN:-https://example.com}
+      REALTIME_AUTH_TOKEN: ${REALTIME_AUTH_TOKEN:-change-me}
+    ports:
+      - "${REALTIME_PORT:-4001}:4001"
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-theater}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --label-enable --scope theater-website --cleanup --interval ${WATCHTOWER_INTERVAL:-300}
+
+volumes:
+  pgdata:

--- a/docs/doco-cd.md
+++ b/docs/doco-cd.md
@@ -59,3 +59,27 @@ docker compose up
 
 Die zusätzlichen Dateien greifen nur, wenn sie explizit in den Compose-Befehl
 aufgenommen werden.
+
+## Fallback-Deployment via Docker Hub und Watchtower
+
+Bis das automatische Deployment über Doco zuverlässig funktioniert, steht eine
+einfache Alternative per `docker-compose.deploy.yml` bereit. Die GitHub Action
+buildet bei jedem Push auf `main` zwei Images und legt sie auf Docker Hub ab:
+
+- `limitlessgreen/theater_website:dev`
+- `limitlessgreen/theater_website:prod`
+
+Der Compose-Stack zieht standardmäßig das `prod`-Image und startet zusätzlich
+eine Watchtower-Instanz, die Container mit dem Label
+`com.centurylinklabs.watchtower.enable=true` automatisch aktualisiert.
+
+```bash
+# optional: Tag wechseln, z. B. THEATER_WEBSITE_TAG=dev
+THEATER_WEBSITE_TAG=prod docker compose -f docker-compose.deploy.yml up -d
+```
+
+Wichtige Umgebungsvariablen können wie gewohnt über eine `.env`-Datei gesetzt
+werden (z. B. `AUTH_SECRET`, `DATABASE_URL`, Mail- und Realtime-Konfiguration).
+Watchtower lässt sich über `WATCHTOWER_INTERVAL` oder weitere Variablen
+konfigurieren, wenn abweichende Update-Intervalle oder Benachrichtigungen
+gewünscht sind.


### PR DESCRIPTION
## Summary
- add a dedicated docker-compose.deploy.yml that runs the site from Docker Hub images and keeps it updated via Watchtower
- extend the Docker publish workflow to build and push both dev and prod tags for limitlessgreen/theater_website
- document the fallback deployment approach and ignore nested node_modules/caches created during local work

## Testing
- not run (infrastructure changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ce7ac474b4832d8295aff94ff60e04