### PR TITLE
Bootstrap Postgres databases from compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ Hub and publishes two app instances via Traefik:
 - `https://devtheater.beegreenx.de` using the `dev` tag
 - `https://prodtheater.beegreenx.de` using the `prod` tag
 
-Both services share a single Postgres container. The database init script under
-`docker/initdb/001-create-databases.sql` provisions the schemas `theater_dev` and
-`theater_prod`. The compose stack expects an external Docker network called
-`proxy` so Traefik can route traffic to the containers.
+Both services share a single Postgres container. A short-lived
+`db-bootstrap` service (part of the compose file) connects to the database and
+creates the schemas `theater_dev` and `theater_prod` on first startup, so no
+external SQL file is required. The compose stack expects an external Docker
+network called `proxy` so Traefik can route traffic to the containers.
 
 ### Run the combined server without Docker
 

--- a/docker-compose.hosting.yml
+++ b/docker-compose.hosting.yml
@@ -7,7 +7,6 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     volumes:
       - pgdata:/var/lib/postgresql/data
-      - ./docker/initdb/001-create-databases.sql:/docker-entrypoint-initdb.d/001-create-databases.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 5s
@@ -18,12 +17,48 @@ services:
     labels:
       com.centurylinklabs.watchtower.enable: true
 
+  db-bootstrap:
+    image: postgres:16
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      set -eu
+      psql --host db --username "$POSTGRES_USER" --dbname postgres <<'SQL'
+      DO
+      $$
+      BEGIN
+          IF NOT EXISTS (
+              SELECT FROM pg_database WHERE datname = 'theater_dev'
+          ) THEN
+              EXECUTE 'CREATE DATABASE theater_dev';
+          END IF;
+
+          IF NOT EXISTS (
+              SELECT FROM pg_database WHERE datname = 'theater_prod'
+          ) THEN
+              EXECUTE 'CREATE DATABASE theater_prod';
+          END IF;
+      END
+      $$
+      ;
+      SQL
+    networks:
+      - internal
+
   app-dev:
     image: "${THEATER_WEBSITE_IMAGE:-limitlessgreen/theater_website}:${DEV_IMAGE_TAG:-dev}"
     restart: unless-stopped
     depends_on:
       db:
         condition: service_healthy
+      db-bootstrap:
+        condition: service_completed_successfully
     environment:
       NODE_ENV: development
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@db:5432/theater_dev?schema=public
@@ -63,6 +98,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      db-bootstrap:
+        condition: service_completed_successfully
     environment:
       NODE_ENV: production
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@db:5432/theater_prod?schema=public

--- a/docker/initdb/001-create-databases.sql
+++ b/docker/initdb/001-create-databases.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE theater_dev;
-CREATE DATABASE theater_prod;

--- a/docs/doco-cd.md
+++ b/docs/doco-cd.md
@@ -18,10 +18,11 @@ unter `/realtime`.
 2. **Secrets**: Hinterlege für beide Instanzen die erforderlichen Variablen, z. B.
    `DEV_AUTH_SECRET`, `DEV_REALTIME_AUTH_TOKEN`, `PROD_AUTH_SECRET`, Mail-Setup
    usw. Die Platzhalter mit `:?set …` erzwingen, dass nichts vergessen wird.
-3. **Datenbank**: Ein einzelner Postgres-Container genügt. Das Init-SQL unter
-   `docker/initdb/001-create-databases.sql` erzeugt die Datenbanken
-   `theater_dev` und `theater_prod`, die den jeweiligen Containern über
-   `DATABASE_URL` zugewiesen werden.
+3. **Datenbank**: Ein einzelner Postgres-Container genügt. Die Compose-Datei
+   bringt einen kurzlebigen Service `db-bootstrap` mit, der sich beim Start mit
+   dem Standard-Postgres-Container verbindet und die Datenbanken
+   `theater_dev` und `theater_prod` anlegt. Zusätzliche SQL-Dateien müssen
+   nicht bereitgestellt werden.
 
 ## Deployment-Befehle
 


### PR DESCRIPTION
## Summary
- switch both compose files back to the upstream `postgres:16` image and drop the custom Dockerfile plus SQL asset
- add a `db-bootstrap` helper service in the hosting compose stack so the `theater_dev` and `theater_prod` databases are created automatically before the apps start
- document the new bootstrap flow in the README and Doco CD deployment guide

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cef1ce207c832da20930cc49caca9a