### PR TITLE
Fix owner role migration for missing BlockedDay

### DIFF
--- a/prisma/migrations/20250919044624_add_owner_role/migration.sql
+++ b/prisma/migrations/20250919044624_add_owner_role/migration.sql
@@ -1,9 +1,6 @@
 -- AlterEnum
 ALTER TYPE "public"."Role" ADD VALUE 'owner';
 
--- AlterTable
-ALTER TABLE "public"."BlockedDay" ALTER COLUMN "updatedAt" DROP DEFAULT;
-
 -- CreateTable
 CREATE TABLE "public"."RehearsalInvitee" (
     "id" TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- remove the BlockedDay column alteration from the owner role migration so it no longer references a table that may not exist yet

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cee060c700832d8e507bf10f3a38e9