### PR TITLE
Add final rehearsal week support

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -291,6 +291,7 @@ model Show {
   dates      Json
   posterUrl  String?
   revealedAt DateTime?
+  finalRehearsalWeekStart DateTime?
   meta       Json?
   clues      Clue[]
   rehearsals Rehearsal[]

--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -8,8 +8,9 @@ import { getActiveProductionId } from "@/lib/active-production";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 
-import { setActiveProductionAction } from "../actions";
+import { setActiveProductionAction, updateProductionTimelineAction } from "../actions";
 
 function formatShowTitle(show: { title: string | null; year: number }) {
   if (show.title && show.title.trim()) return show.title;
@@ -35,6 +36,7 @@ export default async function ProduktionDetailPage({ params }: { params: { showI
         title: true,
         year: true,
         synopsis: true,
+        finalRehearsalWeekStart: true,
         _count: { select: { characters: true, scenes: true } },
       },
     }),
@@ -48,6 +50,12 @@ export default async function ProduktionDetailPage({ params }: { params: { showI
   const activeProductionId = await getActiveProductionId();
   const isActive = activeProductionId === show.id;
   const title = formatShowTitle(show);
+  const finalRehearsalWeekStartValue = show.finalRehearsalWeekStart
+    ? show.finalRehearsalWeekStart.toISOString().slice(0, 10)
+    : "";
+  const finalRehearsalWeekStartLabel = show.finalRehearsalWeekStart
+    ? new Intl.DateTimeFormat("de-DE", { dateStyle: "long" }).format(show.finalRehearsalWeekStart)
+    : null;
 
   return (
     <div className="space-y-10">
@@ -115,6 +123,43 @@ export default async function ProduktionDetailPage({ params }: { params: { showI
               </form>
             ) : null}
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-lg font-semibold">Endprobenwoche</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Hinterlege den Start der großen Endprobenwoche. Mitglieder sehen darauf basierend einen Countdown
+            im Dashboard.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form action={updateProductionTimelineAction} className="flex flex-col gap-4 sm:flex-row sm:items-end">
+            <input type="hidden" name="showId" value={show.id} />
+            <input type="hidden" name="redirectPath" value={`/mitglieder/produktionen/${show.id}`} />
+            <div className="space-y-2 sm:max-w-xs">
+              <div className="space-y-1">
+                <label className="text-sm font-medium" htmlFor="finalRehearsalWeekStart">
+                  Beginn der Endprobenwoche
+                </label>
+                <Input
+                  id="finalRehearsalWeekStart"
+                  type="date"
+                  name="finalRehearsalWeekStart"
+                  defaultValue={finalRehearsalWeekStartValue}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {finalRehearsalWeekStartLabel
+                  ? `Aktueller Start: ${finalRehearsalWeekStartLabel}`
+                  : "Kein Datum hinterlegt."}
+              </p>
+            </div>
+            <Button type="submit" className="sm:w-auto">
+              Zeitplan aktualisieren
+            </Button>
+          </form>
         </CardContent>
       </Card>
 

--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -218,15 +218,19 @@ export default async function ProduktionenPage() {
                     <label className="text-sm font-medium">Startdatum</label>
                     <Input type="date" name="startDate" />
                   </div>
-                  <div className="space-y-1">
-                    <label className="text-sm font-medium">Enddatum</label>
-                    <Input type="date" name="endDate" />
-                  </div>
-                  <div className="space-y-1 sm:col-span-2">
-                    <label className="text-sm font-medium">Premierenankündigung</label>
-                    <Input type="date" name="revealDate" />
-                  </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Enddatum</label>
+                  <Input type="date" name="endDate" />
                 </div>
+                <div className="space-y-1 sm:col-span-2">
+                  <label className="text-sm font-medium">Beginn der Endprobenwoche</label>
+                  <Input type="date" name="finalRehearsalWeekStart" />
+                </div>
+                <div className="space-y-1 sm:col-span-2">
+                  <label className="text-sm font-medium">Premierenankündigung</label>
+                  <Input type="date" name="revealDate" />
+                </div>
+              </div>
               </details>
 
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
## Summary
- erweitere die `Show`-Entität um das optionale Feld `finalRehearsalWeekStart`, binde es im Erstellungsformular ein und stelle mit einer neuen Server-Action das Aktualisieren in der Produktionsdetailansicht bereit
- liefere das Datum der Endprobenwoche über `/api/dashboard/overview` aus und zeige Mitgliedern im Dashboard eine Countdown-Kennzahl samt Parsing-Logik
- generiere den Prisma Client nach dem Schema-Update neu

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cff34143bc832da323a4f9ab1cfd5e