### PR TITLE
Fix NextAuth cookie handling in development

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -111,8 +111,13 @@ function extractRolesFromSource(source: RoleSource | undefined): Role[] | undefi
   return extractRoles(source.roles) ?? extractRoles(source.role);
 }
 
+// Force secure cookies only in production so local http development works even
+// when NEXTAUTH_URL points to an https domain (avoids login redirect loops).
+const useSecureCookies = process.env.NODE_ENV === "production";
+
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
+  useSecureCookies,
   // Use JWT sessions for reliability in dev (works with Credentials + Email).
   session: { strategy: "jwt" },
   providers: [


### PR DESCRIPTION
## Summary
- force NextAuth to only mark cookies as secure in production so local HTTP logins keep their session token

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfae21f7e8832da97e18e4128a1f0e