### PR TITLE
Refine member profile layout and styling

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -2,18 +2,60 @@ import { notFound } from "next/navigation";
 import { PageHeader } from "@/components/members/page-header";
 import { PhotoConsentCard } from "@/components/members/photo-consent-card";
 import { ProfileForm } from "@/components/members/profile-form";
+import { ProfileSummaryCard } from "@/components/members/profile-summary-card";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
-import { ROLE_BADGE_VARIANTS, ROLE_LABELS, sortRoles, type Role } from "@/lib/roles";
+import {
+  ROLE_BADGE_VARIANTS,
+  ROLE_DESCRIPTIONS,
+  ROLE_LABELS,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
+import { cn } from "@/lib/utils";
+import type { LucideIcon } from "lucide-react";
+import {
+  CheckCircle2,
+  Crown,
+  Gavel,
+  PiggyBank,
+  ShieldCheck,
+  UsersRound,
+  VenetianMask,
+  Wrench,
+} from "lucide-react";
+
+const ROLE_ICON_MAP: Record<Role, LucideIcon> = {
+  member: UsersRound,
+  cast: VenetianMask,
+  tech: Wrench,
+  board: Gavel,
+  finance: PiggyBank,
+  owner: Crown,
+  admin: ShieldCheck,
+};
+
+const ROLE_ICON_ACCENTS: Record<Role, string> = {
+  member: "border-emerald-400/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-200",
+  cast: "border-fuchsia-400/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-200",
+  tech: "border-sky-400/40 bg-sky-500/10 text-sky-600 dark:text-sky-200",
+  board: "border-teal-400/40 bg-teal-500/10 text-teal-600 dark:text-teal-200",
+  finance: "border-amber-400/40 bg-amber-500/10 text-amber-600 dark:text-amber-200",
+  owner: "border-purple-400/40 bg-purple-500/10 text-purple-600 dark:text-purple-200",
+  admin: "border-rose-400/40 bg-rose-500/10 text-rose-600 dark:text-rose-200",
+};
+
+const ROLE_STATUS_BADGE_CLASSES =
+  "border-emerald-400/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200";
 
 export default async function ProfilePage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.profil");
   if (!allowed) {
-    return <div className="text-sm text-red-600">Kein Zugriff auf den Profilbereich</div>;
+    return <div className="text-sm text-destructive">Kein Zugriff auf den Profilbereich</div>;
   }
   const userId = session.user?.id;
 
@@ -41,43 +83,105 @@ export default async function ProfilePage() {
   const roles = sortRoles([user.role as Role, ...user.roles.map((r) => r.role as Role)]);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <PageHeader
         title="Mein Profil"
-        description="Pflege deine Kontaktdaten und behalte den Überblick über deine Berechtigungsrollen."
+        description="Halte deine Stammdaten aktuell und behalte im Blick, welche Rollen dir Zugriff auf die Module geben."
       />
 
-      <PhotoConsentCard />
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.48fr)_minmax(0,1fr)]">
+        <div className="space-y-6">
+          <ProfileSummaryCard
+            userId={userId}
+            name={user.name}
+            email={user.email}
+            roles={roles}
+            avatarSource={user.avatarSource}
+            avatarUpdatedAt={user.avatarImageUpdatedAt?.toISOString() ?? null}
+          />
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.65fr)_minmax(0,1fr)]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Rollen & Berechtigungen</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm text-foreground/80">
-            <p>
-              Deine Rollen bestimmen, welche Bereiche im Mitgliederportal sichtbar sind und welche Aktionen du ausführen
-              darfst. Für weitere Rechte wende dich bitte an die Administration.
-            </p>
-            <div className="flex flex-wrap gap-2">
+          <PhotoConsentCard />
+
+          <Card>
+            <CardHeader className="space-y-2">
+              <CardTitle>Rollen & Berechtigungen</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Deine Rollen steuern Sichtbarkeit und Handlungsrechte im Mitgliederportal. Wende dich bei fehlenden Rechten an
+                die Administration.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-5">
               {roles.length > 0 ? (
-                roles.map((role) => (
-                  <Badge key={role} className={ROLE_BADGE_VARIANTS[role]}>
-                    {ROLE_LABELS[role] ?? role}
-                  </Badge>
-                ))
+                <>
+                  <div className="flex flex-wrap gap-2">
+                    {roles.map((role) => (
+                      <Badge
+                        key={role}
+                        className={cn(
+                          "px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide shadow-sm",
+                          ROLE_BADGE_VARIANTS[role],
+                        )}
+                      >
+                        {ROLE_LABELS[role] ?? role}
+                      </Badge>
+                    ))}
+                  </div>
+                  <ul className="space-y-3">
+                    {roles.map((role) => {
+                      const Icon = ROLE_ICON_MAP[role];
+                      const description = ROLE_DESCRIPTIONS[role] ?? "Diese Rolle ist aktuell aktiv.";
+                      return (
+                        <li
+                          key={role}
+                          className="flex gap-3 rounded-lg border border-border/60 bg-background/70 p-3 shadow-sm"
+                        >
+                          <div
+                            className={cn(
+                              "flex h-10 w-10 items-center justify-center rounded-full border text-sm",
+                              ROLE_ICON_ACCENTS[role],
+                            )}
+                            aria-hidden
+                          >
+                            <Icon className="h-5 w-5" />
+                          </div>
+                          <div className="space-y-1.5">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="text-sm font-semibold text-foreground">{ROLE_LABELS[role] ?? role}</span>
+                              <Badge
+                                variant="outline"
+                                className={cn(
+                                  "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide",
+                                  ROLE_STATUS_BADGE_CLASSES,
+                                )}
+                              >
+                                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+                                Aktiv
+                              </Badge>
+                            </div>
+                            <p className="text-xs text-muted-foreground">{description}</p>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </>
               ) : (
-                <span className="text-foreground/70">Derzeit sind keine Rollen hinterlegt.</span>
+                <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-4 text-sm text-muted-foreground">
+                  Dir sind aktuell keine Rollen zugewiesen. Wende dich an die Produktionsleitung, wenn dir Inhalte fehlen.
+                </div>
               )}
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        </div>
 
         <Card>
-          <CardHeader>
+          <CardHeader className="space-y-2">
             <CardTitle>Profildaten</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Name, Kontaktadresse und Passwort kannst du hier eigenständig anpassen. Änderungen werden sofort übernommen.
+            </p>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-0">
             <ProfileForm
               userId={userId}
               initialName={user.name}

--- a/src/components/members/profile-form.tsx
+++ b/src/components/members/profile-form.tsx
@@ -276,7 +276,7 @@ export function ProfileForm({
           placeholder="Vorname Nachname"
           autoComplete="name"
         />
-        <p className="text-xs text-foreground/70">
+        <p className="text-xs text-muted-foreground">
           Der Name wird in internen Übersichten und im Mitgliederbereich angezeigt.
         </p>
       </div>
@@ -293,7 +293,7 @@ export function ProfileForm({
           autoComplete="email"
           required
         />
-        <p className="text-xs text-foreground/70">
+        <p className="text-xs text-muted-foreground">
           Diese E-Mail dient sowohl zur Anmeldung als auch für Benachrichtigungen.
         </p>
       </div>
@@ -351,7 +351,7 @@ export function ProfileForm({
             {avatarSource === "UPLOAD" && (
               <div className="space-y-2">
                 <Input type="file" accept="image/png,image/jpeg,image/webp" onChange={handleAvatarFileChange} />
-                <p className="text-xs text-foreground/70">Unterstützt JPG, PNG und WebP bis 2&nbsp;MB.</p>
+                <p className="text-xs text-muted-foreground">Unterstützt JPG, PNG und WebP bis 2&nbsp;MB.</p>
                 {hasStoredAvatar && !avatarFile && !avatarPreview && !removeAvatar && (
                   <Button type="button" variant="outline" size="sm" onClick={handleRemoveAvatar}>
                     Eigenes Bild entfernen
@@ -367,10 +367,10 @@ export function ProfileForm({
             )}
 
             {removeAvatar && (
-              <p className="text-xs text-foreground/70">Das aktuelle Upload-Bild wird nach dem Speichern entfernt.</p>
+              <p className="text-xs text-muted-foreground">Das aktuelle Upload-Bild wird nach dem Speichern entfernt.</p>
             )}
 
-            {avatarError && <p className="text-sm text-red-600">{avatarError}</p>}
+            {avatarError && <p className="text-sm text-destructive">{avatarError}</p>}
           </div>
         </div>
       </div>
@@ -416,13 +416,13 @@ export function ProfileForm({
           autoComplete="bday"
           max={toDateInputValue(new Date().toISOString())}
         />
-        <p className="text-xs text-foreground/70">
+        <p className="text-xs text-muted-foreground">
           Das Geburtsdatum hilft uns, notwendige Einverständniserklärungen korrekt zu verwalten.
         </p>
       </div>
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
-      {success && <p className="text-sm text-emerald-600">{success}</p>}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {success && <p className="text-sm text-emerald-500">{success}</p>}
 
       <div className="flex flex-wrap items-center justify-end gap-2">
         <Button type="button" variant="outline" onClick={resetForm} disabled={saving}>

--- a/src/components/members/profile-summary-card.tsx
+++ b/src/components/members/profile-summary-card.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { Mail, UserRoundCheck } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { UserAvatar, type AvatarSource } from "@/components/user-avatar";
+import { ROLE_LABELS, type Role } from "@/lib/roles";
+import { cn } from "@/lib/utils";
+
+const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+
+const AVATAR_SOURCE_LABELS: Record<AvatarSource, string> = {
+  GRAVATAR: "Gravatar",
+  INITIALS: "Initialen",
+  UPLOAD: "Eigenes Bild",
+};
+
+function normalizeAvatarSource(value?: AvatarSource | string | null): AvatarSource | null {
+  if (!value) return null;
+  const normalized = value.toString().trim().toUpperCase();
+  if (normalized === "GRAVATAR" || normalized === "UPLOAD" || normalized === "INITIALS") {
+    return normalized as AvatarSource;
+  }
+  return null;
+}
+
+function formatUpdatedAt(value: string | null | undefined) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return null;
+  return `Aktualisiert am ${dateFormatter.format(parsed)}`;
+}
+
+export interface ProfileSummaryCardProps {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  roles: Role[];
+  avatarSource: AvatarSource | string | null;
+  avatarUpdatedAt: string | null;
+}
+
+export function ProfileSummaryCard({
+  userId,
+  name,
+  email,
+  roles,
+  avatarSource,
+  avatarUpdatedAt,
+}: ProfileSummaryCardProps) {
+  const displayName = name?.trim() ? name.trim() : "Unbenanntes Profil";
+  const normalizedEmail = email?.trim() ?? "";
+  const hasEmail = Boolean(normalizedEmail);
+  const normalizedSource = normalizeAvatarSource(avatarSource);
+  const avatarSourceLabel = normalizedSource ? AVATAR_SOURCE_LABELS[normalizedSource] : "Automatisch";
+  const avatarInfo = formatUpdatedAt(avatarUpdatedAt);
+  const rolesSummary = roles.length
+    ? `Aktive Rollen: ${roles.map((role) => ROLE_LABELS[role] ?? role).join(", ")}`
+    : "Noch keine Rollen zugewiesen.";
+
+  return (
+    <Card className="relative overflow-hidden border border-border/70 bg-gradient-to-br from-background/85 via-background/70 to-background/80">
+      <CardHeader className="space-y-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-4">
+            <UserAvatar
+              userId={userId}
+              name={name}
+              email={email}
+              avatarSource={avatarSource}
+              avatarUpdatedAt={avatarUpdatedAt}
+              size={76}
+              className="h-[76px] w-[76px] border-border/80 text-xl shadow-sm"
+            />
+            <div className="space-y-1.5">
+              <CardTitle className="text-xl font-semibold leading-tight text-foreground">{displayName}</CardTitle>
+              <p className="text-sm text-muted-foreground">{rolesSummary}</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Primäre Adresse</div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <Badge
+                variant="outline"
+                className={cn(
+                  "px-3 py-1 text-xs font-medium",
+                  hasEmail
+                    ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
+                    : "border-amber-400/40 bg-amber-500/10 text-amber-700 dark:text-amber-200"
+                )}
+              >
+                <Mail className="h-3.5 w-3.5" aria-hidden />
+                {hasEmail ? normalizedEmail : "keine Adresse"}
+              </Badge>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {hasEmail
+                ? "Wir verwenden diese Adresse für Login und Benachrichtigungen."
+                : "Ohne Adresse können wir dich nicht erreichen – ergänze sie im Formular."}
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Profilbild</div>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <Badge
+                variant="outline"
+                className="px-3 py-1 text-xs font-medium border-primary/40 bg-primary/10 text-primary/80 dark:text-primary/60"
+              >
+                <UserRoundCheck className="h-3.5 w-3.5" aria-hidden />
+                {avatarSourceLabel}
+              </Badge>
+              {avatarInfo ? <span className="text-xs text-muted-foreground">{avatarInfo}</span> : null}
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Passe Quelle oder Bild direkt im Formular an – Änderungen erscheinen sofort im Portal.
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="text-xs text-muted-foreground">
+        Aktualisiere deine Stammdaten regelmäßig, damit Teamlisten, Einladungen und Rollenbadges auf dem neuesten Stand bleiben.
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...pr
     <input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring",
+        "flex h-10 w-full rounded-md border border-input bg-card px-3 py-2 text-sm shadow-sm transition",
+        "placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
         className
       )}
       {...props}

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -20,6 +20,16 @@ export const ROLE_LABELS: Record<Role, string> = {
   admin: "Admin",
 };
 
+export const ROLE_DESCRIPTIONS: Record<Role, string> = {
+  member: "Grundzugriff auf das Mitgliederportal und persönliche Bereiche.",
+  cast: "Schauspiel-spezifische Proben, Rollen und Szenenübersichten.",
+  tech: "Technik- und Gewerkeaufgaben inklusive Checklisten verwalten.",
+  board: "Organisation und Produktionsleitung mit erweiterten Dashboards.",
+  finance: "Finanz- und Budgetmodule inklusive Abrechnungen einsehen.",
+  owner: "Systemweite Superuser-Rechte inklusive Rollenverwaltung.",
+  admin: "Administrativer Vollzugriff ohne Besitzerrechte.",
+};
+
 export const ROLE_BADGE_VARIANTS: Record<Role, string> = {
   member: "bg-slate-100 text-slate-700 border-slate-200",
   cast: "bg-purple-100 text-purple-700 border-purple-200",


### PR DESCRIPTION
## Summary
- add a reusable profile summary card that highlights avatar source, primary email and role overview
- reorganize the member profile page with the new summary, richer role descriptions and updated copy
- refresh shared input styling and form helper texts for better contrast

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cfe4548e00832d9b4b7dfa117c13b3