### PR TITLE
Add secondary button variant

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,6 +11,7 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:opacity-95",
         outline: "border border-border hover:bg-accent/30",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/90",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         ghost: "hover:bg-accent/30",
       },


### PR DESCRIPTION
## Summary
- add a `secondary` style to the shared button component so pages using that variant type-check

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ceab31e518832dad96d175b70ae342