### PR TITLE
Use Alpine base images for Docker builds

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Development Dockerfile bundling the Next.js app and realtime server
-FROM node:20-slim
+FROM node:20-alpine
 
 ARG NODE_ENV=development
 
@@ -13,7 +13,7 @@ ENV PNPM_HOME=/root/.local/share/pnpm \
     REALTIME_SERVER_EVENT_PATH=/realtime/events \
     TURBOPACK=1
 
-RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/* \
+RUN apk add --no-cache openssl \
     && corepack enable
 
 WORKDIR /app

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,15 +1,15 @@
 # Production Dockerfile bundling the Next.js app and realtime server
-FROM node:20-slim AS deps
+FROM node:20-alpine AS deps
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NEXT_TELEMETRY_DISABLED=1
-RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/* \
+RUN apk add --no-cache openssl \
     && corepack enable
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --frozen-lockfile
 
-FROM node:20-slim AS builder
+FROM node:20-alpine AS builder
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NODE_ENV=production \
@@ -18,7 +18,7 @@ ENV PNPM_HOME=/root/.local/share/pnpm \
     NEXT_PUBLIC_REALTIME_URL=/realtime \
     NEXT_PUBLIC_REALTIME_PATH=/realtime/socket.io \
     REALTIME_SERVER_EVENT_PATH=/realtime/events
-RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/* \
+RUN apk add --no-cache openssl \
     && corepack enable
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -27,7 +27,7 @@ RUN pnpm prisma:generate
 RUN pnpm build
 RUN pnpm prune --prod
 
-FROM node:20-slim AS runner
+FROM node:20-alpine AS runner
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NODE_ENV=production \
@@ -39,7 +39,7 @@ ENV PNPM_HOME=/root/.local/share/pnpm \
     REALTIME_SERVER_EVENT_PATH=/realtime/events \
     REALTIME_INTERNAL_ORIGIN=http://127.0.0.1:3000 \
     REALTIME_SERVER_URL=http://127.0.0.1:3000/realtime
-RUN apt-get update -y && apt-get install -y openssl && rm -rf /var/lib/apt/lists/* \
+RUN apk add --no-cache openssl \
     && corepack enable
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
- switch the development and production Dockerfiles to the slimmer `node:20-alpine` base image
- install runtime dependencies with `apk add --no-cache openssl` to keep Prisma happy without pulling in Debian tooling

## Testing
- CI=1 pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ceef4cdb3c832d8b3f0cc5d88b8aa0