### PR TITLE
Add members feedback issue system

### DIFF
--- a/prisma/migrations/20260107120000_member_issues/migration.sql
+++ b/prisma/migrations/20260107120000_member_issues/migration.sql
@@ -1,0 +1,63 @@
+-- CreateEnum
+CREATE TYPE "public"."IssueCategory" AS ENUM ('general', 'website_bug', 'improvement', 'support', 'other');
+
+-- CreateEnum
+CREATE TYPE "public"."IssueStatus" AS ENUM ('open', 'in_progress', 'resolved', 'closed');
+
+-- CreateEnum
+CREATE TYPE "public"."IssuePriority" AS ENUM ('low', 'medium', 'high', 'urgent');
+
+-- CreateTable
+CREATE TABLE "public"."Issue" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "category" "public"."IssueCategory" NOT NULL DEFAULT 'general',
+    "status" "public"."IssueStatus" NOT NULL DEFAULT 'open',
+    "priority" "public"."IssuePriority" NOT NULL DEFAULT 'medium',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "lastActivityAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+    "createdById" TEXT NOT NULL,
+    "updatedById" TEXT,
+
+    CONSTRAINT "Issue_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."IssueComment" (
+    "id" TEXT NOT NULL,
+    "issueId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IssueComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Issue_status_lastActivityAt_idx" ON "public"."Issue"("status", "lastActivityAt");
+
+-- CreateIndex
+CREATE INDEX "Issue_category_idx" ON "public"."Issue"("category");
+
+-- CreateIndex
+CREATE INDEX "Issue_createdById_idx" ON "public"."Issue"("createdById");
+
+-- CreateIndex
+CREATE INDEX "IssueComment_issueId_idx" ON "public"."IssueComment"("issueId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Issue" ADD CONSTRAINT "Issue_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Issue" ADD CONSTRAINT "Issue_updatedById_fkey" FOREIGN KEY ("updatedById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."IssueComment" ADD CONSTRAINT "IssueComment_issueId_fkey" FOREIGN KEY ("issueId") REFERENCES "public"."Issue"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."IssueComment" ADD CONSTRAINT "IssueComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -165,6 +165,28 @@ enum Audience {
   role
 }
 
+enum IssueCategory {
+  general
+  website_bug
+  improvement
+  support
+  other
+}
+
+enum IssueStatus {
+  open
+  in_progress
+  resolved
+  closed
+}
+
+enum IssuePriority {
+  low
+  medium
+  high
+  urgent
+}
+
 model User {
   id        String   @id @default(cuid())
   name      String?
@@ -209,6 +231,9 @@ model User {
   interests              UserInterest[]
   rolePreferences        MemberRolePreference[]
   interestsAuthored      Interest[]             @relation("InterestCreatedBy")
+  issuesCreated          Issue[]                @relation("IssueCreatedBy")
+  issuesUpdated          Issue[]                @relation("IssueUpdatedBy")
+  issueComments          IssueComment[]         @relation("IssueCommentAuthor")
 }
 
 model Account {
@@ -694,6 +719,41 @@ model NotificationRecipient {
   user           User          @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([notificationId, userId])
+}
+
+model Issue {
+  id             String        @id @default(cuid())
+  title          String
+  description    String
+  category       IssueCategory  @default(general)
+  status         IssueStatus    @default(open)
+  priority       IssuePriority  @default(medium)
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
+  lastActivityAt DateTime       @default(now())
+  resolvedAt     DateTime?
+  createdById    String
+  updatedById    String?
+  createdBy      User           @relation("IssueCreatedBy", fields: [createdById], references: [id])
+  updatedBy      User?          @relation("IssueUpdatedBy", fields: [updatedById], references: [id])
+  comments       IssueComment[]
+
+  @@index([status, lastActivityAt])
+  @@index([category])
+  @@index([createdById])
+}
+
+model IssueComment {
+  id        String   @id @default(cuid())
+  issueId   String
+  authorId  String
+  body      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  issue     Issue    @relation(fields: [issueId], references: [id], onDelete: Cascade)
+  author    User     @relation("IssueCommentAuthor", fields: [authorId], references: [id], onDelete: Cascade)
+
+  @@index([issueId])
 }
 
 enum PhotoConsentStatus {

--- a/src/app/(members)/mitglieder/issues/page.tsx
+++ b/src/app/(members)/mitglieder/issues/page.tsx
@@ -1,0 +1,88 @@
+import { PageHeader } from "@/components/members/page-header";
+import { IssueOverview } from "@/components/members/issues/issue-overview";
+import type { IssueStatusCounts, IssueSummary } from "@/components/members/issues/types";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import type { IssueStatus } from "@prisma/client";
+
+function createEmptyCounts(): IssueStatusCounts {
+  return {
+    open: 0,
+    in_progress: 0,
+    resolved: 0,
+    closed: 0,
+  };
+}
+
+export default async function IssuesPage() {
+  const session = await requireAuth();
+  const [canView, canManage] = await Promise.all([
+    hasPermission(session.user, "mitglieder.issues"),
+    hasPermission(session.user, "mitglieder.issues.manage"),
+  ]);
+
+  if (!canView) {
+    return <div className="text-sm text-red-600">Kein Zugriff auf den Feedback-Bereich.</div>;
+  }
+
+  const currentUserId = session.user?.id ?? "";
+
+  const [issuesRaw, countsRaw] = await Promise.all([
+    prisma.issue.findMany({
+      orderBy: { lastActivityAt: "desc" },
+      take: 50,
+      include: {
+        createdBy: { select: { id: true, name: true, email: true } },
+        updatedBy: { select: { id: true, name: true, email: true } },
+        _count: { select: { comments: true } },
+      },
+    }),
+    prisma.issue.groupBy({
+      by: ["status"],
+      _count: { _all: true },
+    }),
+  ]);
+
+  const counts = countsRaw.reduce((acc, entry) => {
+    acc[entry.status as IssueStatus] = entry._count._all;
+    return acc;
+  }, createEmptyCounts());
+
+  const initialIssues: IssueSummary[] = issuesRaw.map((issue) => ({
+    id: issue.id,
+    title: issue.title,
+    description: issue.description,
+    category: issue.category,
+    status: issue.status,
+    priority: issue.priority,
+    createdAt: issue.createdAt.toISOString(),
+    updatedAt: issue.updatedAt.toISOString(),
+    lastActivityAt: issue.lastActivityAt.toISOString(),
+    resolvedAt: issue.resolvedAt ? issue.resolvedAt.toISOString() : null,
+    createdById: issue.createdById,
+    updatedById: issue.updatedById ?? null,
+    createdBy: issue.createdBy
+      ? { id: issue.createdBy.id, name: issue.createdBy.name, email: issue.createdBy.email }
+      : null,
+    updatedBy: issue.updatedBy
+      ? { id: issue.updatedBy.id, name: issue.updatedBy.name, email: issue.updatedBy.email }
+      : null,
+    commentCount: issue._count.comments,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Feedback & Support"
+        description="Melde Probleme, Bugs oder Verbesserungsvorschläge und verfolge den Bearbeitungsstand im Mitglieder-Issue-Board."
+      />
+      <IssueOverview
+        initialIssues={initialIssues}
+        initialCounts={counts}
+        canManage={canManage}
+        currentUserId={currentUserId}
+      />
+    </div>
+  );
+}

--- a/src/app/api/issues/[issueId]/comments/route.ts
+++ b/src/app/api/issues/[issueId]/comments/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { mapIssueDetail } from "../../utils";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ issueId: string }> },
+) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.issues");
+  if (!allowed) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const { issueId } = await params;
+  if (!issueId) {
+    return NextResponse.json({ error: "Ungültige ID" }, { status: 400 });
+  }
+
+  const issueExists = await prisma.issue.findUnique({ where: { id: issueId }, select: { id: true } });
+  if (!issueExists) {
+    return NextResponse.json({ error: "Anliegen nicht gefunden" }, { status: 404 });
+  }
+
+  const rawBody = await request.json().catch(() => null);
+  if (!rawBody || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const body = rawBody as Record<string, unknown>;
+  const content = typeof body.body === "string" ? body.body.trim() : "";
+  if (content.length < 2) {
+    return NextResponse.json({ error: "Kommentar muss mindestens 2 Zeichen enthalten" }, { status: 400 });
+  }
+  if (content.length > 4000) {
+    return NextResponse.json({ error: "Kommentar darf maximal 4000 Zeichen enthalten" }, { status: 400 });
+  }
+
+  const [comment, updatedIssue] = await prisma.$transaction([
+    prisma.issueComment.create({
+      data: {
+        issueId,
+        authorId: userId,
+        body: content,
+      },
+      include: { author: { select: { id: true, name: true, email: true } } },
+    }),
+    prisma.issue.update({
+      where: { id: issueId },
+      data: {
+        lastActivityAt: new Date(),
+        updatedBy: { connect: { id: userId } },
+      },
+      include: {
+        createdBy: { select: { id: true, name: true, email: true } },
+        updatedBy: { select: { id: true, name: true, email: true } },
+        _count: { select: { comments: true } },
+        comments: {
+          orderBy: { createdAt: "asc" },
+          include: { author: { select: { id: true, name: true, email: true } } },
+        },
+      },
+    }),
+  ]);
+
+  return NextResponse.json({
+    comment: {
+      id: comment.id,
+      issueId: comment.issueId,
+      body: comment.body,
+      createdAt: comment.createdAt.toISOString(),
+      updatedAt: comment.updatedAt.toISOString(),
+      authorId: comment.authorId,
+      author: comment.author
+        ? { id: comment.author.id, name: comment.author.name, email: comment.author.email }
+        : null,
+    },
+    issue: mapIssueDetail(updatedIssue),
+  });
+}

--- a/src/app/api/issues/[issueId]/route.ts
+++ b/src/app/api/issues/[issueId]/route.ts
@@ -1,0 +1,158 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { isIssueCategory, isIssuePriority, isIssueStatus } from "@/lib/issues";
+import { mapIssueDetail } from "../utils";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ issueId: string }> },
+) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.issues");
+  if (!allowed) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const { issueId } = await params;
+  if (!issueId) {
+    return NextResponse.json({ error: "Ungültige ID" }, { status: 400 });
+  }
+
+  const issue = await prisma.issue.findUnique({
+    where: { id: issueId },
+    include: {
+      createdBy: { select: { id: true, name: true, email: true } },
+      updatedBy: { select: { id: true, name: true, email: true } },
+      _count: { select: { comments: true } },
+      comments: {
+        orderBy: { createdAt: "asc" },
+        include: { author: { select: { id: true, name: true, email: true } } },
+      },
+    },
+  });
+
+  if (!issue) {
+    return NextResponse.json({ error: "Anliegen nicht gefunden" }, { status: 404 });
+  }
+
+  return NextResponse.json({ issue: mapIssueDetail(issue) });
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ issueId: string }> },
+) {
+  const session = await requireAuth();
+  const [canView, canManage] = await Promise.all([
+    hasPermission(session.user, "mitglieder.issues"),
+    hasPermission(session.user, "mitglieder.issues.manage"),
+  ]);
+
+  if (!canView) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const { issueId } = await params;
+  if (!issueId) {
+    return NextResponse.json({ error: "Ungültige ID" }, { status: 400 });
+  }
+
+  const existing = await prisma.issue.findUnique({
+    where: { id: issueId },
+    select: { createdById: true, status: true, priority: true, category: true, resolvedAt: true },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "Anliegen nicht gefunden" }, { status: 404 });
+  }
+
+  const canUpdate = canManage || existing.createdById === userId;
+
+  const rawBody = await request.json().catch(() => null);
+  if (!rawBody || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const body = rawBody as Record<string, unknown>;
+  const updateData: Prisma.IssueUpdateInput = {};
+  let touched = false;
+  const now = new Date();
+
+  if (body.status !== undefined) {
+    if (typeof body.status !== "string" || !isIssueStatus(body.status)) {
+      return NextResponse.json({ error: "Ungültiger Status" }, { status: 400 });
+    }
+    if (!canUpdate) {
+      return NextResponse.json({ error: "Keine Berechtigung für Statusänderungen" }, { status: 403 });
+    }
+    if (body.status !== existing.status) {
+      updateData.status = body.status;
+      updateData.updatedBy = { connect: { id: userId } };
+      updateData.lastActivityAt = now;
+      if (body.status === "resolved" || body.status === "closed") {
+        updateData.resolvedAt = now;
+      } else if (existing.resolvedAt) {
+        updateData.resolvedAt = null;
+      }
+      touched = true;
+    }
+  }
+
+  if (body.priority !== undefined) {
+    if (typeof body.priority !== "string" || !isIssuePriority(body.priority)) {
+      return NextResponse.json({ error: "Ungültige Priorität" }, { status: 400 });
+    }
+    if (!canManage) {
+      return NextResponse.json({ error: "Keine Berechtigung zur Prioritätsänderung" }, { status: 403 });
+    }
+    if (body.priority !== existing.priority) {
+      updateData.priority = body.priority;
+      updateData.updatedBy = { connect: { id: userId } };
+      updateData.lastActivityAt = now;
+      touched = true;
+    }
+  }
+
+  if (body.category !== undefined) {
+    if (typeof body.category !== "string" || !isIssueCategory(body.category)) {
+      return NextResponse.json({ error: "Ungültige Kategorie" }, { status: 400 });
+    }
+    if (!canManage) {
+      return NextResponse.json({ error: "Keine Berechtigung zur Kategorienänderung" }, { status: 403 });
+    }
+    if (body.category !== existing.category) {
+      updateData.category = body.category;
+      updateData.updatedBy = { connect: { id: userId } };
+      updateData.lastActivityAt = now;
+      touched = true;
+    }
+  }
+
+  if (!touched) {
+    return NextResponse.json({ error: "Keine Änderungen erkannt" }, { status: 400 });
+  }
+
+  const updated = await prisma.issue.update({
+    where: { id: issueId },
+    data: updateData,
+    include: {
+      createdBy: { select: { id: true, name: true, email: true } },
+      updatedBy: { select: { id: true, name: true, email: true } },
+      _count: { select: { comments: true } },
+      comments: {
+        orderBy: { createdAt: "asc" },
+        include: { author: { select: { id: true, name: true, email: true } } },
+      },
+    },
+  });
+
+  return NextResponse.json({ issue: mapIssueDetail(updated) });
+}

