### PR TITLE
Add realtime server docker builds to CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,10 +8,11 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: limitlessgreen/theater_website
+  WEBSITE_IMAGE_NAME: limitlessgreen/theater_website
+  REALTIME_IMAGE_NAME: limitlessgreen/theater_realtime
 
 jobs:
-  build-and-push:
+  build-and-push-website:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,7 +31,7 @@ jobs:
             metadata_tags: |
               type=raw,value=prod
               type=sha,prefix=prod-
-    name: Build and Push Docker Image (${{ matrix.environment }})
+    name: Build and Push Website Docker Image (${{ matrix.environment }})
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,14 +43,14 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKER_USERNAME }}   # z.B. dein Docker Hub Username
-          password: ${{ secrets.DOCKER_PAT }}        # Docker Hub Access Token (kein GitHub PAT!)
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Extract Docker metadata (${{ matrix.environment }})
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.WEBSITE_IMAGE_NAME }}
           tags: ${{ matrix.metadata_tags }}
 
       - name: Build and push ${{ matrix.environment }} Docker image
@@ -57,6 +58,55 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build_args }}
+
+  build-and-push-realtime:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - environment: dev
+            build_args: NODE_ENV=development
+            metadata_tags: |
+              type=raw,value=dev
+              type=sha,prefix=dev-
+          - environment: prod
+            build_args: NODE_ENV=production
+            metadata_tags: |
+              type=raw,value=prod
+              type=sha,prefix=prod-
+    name: Build and Push Realtime Docker Image (${{ matrix.environment }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Extract Docker metadata (${{ matrix.environment }})
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REALTIME_IMAGE_NAME }}
+          tags: ${{ matrix.metadata_tags }}
+
+      - name: Build and push ${{ matrix.environment }} Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./realtime-server
+          file: realtime-server/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/realtime-server/Dockerfile
+++ b/realtime-server/Dockerfile
@@ -1,10 +1,12 @@
 FROM node:20-slim
 
-ENV NODE_ENV=production
+ARG NODE_ENV=production
+
+ENV NODE_ENV=${NODE_ENV}
 WORKDIR /app
 
 COPY package.json ./
-RUN npm install --production
+RUN if [ "$NODE_ENV" = "production" ]; then npm install --omit=dev; else npm install; fi
 
 COPY src ./src
 


### PR DESCRIPTION
## Summary
- extend the docker publishing workflow to also build and push the realtime server images with dev and prod tags
- allow the realtime server Dockerfile to switch between dev and prod installs via NODE_ENV

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cebddf3a20832d85687f901b8135ac