### PR TITLE
Fix hydration mismatch for build timestamp

### DIFF
--- a/src/components/build-info-timestamp.tsx
+++ b/src/components/build-info-timestamp.tsx
@@ -60,11 +60,7 @@ export function BuildInfoTimestamp({
     [],
   );
   const isValidTimestamp = !Number.isNaN(buildDate.getTime());
-  const [relativeTime, setRelativeTime] = useState(() =>
-    isValidTimestamp
-      ? formatRelativeTime(buildDate, relativeTimeFormatter)
-      : "",
-  );
+  const [relativeTime, setRelativeTime] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isValidTimestamp) {
@@ -91,8 +87,12 @@ export function BuildInfoTimestamp({
   return (
     <span className="inline-flex items-baseline gap-1">
       <time dateTime={isoTimestamp}>Stand {formattedTimestamp}</time>
-      <span aria-hidden>({relativeTime})</span>
-      <span className="sr-only">, aktualisiert {relativeTime}</span>
+      {relativeTime !== null ? (
+        <>
+          <span aria-hidden>({relativeTime})</span>
+          <span className="sr-only">, aktualisiert {relativeTime}</span>
+        </>
+      ) : null}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- stop precomputing the relative build timestamp during SSR so the markup matches the client
- render the relative timestamp after hydration to avoid mismatches while keeping the accessible text

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d00bc27a7c832da7075797e6b99b40