### PR TITLE
Ensure Prisma CLI available in production image

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^3.1.1",
-    "zod": "^4.1.8"
+    "zod": "^4.1.8",
+    "prisma": "6.16.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -61,7 +62,6 @@
     "@types/sanitize-html": "^2.16.0",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
-    "prisma": "6.16.2",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prisma:
+        specifier: 6.16.2
+        version: 6.16.2(typescript@5.9.2)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -132,9 +135,6 @@ importers:
       eslint-config-next:
         specifier: 15.5.3
         version: 15.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
-      prisma:
-        specifier: 6.16.2
-        version: 6.16.2(typescript@5.9.2)
       tailwindcss:
         specifier: ^4
         version: 4.1.13


### PR DESCRIPTION
## Summary
- move the Prisma CLI package into runtime dependencies so the published image can run `prisma migrate deploy`
- update the lockfile to reflect the dependency change

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ced5aa3738832d9eb57b14ecdec753