### PR TITLE
Ensure Prisma client is generated before production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "predev": "node scripts/run-prisma-migrate.mjs",
     "dev": "next dev --turbopack",
+    "prebuild": "pnpm prisma:generate",
     "build": "next build --turbopack",
     "prestart": "node scripts/run-prisma-migrate.mjs",
     "postinstall": "node -e \"if(!process.env.SKIP_PRISMA_POSTINSTALL){require('child_process').execSync('pnpm prisma:generate',{stdio:'inherit'})}\"",


### PR DESCRIPTION
## Summary
- add a `prebuild` script that runs `pnpm prisma:generate` so the Prisma client is always generated before the Next.js build

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cffe8d53f8832d856f98a8a55016b3