### PR TITLE
Add environment example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# Environment template for the Next.js app and realtime server.
+# Copy this file to .env.local (Next.js) and/or .env (Docker) and adjust the
+# values for your deployment. Secrets should be replaced with strong random
+# strings (e.g. via `openssl rand -base64 32`).
+
+# ------------------------------------------------------------------------------
+# Shared application secrets and toggles
+# ------------------------------------------------------------------------------
+AUTH_SECRET=change-me-with-a-long-random-string
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/theater?schema=public
+
+# Mirror to the client to avoid hydration mismatches ("1" enables dev-only login)
+NEXT_PUBLIC_AUTH_DEV_NO_DB=0
+
+# Realtime service authentication
+REALTIME_AUTH_TOKEN=replace-with-realtime-token
+REALTIME_SERVER_TOKEN=replace-with-realtime-token
+REALTIME_HANDSHAKE_SECRET=replace-with-realtime-token
+REALTIME_HANDSHAKE_TTL=900
+REALTIME_SERVER_EVENT_PATH=/events
+
+# API route protection for scheduled tasks
+CRON_SECRET=replace-with-cron-secret
+
+# ------------------------------------------------------------------------------
+# Email delivery (choose one provider)
+# ------------------------------------------------------------------------------
+EMAIL_SERVER=smtp://user:pass@mail.example.com:587
+EMAIL_FROM="Theaterverein <noreply@example.com>"
+#EMAIL_SERVICE=sendgrid
+#SENDGRID_API_KEY=your_sendgrid_api_key
+
+# ------------------------------------------------------------------------------
+# Socket / realtime defaults
+# ------------------------------------------------------------------------------
+NEXT_PUBLIC_REALTIME_PATH=/socket.io
+SOCKET_PATH=/socket.io
+EVENT_PATH=/events
+PORT=4001
+
+# ------------------------------------------------------------------------------
+# Deployment targets
+# ------------------------------------------------------------------------------
+# Keep NEXTAUTH_URL and NEXT_PUBLIC_BASE_URL identical and without trailing slash.
+
+# Development deployment (devtheater.beegreenx.de)
+NEXTAUTH_URL=https://devtheater.beegreenx.de
+NEXT_PUBLIC_BASE_URL=https://devtheater.beegreenx.de
+NEXT_PUBLIC_REALTIME_URL=https://devtheater.beegreenx.de/realtime
+REALTIME_SERVER_URL=https://devtheater.beegreenx.de/realtime
+CORS_ORIGIN=https://devtheater.beegreenx.de
+#REALTIME_CORS_ORIGIN=https://devtheater.beegreenx.de
+
+# Production deployment (prodtheater.beegreenx.de)
+#NEXTAUTH_URL=https://prodtheater.beegreenx.de
+#NEXT_PUBLIC_BASE_URL=https://prodtheater.beegreenx.de
+#NEXT_PUBLIC_REALTIME_URL=https://prodtheater.beegreenx.de/realtime
+#REALTIME_SERVER_URL=https://prodtheater.beegreenx.de/realtime
+#CORS_ORIGIN=https://prodtheater.beegreenx.de
+#REALTIME_CORS_ORIGIN=https://prodtheater.beegreenx.de

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- add an `.env.example` template that documents required secrets and provides dev/prod host defaults for devtheater.beegreenx.de and prodtheater.beegreenx.de
- allow committing the example by adding an exception for `.env.example` in `.gitignore`

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ceae23e54c832d9009e40633b1a024