### PR TITLE
Use registry cache for Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,5 +85,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ matrix.build_args }}
-          cache-from: type=gha,scope=${{ matrix.environment }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.environment }}
+          cache-from: type=registry,ref=${{ env.WEBSITE_IMAGE_NAME }}:${{ matrix.environment }}-buildcache
+          cache-to: type=registry,ref=${{ env.WEBSITE_IMAGE_NAME }}:${{ matrix.environment }}-buildcache,mode=max,oci-mediatypes=true


### PR DESCRIPTION
## Summary
- adjust the docker-publish workflow to use registry-backed BuildKit cache images per environment instead of GitHub Actions cache

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cff8ed9eb8832d8a262d3956f84189