### PR TITLE
Run owner setup script during container startup

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,4 +30,4 @@ RUN pnpm prisma:generate
 
 EXPOSE 3000
 
-CMD ["sh", "-c", "pnpm -s prisma:generate && pnpm -s prisma migrate deploy && (pnpm -s db:seed || true) && pnpm -s start:combined"]
+CMD ["sh", "-c", "pnpm -s prisma:generate && node scripts/run-prisma-migrate.mjs && (pnpm -s db:seed || true) && pnpm -s start:combined"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -53,4 +53,4 @@ COPY --from=builder /app/realtime-server ./realtime-server
 
 EXPOSE 3000
 
-CMD ["sh", "-c", "pnpm prisma migrate deploy && node scripts/start-combined-server.mjs"]
+CMD ["sh", "-c", "node scripts/run-prisma-migrate.mjs && node scripts/start-combined-server.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - .:/app
       - /app/node_modules
     command: >-
-      sh -c "pnpm -s prisma:generate && pnpm -s prisma migrate deploy && (pnpm -s db:seed || true) && pnpm -s start:combined"
+      sh -c "pnpm -s prisma:generate && node scripts/run-prisma-migrate.mjs && (pnpm -s db:seed || true) && pnpm -s start:combined"
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- run the Prisma migrate helper script during the dev container startup so the owner setup link is logged
- use the same helper script in both development and production Docker images before the combined server starts

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cf23349db8832db6b98bfcb57b342d