### PR TITLE
Align marketing surfaces with tokens

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
@@ -136,14 +136,14 @@ export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: 
             </div>
             <div className="flex items-start gap-3">
               <div className="flex flex-wrap items-center gap-3 text-sm">
-                <span className="inline-flex items-center gap-1 rounded-full border border-emerald-300/50 bg-emerald-500/10 px-2 py-1 text-emerald-600">
-                  <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" /> {yes.length}
+                <span className="inline-flex items-center gap-1 rounded-full border border-success/45 bg-success/15 px-2 py-1 text-success">
+                  <span className="inline-block h-2 w-2 rounded-full bg-success" /> {yes.length}
                 </span>
-                <span className="inline-flex items-center gap-1 rounded-full border border-rose-300/50 bg-rose-500/10 px-2 py-1 text-rose-600">
-                  <span className="inline-block h-2 w-2 rounded-full bg-rose-500" /> {no.length}
+                <span className="inline-flex items-center gap-1 rounded-full border border-destructive/45 bg-destructive/15 px-2 py-1 text-destructive">
+                  <span className="inline-block h-2 w-2 rounded-full bg-destructive" /> {no.length}
                 </span>
-                <span className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-muted px-2 py-1 text-muted-foreground">
-                  <span className="inline-block h-2 w-2 rounded-full bg-slate-400" /> {pending.length}
+                <span className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-muted/60 px-2 py-1 text-muted-foreground">
+                  <span className="inline-block h-2 w-2 rounded-full bg-muted-foreground/70" /> {pending.length}
                 </span>
               </div>
               <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>

