### PR TITLE
Partial production build fixes

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -35,7 +35,7 @@ export default async function ProduktionDetailPage({ params }: { params: { showI
         title: true,
         year: true,
         synopsis: true,
-        _count: { characters: true, scenes: true },
+        _count: { select: { characters: true, scenes: true } },
       },
     }),
     prisma.sceneBreakdownItem.count({ where: { scene: { showId: params.showId } } }),

--- a/src/app/api/member-invites/[id]/route.ts
+++ b/src/app/api/member-invites/[id]/route.ts
@@ -57,13 +57,16 @@ function parseDate(value: unknown) {
   return parsed;
 }
 
-export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
   const session = await requireAuth();
   if (!(await canManageInvites(session.user))) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const id = params.id;
+  const { id } = await context.params;
   if (!id) {
     return NextResponse.json({ error: "Ungültige Einladung" }, { status: 400 });
   }

--- a/src/app/api/photo-consents/[id]/document/route.ts
+++ b/src/app/api/photo-consents/[id]/document/route.ts
@@ -8,12 +8,16 @@ function sanitizeForHeader(value: string): string {
   return value.replace(/"/g, "").replace(/\r|\n/g, "");
 }
 
-export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
   const session = await requireAuth();
   if (!(await hasPermission(session.user, "mitglieder.fotoerlaubnisse"))) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  const params = await context.params;
   const id = params.id?.trim();
   if (!id) {
     return NextResponse.json({ error: "Fehlende ID" }, { status: 400 });

--- a/src/components/members/members-table.tsx
+++ b/src/components/members/members-table.tsx
@@ -16,7 +16,7 @@ export type MembersTableUser = {
   roles: Role[];
   customRoles: { id: string; name: string }[];
   avatarSource?: AvatarSource | null;
-  avatarUpdatedAt?: Date | null;
+  avatarUpdatedAt?: string | number | Date | null;
 };
 
 export function MembersTable({


### PR DESCRIPTION
## Summary
- update API route handlers to consume the new Promise-based params context
- relax several type expectations to unblock Next.js 15 production builds
- start migrating production management server actions to void-returning signatures and await cookie store operations

## Testing
- `CI=1 pnpm build` *(fails: stops at removeCharacterCastingAction still returning ActionResult)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9201e7e4832da76a3b47a999ca0c