### PR TITLE
Add migration for final rehearsal week column

### DIFF
--- a/prisma/migrations/20250921141000_add_show_final_rehearsal_week_start/migration.sql
+++ b/prisma/migrations/20250921141000_add_show_final_rehearsal_week_start/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Show" ADD COLUMN "finalRehearsalWeekStart" TIMESTAMP(3);


### PR DESCRIPTION
## Summary
- add a Prisma migration that introduces the `finalRehearsalWeekStart` column on the Show table to match the current schema

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d006fe66e0832d833438e66e60d278