--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -31,14 +31,7 @@ export default async function ProduktionDetailPage({ params }: { params: { showI
   const [show, breakdownCount] = await Promise.all([
     prisma.show.findUnique({
       where: { id: params.showId },
-      select: {
-        id: true,
-        title: true,
-        year: true,
-        synopsis: true,
-        finalRehearsalWeekStart: true,
-        _count: { select: { characters: true, scenes: true } },
-      },
+      include: { _count: { select: { characters: true, scenes: true } } },
     }),
     prisma.sceneBreakdownItem.count({ where: { scene: { showId: params.showId } } }),
   ]);

--- a/src/app/chronik/page.tsx
+++ b/src/app/chronik/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import type { Prisma, Show } from "@prisma/client";
+import { Heading, Text } from "@/components/ui/typography";
 import { ChronikStacked } from "./stacked";
 import { ChronikTimeline } from "./timeline";
 
@@ -46,17 +47,19 @@ export default async function ChronikPage() {
 
   if (shows.length === 0) {
     return (
-      <div className="container mx-auto px-4 sm:px-6 py-12 sm:py-16">
-        <div className="max-w-2xl mx-auto text-center space-y-6">
-          <div className="w-24 h-24 mx-auto bg-gradient-to-br from-primary/20 to-primary/10 rounded-full flex items-center justify-center">
-            <svg className="w-12 h-12 text-primary/60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="layout-container py-16">
+        <div className="mx-auto max-w-2xl space-y-6 text-center">
+          <div className="mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-gradient-to-br from-primary/20 to-primary/10">
+            <svg className="h-12 w-12 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0118 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
             </svg>
           </div>
-          <h1 className="font-serif text-3xl text-foreground/90">Chronik erwacht bald</h1>
-          <p className="text-foreground/70 leading-relaxed">
+          <Heading level="h2" align="center">
+            Chronik erwacht bald
+          </Heading>
+          <Text tone="muted" align="center">
             Die Geschichten vergangener Sommer werden bald enthüllt. Hier werden die mystischen Momente unserer Aufführungen für die Ewigkeit bewahrt.
-          </p>
+          </Text>
         </div>
       </div>
     );
@@ -73,20 +76,16 @@ export default async function ChronikPage() {
   
   return (
     <div className="relative">
-      {/* Header Section */}
-      <div className="container mx-auto px-4 sm:px-6 py-12 sm:py-16 text-center space-y-6">
-        <h1 className="font-serif text-4xl sm:text-5xl lg:text-6xl text-white [text-shadow:_0_0_10px_rgba(0,0,0,0.9),_2px_2px_6px_rgba(0,0,0,0.8)]">
+      <div className="layout-container space-y-6 py-16 text-center">
+        <Heading level="h1" align="center">
           Chronik vergangener Sommer
-        </h1>
-        <p className="text-lg sm:text-xl text-white/90 max-w-2xl mx-auto [text-shadow:_0_0_8px_rgba(0,0,0,0.9),_1px_1px_4px_rgba(0,0,0,0.8)]">
+        </Heading>
+        <Text variant="bodyLg" tone="muted" align="center" className="mx-auto max-w-2xl">
           Eine Reise durch die mystischen Momente unserer Aufführungen
-        </p>
+        </Text>
       </div>
 
-      {/* Gallery Content */}
       <ChronikStacked items={items} />
-      
-      {/* Animated Bottom Timeline */}
       <ChronikTimeline items={items} />
     </div>
   );

--- a/src/app/chronik/stacked.tsx
+++ b/src/app/chronik/stacked.tsx
@@ -1,5 +1,6 @@
 "use client";
 import Image from "next/image";
+import { Heading, Text } from "@/components/ui/typography";
 
 type ChronikMeta = {
   author?: string | null;
@@ -27,7 +28,7 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
   const sorted = [...items].sort((a, b) => b.year - a.year);
 
   return (
-    <div className="space-y-12 lg:space-y-16 pb-24 container mx-auto px-4 sm:px-6">
+    <div className="layout-container space-y-12 pb-24 lg:space-y-16">
       {sorted.map((s, idx) => {
         const meta: ChronikMeta = s.meta ?? {};
         const sources = toStringArray(meta.sources);
@@ -35,7 +36,7 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
           <section
             key={s.id}
             id={s.id}
-            className="group relative overflow-hidden rounded-2xl sm:rounded-3xl border border-border/30 shadow-2xl transition-all duration-500 hover:scale-[1.02] hover:shadow-3xl"
+            className="group relative overflow-hidden rounded-2xl border border-border/60 shadow-2xl transition-all duration-500 hover:scale-[1.02] hover:shadow-3xl sm:rounded-3xl"
           >
             <div className="relative h-[60vh] sm:h-[70vh] lg:h-[75vh] xl:h-[65vh] 2xl:h-[60vh] w-full max-h-[800px]">
               {s.posterUrl && (
@@ -48,43 +49,46 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
                 />
               )}
               {/* Enhanced overlays */}
-              <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+              <div className="absolute inset-0 bg-gradient-to-t from-[color:color-mix(in_oklab,var(--foreground)_70%,transparent)] via-[color:color-mix(in_oklab,var(--foreground)_30%,transparent)] to-transparent" />
               <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-background/90" />
               <div className="absolute inset-0 bg-[radial-gradient(ellipse_60rem_40rem_at_30%_70%,_color-mix(in_oklab,var(--primary)_12%,transparent),transparent_80%)]" />
 
               <div className="absolute inset-0 flex items-end">
                 <div className="w-full p-6 sm:p-8">
-                  <div className="max-w-5xl mx-auto rounded-2xl border border-white/10 bg-black/20 p-5 sm:p-6 lg:p-8 xl:p-10 backdrop-blur-sm shadow-2xl transition-all duration-500 group-hover:bg-black/30">
-                    <div className="inline-flex items-center gap-2 px-3 py-1 bg-primary/20 border border-primary/30 rounded-full text-sm text-primary font-medium">
+                  <div className="mx-auto max-w-5xl rounded-2xl border border-border/60 bg-background/70 p-5 shadow-2xl backdrop-blur transition-all duration-500 group-hover:bg-background/80 sm:p-6 lg:p-8 xl:p-10">
+                    <div className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/15 px-3 py-1 text-sm font-medium text-primary">
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
                       </svg>
                       {s.year}
                     </div>
-                    <h2 className="mt-4 font-serif text-3xl md:text-4xl lg:text-5xl xl:text-4xl 2xl:text-5xl text-white [text-shadow:_0_0_10px_rgba(0,0,0,0.9),_2px_2px_6px_rgba(0,0,0,0.8)] leading-tight max-w-4xl">
+                    <Heading
+                      level="h2"
+                      className="mt-4 max-w-4xl text-balance leading-tight [text-shadow:_0_0_14px_rgba(0,0,0,0.55)]"
+                    >
                       {s.title ?? `Saison ${s.year}`}
-                    </h2>
-                    
-                    <div className="mt-6 grid gap-x-8 gap-y-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-3 text-white/90">
+                    </Heading>
+
+                    <div className="mt-6 grid gap-x-8 gap-y-3 text-foreground/90 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-3">
                       {meta?.author && (
-                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.8)]">
-                          <svg className="w-4 h-4 text-primary/80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.5)]">
+                          <svg className="h-4 w-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                           </svg>
                           <span className="font-medium">Autor:</span> {meta.author}
                         </div>
                       )}
                       {meta?.director && (
-                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.8)]">
-                          <svg className="w-4 h-4 text-primary/80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.5)]">
+                          <svg className="h-4 w-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 4V2a1 1 0 011-1h8a1 1 0 011 1v2m0 0V3a1 1 0 011 1v10a1 1 0 01-1 1H8a1 1 0 01-1-1V4a1 1 0 011-1V2" />
                           </svg>
                           <span className="font-medium">Regie:</span> {meta.director}
                         </div>
                       )}
                       {meta?.venue && (
-                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.8)]">
-                          <svg className="w-4 h-4 text-primary/80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.5)]">
+                          <svg className="h-4 w-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
                           </svg>
@@ -92,19 +96,19 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
                         </div>
                       )}
                       {meta?.ticket_info && (
-                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.8)]">
-                          <svg className="w-4 h-4 text-primary/80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <div className="flex items-center gap-2 text-sm [text-shadow:_1px_1px_3px_rgba(0,0,0,0.5)]">
+                          <svg className="h-4 w-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
                           </svg>
                           <span className="font-medium">Tickets:</span> {meta.ticket_info}
                         </div>
                       )}
                     </div>
-                    
+
                     {s.synopsis && (
-                      <p className="mt-6 text-base lg:text-lg xl:text-xl text-white/90 leading-relaxed [text-shadow:_1px_1px_3px_rgba(0,0,0,0.8)] max-w-4xl">
+                      <Text className="mt-6 max-w-4xl text-base leading-relaxed text-foreground/90 [text-shadow:_1px_1px_3px_rgba(0,0,0,0.45)] lg:text-lg xl:text-xl">
                         {s.synopsis}
-                      </p>
+                      </Text>
                     )}
                     {sources.length > 0 && (
                       <div className="mt-8 flex flex-wrap gap-3">
@@ -114,7 +118,7 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
                             href={src}
                             target="_blank"
                             rel="noreferrer"
-                            className="inline-flex items-center gap-2 px-4 py-2 bg-white/10 hover:bg-white/20 border border-white/20 hover:border-white/30 rounded-full text-sm text-white backdrop-blur-sm transition-all duration-200 hover:scale-105 [text-shadow:_1px_1px_2px_rgba(0,0,0,0.8)]"
+                            className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-4 py-2 text-sm text-foreground transition-all duration-200 hover:scale-105 hover:border-primary/50 hover:bg-background/80 backdrop-blur-sm"
                           >
                             <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />

--- a/src/app/chronik/timeline.tsx
+++ b/src/app/chronik/timeline.tsx
@@ -77,9 +77,9 @@ export function ChronikTimeline({ items }: { items: ChronikItem[] }) {
   return (
     <div className="px-4 pb-12 sm:px-0 sm:pb-0">
       <div className="relative w-full sm:fixed sm:bottom-8 sm:left-1/2 sm:z-40 sm:w-auto sm:-translate-x-1/2 sm:transform">
-        <div className="relative overflow-hidden rounded-xl border border-white/10 bg-black/65 px-5 py-4 shadow-xl backdrop-blur-lg sm:rounded-2xl sm:px-8">
+        <div className="relative overflow-hidden rounded-xl border border-border/60 bg-background/80 px-5 py-4 shadow-xl backdrop-blur-lg sm:rounded-2xl sm:px-8">
           <div className="pointer-events-none absolute inset-0 rounded-xl bg-gradient-to-r from-primary/5 via-primary/10 to-primary/5 sm:rounded-2xl" />
-          <div className="pointer-events-none absolute top-2 left-4 right-4 h-0.5 rounded-full bg-white/10" />
+          <div className="pointer-events-none absolute top-2 left-4 right-4 h-0.5 rounded-full bg-border/60" />
           <div
             className="pointer-events-none absolute top-2 left-4 h-0.5 rounded-full bg-gradient-to-r from-primary to-primary/60 transition-all duration-500 ease-out"
             style={{ width: `${completion}%` }}
@@ -95,19 +95,21 @@ export function ChronikTimeline({ items }: { items: ChronikItem[] }) {
                 <button
                   key={item.id}
                   onClick={() => scrollToSection(item.id)}
-                  className="group relative m-1 flex min-w-fit flex-col items-center gap-2 rounded-lg p-3 transition-all duration-300 hover:scale-105 focus:outline-none"
+                  className={cn(
+                    "group relative m-1 flex min-w-fit flex-col items-center gap-2 rounded-lg p-3 transition-all duration-300 hover:scale-105 focus:outline-none",
+                    isActive ? "ring-2 ring-primary/70" : "ring-1 ring-border/50",
+                  )}
                   title={item.title || `Saison ${item.year}`}
-                  style={{ boxShadow: isActive ? "0 0 0 2px rgba(184, 139, 46, 0.5)" : "none" }}
                 >
                   <div className="relative">
                     <div
                       className={cn(
                         "h-4 w-4 rounded-full border-2 transition-all duration-500",
-                        isActive && "scale-110 bg-primary border-primary shadow-lg shadow-primary/50",
+                        isActive && "scale-110 border-primary bg-primary shadow-lg shadow-primary/40",
                         !isActive &&
                           (isPast
-                            ? "bg-primary/60 border-primary/60 shadow-md shadow-primary/25"
-                            : "border-white/40 bg-transparent group-hover:scale-110 group-hover:border-primary group-hover:bg-primary/20"),
+                            ? "border-primary/50 bg-primary/40 shadow-md shadow-primary/25"
+                            : "border-border/60 bg-transparent group-hover:scale-110 group-hover:border-primary group-hover:bg-primary/15"),
                       )}
                     />
                     {isActive && (
@@ -120,9 +122,9 @@ export function ChronikTimeline({ items }: { items: ChronikItem[] }) {
 
                   <span
                     className={cn(
-                      "text-sm font-semibold [text-shadow:_1px_1px_3px_rgba(0,0,0,0.9)] transition-all duration-300",
+                      "text-sm font-semibold transition-all duration-300",
                       isActive && "scale-105 text-primary",
-                      !isActive && (isPast ? "text-primary/80" : "text-white/70 group-hover:scale-105 group-hover:text-white"),
+                      !isActive && (isPast ? "text-primary/80" : "text-muted-foreground group-hover:scale-105 group-hover:text-foreground"),
                     )}
                   >
                     {item.year}

--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -1,27 +1,37 @@
+import { Heading, Text } from "@/components/ui/typography";
+
 export default function ImpressumPage() {
   return (
-    <div className="container mx-auto px-6 py-8 space-y-4">
-      <h1 className="font-serif text-3xl">Impressum</h1>
-      <p>Bitte Platzhalter durch echte Schultheater- bzw. Anbieter-Daten ersetzen.</p>
-      <div>
-        <h2 className="text-xl font-semibold">Schultheater</h2>
-        <p>Schultheater „Sommertheater im Schlosspark Altrossthal“</p>
-        <p>Altrossthal 1, 01169 Dresden</p>
-        <p>Vertreten durch die Projektleitung (Vorname Nachname)</p>
+    <div className="layout-container space-y-6 py-12">
+      <Heading level="h1">Impressum</Heading>
+      <Text tone="muted">Bitte Platzhalter durch echte Schultheater- bzw. Anbieter-Daten ersetzen.</Text>
+      <div className="space-y-2">
+        <Heading level="h3" className="text-xl" weight="bold">
+          Schultheater
+        </Heading>
+        <Text>Schultheater „Sommertheater im Schlosspark Altrossthal“</Text>
+        <Text>Altrossthal 1, 01169 Dresden</Text>
+        <Text>Vertreten durch die Projektleitung (Vorname Nachname)</Text>
       </div>
-      <div>
-        <h2 className="text-xl font-semibold">Kontakt</h2>
-        <p>E-Mail: kontakt@example.org</p>
-        <p>Telefon: +49 (0) 000 000 00</p>
+      <div className="space-y-2">
+        <Heading level="h3" className="text-xl" weight="bold">
+          Kontakt
+        </Heading>
+        <Text>E-Mail: kontakt@example.org</Text>
+        <Text>Telefon: +49 (0) 000 000 00</Text>
       </div>
-      <div>
-        <h2 className="text-xl font-semibold">Schule / Träger</h2>
-        <p>Schule: Gymnasium Altrossthal (Platzhalter)</p>
-        <p>Schulträger: Landeshauptstadt Dresden (Platzhalter)</p>
+      <div className="space-y-2">
+        <Heading level="h3" className="text-xl" weight="bold">
+          Schule / Träger
+        </Heading>
+        <Text>Schule: Gymnasium Altrossthal (Platzhalter)</Text>
+        <Text>Schulträger: Landeshauptstadt Dresden (Platzhalter)</Text>
       </div>
-      <div>
-        <h2 className="text-xl font-semibold">Haftung</h2>
-        <p>Inhalte mit Sorgfalt erstellt. Keine Haftung für externe Links.</p>
+      <div className="space-y-2">
+        <Heading level="h3" className="text-xl" weight="bold">
+          Haftung
+        </Heading>
+        <Text>Inhalte mit Sorgfalt erstellt. Keine Haftung für externe Links.</Text>
       </div>
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,8 +45,8 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   themeColor: [
-    { media: "(prefers-color-scheme: dark)", color: "#b68b2e" },
-    { color: "#b68b2e" },
+    { media: "(prefers-color-scheme: dark)", color: "oklch(0.75 0.14 63.3)" },
+    { color: "oklch(0.78 0.146 63.3)" },
   ],
   colorScheme: "dark",
 };

--- a/src/app/mystery/page.tsx
+++ b/src/app/mystery/page.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import type { Clue, Prisma } from "@prisma/client";
 import Image from "next/image";
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 type ClueContent = {
   text?: string;
@@ -36,11 +37,11 @@ export default async function MysteryPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 sm:px-6 py-10 space-y-6">
-      <h1 className="font-serif text-3xl">Das Geheimnis</h1>
-      {clues.length === 0 && <p>Die Schatten sind noch still…</p>}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {clues.map((c) => {
+    <div className="layout-container space-y-6 py-12">
+      <Heading level="h1">Das Geheimnis</Heading>
+      {clues.length === 0 && <Text tone="muted">Die Schatten sind noch still…</Text>}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {clues.map((c) => {
           const content = parseClueContent(c.content);
           return (
             <Card key={c.id}>
@@ -48,13 +49,13 @@ export default async function MysteryPage() {
                 Hinweis {c.index} • {c.points} Punkte
               </CardTitle>
               <CardContent>
-                {c.type === "text" && <p>{content.text}</p>}
+                {c.type === "text" && <Text>{content.text}</Text>}
                 {c.type === "image" && (
                   <div className="relative w-full h-64">
                     <Image src={content.url ?? "/next.svg"} alt={content.alt ?? "Hinweis"} fill className="object-contain" />
                   </div>
                 )}
-                {c.type !== "text" && c.type !== "image" && <p>Ein Rätsel wartet…</p>}
+                {c.type !== "text" && c.type !== "image" && <Text>Ein Rätsel wartet…</Text>}
               </CardContent>
             </Card>
           );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,38 +41,43 @@ export default function Home() {
   return (
     <div>
       <Hero images={heroImages} />
-      <div className="container mx-auto px-4 sm:px-6">
-        <div className="space-y-8 py-12 sm:py-16">
-          <section className="py-6 text-center sm:py-8">
-            <Text tone="muted" className="mt-2 text-sm opacity-80 sm:text-base">
-              Ein einziges Wochenende. Ein Sommer. Ein Stück.
+      <div className="layout-container">
+        <div className="space-y-12 py-16">
+          <section className="flex flex-col items-center gap-4 text-center">
+            <Text variant="eyebrow" uppercase tone="primary">
+              Sommertheater Altrossthal
             </Text>
-            <Heading level="h3" className="mt-4 text-xl text-foreground sm:text-2xl">
+            <Heading level="h3" align="center" tone="default">
               Countdown: bald verfügbar…
             </Heading>
+            <Text variant="bodyLg" align="center" tone="muted">
+              Ein einziges Wochenende. Ein Sommer. Ein Stück.
+            </Text>
           </section>
           <Card>
-            <CardTitle className="p-4">Teaser-Hinweis</CardTitle>
-            <CardContent>Folge den Spuren im Nebel…</CardContent>
+            <CardTitle className="px-6 pt-6 text-sm font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+              Teaser-Hinweis
+            </CardTitle>
+            <CardContent className="pb-6 text-muted-foreground">Folge den Spuren im Nebel…</CardContent>
           </Card>
-          <section className="relative overflow-hidden rounded-3xl border border-slate-100/10 bg-slate-900 text-slate-50 shadow-2xl">
+          <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-card/90 text-card-foreground shadow-2xl">
             <div
-              className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.35),_transparent_60%),radial-gradient(circle_at_bottom,_rgba(14,165,233,0.25),_transparent_55%)]"
+              className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_color-mix(in_oklab,var(--primary)_35%,transparent),_transparent_60%),radial-gradient(circle_at_bottom,_color-mix(in_oklab,var(--info)_25%,transparent),_transparent_55%)]"
               aria-hidden="true"
             />
-            <div className="relative mx-auto max-w-4xl space-y-8 px-6 py-12 sm:px-10 sm:py-16">
-              <div className="space-y-4 text-center sm:space-y-5">
+            <div className="relative mx-auto max-w-4xl space-y-8 px-8 py-14 sm:px-12">
+              <div className="space-y-4 text-center">
                 <Badge
-                  variant="ghost"
+                  variant="outline"
                   size="sm"
-                  className="inline-flex rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-indigo-200 shadow-sm"
+                  className="inline-flex rounded-full border-primary/40 bg-primary/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary shadow-sm"
                 >
                   FAQ
                 </Badge>
-                <Heading level="h2" className="text-3xl font-semibold text-white sm:text-4xl">
+                <Heading level="h2" align="center">
                   Häufig gestellte Fragen
                 </Heading>
-                <Text variant="bodyLg" tone="muted" className="text-slate-200 sm:text-lg">
+                <Text variant="bodyLg" align="center" tone="muted">
                   Die wichtigsten Antworten rund um das Sommertheater – kompakt und jederzeit nachlesbar.
                 </Text>
               </div>
@@ -80,19 +85,13 @@ export default function Home() {
                 {faqs.map((faq) => (
                   <details
                     key={faq.question}
-                    className="group rounded-2xl border border-white/10 bg-white/10 p-6 text-left shadow-lg backdrop-blur transition duration-300 open:border-white/20 open:bg-white/20"
+                    className="group rounded-2xl border border-border/60 bg-background/60 p-6 text-left shadow-lg backdrop-blur transition duration-300 open:border-primary/40 open:bg-background/80"
                   >
                     <summary className="flex cursor-pointer list-none items-center justify-between gap-4">
-                      <Text
-                        asChild
-                        variant="bodyLg"
-                        tone="default"
-                        weight="semibold"
-                        className="text-slate-50 sm:text-xl"
-                      >
+                      <Text asChild variant="bodyLg" weight="semibold">
                         <span>{faq.question}</span>
                       </Text>
-                      <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-indigo-100 transition duration-300 group-open:rotate-180">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/50 bg-background/70 text-primary transition duration-300 group-open:rotate-180">
                         <svg
                           className="h-4 w-4"
                           viewBox="0 0 24 24"
@@ -107,12 +106,14 @@ export default function Home() {
                         </svg>
                       </span>
                     </summary>
-                    <Text className="mt-4 text-base leading-relaxed text-indigo-100">{faq.answer}</Text>
+                    <Text tone="muted" className="mt-4 leading-relaxed">
+                      {faq.answer}
+                    </Text>
                   </details>
                 ))}
               </div>
-              <div className="rounded-2xl border border-white/10 bg-white/10 px-6 py-5 text-sm text-slate-100 backdrop-blur sm:text-base">
-                <Text tone="default" className="text-slate-100">
+              <div className="rounded-2xl border border-border/60 bg-background/70 px-6 py-5 text-sm text-muted-foreground backdrop-blur">
+                <Text>
                   Noch Fragen offen? Schreib uns jederzeit an
                   <TextLink className="ml-2" href="mailto:hallo@sommertheater.de" variant="accent" weight="semibold">
                     hallo@sommertheater.de

--- a/src/app/ueber-uns/page.tsx
+++ b/src/app/ueber-uns/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Heading, Text } from "@/components/ui/typography";
 
 export const metadata: Metadata = {
   title: "Über uns",
@@ -173,18 +174,22 @@ export default function AboutPage() {
         />
       </div>
 
-      <section className="container mx-auto px-4 sm:px-6 pt-16 sm:pt-24 pb-12">
+      <section className="layout-container pb-12 pt-16 sm:pt-24">
         <div className="max-w-3xl">
-          <p className="text-sm font-medium uppercase tracking-[0.2em] text-primary/80">Sommertheater Altrossthal</p>
-          <h1 className="mt-4 font-serif text-4xl tracking-tight sm:text-5xl">Über uns</h1>
-          <p className="mt-6 text-lg text-muted-foreground">
+          <Text variant="eyebrow" uppercase tone="primary">
+            Sommertheater Altrossthal
+          </Text>
+          <Heading level="h1" className="mt-4">
+            Über uns
+          </Heading>
+          <Text variant="bodyLg" tone="muted" className="mt-6">
             Wir erzählen Geschichten für laue Sommernächte. Unser Ensemble verbindet professionelle Theaterarbeit mit ehrenamtlichem Herzblut – mitten im
             Schlosspark Altrossthal.
-          </p>
-          <p className="mt-4 text-base text-muted-foreground">
+          </Text>
+          <Text tone="muted" className="mt-4">
             Gegründet wurde das Sommertheater 2009 vom damaligen Schüler Toni Burghard Friedrich. Seitdem treffen sich Lernende, Alumni und Freund:innen des
             BSZ Altroßthal, um eine Bühne zu schaffen, die weit über klassischen Unterricht hinausgeht.
-          </p>
+          </Text>
         </div>
 
         <div className="mt-10 grid gap-4 sm:grid-cols-3">
@@ -202,15 +207,15 @@ export default function AboutPage() {
         </div>
       </section>
 
-      <section className="container mx-auto px-4 sm:px-6 pb-16 sm:pb-24">
+      <section className="layout-container pb-16 sm:pb-24">
         <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
           <div className="space-y-6">
-            <h2 className="font-serif text-3xl sm:text-4xl">Unsere Handschrift</h2>
-            <p className="text-lg text-muted-foreground">
+            <Heading level="h2">Unsere Handschrift</Heading>
+            <Text variant="bodyLg" tone="muted">
               Die Sommerproduktionen entstehen über Monate hinweg – von der ersten Idee bis zur letzten Generalprobe. Dabei verbinden wir poetische Stoffe mit
               immersiven Erlebnissen, die nur unter freiem Himmel möglich sind. Werkstätten für Floristik, Holz- und Metallgestaltung sowie Maskenbild des
               Berufsschulzentrums fließen direkt in Bühnenwelten ein.
-            </p>
+            </Text>
             <div className="space-y-5">
               {signature.map(({ icon: Icon, title, description }) => (
                 <div
@@ -221,8 +226,12 @@ export default function AboutPage() {
                     <Icon className="h-6 w-6" aria-hidden />
                   </div>
                   <div>
-                    <h3 className="text-lg font-semibold">{title}</h3>
-                    <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+                    <Heading level="h4" className="text-lg" weight="bold">
+                      {title}
+                    </Heading>
+                    <Text variant="small" tone="muted" className="mt-1">
+                      {description}
+                    </Text>
                   </div>
                 </div>
               ))}
@@ -232,26 +241,28 @@ export default function AboutPage() {
           <div className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/10 via-background to-background p-8 shadow-lg">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(248,223,150,0.18),_transparent_60%)]" aria-hidden />
             <div className="relative space-y-4">
-              <p className="text-sm font-medium uppercase tracking-[0.2em] text-primary/80">Atmosphäre</p>
-              <p className="font-serif text-2xl">
+              <Text variant="eyebrow" uppercase tone="primary">
+                Atmosphäre
+              </Text>
+              <Heading level="h3" className="text-2xl">
                 Wenn die Sonne hinter den Baumwipfeln verschwindet, beginnt unser Bühnenraum zu leben: leuchtende Pfade, flüsternde Bäume und ein Ensemble, das
                 das Publikum mitnimmt in eine andere Welt.
-              </p>
-              <p className="text-sm text-muted-foreground">
+              </Heading>
+              <Text variant="small" tone="muted">
                 Jedes Szenenbild wird speziell für den Schlosspark entwickelt. Lichtinstallationen und räumlicher Klang lassen die Besucher:innen mitten in der
                 Geschichte stehen.
-              </p>
+              </Text>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="container mx-auto px-4 sm:px-6 pb-16 sm:pb-24">
+      <section className="layout-container pb-16 sm:pb-24">
         <div className="max-w-2xl">
-          <h2 className="font-serif text-3xl sm:text-4xl">Werte, die wir leben</h2>
-          <p className="mt-4 text-lg text-muted-foreground">
+          <Heading level="h2">Werte, die wir leben</Heading>
+          <Text variant="bodyLg" tone="muted" className="mt-4">
             Ensemblearbeit bedeutet Vertrauen. Unsere Werte spiegeln sich in jeder Probe, jedem Ehrenamt und jedem Gast wider, der den Weg nach Altrossthal findet.
-          </p>
+          </Text>
         </div>
         <div className="mt-10 grid gap-6 md:grid-cols-3">
           {values.map(({ icon: Icon, title, description }) => (
@@ -262,20 +273,22 @@ export default function AboutPage() {
               </CardHeader>
               <CardContent>
                 <CardTitle className="text-xl">{title}</CardTitle>
-                <p className="mt-2 text-sm text-muted-foreground">{description}</p>
+                <Text variant="small" tone="muted" className="mt-2">
+                  {description}
+                </Text>
               </CardContent>
             </Card>
           ))}
         </div>
       </section>
 
-      <section className="container mx-auto px-4 sm:px-6 pb-16 sm:pb-24">
+      <section className="layout-container pb-16 sm:pb-24">
         <div className="grid gap-10 lg:grid-cols-2">
           <div>
-            <h2 className="font-serif text-3xl sm:text-4xl">Meilensteine</h2>
-            <p className="mt-4 text-lg text-muted-foreground">
+            <Heading level="h2">Meilensteine</Heading>
+            <Text variant="bodyLg" tone="muted" className="mt-4">
               Wir wachsen organisch und mit viel Leidenschaft. Ein paar Stationen auf unserem Weg:
-            </p>
+            </Text>
           </div>
           <div className="relative">
             <div className="absolute left-3 top-1 bottom-1 w-px bg-gradient-to-b from-primary/60 via-primary/20 to-transparent" aria-hidden />
@@ -285,8 +298,12 @@ export default function AboutPage() {
                   <div className="absolute left-0 top-1.5 flex h-6 w-6 items-center justify-center rounded-full border border-primary/50 bg-primary/20 text-primary">
                     <span className="text-xs font-semibold">{milestone.year}</span>
                   </div>
-                  <h3 className="text-lg font-semibold">{milestone.title}</h3>
-                  <p className="mt-2 text-sm text-muted-foreground">{milestone.description}</p>
+                  <Heading level="h4" className="text-lg" weight="bold">
+                    {milestone.title}
+                  </Heading>
+                  <Text variant="small" tone="muted" className="mt-2">
+                    {milestone.description}
+                  </Text>
                 </li>
               ))}
             </ul>
@@ -294,15 +311,15 @@ export default function AboutPage() {
         </div>
       </section>
 
-      <section className="container mx-auto px-4 sm:px-6 pb-20 sm:pb-28">
+      <section className="layout-container pb-20 sm:pb-28">
         <div className="rounded-3xl border border-border/40 bg-card/60 p-8 sm:p-12">
           <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
             <div className="space-y-5">
-              <h2 className="font-serif text-3xl sm:text-4xl">Engagement rund um das Ensemble</h2>
-              <p className="text-lg text-muted-foreground">
+              <Heading level="h2">Engagement rund um das Ensemble</Heading>
+              <Text variant="bodyLg" tone="muted">
                 Unser Sommertheater lebt von Menschen, die ihre Zeit und ihr Können einbringen. Wir begleiten neue Mitglieder mit Mentoring-Formaten, öffnen die
                 Werkstätten des BSZ Altroßthal für Floristik, Holz und Metall und bieten Fortbildungen für Licht, Ton und Bühnenbild an.
-              </p>
+              </Text>
               <div className="flex items-center gap-3 text-sm text-muted-foreground">
                 <MapPin className="h-5 w-5 text-primary" aria-hidden />
                 <span>Schlosspark Altrossthal · Probenscheune im Alten Forsthaus</span>
@@ -311,8 +328,12 @@ export default function AboutPage() {
             <div className="grid gap-4 sm:grid-cols-2">
               {engagement.map((item) => (
                 <div key={item.title} className="rounded-2xl border border-border/40 bg-background/70 p-5">
-                  <h3 className="text-lg font-semibold">{item.title}</h3>
-                  <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
+                  <Heading level="h4" className="text-lg" weight="bold">
+                    {item.title}
+                  </Heading>
+                  <Text variant="small" tone="muted" className="mt-2">
+                    {item.description}
+                  </Text>
                   <Link
                     href={item.action.href}
                     className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:text-primary/80"

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -31,7 +31,9 @@ export function Hero({ images }: { images: string[] }) {
       </div>
       
       {/* Lighter overlays for better image visibility */}
-      <div className="absolute inset-0 z-10 bg-gradient-to-t from-black/60 via-black/20 to-transparent pointer-events-none" />
+      <div
+        className="absolute inset-0 z-10 bg-gradient-to-t from-[color:color-mix(in_oklab,var(--foreground)_65%,transparent)] via-[color:color-mix(in_oklab,var(--foreground)_25%,transparent)] to-transparent pointer-events-none"
+      />
       <div className="absolute inset-0 z-10 bg-gradient-to-b from-transparent via-transparent to-background/80 pointer-events-none" />
       
       {/* Subtle mystical color overlays */}
@@ -49,35 +51,35 @@ export function Hero({ images }: { images: string[] }) {
           >
             <div className="flex flex-col items-center gap-6 md:gap-7 lg:gap-9">
               <Badge
-                variant="ghost"
+                variant="outline"
                 size="sm"
-                className="rounded-full border border-white/20 bg-white/10 px-5 py-2 text-[11px] font-semibold uppercase tracking-[0.28em] text-indigo-100 shadow-lg backdrop-blur"
+                className="rounded-full border-primary/50 bg-primary/15 px-5 py-2 text-[11px] font-semibold uppercase tracking-[0.28em] text-primary shadow-lg backdrop-blur"
               >
                 Sommer 2025
               </Badge>
               <Heading
                 level="display"
-                className="text-balance text-white [text-shadow:_0_0_14px_rgba(0,0,0,0.85),_2px_2px_8px_rgba(0,0,0,0.65)]"
+                className="text-balance text-foreground [text-shadow:_0_0_18px_rgba(0,0,0,0.55)]"
               >
                 Magische Nächte unter freiem Himmel
               </Heading>
               <Text
                 variant="lead"
                 tone="default"
-                className="mx-auto max-w-2xl text-balance text-white/95 [text-shadow:_0_0_10px_rgba(0,0,0,0.65)]"
+                className="mx-auto max-w-2xl text-balance text-foreground/90 [text-shadow:_0_0_14px_rgba(0,0,0,0.5)]"
               >
                 Das Ensemble des Sommertheaters lädt zu einem neuen Erlebnis aus Licht, Musik und
                 Erzählung ein – nur an einem Wochenende im Schlosspark.
               </Text>
               <div className="flex flex-col items-center gap-6">
-                <ul className="grid gap-3 text-sm font-medium text-white/80 md:grid-cols-3 md:gap-4">
-                  <li className="rounded-full border border-white/20 bg-black/20 px-5 py-2 shadow-md backdrop-blur">
+                <ul className="grid gap-3 text-sm font-medium text-foreground/90 md:grid-cols-3 md:gap-4">
+                  <li className="rounded-full border border-border/60 bg-background/70 px-5 py-2 shadow-md backdrop-blur">
                     Live-Orchester &amp; Chor
                   </li>
-                  <li className="rounded-full border border-white/20 bg-black/20 px-5 py-2 shadow-md backdrop-blur">
+                  <li className="rounded-full border border-border/60 bg-background/70 px-5 py-2 shadow-md backdrop-blur">
                     Immersive Lichtinstallationen
                   </li>
-                  <li className="rounded-full border border-white/20 bg-black/20 px-5 py-2 shadow-md backdrop-blur">
+                  <li className="rounded-full border border-border/60 bg-background/70 px-5 py-2 shadow-md backdrop-blur">
                     Familienfreundliches Rahmenprogramm
                   </li>
                 </ul>
@@ -89,7 +91,7 @@ export function Hero({ images }: { images: string[] }) {
                     variant="ghost"
                     asChild
                     size="lg"
-                    className="border border-white/40 bg-white/10 px-8 py-5 text-base text-white shadow-lg backdrop-blur hover:border-white/60 hover:bg-white/20 md:text-lg"
+                    className="border border-border/60 bg-background/70 px-8 py-5 text-base text-foreground shadow-lg backdrop-blur hover:border-primary/60 hover:bg-background/80 md:text-lg"
                   >
                     <Link href="/chronik">Rückblick 2024</Link>
                   </Button>

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -101,8 +101,8 @@ const ONBOARDING_FOCUS_DESCRIPTIONS: Record<"acting" | "tech" | "both", string> 
 };
 
 const ONBOARDING_DOMAIN_ACCENT: Record<"acting" | "crew", string> = {
-  acting: "from-violet-500/70 to-fuchsia-500/70",
-  crew: "from-cyan-500/70 to-teal-500/70",
+  acting: "from-primary/60 via-primary/30 to-transparent",
+  crew: "from-info/60 via-info/30 to-transparent",
 };
 
 const ONBOARDING_PHOTO_STATUS_LABELS: Record<OnboardingPhotoStatus, string> = {
@@ -113,10 +113,10 @@ const ONBOARDING_PHOTO_STATUS_LABELS: Record<OnboardingPhotoStatus, string> = {
 };
 
 const ONBOARDING_PHOTO_STATUS_CLASSES: Record<OnboardingPhotoStatus, string> = {
-  none: "border-border/60 bg-muted/40 text-muted-foreground",
-  pending: "border-amber-400/40 bg-amber-50 text-amber-700",
-  approved: "border-emerald-400/40 bg-emerald-50 text-emerald-700",
-  rejected: "border-red-400/40 bg-red-50 text-red-700",
+  none: "border border-border/60 bg-muted/40 text-muted-foreground",
+  pending: "border border-warning/45 bg-warning/15 text-warning",
+  approved: "border border-success/45 bg-success/15 text-success",
+  rejected: "border border-destructive/45 bg-destructive/15 text-destructive",
 };
 
 const DIETARY_LEVEL_LABELS: Record<string, string> = {
@@ -430,12 +430,12 @@ export function MembersDashboard() {
   const getActivityIcon = useCallback((type: RecentActivity["type"]) => {
     switch (type) {
       case "attendance":
-        return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+        return <CheckCircle2 className="h-4 w-4 text-success" />;
       case "rehearsal":
-        return <Calendar className="h-4 w-4 text-blue-500" />;
+        return <Calendar className="h-4 w-4 text-info" />;
       case "notification":
       default:
-        return <Bell className="h-4 w-4 text-purple-500" />;
+        return <Bell className="h-4 w-4 text-accent" />;
     }
   }, []);
 
@@ -499,9 +499,9 @@ export function MembersDashboard() {
     const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
 
     if (diffDays > 0) {
-      let tone: "info" | "warning" | "danger" = "info";
+      let tone: "info" | "warning" | "destructive" = "info";
       if (diffDays <= 3) {
-        tone = "danger";
+        tone = "destructive";
       } else if (diffDays <= 7) {
         tone = "warning";
       }
@@ -564,11 +564,11 @@ export function MembersDashboard() {
       ? new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(onboarding.completedAt)
       : null;
     const statusBadge = onboarding.completed ? (
-      <Badge variant="secondary" className="bg-emerald-100 text-emerald-700">
+      <Badge variant="secondary" className="border-success/45 bg-success/15 text-success">
         Abgeschlossen
       </Badge>
     ) : (
-      <Badge variant="outline" className="border-amber-400/40 text-amber-700">
+      <Badge variant="outline" className="border-warning/45 text-warning">
         In Bearbeitung
       </Badge>
     );
@@ -708,7 +708,7 @@ export function MembersDashboard() {
             </div>
             <p className="text-xs text-muted-foreground">{photoText}</p>
             {!onboarding.photoConsent.hasDocument && onboarding.photoConsent.consentGiven && (
-              <p className="text-[11px] text-amber-600">Hinweis: Dokument noch ausstehend.</p>
+              <p className="text-[11px] text-warning">Hinweis: Dokument noch ausstehend.</p>
             )}
             {photoUpdatedLabel ? (
               <p className="text-[11px] text-muted-foreground">Zuletzt aktualisiert am {photoUpdatedLabel}</p>
@@ -843,7 +843,7 @@ export function MembersDashboard() {
                 {onlineList.map((user) => (
                   <li key={`${user.id}-${user.joinedAt.getTime()}`} className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
-                      <div className="h-2.5 w-2.5 rounded-full bg-green-500" />
+                      <div className="h-2.5 w-2.5 rounded-full bg-success" />
                       <span className="text-sm font-medium">{user.name}</span>
                     </div>
                     <span className="text-xs text-muted-foreground">

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -32,13 +32,13 @@ const statusVariants: Record<PhotoConsentSummary["status"], "default" | "seconda
 
 const statusBadgeClasses: Record<PhotoConsentSummary["status"], string> = {
   none:
-    "border-indigo-200 bg-indigo-50/90 text-indigo-700 shadow-[0_12px_32px_rgba(99,102,241,0.18)] dark:border-indigo-400/40 dark:bg-indigo-400/15 dark:text-indigo-50",
+    "border-info/45 bg-info/15 text-info shadow-[0_12px_32px_color-mix(in_oklab,var(--info)_22%,transparent)]",
   pending:
-    "border-amber-200 bg-amber-50/90 text-amber-700 shadow-[0_12px_32px_rgba(245,158,11,0.18)] dark:border-amber-400/30 dark:bg-amber-400/15 dark:text-amber-100",
+    "border-warning/45 bg-warning/15 text-warning shadow-[0_12px_32px_color-mix(in_oklab,var(--warning)_22%,transparent)]",
   approved:
-    "border-emerald-200 bg-emerald-50/90 text-emerald-700 shadow-[0_12px_36px_rgba(16,185,129,0.22)] dark:border-emerald-400/40 dark:bg-emerald-400/15 dark:text-emerald-50",
+    "border-success/45 bg-success/15 text-success shadow-[0_12px_36px_color-mix(in_oklab,var(--success)_24%,transparent)]",
   rejected:
-    "border-rose-200 bg-rose-50/90 text-rose-700 shadow-[0_12px_32px_rgba(244,63,94,0.18)] dark:border-rose-400/40 dark:bg-rose-400/15 dark:text-rose-50",
+    "border-destructive/45 bg-destructive/15 text-destructive shadow-[0_12px_32px_color-mix(in_oklab,var(--destructive)_22%,transparent)]",
 };
 
 const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
@@ -203,14 +203,14 @@ export function PhotoConsentCard() {
   const showIntro = !loading && status !== "approved";
 
   return (
-    <Card className="relative overflow-hidden border border-primary/30 bg-gradient-to-br from-primary/10 via-background to-background shadow-xl shadow-primary/10 dark:from-primary/20">
+    <Card className="relative overflow-hidden border border-primary/30 bg-gradient-to-br from-primary/10 via-background to-background shadow-xl shadow-primary/10">
       <div
         aria-hidden="true"
         className="pointer-events-none absolute -left-20 top-0 h-40 w-40 rounded-full bg-primary/20 opacity-70 blur-3xl dark:bg-primary/30"
       />
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute -right-16 top-16 h-36 w-36 rounded-full bg-amber-100 opacity-60 blur-3xl dark:bg-amber-300/20"
+        className="pointer-events-none absolute -right-16 top-16 h-36 w-36 rounded-full bg-warning/20 opacity-60 blur-3xl"
       />
       <CardHeader className="mb-2 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
@@ -224,14 +224,14 @@ export function PhotoConsentCard() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2 self-start rounded-full border border-primary/20 bg-background/80 px-3 py-1 text-xs font-medium uppercase tracking-wide text-foreground/60 shadow-sm backdrop-blur dark:border-primary/40 dark:bg-slate-900/70">
+        <div className="flex items-center gap-2 self-start rounded-full border border-primary/30 bg-background/80 px-3 py-1 text-xs font-medium uppercase tracking-wide text-foreground/60 shadow-sm backdrop-blur">
           <span>Status</span>
           {statusBadge}
         </div>
       </CardHeader>
       <CardContent className="relative space-y-5 text-sm">
         {showIntro && (
-          <div className="rounded-xl border border-primary/25 bg-background/90 p-4 text-sm text-foreground/80 shadow-[0_18px_45px_rgba(59,130,246,0.12)] backdrop-blur dark:border-primary/40 dark:bg-slate-900/70">
+          <div className="rounded-xl border border-primary/25 bg-background/90 p-4 text-sm text-foreground/80 shadow-[0_18px_45px_color-mix(in_oklab,var(--info)_18%,transparent)] backdrop-blur">
             <p className="font-semibold text-foreground">Mit deinem „Okay“ hilfst du unserem Auftrittsteam.</p>
             <p className="mt-1 text-foreground/70">
               Du kannst deine Entscheidung jederzeit hier im Profil anpassen – ganz wie beim Cookiebanner am Seitenrand.
@@ -249,13 +249,13 @@ export function PhotoConsentCard() {
             </Button>
           </div>
         ) : requiresDateOfBirth ? (
-          <div className="rounded-md border border-amber-300 bg-amber-50/60 p-3 text-amber-900">
+          <div className="rounded-md border border-warning/45 bg-warning/15 p-3 text-warning">
             Bitte hinterlege dein Geburtsdatum im <Link className="underline" href="/mitglieder/profil">Profil</Link>, damit wir prüfen können, ob ein Elternformular notwendig ist.
           </div>
         ) : status === "approved" ? (
-          <div className="space-y-2 rounded-md border border-emerald-300 bg-emerald-50/70 p-3 text-emerald-900">
+          <div className="space-y-2 rounded-md border border-success/45 bg-success/15 p-3 text-success">
             <p>Vielen Dank – deine Fotoeinwilligung ist freigegeben.</p>
-            <ul className="text-xs text-emerald-800">
+            <ul className="text-xs text-success/90">
               <li>
                 Bestätigt am {formatDate(summary?.approvedAt) ?? "unbekannt"}
                 {summary?.approvedByName ? ` durch ${summary.approvedByName}` : ""}.
@@ -273,7 +273,7 @@ export function PhotoConsentCard() {
               </div>
             )}
 
-            <div className="rounded-xl border border-primary/25 bg-background/80 p-4 shadow-inner shadow-primary/5 backdrop-blur dark:border-primary/40 dark:bg-slate-900/70">
+            <div className="rounded-xl border border-primary/25 bg-background/80 p-4 shadow-inner shadow-primary/5 backdrop-blur">
               <label className="flex items-start gap-3">
                 <input
                   type="checkbox"
@@ -290,7 +290,7 @@ export function PhotoConsentCard() {
             </div>
 
             {requiresDocument && (
-              <div className="space-y-3 rounded-xl border border-dashed border-primary/30 bg-background/80 p-4 shadow-sm backdrop-blur dark:border-primary/40 dark:bg-slate-900/70">
+              <div className="space-y-3 rounded-xl border border-dashed border-primary/30 bg-background/80 p-4 shadow-sm backdrop-blur">
                 <div className="font-medium text-foreground">Elterliche Einwilligung (PDF oder JPG/PNG)</div>
                 <Input
                   ref={fileInputRef}
@@ -315,7 +315,7 @@ export function PhotoConsentCard() {
               <Button
                 type="submit"
                 size="lg"
-                className="shadow-[0_20px_45px_rgba(59,130,246,0.25)] transition-shadow duration-200 hover:shadow-[0_22px_52px_rgba(59,130,246,0.32)]"
+                className="shadow-[0_20px_45px_color-mix(in_oklab,var(--info)_25%,transparent)] transition-shadow duration-200 hover:shadow-[0_22px_52px_color-mix(in_oklab,var(--info)_32%,transparent)]"
                 disabled={
                   submitting ||
                   !confirm ||

--- a/src/components/realtime-status.tsx
+++ b/src/components/realtime-status.tsx
@@ -78,22 +78,22 @@ export function RealtimeStatus({ rehearsalId, showPresence = true }: RealtimeSta
   const getConnectionIcon = () => {
     switch (connectionStatus) {
       case 'connected':
-        return <Wifi className="h-4 w-4 text-green-500" />;
+        return <Wifi className="h-4 w-4 text-success" />;
       case 'connecting':
-        return <Clock className="h-4 w-4 text-yellow-500 animate-pulse" />;
+        return <Clock className="h-4 w-4 text-warning animate-pulse" />;
       case 'error':
-        return <AlertCircle className="h-4 w-4 text-red-500" />;
+        return <AlertCircle className="h-4 w-4 text-destructive" />;
       default:
-        return <WifiOff className="h-4 w-4 text-gray-500" />;
+        return <WifiOff className="h-4 w-4 text-muted-foreground" />;
     }
   };
 
   const getConnectionBadge = () => {
     switch (connectionStatus) {
       case 'connected':
-        return <Badge variant="secondary" className="text-green-700 bg-green-100">Verbunden</Badge>;
+        return <Badge variant="secondary" className="border-success/45 bg-success/15 text-success">Verbunden</Badge>;
       case 'connecting':
-        return <Badge variant="secondary" className="text-yellow-700 bg-yellow-100">Verbinde...</Badge>;
+        return <Badge variant="secondary" className="border-warning/45 bg-warning/15 text-warning">Verbinde...</Badge>;
       case 'error':
         return <Badge variant="destructive">Fehler</Badge>;
       default:
@@ -115,7 +115,7 @@ export function RealtimeStatus({ rehearsalId, showPresence = true }: RealtimeSta
         {/* Connection Status */}
         <div className="flex items-center justify-between text-sm">
           <span className="text-muted-foreground">Verbindung:</span>
-          <span className={`font-medium ${isConnected ? 'text-green-600' : 'text-red-600'}`}>
+          <span className={`font-medium ${isConnected ? 'text-success' : 'text-destructive'}`}>
             {isConnected ? 'Aktiv' : 'Getrennt'}
           </span>
         </div>
@@ -152,7 +152,7 @@ export function RealtimeStatus({ rehearsalId, showPresence = true }: RealtimeSta
               ) : (
                 presentUsers.map((user) => (
                   <div key={user.id} className="flex items-center gap-2">
-                    <div className="w-2 h-2 bg-green-500 rounded-full" />
+                    <div className="h-2 w-2 rounded-full bg-success" />
                     <span className="text-xs">{user.name}</span>
                   </div>
                 ))
@@ -165,7 +165,7 @@ export function RealtimeStatus({ rehearsalId, showPresence = true }: RealtimeSta
         {!isConnected && (
           <button
             onClick={reconnect}
-            className="w-full mt-3 px-3 py-2 text-xs bg-blue-50 hover:bg-blue-100 text-blue-700 rounded-md transition-colors"
+            className="w-full mt-3 rounded-md bg-info/15 px-3 py-2 text-xs text-info transition-colors hover:bg-info/20"
           >
             Neu verbinden
           </button>
@@ -209,11 +209,11 @@ export function AttendanceUpdates({ rehearsalId }: AttendanceUpdatesProps) {
   const getStatusIcon = (status: string | null) => {
     switch (status) {
       case 'yes':
-        return <CheckCircle className="h-4 w-4 text-green-500" />;
+        return <CheckCircle className="h-4 w-4 text-success" />;
       case 'no':
-        return <XCircle className="h-4 w-4 text-red-500" />;
+        return <XCircle className="h-4 w-4 text-destructive" />;
       case 'emergency':
-        return <AlertCircle className="h-4 w-4 text-amber-500" />;
+        return <AlertCircle className="h-4 w-4 text-warning" />;
       default:
         return null;
     }
@@ -240,8 +240,8 @@ export function AttendanceUpdates({ rehearsalId }: AttendanceUpdatesProps) {
         <CardTitle className="text-sm">Live-Updates</CardTitle>
       </CardHeader>
       <CardContent className="space-y-2">
-        {recentUpdates.map((update) => (
-          <div key={update.id} className="flex items-start gap-2 rounded-lg bg-gray-50 p-2">
+          {recentUpdates.map((update) => (
+            <div key={update.id} className="flex items-start gap-2 rounded-lg bg-muted/40 p-2">
             {getStatusIcon(update.status)}
             <div className="flex-1 min-w-0 space-y-1">
               <p className="text-sm">

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -72,7 +72,7 @@ export function SiteHeader() {
           className={`font-serif text-lg transition-all duration-300 sm:text-xl ${
             scrolled || !isHomePage
               ? "text-primary hover:opacity-90"
-              : "text-white drop-shadow-lg hover:text-primary/90"
+              : "text-foreground drop-shadow-lg hover:text-primary/90"
           }`}
           href="/"
         >
@@ -90,7 +90,7 @@ export function SiteHeader() {
                 className={`transition-all duration-300 ${
                   scrolled || !isHomePage
                     ? "text-foreground/90 hover:text-primary"
-                    : "text-white/90 drop-shadow-lg hover:text-white"
+                    : "text-foreground/90 drop-shadow-lg hover:text-foreground"
                 } ${isActive ? "font-semibold" : ""}`}
                 href={item.href}
                 aria-current={isActive ? "page" : undefined}
@@ -116,7 +116,7 @@ export function SiteHeader() {
             className={`inline-flex h-9 w-9 items-center justify-center rounded-md transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-ring md:hidden ${
               scrolled || !isHomePage
                 ? "border border-border/60 text-foreground hover:bg-accent/30"
-                : "border border-white/30 text-white drop-shadow-lg hover:bg-white/20"
+                : "border border-border/60 text-foreground drop-shadow-lg hover:bg-accent/20"
             }`}
           >
             <span className="sr-only">Menü</span>

--- a/src/design-system/patterns/key-metric.tsx
+++ b/src/design-system/patterns/key-metric.tsx
@@ -10,11 +10,10 @@ const keyMetricValueVariants = cva(
     variants: {
       tone: {
         default: "text-foreground",
-        positive:
-          "text-emerald-600 dark:text-emerald-400",
-        info: "text-sky-600 dark:text-sky-400",
-        warning: "text-amber-600 dark:text-amber-400",
-        danger: "text-rose-600 dark:text-rose-400",
+        positive: "text-success",
+        info: "text-info",
+        warning: "text-warning",
+        destructive: "text-destructive",
       },
     },
     defaultVariants: {

--- a/src/design-system/patterns/page-header.tsx
+++ b/src/design-system/patterns/page-header.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 
+import { Heading, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
 type PageHeaderProps = React.HTMLAttributes<HTMLDivElement>;
@@ -21,15 +22,7 @@ export function PageHeader({ className, ...props }: PageHeaderProps) {
 type PageHeaderTitleProps = React.HTMLAttributes<HTMLHeadingElement>;
 
 export function PageHeaderTitle({ className, ...props }: PageHeaderTitleProps) {
-  return (
-    <h1
-      className={cn(
-        "text-3xl font-semibold tracking-tight text-foreground sm:text-4xl",
-        className,
-      )}
-      {...props}
-    />
-  );
+  return <Heading level="h1" className={cn("text-3xl sm:text-4xl", className)} {...props} />;
 }
 
 type PageHeaderDescriptionProps = React.HTMLAttributes<HTMLParagraphElement>;
@@ -38,15 +31,7 @@ export function PageHeaderDescription({
   className,
   ...props
 }: PageHeaderDescriptionProps) {
-  return (
-    <p
-      className={cn(
-        "max-w-2xl text-sm text-muted-foreground sm:text-base",
-        className,
-      )}
-      {...props}
-    />
-  );
+  return <Text className={cn("max-w-2xl", className)} tone="muted" variant="body" {...props} />;
 }
 
 type PageHeaderActionsProps = React.HTMLAttributes<HTMLDivElement>;
@@ -68,15 +53,11 @@ const pageHeaderStatusVariants = cva(
   {
     variants: {
       state: {
-        idle: "bg-muted text-muted-foreground ring-border/60",
-        online:
-          "bg-emerald-50 text-emerald-700 ring-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-200 dark:ring-emerald-400/40",
-        offline:
-          "bg-muted text-muted-foreground ring-border/60 dark:bg-muted/40 dark:text-muted-foreground",
-        error:
-          "bg-rose-50 text-rose-700 ring-rose-500/40 dark:bg-rose-500/10 dark:text-rose-200 dark:ring-rose-400/40",
-        warning:
-          "bg-amber-50 text-amber-700 ring-amber-500/40 dark:bg-amber-500/10 dark:text-amber-100 dark:ring-amber-400/40",
+        idle: "bg-muted/60 text-muted-foreground ring-border/60",
+        online: "bg-success/15 text-success ring-success/40",
+        offline: "bg-muted/40 text-muted-foreground ring-border/60",
+        error: "bg-destructive/15 text-destructive ring-destructive/40",
+        warning: "bg-warning/15 text-warning ring-warning/40",
       },
     },
     defaultVariants: {

--- a/src/lib/issues.ts
+++ b/src/lib/issues.ts
@@ -66,30 +66,30 @@ export const ISSUE_VISIBILITY_DESCRIPTIONS: Record<IssueVisibility, string> = {
 };
 
 export const ISSUE_STATUS_BADGE_CLASSES: Record<IssueStatus, string> = {
-  open: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200",
-  in_progress: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200",
-  resolved: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
-  closed: "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-200",
+  open: "border-warning/45 bg-warning/15 text-warning",
+  in_progress: "border-info/45 bg-info/15 text-info",
+  resolved: "border-success/45 bg-success/15 text-success",
+  closed: "border-muted/50 bg-muted/40 text-muted-foreground",
 };
 
 export const ISSUE_CATEGORY_BADGE_CLASSES: Record<IssueCategory, string> = {
-  general: "border-slate-400/40 bg-slate-500/10 text-slate-700 dark:text-slate-200",
-  website_bug: "border-rose-500/35 bg-rose-500/10 text-rose-700 dark:text-rose-200",
-  improvement: "border-emerald-500/35 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
-  support: "border-indigo-500/35 bg-indigo-500/10 text-indigo-700 dark:text-indigo-200",
-  other: "border-zinc-500/35 bg-zinc-500/10 text-zinc-700 dark:text-zinc-200",
+  general: "border-muted/50 bg-muted/35 text-muted-foreground",
+  website_bug: "border-destructive/45 bg-destructive/15 text-destructive",
+  improvement: "border-success/45 bg-success/15 text-success",
+  support: "border-primary/45 bg-primary/15 text-primary",
+  other: "border-secondary/45 bg-secondary/15 text-secondary",
 };
 
 export const ISSUE_PRIORITY_BADGE_CLASSES: Record<IssuePriority, string> = {
-  low: "border-slate-400/40 bg-slate-500/10 text-slate-700 dark:text-slate-200",
-  medium: "border-sky-500/35 bg-sky-500/10 text-sky-700 dark:text-sky-200",
-  high: "border-orange-500/35 bg-orange-500/10 text-orange-700 dark:text-orange-200",
-  urgent: "border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-200",
+  low: "border-muted/50 bg-muted/35 text-muted-foreground",
+  medium: "border-info/45 bg-info/15 text-info",
+  high: "border-warning/45 bg-warning/15 text-warning",
+  urgent: "border-destructive/50 bg-destructive/15 text-destructive",
 };
 
 export const ISSUE_VISIBILITY_BADGE_CLASSES: Record<IssueVisibility, string> = {
-  public: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
-  private: "border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200",
+  public: "border-success/45 bg-success/15 text-success",
+  private: "border-destructive/45 bg-destructive/15 text-destructive",
 };
 
 const ISSUE_STATUS_SET = new Set<IssueStatus>(ISSUE_STATUS_VALUES);

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -31,13 +31,13 @@ export const ROLE_DESCRIPTIONS: Record<Role, string> = {
 };
 
 export const ROLE_BADGE_VARIANTS: Record<Role, string> = {
-  member: "bg-slate-100 text-slate-700 border-slate-200",
-  cast: "bg-purple-100 text-purple-700 border-purple-200",
-  tech: "bg-blue-100 text-blue-700 border-blue-200",
-  board: "bg-emerald-100 text-emerald-700 border-emerald-200",
-  finance: "bg-amber-100 text-amber-700 border-amber-200",
-  owner: "bg-fuchsia-100 text-fuchsia-700 border-fuchsia-200",
-  admin: "bg-red-100 text-red-700 border-red-200",
+  member: "border border-border/60 bg-muted/50 text-muted-foreground",
+  cast: "border border-primary/45 bg-primary/15 text-primary",
+  tech: "border border-info/45 bg-info/15 text-info",
+  board: "border border-success/45 bg-success/15 text-success",
+  finance: "border border-warning/45 bg-warning/15 text-warning",
+  owner: "border border-secondary/45 bg-secondary/15 text-secondary",
+  admin: "border border-destructive/45 bg-destructive/15 text-destructive",
 };
 
 export function sortRoles(roles: Role[]) {


### PR DESCRIPTION
## Summary
- standardize marketing and informational pages to use the shared layout container, semantic tokens, and the Heading/Text components while keeping existing copy intact
- rework chronicle modules, hero, and site header styling to lean on the design token palette for overlays, badges, and timeline indicators
- update shared design patterns, dashboard surfaces, photo consent flow, realtime widget, and status registries so badges and metrics source colors from semantic tokens, and adjust the production detail query to fetch counts via include

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cffeb98c8c832db5ec17e77e7511a9