### PR TITLE
Add rich text and visibility controls to member support issues

### DIFF
--- a/prisma/migrations/20260108120000_issue_visibility/migration.sql
+++ b/prisma/migrations/20260108120000_issue_visibility/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "public"."IssueVisibility" AS ENUM ('public', 'private');
+
+-- AlterTable
+ALTER TABLE "public"."Issue"
+ADD COLUMN     "visibility" "public"."IssueVisibility" NOT NULL DEFAULT 'public';
+
+-- CreateIndex
+CREATE INDEX "Issue_visibility_idx" ON "public"."Issue"("visibility");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,11 @@ enum IssuePriority {
   urgent
 }
 
+enum IssueVisibility {
+  public
+  private
+}
+
 model User {
   id        String   @id @default(cuid())
   name      String?
@@ -728,6 +733,7 @@ model Issue {
   category       IssueCategory  @default(general)
   status         IssueStatus    @default(open)
   priority       IssuePriority  @default(medium)
+  visibility     IssueVisibility @default(public)
   createdAt      DateTime       @default(now())
   updatedAt      DateTime       @updatedAt
   lastActivityAt DateTime       @default(now())
@@ -741,6 +747,7 @@ model Issue {
   @@index([status, lastActivityAt])
   @@index([category])
   @@index([createdById])
+  @@index([visibility])
 }
 
 model IssueComment {

--- a/src/components/members/issues/issue-overview.tsx
+++ b/src/components/members/issues/issue-overview.tsx
@@ -25,6 +25,8 @@ import {
   ISSUE_STATUS_BADGE_CLASSES,
   ISSUE_STATUS_LABELS,
   ISSUE_STATUS_VALUES,
+  ISSUE_VISIBILITY_BADGE_CLASSES,
+  ISSUE_VISIBILITY_LABELS,
 } from "@/lib/issues";
 import { cn } from "@/lib/utils";
 import { IssueCreateForm } from "./issue-create-form";
@@ -333,6 +335,9 @@ export function IssueOverview({ initialIssues, initialCounts, canManage, current
                       </Badge>
                       <Badge className={cn("border", ISSUE_CATEGORY_BADGE_CLASSES[issue.category])}>
                         {ISSUE_CATEGORY_LABELS[issue.category]}
+                      </Badge>
+                      <Badge className={cn("border", ISSUE_VISIBILITY_BADGE_CLASSES[issue.visibility])}>
+                        {ISSUE_VISIBILITY_LABELS[issue.visibility]}
                       </Badge>
                     </div>
                     <h3 className="mt-2 text-lg font-semibold text-foreground">{issue.title}</h3>

--- a/src/components/members/issues/types.ts
+++ b/src/components/members/issues/types.ts
@@ -1,4 +1,4 @@
-import type { IssueCategory, IssuePriority, IssueStatus } from "@prisma/client";
+import type { IssueCategory, IssuePriority, IssueStatus, IssueVisibility } from "@prisma/client";
 
 export type IssueActor = {
   id: string;
@@ -10,9 +10,11 @@ export type IssueSummary = {
   id: string;
   title: string;
   description: string;
+  descriptionHtml: string;
   category: IssueCategory;
   status: IssueStatus;
   priority: IssuePriority;
+  visibility: IssueVisibility;
   createdAt: string;
   updatedAt: string;
   lastActivityAt: string;

--- a/src/lib/issues.ts
+++ b/src/lib/issues.ts
@@ -1,4 +1,4 @@
-import type { IssueCategory, IssuePriority, IssueStatus } from "@prisma/client";
+import type { IssueCategory, IssuePriority, IssueStatus, IssueVisibility } from "@prisma/client";
 
 export const ISSUE_STATUS_VALUES = ["open", "in_progress", "resolved", "closed"] as const satisfies readonly IssueStatus[];
 export const ISSUE_STATUS_ORDER: readonly IssueStatus[] = ISSUE_STATUS_VALUES;
@@ -13,6 +13,8 @@ export const ISSUE_CATEGORY_VALUES = [
 
 export const ISSUE_PRIORITY_VALUES = ["low", "medium", "high", "urgent"] as const satisfies readonly IssuePriority[];
 export const ISSUE_PRIORITY_ORDER: readonly IssuePriority[] = ISSUE_PRIORITY_VALUES;
+
+export const ISSUE_VISIBILITY_VALUES = ["public", "private"] as const satisfies readonly IssueVisibility[];
 
 export const ISSUE_STATUS_LABELS: Record<IssueStatus, string> = {
   open: "Offen",
@@ -51,6 +53,16 @@ export const ISSUE_PRIORITY_LABELS: Record<IssuePriority, string> = {
   urgent: "Dringend",
 };
 
+export const ISSUE_VISIBILITY_LABELS: Record<IssueVisibility, string> = {
+  public: "Öffentlich",
+  private: "Privat",
+};
+
+export const ISSUE_VISIBILITY_DESCRIPTIONS: Record<IssueVisibility, string> = {
+  public: "Das Anliegen ist für alle Mitglieder mit Support-Zugang sichtbar.",
+  private: "Nur du und das Support-Team können dieses Anliegen sehen.",
+};
+
 export const ISSUE_STATUS_BADGE_CLASSES: Record<IssueStatus, string> = {
   open: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200",
   in_progress: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200",
@@ -73,9 +85,15 @@ export const ISSUE_PRIORITY_BADGE_CLASSES: Record<IssuePriority, string> = {
   urgent: "border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-200",
 };
 
+export const ISSUE_VISIBILITY_BADGE_CLASSES: Record<IssueVisibility, string> = {
+  public: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+  private: "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200",
+};
+
 const ISSUE_STATUS_SET = new Set<IssueStatus>(ISSUE_STATUS_VALUES);
 const ISSUE_CATEGORY_SET = new Set<IssueCategory>(ISSUE_CATEGORY_VALUES);
 const ISSUE_PRIORITY_SET = new Set<IssuePriority>(ISSUE_PRIORITY_VALUES);
+const ISSUE_VISIBILITY_SET = new Set<IssueVisibility>(ISSUE_VISIBILITY_VALUES);
 
 export function isIssueStatus(value: unknown): value is IssueStatus {
   return typeof value === "string" && ISSUE_STATUS_SET.has(value as IssueStatus);
@@ -89,6 +107,11 @@ export function isIssuePriority(value: unknown): value is IssuePriority {
   return typeof value === "string" && ISSUE_PRIORITY_SET.has(value as IssuePriority);
 }
 
+export function isIssueVisibility(value: unknown): value is IssueVisibility {
+  return typeof value === "string" && ISSUE_VISIBILITY_SET.has(value as IssueVisibility);
+}
+
 export const DEFAULT_ISSUE_STATUS: IssueStatus = "open";
 export const DEFAULT_ISSUE_PRIORITY: IssuePriority = "medium";
 export const DEFAULT_ISSUE_CATEGORY: IssueCategory = "general";
+export const DEFAULT_ISSUE_VISIBILITY: IssueVisibility = "public";


### PR DESCRIPTION
## Summary
- add an IssueVisibility enum and migration so support requests can be stored as public or private
- expose visibility selection and a rich text editor in the issue creation form and display rich descriptions in the overview/detail views
- sanitize descriptions and restrict private issue access across the API and initial server-side queries

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfb7ffaab0832d89d051598f916b63