### PR TITLE
Allow owner setup link to add additional owners

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ example:
 ```
 
 Open the URL in a browser to create the first owner account. The link becomes
-invalid as soon as it has been used or as soon as any owner exists. Restart the
-server to generate a new link if necessary.
+invalid as soon as it has been used. Restart the server to generate a new link
+whenever you need to add another owner.
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 

--- a/scripts/run-prisma-migrate.mjs
+++ b/scripts/run-prisma-migrate.mjs
@@ -28,9 +28,9 @@ async function announceOwnerSetupLink() {
 
     const ownerAlreadyExists = ownerCount > 0;
     const removed = await prisma.ownerSetupToken.deleteMany({ where: { consumedAt: null } });
-    if (ownerAlreadyExists && removed.count > 0) {
+    if (removed.count > 0) {
       console.log(
-        `[owner-setup] Removed ${removed.count} unused owner setup token(s) because an owner already exists.`,
+        `[owner-setup] Removed ${removed.count} unused owner setup token(s) before generating a fresh link.`,
       );
     }
 
@@ -51,7 +51,7 @@ async function announceOwnerSetupLink() {
 
     if (ownerAlreadyExists) {
       console.log(
-        "[owner-setup] Hinweis: Es existiert bereits ein Owner. Falls du den Owner neu aufsetzen musst, entferne den bestehenden Eintrag und nutze anschließend den folgenden Link:",
+        "[owner-setup] Hinweis: Es existiert bereits mindestens ein Owner-Konto. Mit dem folgenden Link kannst du einen weiteren Owner hinzufügen oder Zugangsdaten erneuern.",
       );
     } else {
       console.log(
@@ -64,9 +64,7 @@ async function announceOwnerSetupLink() {
         `[owner-setup] Hinweis: Passe den Host an, falls der Server nicht unter ${fallbackBase} erreichbar ist.`,
       );
     }
-    console.log(
-      "[owner-setup] Der Link ist einmalig gültig und wird ungültig, sobald ein Owner angelegt wurde.",
-    );
+    console.log("[owner-setup] Der Link ist einmalig gültig und wird ungültig, sobald er verwendet wurde.");
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`[owner-setup] Konnte Owner-Setup-Link nicht erzeugen: ${message}`);

--- a/src/app/api/setup/owner/route.ts
+++ b/src/app/api/setup/owner/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
-import { hashOwnerSetupToken, ownerExists } from "@/lib/owner-setup";
+import { hashOwnerSetupToken } from "@/lib/owner-setup";
 import { hashPassword } from "@/lib/password";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -80,10 +80,6 @@ export async function POST(request: NextRequest) {
         throw new Error("TOKEN_ALREADY_USED");
       }
 
-      if (await ownerExists(tx)) {
-        throw new Error("OWNER_ALREADY_EXISTS");
-      }
-
       const created = await tx.user.create({
         data: {
           email,
@@ -107,9 +103,6 @@ export async function POST(request: NextRequest) {
     if (error instanceof Error) {
       if (error.message === "TOKEN_ALREADY_USED") {
         return NextResponse.json({ error: "Dieser Link wurde bereits verwendet." }, { status: 410 });
-      }
-      if (error.message === "OWNER_ALREADY_EXISTS") {
-        return NextResponse.json({ error: "Es existiert bereits ein Owner." }, { status: 409 });
       }
     }
 

--- a/src/app/setup/owner/[token]/page.tsx
+++ b/src/app/setup/owner/[token]/page.tsx
@@ -41,19 +41,26 @@ export default async function OwnerSetupPage({ params }: OwnerSetupPageProps) {
     return <InvalidToken message="Dieser Link wurde bereits verwendet." />;
   }
 
-  if (hasOwner) {
-    return <InvalidToken message="Es existiert bereits ein Owner. Du kannst dich mit deinem Konto anmelden." />;
-  }
-
   return (
     <main className="mx-auto flex min-h-[70vh] max-w-2xl flex-col justify-center gap-8 px-4 py-16">
       <div className="space-y-4">
         <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Erstkonfiguration</p>
         <h1 className="font-serif text-4xl">Owner-Zugang anlegen</h1>
         <p className="text-base text-muted-foreground">
-          Für eine neue Installation ist mindestens ein Owner-Konto erforderlich. Bitte vergebe unten Zugangsdaten.
+          {hasOwner
+            ? "Es existiert bereits mindestens ein Owner-Konto. Über dieses Formular kannst du einen weiteren Owner hinzufügen oder Zugangsdaten erneuern."
+            : "Für eine neue Installation ist mindestens ein Owner-Konto erforderlich. Bitte vergebe unten Zugangsdaten."}
         </p>
       </div>
+
+      {hasOwner && (
+        <div className="rounded-2xl border border-amber-200/80 bg-amber-50/70 p-4 text-sm text-amber-900 shadow-sm">
+          <p className="font-medium text-amber-900">Hinweis</p>
+          <p className="mt-1 text-amber-900/90">
+            Der bestehende Owner bleibt unverändert bestehen. Nach der Anmeldung kannst du weitere Rechte jederzeit in der Mitgliederverwaltung anpassen.
+          </p>
+        </div>
+      )}
 
       <div className="rounded-2xl border border-border/60 bg-card/80 p-6 shadow-sm">
         <OwnerSetupForm token={token} />
@@ -76,7 +83,7 @@ function InvalidToken({ message }: InvalidTokenProps) {
       <h1 className="font-serif text-4xl">Owner-Link ungültig</h1>
       <p className="text-base text-muted-foreground">{message}</p>
       <p className="text-sm text-muted-foreground">
-        Falls du noch keinen Owner angelegt hast, starte den Server neu, um einen neuen Link in der Konsole zu erhalten.
+        Falls du einen Owner hinzufügen möchtest, starte den Server neu, um einen aktuellen Link in der Konsole zu erhalten.
       </p>
       <p className="text-sm text-muted-foreground">
         Bereits eingerichtet? Dann geht es hier zum <Link href="/login" className="font-medium text-primary underline-offset-2 hover:underline">Login</Link>.


### PR DESCRIPTION
## Summary
- allow the owner setup API to create additional owners instead of failing once one exists
- surface helpful hints on the owner setup page and in the startup log when further owners are added via the link
- update the README to explain the refreshed behaviour of the one-time link

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfb6ce2e20832da7b26f6219e337f4