--- a/src/app/api/issues/route.ts
+++ b/src/app/api/issues/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import {
+  DEFAULT_ISSUE_CATEGORY,
+  DEFAULT_ISSUE_PRIORITY,
+  isIssueCategory,
+  isIssuePriority,
+  isIssueStatus,
+} from "@/lib/issues";
+import type { IssueStatusCounts } from "@/components/members/issues/types";
+import { mapIssueSummary } from "./utils";
+
+const MAX_RESULTS = 100;
+
+export async function GET(request: NextRequest) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.issues");
+  if (!allowed) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const statusParam = url.searchParams.get("status");
+  const categoryParam = url.searchParams.get("category");
+  const searchParam = url.searchParams.get("q");
+
+  const where: Prisma.IssueWhereInput = {};
+
+  if (statusParam && isIssueStatus(statusParam)) {
+    where.status = statusParam;
+  }
+
+  if (categoryParam && isIssueCategory(categoryParam)) {
+    where.category = categoryParam;
+  }
+
+  if (searchParam && searchParam.trim()) {
+    const term = searchParam.trim();
+    const searchFilter: Prisma.IssueWhereInput = {
+      OR: [
+        { title: { contains: term, mode: "insensitive" } },
+        { description: { contains: term, mode: "insensitive" } },
+      ],
+    };
+    if (Array.isArray(where.AND)) {
+      where.AND.push(searchFilter);
+    } else if (where.AND) {
+      where.AND = [where.AND, searchFilter];
+    } else {
+      where.AND = [searchFilter];
+    }
+  }
+
+  const [issuesRaw, countsRaw] = await Promise.all([
+    prisma.issue.findMany({
+      where,
+      orderBy: { lastActivityAt: "desc" },
+      take: MAX_RESULTS,
+      include: {
+        createdBy: { select: { id: true, name: true, email: true } },
+        updatedBy: { select: { id: true, name: true, email: true } },
+        _count: { select: { comments: true } },
+      },
+    }),
+    prisma.issue.groupBy({ by: ["status"], _count: { _all: true } }),
+  ]);
+
+  const counts: IssueStatusCounts = { open: 0, in_progress: 0, resolved: 0, closed: 0 };
+  for (const entry of countsRaw) {
+    counts[entry.status] = entry._count._all;
+  }
+
+  return NextResponse.json({
+    issues: issuesRaw.map(mapIssueSummary),
+    counts,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.issues");
+  if (!allowed) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const rawBody = await request.json().catch(() => null);
+  if (!rawBody || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const body = rawBody as Record<string, unknown>;
+
+  const titleValue = typeof body.title === "string" ? body.title.trim() : "";
+  if (titleValue.length < 4) {
+    return NextResponse.json({ error: "Titel muss mindestens 4 Zeichen lang sein" }, { status: 400 });
+  }
+  if (titleValue.length > 160) {
+    return NextResponse.json({ error: "Titel darf maximal 160 Zeichen haben" }, { status: 400 });
+  }
+
+  const descriptionValue = typeof body.description === "string" ? body.description.trim() : "";
+  if (descriptionValue.length < 10) {
+    return NextResponse.json({ error: "Beschreibung muss mindestens 10 Zeichen enthalten" }, { status: 400 });
+  }
+  if (descriptionValue.length > 4000) {
+    return NextResponse.json({ error: "Beschreibung darf maximal 4000 Zeichen enthalten" }, { status: 400 });
+  }
+
+  let category = DEFAULT_ISSUE_CATEGORY;
+  if (typeof body.category === "string" && isIssueCategory(body.category)) {
+    category = body.category;
+  }
+
+  let priority = DEFAULT_ISSUE_PRIORITY;
+  if (typeof body.priority === "string" && isIssuePriority(body.priority)) {
+    priority = body.priority;
+  }
+
+  const issue = await prisma.issue.create({
+    data: {
+      title: titleValue,
+      description: descriptionValue,
+      category,
+      priority,
+      status: "open",
+      createdById: userId,
+      updatedById: userId,
+      lastActivityAt: new Date(),
+    },
+    include: {
+      createdBy: { select: { id: true, name: true, email: true } },
+      updatedBy: { select: { id: true, name: true, email: true } },
+      _count: { select: { comments: true } },
+    },
+  });
+
+  return NextResponse.json({ issue: mapIssueSummary(issue) }, { status: 201 });
+}

--- a/src/app/api/issues/utils.ts
+++ b/src/app/api/issues/utils.ts
@@ -1,0 +1,64 @@
+import type { Prisma } from "@prisma/client";
+import type { IssueDetail, IssueSummary } from "@/components/members/issues/types";
+
+type IssueSummaryPayload = Prisma.IssueGetPayload<{
+  include: {
+    createdBy: { select: { id: true; name: true; email: true } };
+    updatedBy: { select: { id: true; name: true; email: true } };
+    _count: { select: { comments: true } };
+  };
+}>;
+
+type IssueDetailPayload = Prisma.IssueGetPayload<{
+  include: {
+    createdBy: { select: { id: true; name: true; email: true } };
+    updatedBy: { select: { id: true; name: true; email: true } };
+    _count: { select: { comments: true } };
+    comments: {
+      orderBy: { createdAt: "asc" };
+      include: { author: { select: { id: true; name: true; email: true } } };
+    };
+  };
+}>;
+
+export function mapIssueSummary(issue: IssueSummaryPayload): IssueSummary {
+  return {
+    id: issue.id,
+    title: issue.title,
+    description: issue.description,
+    category: issue.category,
+    status: issue.status,
+    priority: issue.priority,
+    createdAt: issue.createdAt.toISOString(),
+    updatedAt: issue.updatedAt.toISOString(),
+    lastActivityAt: issue.lastActivityAt.toISOString(),
+    resolvedAt: issue.resolvedAt ? issue.resolvedAt.toISOString() : null,
+    createdById: issue.createdById,
+    updatedById: issue.updatedById ?? null,
+    createdBy: issue.createdBy
+      ? { id: issue.createdBy.id, name: issue.createdBy.name, email: issue.createdBy.email }
+      : null,
+    updatedBy: issue.updatedBy
+      ? { id: issue.updatedBy.id, name: issue.updatedBy.name, email: issue.updatedBy.email }
+      : null,
+    commentCount: issue._count.comments,
+  };
+}
+
+export function mapIssueDetail(issue: IssueDetailPayload): IssueDetail {
+  const summary = mapIssueSummary(issue);
+  return {
+    ...summary,
+    comments: issue.comments.map((comment) => ({
+      id: comment.id,
+      issueId: comment.issueId,
+      body: comment.body,
+      createdAt: comment.createdAt.toISOString(),
+      updatedAt: comment.updatedAt.toISOString(),
+      authorId: comment.authorId,
+      author: comment.author
+        ? { id: comment.author.id, name: comment.author.name, email: comment.author.email }
+        : null,
+    })),
+  };
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -15,6 +15,7 @@ const groupedConfig: Group[] = [
     items: [
       { href: "/mitglieder", label: "Dashboard", permissionKey: "mitglieder.dashboard" },
       { href: "/mitglieder/profil", label: "Profil", permissionKey: "mitglieder.profil" },
+      { href: "/mitglieder/issues", label: "Feedback & Support", permissionKey: "mitglieder.issues" },
     ],
   },
   {
@@ -73,6 +74,14 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
         <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <circle cx="12" cy="8" r="4" />
           <path d="M6 20c0-3.314 2.686-6 6-6s6 2.686 6 6" />
+        </svg>
+      );
+    case "/mitglieder/issues":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 15a2 2 0 0 1-2 2H9l-4 4v-4H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" />
+          <path d="M9 7h6" />
+          <path d="M9 11h6" />
         </svg>
       );
     case "/mitglieder/meine-proben":

--- a/src/components/members/issues/issue-create-form.tsx
+++ b/src/components/members/issues/issue-create-form.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { IssueSummary } from "./types";
+import {
+  DEFAULT_ISSUE_CATEGORY,
+  DEFAULT_ISSUE_PRIORITY,
+  ISSUE_CATEGORY_DESCRIPTIONS,
+  ISSUE_CATEGORY_LABELS,
+  ISSUE_CATEGORY_VALUES,
+  ISSUE_PRIORITY_LABELS,
+  ISSUE_PRIORITY_VALUES,
+  isIssueCategory,
+  isIssuePriority,
+} from "@/lib/issues";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+
+type IssueCreateFormValues = {
+  title: string;
+  description: string;
+  category: string;
+  priority: string;
+};
+
+const schema = z.object({
+  title: z
+    .string()
+    .min(4, "Bitte gib einen aussagekräftigen Titel ein")
+    .max(160, "Titel darf höchstens 160 Zeichen lang sein"),
+  description: z
+    .string()
+    .min(10, "Beschreibe dein Anliegen mit mindestens 10 Zeichen")
+    .max(4000, "Beschreibung darf höchstens 4000 Zeichen lang sein"),
+  category: z
+    .string()
+    .refine(isIssueCategory, "Ungültige Kategorie"),
+  priority: z
+    .string()
+    .refine(isIssuePriority, "Ungültige Priorität"),
+});
+
+type IssueCreateFormProps = {
+  onCreated: (issue: IssueSummary) => void;
+  onSuccess?: () => void;
+};
+
+export function IssueCreateForm({ onCreated, onSuccess }: IssueCreateFormProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const form = useForm<IssueCreateFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      title: "",
+      description: "",
+      category: DEFAULT_ISSUE_CATEGORY,
+      priority: DEFAULT_ISSUE_PRIORITY,
+    },
+  });
+
+  const categoryOptions = useMemo(() => ISSUE_CATEGORY_VALUES, []);
+  const priorityOptions = useMemo(() => ISSUE_PRIORITY_VALUES, []);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    const { title, description, category, priority } = values;
+    setSubmitting(true);
+    try {
+      const response = await fetch("/api/issues", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim(),
+          category,
+          priority,
+        }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Anliegen konnte nicht erstellt werden");
+      }
+      if (!data?.issue) {
+        throw new Error("Unerwartete Antwort vom Server");
+      }
+      onCreated(data.issue as IssueSummary);
+      toast.success("Anliegen wurde erstellt");
+      form.reset({
+        title: "",
+        description: "",
+        category,
+        priority,
+      });
+      onSuccess?.();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Anliegen konnte nicht erstellt werden";
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Titel</FormLabel>
+              <FormControl>
+                <Input placeholder="Worum geht es?" autoComplete="off" {...field} />
+              </FormControl>
+              <FormDescription>Fasse dein Anliegen in einem kurzen Satz zusammen.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="category"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Kategorie</FormLabel>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Kategorie wählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {categoryOptions.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        <div className="flex flex-col text-left">
+                          <span>{ISSUE_CATEGORY_LABELS[option]}</span>
+                          <span className="text-[11px] text-muted-foreground">
+                            {ISSUE_CATEGORY_DESCRIPTIONS[option]}
+                          </span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="priority"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Priorität</FormLabel>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Priorität wählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {priorityOptions.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {ISSUE_PRIORITY_LABELS[option]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  Die Priorität hilft dem Team dabei, dringende Anliegen zuerst zu bearbeiten.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Beschreibung</FormLabel>
+              <FormControl>
+                <Textarea
+                  rows={6}
+                  placeholder="Beschreibe das Problem, gewünschte Verbesserungen oder relevante Schritte im Detail."
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Je genauer du dein Anliegen beschreibst, desto schneller kann es bearbeitet werden.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex justify-end gap-3">
+          <Button type="submit" disabled={submitting}>
+            {submitting ? "Speichern..." : "Anliegen melden"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/members/issues/issue-detail.tsx
+++ b/src/components/members/issues/issue-detail.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { IssueCategory, IssuePriority, IssueStatus } from "@prisma/client";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  ISSUE_CATEGORY_BADGE_CLASSES,
+  ISSUE_CATEGORY_LABELS,
+  ISSUE_CATEGORY_VALUES,
+  ISSUE_PRIORITY_BADGE_CLASSES,
+  ISSUE_PRIORITY_LABELS,
+  ISSUE_PRIORITY_VALUES,
+  ISSUE_STATUS_BADGE_CLASSES,
+  ISSUE_STATUS_LABELS,
+  ISSUE_STATUS_VALUES,
+  isIssueCategory,
+  isIssuePriority,
+  isIssueStatus,
+} from "@/lib/issues";
+import { cn } from "@/lib/utils";
+import type { IssueDetail as IssueDetailType, IssueSummary } from "./types";
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "-";
+  return new Intl.DateTimeFormat("de-DE", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+type IssueDetailProps = {
+  issueId: string;
+  canManage: boolean;
+  currentUserId: string;
+  onIssueUpdated: (issue: IssueSummary) => void;
+};
+
+export function IssueDetail({ issueId, canManage, currentUserId, onIssueUpdated }: IssueDetailProps) {
+  const [issue, setIssue] = useState<IssueDetailType | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [commentDraft, setCommentDraft] = useState("");
+  const [postingComment, setPostingComment] = useState(false);
+
+  const canUpdate = useMemo(() => {
+    if (canManage) return true;
+    if (!issue) return false;
+    return issue.createdById === currentUserId;
+  }, [canManage, issue, currentUserId]);
+
+  const loadIssue = useCallback(
+    async (emitUpdate = false) => {
+      if (!issueId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/issues/${issueId}`);
+        const data = await response.json().catch(() => null);
+        if (!response.ok) {
+          throw new Error(data?.error ?? "Anliegen konnte nicht geladen werden");
+        }
+        if (!data?.issue) {
+          throw new Error("Anliegen nicht gefunden");
+        }
+        setIssue(data.issue as IssueDetailType);
+        if (emitUpdate) {
+          const { comments, ...summary } = data.issue as IssueDetailType;
+          void comments;
+          onIssueUpdated(summary);
+        }
+      } catch (err) {
+        console.error("[IssueDetail] load", err);
+        setError(err instanceof Error ? err.message : "Anliegen konnte nicht geladen werden");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [issueId, onIssueUpdated],
+  );
+
+  useEffect(() => {
+    void loadIssue(false);
+    setCommentDraft("");
+  }, [issueId, loadIssue]);
+
+  const handleUpdate = useCallback(
+    async (updates: Partial<{ status: IssueStatus; priority: IssuePriority; category: IssueCategory }>) => {
+      if (!issue) return;
+      if (updates.status && !isIssueStatus(updates.status)) return;
+      if (updates.priority && !isIssuePriority(updates.priority)) return;
+      if (updates.category && !isIssueCategory(updates.category)) return;
+      setUpdating(true);
+      try {
+        const response = await fetch(`/api/issues/${issue.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updates),
+        });
+        const data = await response.json().catch(() => null);
+        if (!response.ok) {
+          throw new Error(data?.error ?? "Aktualisierung fehlgeschlagen");
+        }
+        if (!data?.issue) {
+          throw new Error("Unerwartete Antwort vom Server");
+        }
+        setIssue(data.issue as IssueDetailType);
+        const { comments, ...summary } = data.issue as IssueDetailType;
+        void comments;
+        onIssueUpdated(summary);
+        toast.success("Änderungen gespeichert");
+      } catch (err) {
+        console.error("[IssueDetail] update", err);
+        toast.error(err instanceof Error ? err.message : "Änderung fehlgeschlagen");
+      } finally {
+        setUpdating(false);
+      }
+    },
+    [issue, onIssueUpdated],
+  );
+
+  const handleStatusChange = async (nextStatus: string) => {
+    if (!issue) return;
+    if (issue.status === nextStatus) return;
+    if (!isIssueStatus(nextStatus)) return;
+    await handleUpdate({ status: nextStatus });
+  };
+
+  const handlePriorityChange = async (nextPriority: string) => {
+    if (!issue) return;
+    if (issue.priority === nextPriority) return;
+    if (!isIssuePriority(nextPriority)) return;
+    await handleUpdate({ priority: nextPriority });
+  };
+
+  const handleCategoryChange = async (nextCategory: string) => {
+    if (!issue) return;
+    if (issue.category === nextCategory) return;
+    if (!isIssueCategory(nextCategory)) return;
+    await handleUpdate({ category: nextCategory });
+  };
+
+  const handleCommentSubmit = async () => {
+    if (!issue) return;
+    const trimmed = commentDraft.trim();
+    if (!trimmed) {
+      toast.error("Kommentar darf nicht leer sein");
+      return;
+    }
+    setPostingComment(true);
+    try {
+      const response = await fetch(`/api/issues/${issue.id}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: trimmed }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Kommentar konnte nicht gespeichert werden");
+      }
+      if (!data?.issue) {
+        throw new Error("Unerwartete Antwort vom Server");
+      }
+      setCommentDraft("");
+      setIssue(data.issue as IssueDetailType);
+      const { comments, ...summary } = data.issue as IssueDetailType;
+      void comments;
+      onIssueUpdated(summary);
+      toast.success("Kommentar hinzugefügt");
+    } catch (err) {
+      console.error("[IssueDetail] comment", err);
+      toast.error(err instanceof Error ? err.message : "Kommentar konnte nicht gespeichert werden");
+    } finally {
+      setPostingComment(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <div className="h-6 w-2/3 animate-pulse rounded bg-muted/40" />
+        <div className="space-y-2">
+          <div className="h-4 w-full animate-pulse rounded bg-muted/40" />
+          <div className="h-4 w-5/6 animate-pulse rounded bg-muted/30" />
+        </div>
+        <div className="h-48 w-full animate-pulse rounded bg-muted/20" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-destructive">{error}</p>
+        <Button type="button" variant="outline" onClick={() => loadIssue(true)}>
+          Erneut versuchen
+        </Button>
+      </div>
+    );
+  }
+
+  if (!issue) {
+    return <p className="text-sm text-muted-foreground">Anliegen konnte nicht geladen werden.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge className={cn("border", ISSUE_STATUS_BADGE_CLASSES[issue.status])}>
+            {ISSUE_STATUS_LABELS[issue.status]}
+          </Badge>
+          <Badge className={cn("border", ISSUE_PRIORITY_BADGE_CLASSES[issue.priority])}>
+            Priorität: {ISSUE_PRIORITY_LABELS[issue.priority]}
+          </Badge>
+          <Badge className={cn("border", ISSUE_CATEGORY_BADGE_CLASSES[issue.category])}>
+            {ISSUE_CATEGORY_LABELS[issue.category]}
+          </Badge>
+        </div>
+        <h2 className="text-xl font-semibold">{issue.title}</h2>
+        <p className="whitespace-pre-line text-sm text-foreground/80">{issue.description}</p>
+      </div>
+
+      <div className="grid gap-4 rounded-lg border border-border/40 bg-muted/10 p-4 text-sm text-muted-foreground md:grid-cols-2">
+        <div>
+          <div className="font-medium text-foreground/80">Erstellt von</div>
+          <div>
+            {issue.createdBy?.name || issue.createdBy?.email || "Unbekannt"}
+            <span className="ml-2 text-xs text-muted-foreground">am {formatDateTime(issue.createdAt)}</span>
+          </div>
+        </div>
+        <div>
+          <div className="font-medium text-foreground/80">Letzte Aktivität</div>
+          <div>
+            {formatDateTime(issue.lastActivityAt)}
+            {issue.updatedBy?.name ? (
+              <span className="ml-2 text-xs text-muted-foreground">durch {issue.updatedBy.name}</span>
+            ) : null}
+          </div>
+        </div>
+        <div>
+          <div className="font-medium text-foreground/80">Status geändert</div>
+          <div>{formatDateTime(issue.updatedAt)}</div>
+        </div>
+        <div>
+          <div className="font-medium text-foreground/80">Kommentare</div>
+          <div>{issue.commentCount}</div>
+        </div>
+      </div>
+
+      {(canUpdate || canManage) && (
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground/80">Status</label>
+            <Select value={issue.status} onValueChange={handleStatusChange} disabled={!canUpdate || updating}>
+              <SelectTrigger>
+                <SelectValue placeholder="Status wählen" />
+              </SelectTrigger>
+              <SelectContent>
+                {ISSUE_STATUS_VALUES.map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {ISSUE_STATUS_LABELS[status]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground/80">Priorität</label>
+            <Select value={issue.priority} onValueChange={handlePriorityChange} disabled={!canManage || updating}>
+              <SelectTrigger>
+                <SelectValue placeholder="Priorität wählen" />
+              </SelectTrigger>
+              <SelectContent>
+                {ISSUE_PRIORITY_VALUES.map((priority) => (
+                  <SelectItem key={priority} value={priority}>
+                    {ISSUE_PRIORITY_LABELS[priority]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {canManage ? (
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground/80">Kategorie</label>
+              <Select value={issue.category} onValueChange={handleCategoryChange} disabled={updating}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Kategorie wählen" />
+                </SelectTrigger>
+                <SelectContent>
+                  {ISSUE_CATEGORY_VALUES.map((category) => (
+                    <SelectItem key={category} value={category}>
+                      {ISSUE_CATEGORY_LABELS[category]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-semibold text-foreground">Kommentare</h3>
+          <Button type="button" variant="outline" size="sm" onClick={() => loadIssue(true)} disabled={loading}>
+            Aktualisieren
+          </Button>
+        </div>
+        <div className="space-y-4">
+          {issue.comments.length > 0 ? (
+            issue.comments.map((comment) => (
+              <div key={comment.id} className="rounded-lg border border-border/40 bg-background/80 p-3 text-sm">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{comment.author?.name || comment.author?.email || "Unbekannt"}</span>
+                  <span>{formatDateTime(comment.createdAt)}</span>
+                </div>
+                <p className="mt-2 whitespace-pre-line text-foreground/80">{comment.body}</p>
+              </div>
+            ))
+          ) : (
+            <p className="text-sm text-muted-foreground">Noch keine Kommentare vorhanden.</p>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-dashed border-border/50 bg-muted/10 p-4">
+          <h4 className="text-sm font-semibold text-foreground">Kommentar hinzufügen</h4>
+          <Textarea
+            value={commentDraft}
+            onChange={(event) => setCommentDraft(event.target.value)}
+            rows={4}
+            placeholder="Teile Updates, Rückfragen oder weitere Details zu diesem Anliegen."
+            className="mt-2"
+          />
+          <div className="mt-3 flex items-center justify-end gap-3">
+            <input type="hidden" value={issueId} readOnly aria-hidden />
+            <Button type="button" onClick={handleCommentSubmit} disabled={postingComment || commentDraft.trim().length === 0}>
+              {postingComment ? "Wird gespeichert..." : "Kommentar speichern"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/members/issues/issue-overview.tsx
+++ b/src/components/members/issues/issue-overview.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { IssueCategory, IssueStatus } from "@prisma/client";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  ISSUE_CATEGORY_BADGE_CLASSES,
+  ISSUE_CATEGORY_LABELS,
+  ISSUE_CATEGORY_VALUES,
+  ISSUE_PRIORITY_BADGE_CLASSES,
+  ISSUE_PRIORITY_LABELS,
+  ISSUE_STATUS_BADGE_CLASSES,
+  ISSUE_STATUS_LABELS,
+  ISSUE_STATUS_VALUES,
+} from "@/lib/issues";
+import { cn } from "@/lib/utils";
+import { IssueCreateForm } from "./issue-create-form";
+import { IssueDetail } from "./issue-detail";
+import type { IssueStatusCounts, IssueSummary } from "./types";
+
+type IssueOverviewProps = {
+  initialIssues: IssueSummary[];
+  initialCounts: IssueStatusCounts;
+  canManage: boolean;
+  currentUserId: string;
+};
+
+type StatusFilterValue = "all" | IssueStatus;
+type CategoryFilterValue = "all" | IssueCategory;
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return "-";
+  return new Intl.DateTimeFormat("de-DE", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function normalizeCounts(counts?: Partial<IssueStatusCounts> | null): IssueStatusCounts {
+  return {
+    open: counts?.open ?? 0,
+    in_progress: counts?.in_progress ?? 0,
+    resolved: counts?.resolved ?? 0,
+    closed: counts?.closed ?? 0,
+  };
+}
+
+export function IssueOverview({ initialIssues, initialCounts, canManage, currentUserId }: IssueOverviewProps) {
+  const [issues, setIssues] = useState<IssueSummary[]>(initialIssues);
+  const [counts, setCounts] = useState<IssueStatusCounts>(normalizeCounts(initialCounts));
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("open");
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilterValue>("all");
+  const [searchInput, setSearchInput] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [selectedIssueId, setSelectedIssueId] = useState<string | null>(null);
+
+  const totalCount = counts.open + counts.in_progress + counts.resolved + counts.closed;
+
+  const statusOptions = useMemo(
+    () => [
+      { value: "all" as StatusFilterValue, label: "Alle", count: totalCount },
+      ...ISSUE_STATUS_VALUES.map((status) => ({
+        value: status as StatusFilterValue,
+        label: ISSUE_STATUS_LABELS[status],
+        count: counts[status],
+      })),
+    ],
+    [counts, totalCount],
+  );
+
+  const loadIssues = useCallback(async () => {
+    const params = new URLSearchParams();
+    if (statusFilter !== "all") params.set("status", statusFilter);
+    if (categoryFilter !== "all") params.set("category", categoryFilter);
+    if (searchTerm.trim()) params.set("q", searchTerm.trim());
+
+    setLoading(true);
+    try {
+      const query = params.toString();
+      const response = await fetch(`/api/issues${query ? `?${query}` : ""}`, {
+        cache: "no-store",
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Anliegen konnten nicht geladen werden");
+      }
+      const nextIssues = Array.isArray(data?.issues) ? (data.issues as IssueSummary[]) : [];
+      setIssues(nextIssues);
+      setCounts(normalizeCounts(data?.counts as IssueStatusCounts));
+    } catch (err) {
+      console.error("[IssueOverview] load", err);
+      toast.error(err instanceof Error ? err.message : "Anliegen konnten nicht geladen werden");
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, categoryFilter, searchTerm]);
+
+  useEffect(() => {
+    void loadIssues();
+  }, [loadIssues]);
+
+  const handleSearchSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSearchTerm(searchInput.trim());
+  };
+
+  const handleClearFilters = () => {
+    setStatusFilter("open");
+    setCategoryFilter("all");
+    setSearchInput("");
+    setSearchTerm("");
+  };
+
+  const handleIssueCreated = (issue: IssueSummary) => {
+    setCreateOpen(false);
+    const term = searchTerm.trim().toLowerCase();
+    const matchesStatus = statusFilter === "all" || statusFilter === issue.status;
+    const matchesCategory = categoryFilter === "all" || categoryFilter === issue.category;
+    const matchesSearch =
+      term.length === 0 ||
+      issue.title.toLowerCase().includes(term) ||
+      issue.description.toLowerCase().includes(term);
+
+    if (matchesStatus && matchesCategory && matchesSearch) {
+      setIssues((prev) => [issue, ...prev.filter((entry) => entry.id !== issue.id)]);
+    }
+    setCounts((prev) => ({ ...prev, [issue.status]: (prev[issue.status] ?? 0) + 1 }));
+    void loadIssues();
+  };
+
+  const handleIssueUpdated = (issue: IssueSummary) => {
+    setIssues((prev) => {
+      const term = searchTerm.trim().toLowerCase();
+      const matchesStatus = statusFilter === "all" || statusFilter === issue.status;
+      const matchesCategory = categoryFilter === "all" || categoryFilter === issue.category;
+      const matchesSearch =
+        term.length === 0 ||
+        issue.title.toLowerCase().includes(term) ||
+        issue.description.toLowerCase().includes(term);
+
+      const next = prev.filter((entry) => entry.id !== issue.id);
+      if (matchesStatus && matchesCategory && matchesSearch) {
+        next.unshift(issue);
+      }
+      return next;
+    });
+    void loadIssues();
+  };
+
+  const openDetail = (issueId: string) => {
+    setSelectedIssueId(issueId);
+    setDetailOpen(true);
+  };
+
+  const handleDetailOpenChange = (open: boolean) => {
+    setDetailOpen(open);
+    if (!open) {
+      setSelectedIssueId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="grid w-full gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-1">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Offene Anliegen</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold text-foreground">{counts.open}</div>
+              <p className="text-xs text-muted-foreground">Neu oder noch unbearbeitet.</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-1">
+              <CardTitle className="text-sm font-medium text-muted-foreground">In Bearbeitung</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold text-foreground">{counts.in_progress}</div>
+              <p className="text-xs text-muted-foreground">Aktiv in Umsetzung.</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-1">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Gelöst</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold text-foreground">{counts.resolved}</div>
+              <p className="text-xs text-muted-foreground">Erledigt, wartet auf Feedback.</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-1">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Geschlossen</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold text-foreground">{counts.closed}</div>
+              <p className="text-xs text-muted-foreground">Abgeschlossen und dokumentiert.</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+          <DialogTrigger asChild>
+            <Button>Neues Anliegen melden</Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>Neues Anliegen erfassen</DialogTitle>
+              <DialogDescription>
+                Beschreibe dein Problem, einen Bug oder Verbesserungsvorschlag für den Mitgliederbereich.
+              </DialogDescription>
+            </DialogHeader>
+            <IssueCreateForm onCreated={handleIssueCreated} onSuccess={() => setCreateOpen(false)} />
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Filter &amp; Suche</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {statusOptions.map((option) => (
+              <Button
+                key={option.value}
+                variant={statusFilter === option.value ? "default" : "outline"}
+                size="sm"
+                onClick={() => setStatusFilter(option.value)}
+              >
+                {option.label}
+                <span className="ml-2 rounded-full bg-foreground/10 px-2 py-0.5 text-[11px] font-semibold text-foreground/70">
+                  {option.count}
+                </span>
+              </Button>
+            ))}
+          </div>
+
+          <div className="flex flex-col gap-3 md:flex-row md:items-end">
+            <div className="md:w-64">
+              <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Kategorie
+              </label>
+              <Select value={categoryFilter} onValueChange={(value) => setCategoryFilter(value as CategoryFilterValue)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Kategorie filtern" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Alle Kategorien</SelectItem>
+                  {ISSUE_CATEGORY_VALUES.map((category) => (
+                    <SelectItem key={category} value={category}>
+                      {ISSUE_CATEGORY_LABELS[category]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <form onSubmit={handleSearchSubmit} className="flex flex-1 flex-col gap-2 md:flex-row md:items-center">
+              <div className="flex-1">
+                <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Suche
+                </label>
+                <Input
+                  value={searchInput}
+                  onChange={(event) => setSearchInput(event.target.value)}
+                  placeholder="Titel oder Beschreibung durchsuchen"
+                />
+              </div>
+              <div className="flex gap-2">
+                <Button type="submit" variant="secondary">
+                  Anwenden
+                </Button>
+                <Button type="button" variant="ghost" onClick={handleClearFilters}>
+                  Zurücksetzen
+                </Button>
+              </div>
+            </form>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Anliegen</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {loading ? (
+            <div className="space-y-3">
+              {[0, 1, 2].map((index) => (
+                <div key={index} className="space-y-3 rounded-lg border border-border/40 bg-muted/10 p-4">
+                  <div className="h-5 w-2/3 animate-pulse rounded bg-muted/40" />
+                  <div className="flex gap-2">
+                    <div className="h-5 w-24 animate-pulse rounded bg-muted/30" />
+                    <div className="h-5 w-24 animate-pulse rounded bg-muted/30" />
+                  </div>
+                  <div className="h-4 w-full animate-pulse rounded bg-muted/30" />
+                  <div className="h-4 w-4/5 animate-pulse rounded bg-muted/20" />
+                </div>
+              ))}
+            </div>
+          ) : issues.length > 0 ? (
+            issues.map((issue) => (
+              <div key={issue.id} className="rounded-lg border border-border/40 bg-background/80 p-4 shadow-sm">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge className={cn("border", ISSUE_STATUS_BADGE_CLASSES[issue.status])}>
+                        {ISSUE_STATUS_LABELS[issue.status]}
+                      </Badge>
+                      <Badge className={cn("border", ISSUE_PRIORITY_BADGE_CLASSES[issue.priority])}>
+                        {ISSUE_PRIORITY_LABELS[issue.priority]}
+                      </Badge>
+                      <Badge className={cn("border", ISSUE_CATEGORY_BADGE_CLASSES[issue.category])}>
+                        {ISSUE_CATEGORY_LABELS[issue.category]}
+                      </Badge>
+                    </div>
+                    <h3 className="mt-2 text-lg font-semibold text-foreground">{issue.title}</h3>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => openDetail(issue.id)}>
+                    Details ansehen
+                  </Button>
+                </div>
+                <p className="mt-3 text-sm text-foreground/80">{issue.description}</p>
+                <div className="mt-4 grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+                  <div>
+                    <span className="font-semibold text-foreground/70">Erstellt:</span> {formatDateTime(issue.createdAt)}
+                  </div>
+                  <div>
+                    <span className="font-semibold text-foreground/70">Letzte Aktivität:</span> {formatDateTime(issue.lastActivityAt)}
+                  </div>
+                  <div>
+                    <span className="font-semibold text-foreground/70">Kommentare:</span> {issue.commentCount}
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="rounded-lg border border-dashed border-border/60 bg-muted/10 p-6 text-center text-sm text-muted-foreground">
+              Keine Anliegen gefunden. Passe die Filter an oder melde ein neues Anliegen.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={detailOpen} onOpenChange={handleDetailOpenChange}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Anliegen-Details</DialogTitle>
+          </DialogHeader>
+          {selectedIssueId ? (
+            <IssueDetail
+              issueId={selectedIssueId}
+              canManage={canManage}
+              currentUserId={currentUserId}
+              onIssueUpdated={handleIssueUpdated}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">Kein Anliegen ausgewählt.</p>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/members/issues/types.ts
+++ b/src/components/members/issues/types.ts
@@ -1,0 +1,41 @@
+import type { IssueCategory, IssuePriority, IssueStatus } from "@prisma/client";
+
+export type IssueActor = {
+  id: string;
+  name: string | null;
+  email: string | null;
+};
+
+export type IssueSummary = {
+  id: string;
+  title: string;
+  description: string;
+  category: IssueCategory;
+  status: IssueStatus;
+  priority: IssuePriority;
+  createdAt: string;
+  updatedAt: string;
+  lastActivityAt: string;
+  resolvedAt: string | null;
+  createdById: string | null;
+  updatedById: string | null;
+  createdBy: IssueActor | null;
+  updatedBy: IssueActor | null;
+  commentCount: number;
+};
+
+export type IssueComment = {
+  id: string;
+  issueId: string;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  author: IssueActor | null;
+  authorId: string | null;
+};
+
+export type IssueDetail = IssueSummary & {
+  comments: IssueComment[];
+};
+
+export type IssueStatusCounts = Record<IssueStatus, number>;

--- a/src/lib/issues.ts
+++ b/src/lib/issues.ts
@@ -1,0 +1,94 @@
+import type { IssueCategory, IssuePriority, IssueStatus } from "@prisma/client";
+
+export const ISSUE_STATUS_VALUES = ["open", "in_progress", "resolved", "closed"] as const satisfies readonly IssueStatus[];
+export const ISSUE_STATUS_ORDER: readonly IssueStatus[] = ISSUE_STATUS_VALUES;
+
+export const ISSUE_CATEGORY_VALUES = [
+  "general",
+  "website_bug",
+  "improvement",
+  "support",
+  "other",
+] as const satisfies readonly IssueCategory[];
+
+export const ISSUE_PRIORITY_VALUES = ["low", "medium", "high", "urgent"] as const satisfies readonly IssuePriority[];
+export const ISSUE_PRIORITY_ORDER: readonly IssuePriority[] = ISSUE_PRIORITY_VALUES;
+
+export const ISSUE_STATUS_LABELS: Record<IssueStatus, string> = {
+  open: "Offen",
+  in_progress: "In Bearbeitung",
+  resolved: "Gelöst",
+  closed: "Geschlossen",
+};
+
+export const ISSUE_STATUS_DESCRIPTIONS: Record<IssueStatus, string> = {
+  open: "Neues Anliegen, das noch nicht bearbeitet wurde.",
+  in_progress: "Das Anliegen wird aktuell geprüft oder umgesetzt.",
+  resolved: "Das Anliegen wurde gelöst und wartet auf Bestätigung.",
+  closed: "Das Anliegen ist abgeschlossen.",
+};
+
+export const ISSUE_CATEGORY_LABELS: Record<IssueCategory, string> = {
+  general: "Allgemeines",
+  website_bug: "Website-Bug",
+  improvement: "Verbesserung",
+  support: "Support",
+  other: "Sonstiges",
+};
+
+export const ISSUE_CATEGORY_DESCRIPTIONS: Record<IssueCategory, string> = {
+  general: "Organisatorische Fragen oder generelles Feedback.",
+  website_bug: "Fehler oder Probleme mit der Website.",
+  improvement: "Ideen und Verbesserungsvorschläge für Funktionen oder Abläufe.",
+  support: "Hilfestellungen oder Unterstützung bei internen Prozessen.",
+  other: "Alles, was sich keiner anderen Kategorie zuordnen lässt.",
+};
+
+export const ISSUE_PRIORITY_LABELS: Record<IssuePriority, string> = {
+  low: "Niedrig",
+  medium: "Normal",
+  high: "Hoch",
+  urgent: "Dringend",
+};
+
+export const ISSUE_STATUS_BADGE_CLASSES: Record<IssueStatus, string> = {
+  open: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200",
+  in_progress: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200",
+  resolved: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+  closed: "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-200",
+};
+
+export const ISSUE_CATEGORY_BADGE_CLASSES: Record<IssueCategory, string> = {
+  general: "border-slate-400/40 bg-slate-500/10 text-slate-700 dark:text-slate-200",
+  website_bug: "border-rose-500/35 bg-rose-500/10 text-rose-700 dark:text-rose-200",
+  improvement: "border-emerald-500/35 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+  support: "border-indigo-500/35 bg-indigo-500/10 text-indigo-700 dark:text-indigo-200",
+  other: "border-zinc-500/35 bg-zinc-500/10 text-zinc-700 dark:text-zinc-200",
+};
+
+export const ISSUE_PRIORITY_BADGE_CLASSES: Record<IssuePriority, string> = {
+  low: "border-slate-400/40 bg-slate-500/10 text-slate-700 dark:text-slate-200",
+  medium: "border-sky-500/35 bg-sky-500/10 text-sky-700 dark:text-sky-200",
+  high: "border-orange-500/35 bg-orange-500/10 text-orange-700 dark:text-orange-200",
+  urgent: "border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-200",
+};
+
+const ISSUE_STATUS_SET = new Set<IssueStatus>(ISSUE_STATUS_VALUES);
+const ISSUE_CATEGORY_SET = new Set<IssueCategory>(ISSUE_CATEGORY_VALUES);
+const ISSUE_PRIORITY_SET = new Set<IssuePriority>(ISSUE_PRIORITY_VALUES);
+
+export function isIssueStatus(value: unknown): value is IssueStatus {
+  return typeof value === "string" && ISSUE_STATUS_SET.has(value as IssueStatus);
+}
+
+export function isIssueCategory(value: unknown): value is IssueCategory {
+  return typeof value === "string" && ISSUE_CATEGORY_SET.has(value as IssueCategory);
+}
+
+export function isIssuePriority(value: unknown): value is IssuePriority {
+  return typeof value === "string" && ISSUE_PRIORITY_SET.has(value as IssuePriority);
+}
+
+export const DEFAULT_ISSUE_STATUS: IssueStatus = "open";
+export const DEFAULT_ISSUE_PRIORITY: IssuePriority = "medium";
+export const DEFAULT_ISSUE_CATEGORY: IssueCategory = "general";

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -10,6 +10,12 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { key: "mitglieder.dashboard", label: "Mitglieder-Dashboard öffnen" },
   { key: "mitglieder.profil", label: "Profilbereich aufrufen" },
   {
+    key: "mitglieder.issues",
+    label: "Feedback & Support nutzen",
+    description:
+      "Anliegen, Probleme oder Verbesserungsvorschläge im Mitglieder-Issue-Board melden und einsehen.",
+  },
+  {
     key: "mitglieder.meine-proben",
     label: "Eigene Probentermine einsehen",
     description: "Zugang zum Bereich \"Meine Proben\" mit persönlichen Terminen und Fristen.",
@@ -39,6 +45,11 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     label: "Onboarding-Analytics öffnen",
     description: "Statistiken zum Einladungs- und Onboarding-Prozess einsehen.",
   },
+  {
+    key: "mitglieder.issues.manage",
+    label: "Feedback-Anliegen verwalten",
+    description: "Status, Priorität und Moderation für gemeldete Anliegen im Issue-Board übernehmen.",
+  },
 ];
 
 const DEFAULT_PERMISSION_KEYS = DEFAULT_PERMISSION_DEFINITIONS.map((def) => def.key);
@@ -51,6 +62,7 @@ const PERMISSION_KEY_SET = new Set(DEFAULT_PERMISSION_KEYS);
 const BASELINE_PERMISSION_KEYS = new Set([
   "mitglieder.dashboard",
   "mitglieder.profil",
+  "mitglieder.issues",
 ] satisfies PermissionDefinition["key"][]);
 
 let ensurePermissionsPromise: Promise<void> | null = null;


### PR DESCRIPTION
## Summary
- add Prisma models, enums, and migration for member issues and comments
- expose issue management API routes plus shared utilities and permission defaults
- build members UI for listing, creating, and moderating issues with detailed dialog

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfac445870832d8e2f82e325c83ab5