### PR TITLE
Add initial owner setup flow with console link

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ pnpm dev
 bun dev
 ```
 
+### Create the initial owner account
+
+On a fresh database the application does not contain any users yet. During the
+first server startup a one-time setup link is printed to the console, for
+example:
+
+```
+[owner-setup]   http://localhost:3000/setup/owner/<token>
+```
+
+Open the URL in a browser to create the first owner account. The link becomes
+invalid as soon as it has been used or as soon as any owner exists. Restart the
+server to generate a new link if necessary.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/prisma/migrations/20250920000000_owner_setup_token/migration.sql
+++ b/prisma/migrations/20250920000000_owner_setup_token/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "OwnerSetupToken" (
+    "id" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "consumedAt" TIMESTAMP(3),
+
+    CONSTRAINT "OwnerSetupToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OwnerSetupToken_tokenHash_key" ON "OwnerSetupToken"("tokenHash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -246,6 +246,13 @@ model VerificationToken {
   @@unique([identifier, token])
 }
 
+model OwnerSetupToken {
+  id         String   @id @default(cuid())
+  tokenHash  String   @unique
+  createdAt  DateTime @default(now())
+  consumedAt DateTime?
+}
+
 model Show {
   id         String         @id @default(cuid())
   year       Int

--- a/scripts/run-prisma-migrate.mjs
+++ b/scripts/run-prisma-migrate.mjs
@@ -3,6 +3,9 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { randomBytes, createHash } from "node:crypto";
+
+import { PrismaClient } from "@prisma/client";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -14,43 +17,104 @@ function shouldSkip() {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-if (shouldSkip()) {
-  console.log("[prisma-migrate] Skipping Prisma migrations because SKIP_PRISMA_MIGRATE is set.");
-  process.exit(0);
-}
+async function announceOwnerSetupLink() {
+  const prisma = new PrismaClient();
+  try {
+    const ownerCount = await prisma.user.count({
+      where: {
+        OR: [{ role: "owner" }, { roles: { some: { role: "owner" } } }],
+      },
+    });
 
-const databaseUrl = process.env.DATABASE_URL;
-if (!databaseUrl) {
-  console.warn("[prisma-migrate] DATABASE_URL is not set; skipping Prisma migrations.");
-  process.exit(0);
-}
+    if (ownerCount > 0) {
+      const removed = await prisma.ownerSetupToken.deleteMany({ where: { consumedAt: null } });
+      if (removed.count > 0) {
+        console.log(
+          `[owner-setup] Removed ${removed.count} unused owner setup token(s) because an owner already exists.`,
+        );
+      }
+      return;
+    }
 
-const prismaExecutable = join(
-  __dirname,
-  "..",
-  "node_modules",
-  ".bin",
-  process.platform === "win32" ? "prisma.cmd" : "prisma",
-);
+    await prisma.ownerSetupToken.deleteMany({ where: { consumedAt: null } });
 
-if (!existsSync(prismaExecutable)) {
-  console.warn(
-    `[prisma-migrate] Prisma CLI executable not found at ${prismaExecutable}. Have you installed dependencies yet?`,
-  );
-  process.exit(0);
-}
+    const rawToken = randomBytes(32).toString("hex");
+    const tokenHash = createHash("sha256").update(rawToken).digest("hex");
 
-try {
-  console.log("[prisma-migrate] Ensuring database schema is up to date (prisma migrate deploy)...");
-  execFileSync(prismaExecutable, ["migrate", "deploy"], {
-    stdio: "inherit",
-    env: process.env,
-  });
-  console.log("[prisma-migrate] Prisma migrations applied successfully.");
-} catch (error) {
-  console.error("[prisma-migrate] Failed to apply Prisma migrations.");
-  if (error instanceof Error && error.message) {
-    console.error(error.message);
+    await prisma.ownerSetupToken.create({ data: { tokenHash } });
+
+    const configuredBase =
+      (process.env.NEXT_PUBLIC_BASE_URL && process.env.NEXT_PUBLIC_BASE_URL.trim()) ||
+      (process.env.NEXTAUTH_URL && process.env.NEXTAUTH_URL.trim()) ||
+      "";
+    const normalizedBase = configuredBase.replace(/\/$/, "");
+    const port = process.env.PORT || process.env.APP_PORT || "3000";
+    const fallbackBase = `http://localhost:${port}`;
+    const baseUrl = normalizedBase || fallbackBase;
+    const link = `${baseUrl}/setup/owner/${rawToken}`;
+
+    console.log("[owner-setup] Kein Owner-Account gefunden. Bitte richte über den folgenden Link einen Owner ein:");
+    console.log(`[owner-setup]   ${link}`);
+    if (!normalizedBase) {
+      console.log(
+        `[owner-setup] Hinweis: Passe den Host an, falls der Server nicht unter ${fallbackBase} erreichbar ist.`,
+      );
+    }
+    console.log("[owner-setup] Der Link ist einmalig gültig und wird ungültig, sobald ein Owner angelegt wurde.");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[owner-setup] Konnte Owner-Setup-Link nicht erzeugen: ${message}`);
+  } finally {
+    await prisma.$disconnect();
   }
-  process.exit(typeof error?.status === "number" ? error.status : 1);
 }
+
+async function main() {
+  if (shouldSkip()) {
+    console.log("[prisma-migrate] Skipping Prisma migrations because SKIP_PRISMA_MIGRATE is set.");
+    return;
+  }
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.warn("[prisma-migrate] DATABASE_URL is not set; skipping Prisma migrations.");
+    return;
+  }
+
+  const prismaExecutable = join(
+    __dirname,
+    "..",
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "prisma.cmd" : "prisma",
+  );
+
+  if (!existsSync(prismaExecutable)) {
+    console.warn(
+      `[prisma-migrate] Prisma CLI executable not found at ${prismaExecutable}. Have you installed dependencies yet?`,
+    );
+    return;
+  }
+
+  try {
+    console.log("[prisma-migrate] Ensuring database schema is up to date (prisma migrate deploy)...");
+    execFileSync(prismaExecutable, ["migrate", "deploy"], {
+      stdio: "inherit",
+      env: process.env,
+    });
+    console.log("[prisma-migrate] Prisma migrations applied successfully.");
+  } catch (error) {
+    console.error("[prisma-migrate] Failed to apply Prisma migrations.");
+    if (error instanceof Error && error.message) {
+      console.error(error.message);
+    }
+    process.exit(typeof error?.status === "number" ? error.status : 1);
+  }
+
+  await announceOwnerSetupLink();
+}
+
+main().catch((error) => {
+  console.error("[prisma-migrate] Unexpected error", error);
+  process.exit(1);
+});

--- a/src/app/api/setup/owner/route.ts
+++ b/src/app/api/setup/owner/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { hashOwnerSetupToken, ownerExists } from "@/lib/owner-setup";
+import { hashPassword } from "@/lib/password";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PASSWORD_LENGTH = 6;
+
+export async function POST(request: NextRequest) {
+  const rawBody: unknown = await request.json().catch(() => null);
+
+  if (!rawBody || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const { token: tokenValue, email: emailValue, password: passwordValue, name: nameValue } = rawBody as {
+    token?: unknown;
+    email?: unknown;
+    password?: unknown;
+    name?: unknown;
+  };
+
+  if (typeof tokenValue !== "string" || !tokenValue.trim()) {
+    return NextResponse.json({ error: "Der Link ist ungültig." }, { status: 400 });
+  }
+
+  if (typeof emailValue !== "string") {
+    return NextResponse.json({ error: "E-Mail ist erforderlich" }, { status: 400 });
+  }
+
+  const email = emailValue.trim().toLowerCase();
+  if (!EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ error: "Ungültige E-Mail-Adresse" }, { status: 400 });
+  }
+
+  if (typeof passwordValue !== "string") {
+    return NextResponse.json({ error: "Passwort ist erforderlich" }, { status: 400 });
+  }
+
+  const password = passwordValue.trim();
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return NextResponse.json(
+      { error: `Passwort muss mindestens ${MIN_PASSWORD_LENGTH} Zeichen haben` },
+      { status: 400 },
+    );
+  }
+
+  const name = typeof nameValue === "string" && nameValue.trim() ? nameValue.trim() : undefined;
+
+  const tokenHash = hashOwnerSetupToken(tokenValue.trim());
+
+  const setupToken = await prisma.ownerSetupToken.findUnique({
+    where: { tokenHash },
+  });
+
+  if (!setupToken) {
+    return NextResponse.json(
+      { error: "Dieser Link ist nicht mehr gültig. Bitte starte den Server neu, um einen neuen Link zu erhalten." },
+      { status: 410 },
+    );
+  }
+
+  if (setupToken.consumedAt) {
+    return NextResponse.json({ error: "Dieser Link wurde bereits verwendet." }, { status: 410 });
+  }
+
+  const passwordHash = await hashPassword(password);
+
+  try {
+    const user = await prisma.$transaction(async (tx) => {
+      const updateResult = await tx.ownerSetupToken.updateMany({
+        where: { id: setupToken.id, consumedAt: null },
+        data: { consumedAt: new Date() },
+      });
+
+      if (updateResult.count === 0) {
+        throw new Error("TOKEN_ALREADY_USED");
+      }
+
+      if (await ownerExists(tx)) {
+        throw new Error("OWNER_ALREADY_EXISTS");
+      }
+
+      const created = await tx.user.create({
+        data: {
+          email,
+          name: name ?? null,
+          role: "owner",
+          passwordHash,
+          roles: {
+            create: [{ role: "owner" }],
+          },
+        },
+        select: { id: true, email: true, name: true },
+      });
+
+      await tx.ownerSetupToken.deleteMany({ where: { id: { not: setupToken.id } } });
+
+      return created;
+    });
+
+    return NextResponse.json({ ok: true, user });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      if (error.message === "TOKEN_ALREADY_USED") {
+        return NextResponse.json({ error: "Dieser Link wurde bereits verwendet." }, { status: 410 });
+      }
+      if (error.message === "OWNER_ALREADY_EXISTS") {
+        return NextResponse.json({ error: "Es existiert bereits ein Owner." }, { status: 409 });
+      }
+    }
+
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json({ error: "Diese E-Mail existiert bereits" }, { status: 409 });
+    }
+
+    const message = error instanceof Error ? error.message : "Owner konnte nicht angelegt werden";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/setup/owner/[token]/owner-setup-form.tsx
+++ b/src/app/setup/owner/[token]/owner-setup-form.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface OwnerSetupFormProps {
+  token: string;
+}
+
+interface ApiResponse {
+  ok?: boolean;
+  error?: string;
+  user?: { email?: string | null; name?: string | null };
+}
+
+export function OwnerSetupForm({ token }: OwnerSetupFormProps) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [createdEmail, setCreatedEmail] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (loading) return;
+
+    const trimmedEmail = email.trim().toLowerCase();
+    const trimmedName = name.trim();
+    const trimmedPassword = password.trim();
+    const trimmedConfirm = confirmPassword.trim();
+
+    if (!trimmedEmail) {
+      setError("Bitte eine E-Mail-Adresse angeben.");
+      return;
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      setError("Die E-Mail-Adresse ist ungültig.");
+      return;
+    }
+
+    if (trimmedPassword.length < 6) {
+      setError("Das Passwort muss mindestens 6 Zeichen lang sein.");
+      return;
+    }
+
+    if (trimmedPassword !== trimmedConfirm) {
+      setError("Die Passwörter stimmen nicht überein.");
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/setup/owner", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token,
+          name: trimmedName || undefined,
+          email: trimmedEmail,
+          password: trimmedPassword,
+        }),
+      });
+
+      const data: ApiResponse = await response.json().catch(() => ({}));
+
+      if (!response.ok || !data.ok) {
+        const message = data.error || "Owner konnte nicht angelegt werden.";
+        setError(message);
+        return;
+      }
+
+      setCreatedEmail(trimmedEmail);
+      setSuccess(true);
+    } catch {
+      setError("Netzwerkfehler – bitte erneut versuchen.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-2xl font-semibold">Owner erfolgreich angelegt</h2>
+        <p className="text-sm text-muted-foreground">
+          Du kannst dich jetzt mit <span className="font-medium text-foreground">{createdEmail}</span> anmelden.
+        </p>
+        <Button asChild variant="secondary">
+          <Link href="/login">Zum Login</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div className="grid gap-2">
+        <label className="text-sm font-medium" htmlFor="owner-name">
+          Name (optional)
+        </label>
+        <Input
+          id="owner-name"
+          autoComplete="name"
+          placeholder="Max Mustermann"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <label className="text-sm font-medium" htmlFor="owner-email">
+          E-Mail
+        </label>
+        <Input
+          id="owner-email"
+          type="email"
+          autoComplete="email"
+          placeholder="owner@example.com"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          required
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <label className="text-sm font-medium" htmlFor="owner-password">
+          Passwort
+        </label>
+        <Input
+          id="owner-password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="Mindestens 6 Zeichen"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          required
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <label className="text-sm font-medium" htmlFor="owner-password-confirm">
+          Passwort bestätigen
+        </label>
+        <Input
+          id="owner-password-confirm"
+          type="password"
+          autoComplete="new-password"
+          placeholder="Passwort erneut eingeben"
+          value={confirmPassword}
+          onChange={(event) => setConfirmPassword(event.target.value)}
+          required
+        />
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? "Wird angelegt..." : "Owner anlegen"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/setup/owner/[token]/page.tsx
+++ b/src/app/setup/owner/[token]/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+
+import Link from "next/link";
+
+import { prisma } from "@/lib/prisma";
+import { hashOwnerSetupToken, ownerExists } from "@/lib/owner-setup";
+
+import { OwnerSetupForm } from "./owner-setup-form";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Owner anlegen",
+};
+
+interface OwnerSetupPageProps {
+  params: { token?: string };
+}
+
+export default async function OwnerSetupPage({ params }: OwnerSetupPageProps) {
+  const token = typeof params?.token === "string" ? params.token.trim() : "";
+
+  if (!token) {
+    return <InvalidToken message="Dieser Link ist ungültig." />;
+  }
+
+  const tokenHash = hashOwnerSetupToken(token);
+
+  const [setupToken, hasOwner] = await Promise.all([
+    prisma.ownerSetupToken.findUnique({ where: { tokenHash } }),
+    ownerExists(),
+  ]);
+
+  if (!setupToken) {
+    return (
+      <InvalidToken message="Dieser Link ist nicht bekannt. Bitte starte den Server neu, um einen aktuellen Link zu erhalten." />
+    );
+  }
+
+  if (setupToken.consumedAt) {
+    return <InvalidToken message="Dieser Link wurde bereits verwendet." />;
+  }
+
+  if (hasOwner) {
+    return <InvalidToken message="Es existiert bereits ein Owner. Du kannst dich mit deinem Konto anmelden." />;
+  }
+
+  return (
+    <main className="mx-auto flex min-h-[70vh] max-w-2xl flex-col justify-center gap-8 px-4 py-16">
+      <div className="space-y-4">
+        <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Erstkonfiguration</p>
+        <h1 className="font-serif text-4xl">Owner-Zugang anlegen</h1>
+        <p className="text-base text-muted-foreground">
+          Für eine neue Installation ist mindestens ein Owner-Konto erforderlich. Bitte vergebe unten Zugangsdaten.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-border/60 bg-card/80 p-6 shadow-sm">
+        <OwnerSetupForm token={token} />
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Nach erfolgreicher Einrichtung kannst du dich jederzeit über das <Link href="/login" className="font-medium text-primary underline-offset-2 hover:underline">Login</Link> anmelden.
+      </p>
+    </main>
+  );
+}
+
+interface InvalidTokenProps {
+  message: string;
+}
+
+function InvalidToken({ message }: InvalidTokenProps) {
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-xl flex-col justify-center gap-6 px-4 py-16 text-center">
+      <h1 className="font-serif text-4xl">Owner-Link ungültig</h1>
+      <p className="text-base text-muted-foreground">{message}</p>
+      <p className="text-sm text-muted-foreground">
+        Falls du noch keinen Owner angelegt hast, starte den Server neu, um einen neuen Link in der Konsole zu erhalten.
+      </p>
+      <p className="text-sm text-muted-foreground">
+        Bereits eingerichtet? Dann geht es hier zum <Link href="/login" className="font-medium text-primary underline-offset-2 hover:underline">Login</Link>.
+      </p>
+    </main>
+  );
+}

--- a/src/lib/owner-setup.ts
+++ b/src/lib/owner-setup.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+export function hashOwnerSetupToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+type SupportedClient = PrismaClient | Prisma.TransactionClient;
+
+export async function ownerExists(client: SupportedClient = prisma) {
+  const count = await client.user.count({
+    where: {
+      OR: [{ role: "owner" }, { roles: { some: { role: "owner" } } }],
+    },
+  });
+  return count > 0;
+}


### PR DESCRIPTION
## Summary
- add an `OwnerSetupToken` model and generate a one-time setup link when starting the server without an owner
- expose a `/api/setup/owner` endpoint plus setup UI to create the first owner account via the printed link
- document the bootstrap flow in the README and reuse helpers to detect existing owners

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cf1b8b4418832d89ba95e7c47ae25f