### PR TITLE
Add gender and nutrition details to onboarding

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -799,6 +799,10 @@ model MemberOnboardingProfile {
   redemptionId String?         @unique
   focus        OnboardingFocus
   background   String?
+  gender       String?
+  memberSinceYear Int?
+  dietaryPreference String?
+  dietaryPreferenceStrictness String?
   createdAt    DateTime         @default(now())
   updatedAt    DateTime         @updatedAt
 


### PR DESCRIPTION
## Summary
- add gender selection and membership year inputs to the onboarding wizard, including validation and summary display
- extend the nutrition step with dietary style and strictness options and surface the choices in the check step
- persist the new onboarding details through the API and Prisma schema so they are stored with the profile

## Testing
- pnpm prisma:generate
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfab55b7a8832d9c3d28189367bdc7