### PR TITLE
Propagate git commit metadata to Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,7 @@ jobs:
             dockerfile: Dockerfile.dev
             build_args: |
               NODE_ENV=development
+              GIT_COMMIT_SHA=${{ github.sha }}
             metadata_tags: |
               type=raw,value=dev
               type=sha,prefix=dev-
@@ -49,6 +50,7 @@ jobs:
             dockerfile: Dockerfile.prod
             build_args: |
               NODE_ENV=production
+              GIT_COMMIT_SHA=${{ github.sha }}
             metadata_tags: |
               type=raw,value=prod
               type=sha,prefix=prod-

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,11 +2,14 @@
 FROM node:20-alpine
 
 ARG NODE_ENV=development
+ARG GIT_COMMIT_SHA
 
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NEXT_TELEMETRY_DISABLED=1 \
     NODE_ENV=${NODE_ENV} \
+    VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
     PORT=3000 \
     APP_SERVER_PORT=3001 \
     REALTIME_BASE_PATH=/realtime \

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,6 @@
 # Production Dockerfile bundling the Next.js app and realtime server
+ARG GIT_COMMIT_SHA
+
 FROM node:20-alpine AS deps
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
@@ -10,10 +12,13 @@ COPY package.json pnpm-lock.yaml ./
 RUN SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --frozen-lockfile
 
 FROM node:20-alpine AS builder
+ARG GIT_COMMIT_SHA
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
+    VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
     REALTIME_BASE_PATH=/realtime \
     NEXT_PUBLIC_REALTIME_URL=/realtime \
     NEXT_PUBLIC_REALTIME_PATH=/realtime/socket.io \
@@ -28,10 +33,13 @@ RUN pnpm build
 RUN pnpm prune --prod
 
 FROM node:20-alpine AS runner
+ARG GIT_COMMIT_SHA
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
+    VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
+    NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
     PORT=3000 \
     APP_SERVER_PORT=3001 \
     REALTIME_BASE_PATH=/realtime \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ proxy (default external port `3000`). During boot it configures
 `REALTIME_SERVER_EVENT_PATH` automatically based on `REALTIME_BASE_PATH`
 (default `/realtime`).
 
+> [!TIP]
+> Both Dockerfiles accept an optional build argument `GIT_COMMIT_SHA`. Providing
+> the current commit hash ensures the footer in development builds shows the
+> correct revision even when the `.git` directory is not part of the image.
+
 ### Local development stack
 
 ```bash
@@ -37,7 +42,9 @@ the container.
 ### Building the production image from source
 
 ```bash
-docker build -f Dockerfile.prod -t theater-website:prod .
+docker build -f Dockerfile.prod \
+  --build-arg GIT_COMMIT_SHA=$(git rev-parse HEAD) \
+  -t theater-website:prod .
 
 # Run the container (make sure a Postgres instance is reachable)
 docker run --rm -p 3000:3000 \


### PR DESCRIPTION
## Summary
- accept an optional GIT_COMMIT_SHA build argument in both Dockerfiles and surface it via Vercel-compatible env vars
- forward the current commit SHA from the docker-publish workflow and document the new build arg in the README

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68cfd0a110fc832d9f86c5eb93285eeb