### PR TITLE
Configure socket host routing for hosting stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,17 +54,19 @@ REALTIME_INTERNAL_ORIGIN=http://127.0.0.1:3000
 # Keep NEXTAUTH_URL and NEXT_PUBLIC_BASE_URL identical and without trailing slash.
 
 # Development deployment (devtheater.beegreenx.de)
+DEV_SOCKET_HOST=devsocket.beegreenx.de
 NEXTAUTH_URL=https://devtheater.beegreenx.de
 NEXT_PUBLIC_BASE_URL=https://devtheater.beegreenx.de
-NEXT_PUBLIC_REALTIME_URL=https://devtheater.beegreenx.de/realtime
-REALTIME_SERVER_URL=https://devtheater.beegreenx.de/realtime
+NEXT_PUBLIC_REALTIME_URL=https://devsocket.beegreenx.de/realtime
+REALTIME_SERVER_URL=https://devsocket.beegreenx.de/realtime
 CORS_ORIGIN=https://devtheater.beegreenx.de
 #REALTIME_CORS_ORIGIN=https://devtheater.beegreenx.de
 
 # Production deployment (prodtheater.beegreenx.de)
+#PROD_SOCKET_HOST=prodsocket.beegreenx.de
 #NEXTAUTH_URL=https://prodtheater.beegreenx.de
 #NEXT_PUBLIC_BASE_URL=https://prodtheater.beegreenx.de
-#NEXT_PUBLIC_REALTIME_URL=https://prodtheater.beegreenx.de/realtime
-#REALTIME_SERVER_URL=https://prodtheater.beegreenx.de/realtime
+#NEXT_PUBLIC_REALTIME_URL=https://prodsocket.beegreenx.de/realtime
+#REALTIME_SERVER_URL=https://prodsocket.beegreenx.de/realtime
 #CORS_ORIGIN=https://prodtheater.beegreenx.de
 #REALTIME_CORS_ORIGIN=https://prodtheater.beegreenx.de

--- a/docker-compose.hosting.yml
+++ b/docker-compose.hosting.yml
@@ -64,8 +64,8 @@ services:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@db:5432/theater_dev?schema=public
       NEXTAUTH_URL: https://${DEV_HOST:-devtheater.beegreenx.de}
       REALTIME_BASE_PATH: /realtime
-      REALTIME_PUBLIC_ORIGIN: https://${DEV_HOST:-devtheater.beegreenx.de}
-      NEXT_PUBLIC_REALTIME_URL: https://${DEV_HOST:-devtheater.beegreenx.de}/realtime
+      REALTIME_PUBLIC_ORIGIN: https://${DEV_SOCKET_HOST:-devsocket.beegreenx.de}
+      NEXT_PUBLIC_REALTIME_URL: https://${DEV_SOCKET_HOST:-devsocket.beegreenx.de}/realtime
       AUTH_SECRET: ${DEV_AUTH_SECRET:?set DEV_AUTH_SECRET}
       REALTIME_AUTH_TOKEN: ${DEV_REALTIME_AUTH_TOKEN:?set DEV_REALTIME_AUTH_TOKEN}
       REALTIME_HANDSHAKE_SECRET: ${DEV_REALTIME_HANDSHAKE_SECRET:-${DEV_REALTIME_AUTH_TOKEN}}
@@ -86,6 +86,15 @@ services:
       traefik.http.routers.devtheater-secure.tls: "true"
       traefik.http.routers.devtheater-secure.tls.certresolver: myresolver
       traefik.http.routers.devtheater-secure.service: devtheater
+      traefik.http.routers.devsocket.entrypoints: web
+      traefik.http.routers.devsocket.rule: Host(`${DEV_SOCKET_HOST:-devsocket.beegreenx.de}`)
+      traefik.http.routers.devsocket.middlewares: devtheater-https-redirect
+      traefik.http.routers.devsocket.service: devtheater
+      traefik.http.routers.devsocket-secure.entrypoints: websecure
+      traefik.http.routers.devsocket-secure.rule: Host(`${DEV_SOCKET_HOST:-devsocket.beegreenx.de}`)
+      traefik.http.routers.devsocket-secure.tls: "true"
+      traefik.http.routers.devsocket-secure.tls.certresolver: myresolver
+      traefik.http.routers.devsocket-secure.service: devtheater
       traefik.http.services.devtheater.loadbalancer.server.port: 3000
       traefik.docker.network: proxy
 
