### PR TITLE
Limit Docker publish workflow to relevant path changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,26 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/docker-publish.yml'
+      - 'Dockerfile.dev'
+      - 'Dockerfile.prod'
+      - 'docker-compose*.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+      - 'next.config.ts'
+      - 'tsconfig.json'
+      - 'postcss.config.mjs'
+      - 'tailwind.config.js'
+      - 'eslint.config.mjs'
+      - 'vitest.config.ts'
+      - 'components.json'
+      - 'src/**'
+      - 'public/**'
+      - 'prisma/**'
+      - 'realtime-server/**'
+      - 'scripts/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- restrict the docker publish workflow to path changes relevant for the container image

## Testing
- pnpm lint
- pnpm test
- pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68cf1cd9c0b8832daecbf6fa7c59cd61