### PR TITLE
Make members sidebar scrollable on large screens

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -14,7 +14,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
       <div
         className="mx-auto flex w-full max-w-screen-2xl flex-col gap-6 px-4 sm:px-6 lg:grid lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start lg:gap-10 lg:px-8 xl:grid-cols-[300px_minmax(0,1fr)] xl:gap-12 xl:px-10 2xl:grid-cols-[320px_minmax(0,1fr)] 2xl:gap-16 2xl:px-12"
       >
-        <aside className="lg:sticky lg:top-28 lg:h-fit lg:self-start">
+        <aside className="lg:sticky lg:top-28 lg:h-fit lg:self-start lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:pr-2">
           <MembersNav permissions={permissions} activeProduction={activeProduction ?? undefined} />
         </aside>
         <section className="min-w-0 space-y-8">{children}</section>


### PR DESCRIPTION
## Summary
- limit the sticky members sidebar height and enable scrolling so all links stay accessible without scrolling the full page

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfb7121e3c832dafd37e9fd86ce62c