@@ -105,8 +114,8 @@ services:
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@db:5432/theater_prod?schema=public
       NEXTAUTH_URL: https://${PROD_HOST:-prodtheater.beegreenx.de}
       REALTIME_BASE_PATH: /realtime
-      REALTIME_PUBLIC_ORIGIN: https://${PROD_HOST:-prodtheater.beegreenx.de}
-      NEXT_PUBLIC_REALTIME_URL: https://${PROD_HOST:-prodtheater.beegreenx.de}/realtime
+      REALTIME_PUBLIC_ORIGIN: https://${PROD_SOCKET_HOST:-prodsocket.beegreenx.de}
+      NEXT_PUBLIC_REALTIME_URL: https://${PROD_SOCKET_HOST:-prodsocket.beegreenx.de}/realtime
       AUTH_SECRET: ${PROD_AUTH_SECRET:?set PROD_AUTH_SECRET}
       REALTIME_AUTH_TOKEN: ${PROD_REALTIME_AUTH_TOKEN:?set PROD_REALTIME_AUTH_TOKEN}
       REALTIME_HANDSHAKE_SECRET: ${PROD_REALTIME_HANDSHAKE_SECRET:-${PROD_REALTIME_AUTH_TOKEN}}
@@ -127,6 +136,15 @@ services:
       traefik.http.routers.prodtheater-secure.tls: "true"
       traefik.http.routers.prodtheater-secure.tls.certresolver: myresolver
       traefik.http.routers.prodtheater-secure.service: prodtheater
+      traefik.http.routers.prodsocket.entrypoints: web
+      traefik.http.routers.prodsocket.rule: Host(`${PROD_SOCKET_HOST:-prodsocket.beegreenx.de}`)
+      traefik.http.routers.prodsocket.middlewares: prodtheater-https-redirect
+      traefik.http.routers.prodsocket.service: prodtheater
+      traefik.http.routers.prodsocket-secure.entrypoints: websecure
+      traefik.http.routers.prodsocket-secure.rule: Host(`${PROD_SOCKET_HOST:-prodsocket.beegreenx.de}`)
+      traefik.http.routers.prodsocket-secure.tls: "true"
+      traefik.http.routers.prodsocket-secure.tls.certresolver: myresolver
+      traefik.http.routers.prodsocket-secure.service: prodtheater
       traefik.http.services.prodtheater.loadbalancer.server.port: 3000
       traefik.docker.network: proxy
 

--- a/docs/doco-cd.md
+++ b/docs/doco-cd.md
@@ -36,6 +36,8 @@ Traefik routet anschließend automatisch:
 
 - `https://devtheater.beegreenx.de` → Container `app-dev`
 - `https://prodtheater.beegreenx.de` → Container `app-prod`
+- `https://devsocket.beegreenx.de` → Container `app-dev` (Realtime-Endpunkte)
+- `https://prodsocket.beegreenx.de` → Container `app-prod` (Realtime-Endpunkte)
 
 Über `DEV_IMAGE_TAG` bzw. `PROD_IMAGE_TAG` lassen sich bei Bedarf alternative
 Tags (z. B. `sha`-basierte Builds) aus der Registry laden.


### PR DESCRIPTION
## Summary
- default the realtime client URL to the dedicated dev/prod socket hosts in `.env.example`
- update the hosting compose file so Traefik terminates TLS for the dev/prod socket domains and forwards them to the web container
- document the new socket host routing in the Doco CD deployment notes

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: existing Prisma client is missing `ownerSetupToken` delegate)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1ff0c3d4832db158a6eb988e854f