### PR TITLE
Fix hydration mismatch in BuildInfoTimestamp

### DIFF
--- a/src/components/build-info-timestamp.tsx
+++ b/src/components/build-info-timestamp.tsx
@@ -60,11 +60,7 @@ export function BuildInfoTimestamp({
     [],
   );
   const isValidTimestamp = !Number.isNaN(buildDate.getTime());
-  const [relativeTime, setRelativeTime] = useState(() =>
-    isValidTimestamp
-      ? formatRelativeTime(buildDate, relativeTimeFormatter)
-      : "",
-  );
+  const [relativeTime, setRelativeTime] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isValidTimestamp) {
@@ -91,8 +87,12 @@ export function BuildInfoTimestamp({
   return (
     <span className="inline-flex items-baseline gap-1">
       <time dateTime={isoTimestamp}>Stand {formattedTimestamp}</time>
-      <span aria-hidden>({relativeTime})</span>
-      <span className="sr-only">, aktualisiert {relativeTime}</span>
+      {relativeTime ? (
+        <>
+          <span aria-hidden>({relativeTime})</span>
+          <span className="sr-only">, aktualisiert {relativeTime}</span>
+        </>
+      ) : null}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- defer computing the build info relative time until after hydration to avoid stale SSR markup
- render the relative-time spans only once a value is available so the initial DOM stays consistent

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0083342b8832d96458457a3276f11