### PR TITLE
Show relative build age in footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,13 +66,19 @@ function getBuildInfo() {
     dateStyle: "short",
     timeStyle: "medium",
   }).format(buildDate);
+  const isoTimestamp = buildDate.toISOString();
 
   const commit = getCommitInfo();
 
   return {
     commit,
     timestamp,
-  } satisfies { commit: CommitInfo | null; timestamp: string };
+    isoTimestamp,
+  } satisfies {
+    commit: CommitInfo | null;
+    timestamp: string;
+    isoTimestamp: string;
+  };
 }
 
 function getCommitInfo(): CommitInfo | null {

--- a/src/components/build-info-timestamp.tsx
+++ b/src/components/build-info-timestamp.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+type BuildInfoTimestampProps = {
+  formattedTimestamp: string;
+  isoTimestamp: string;
+};
+
+const SECOND = 1;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30.4375 * DAY;
+const YEAR = 365.25 * DAY;
+
+function formatRelativeTime(
+  targetDate: Date,
+  formatter: Intl.RelativeTimeFormat,
+): string {
+  const now = Date.now();
+  const diffInSeconds = (targetDate.getTime() - now) / 1000;
+  const absoluteDiff = Math.abs(diffInSeconds);
+
+  if (absoluteDiff < MINUTE) {
+    return formatter.format(Math.round(diffInSeconds / SECOND), "second");
+  }
+
+  if (absoluteDiff < HOUR) {
+    return formatter.format(Math.round(diffInSeconds / MINUTE), "minute");
+  }
+
+  if (absoluteDiff < DAY) {
+    return formatter.format(Math.round(diffInSeconds / HOUR), "hour");
+  }
+
+  if (absoluteDiff < WEEK) {
+    return formatter.format(Math.round(diffInSeconds / DAY), "day");
+  }
+
+  if (absoluteDiff < MONTH) {
+    return formatter.format(Math.round(diffInSeconds / WEEK), "week");
+  }
+
+  if (absoluteDiff < YEAR) {
+    return formatter.format(Math.round(diffInSeconds / MONTH), "month");
+  }
+
+  return formatter.format(Math.round(diffInSeconds / YEAR), "year");
+}
+
+export function BuildInfoTimestamp({
+  formattedTimestamp,
+  isoTimestamp,
+}: BuildInfoTimestampProps) {
+  const buildDate = useMemo(() => new Date(isoTimestamp), [isoTimestamp]);
+  const relativeTimeFormatter = useMemo(
+    () => new Intl.RelativeTimeFormat("de", { numeric: "auto" }),
+    [],
+  );
+  const isValidTimestamp = !Number.isNaN(buildDate.getTime());
+  const [relativeTime, setRelativeTime] = useState(() =>
+    isValidTimestamp
+      ? formatRelativeTime(buildDate, relativeTimeFormatter)
+      : "",
+  );
+
+  useEffect(() => {
+    if (!isValidTimestamp) {
+      return;
+    }
+
+    const updateRelativeTime = () => {
+      setRelativeTime(formatRelativeTime(buildDate, relativeTimeFormatter));
+    };
+
+    updateRelativeTime();
+
+    const interval = window.setInterval(updateRelativeTime, 1000);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [buildDate, isValidTimestamp, relativeTimeFormatter]);
+
+  if (!isValidTimestamp) {
+    return <span>Stand {formattedTimestamp}</span>;
+  }
+
+  return (
+    <span className="inline-flex items-baseline gap-1">
+      <time dateTime={isoTimestamp}>Stand {formattedTimestamp}</time>
+      <span aria-hidden>({relativeTime})</span>
+      <span className="sr-only">, aktualisiert {relativeTime}</span>
+    </span>
+  );
+}

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { BuildInfoTimestamp } from "@/components/build-info-timestamp";
 import {
   ctaNavigation,
   primaryNavigation,
@@ -14,6 +15,7 @@ type CommitInfo = {
 type BuildInfo = {
   commit: CommitInfo | null;
   timestamp: string;
+  isoTimestamp: string;
 };
 
 type SiteFooterProps = {
@@ -128,10 +130,17 @@ export function SiteFooter({ buildInfo, isDevBuild }: SiteFooterProps) {
                 ) : (
                   "#unbekannt"
                 )}
-                {" "}· Stand {buildInfo.timestamp}
+                {" "}· {" "}
+                <BuildInfoTimestamp
+                  formattedTimestamp={buildInfo.timestamp}
+                  isoTimestamp={buildInfo.isoTimestamp}
+                />
               </>
             ) : (
-              <>Stand {buildInfo.timestamp}</>
+              <BuildInfoTimestamp
+                formattedTimestamp={buildInfo.timestamp}
+                isoTimestamp={buildInfo.isoTimestamp}
+              />
             )}
           </p>
         </div>


### PR DESCRIPTION
## Summary
- add the ISO build timestamp to the layout metadata so the footer has machine-readable timing information
- render the "Stand" information through a new client component that shows the relative age and updates every second

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d002bdd168832d8b0da05eb21f4bc7