### PR TITLE
Skip Prisma postinstall during prod build

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -7,7 +7,7 @@ RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists
     && corepack enable
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --frozen-lockfile
 
 # Build application
 FROM node:20-slim AS builder


### PR DESCRIPTION
## Summary
- skip the Prisma postinstall script during the dependency install stage of the production Docker build so the schema is not required before sources are copied

## Testing
- not run (dockerfile change)


------
https://chatgpt.com/codex/tasks/task_e_68ce7e12a104832d98f7b934bc683475