### PR TITLE
Add profile interest management to member profile

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { PageHeader } from "@/components/members/page-header";
 import { PhotoConsentCard } from "@/components/members/photo-consent-card";
 import { ProfileForm } from "@/components/members/profile-form";
+import { ProfileInterestsCard } from "@/components/members/profile-interests-card";
 import { ProfileSummaryCard } from "@/components/members/profile-summary-card";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -173,25 +174,28 @@ export default async function ProfilePage() {
             </CardContent>
           </Card>
         </div>
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="space-y-2">
+              <CardTitle>Profildaten</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Name, Kontaktadresse und Passwort kannst du hier eigenständig anpassen. Änderungen werden sofort übernommen.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-0">
+              <ProfileForm
+                userId={userId}
+                initialName={user.name}
+                initialEmail={user.email}
+                initialAvatarSource={user.avatarSource}
+                initialAvatarUpdatedAt={user.avatarImageUpdatedAt?.toISOString() ?? null}
+                initialDateOfBirth={user.dateOfBirth?.toISOString() ?? null}
+              />
+            </CardContent>
+          </Card>
 
-        <Card>
-          <CardHeader className="space-y-2">
-            <CardTitle>Profildaten</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Name, Kontaktadresse und Passwort kannst du hier eigenständig anpassen. Änderungen werden sofort übernommen.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-0">
-            <ProfileForm
-              userId={userId}
-              initialName={user.name}
-              initialEmail={user.email}
-              initialAvatarSource={user.avatarSource}
-              initialAvatarUpdatedAt={user.avatarImageUpdatedAt?.toISOString() ?? null}
-              initialDateOfBirth={user.dateOfBirth?.toISOString() ?? null}
-            />
-          </CardContent>
-        </Card>
+          <ProfileInterestsCard />
+        </div>
       </div>
     </div>
   );

--- a/src/app/api/profile/interests/route.ts
+++ b/src/app/api/profile/interests/route.ts
@@ -1,0 +1,152 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+
+const MAX_INTERESTS = 30;
+const MAX_INTEREST_LENGTH = 80;
+
+type NormalizedInterest = { value: string; lower: string };
+
+function normalizeInterest(raw: string): NormalizedInterest | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const limited = trimmed.slice(0, MAX_INTEREST_LENGTH);
+  const lower = limited.toLowerCase();
+  return { value: limited, lower };
+}
+
+export async function GET() {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const interests = await prisma.userInterest.findMany({
+    where: { userId },
+    include: { interest: { select: { name: true } } },
+    orderBy: { interest: { name: "asc" } },
+  });
+
+  return NextResponse.json({
+    interests: interests
+      .map((entry) => entry.interest?.name ?? "")
+      .filter((name) => Boolean(name?.trim())),
+  });
+}
+
+export async function PUT(request: NextRequest) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const payload = await request.json().catch(() => null);
+  if (!payload || typeof payload !== "object" || !Array.isArray((payload as { interests?: unknown }).interests)) {
+    return NextResponse.json({ error: "Ungültige Eingabe" }, { status: 400 });
+  }
+
+  const rawInterests = (payload as { interests: unknown[] }).interests;
+  const seen = new Set<string>();
+  const normalized: NormalizedInterest[] = [];
+
+  for (const raw of rawInterests) {
+    if (typeof raw !== "string") {
+      return NextResponse.json({ error: "Interessen müssen Text sein" }, { status: 400 });
+    }
+    const entry = normalizeInterest(raw);
+    if (!entry) {
+      continue;
+    }
+    if (seen.has(entry.lower)) {
+      continue;
+    }
+    seen.add(entry.lower);
+    normalized.push(entry);
+    if (normalized.length > MAX_INTERESTS) {
+      return NextResponse.json({ error: `Maximal ${MAX_INTERESTS} Interessen erlaubt` }, { status: 400 });
+    }
+  }
+
+  try {
+    const updatedNames = await prisma.$transaction(async (tx) => {
+      const existing = await tx.userInterest.findMany({
+        where: { userId },
+        include: { interest: { select: { id: true, name: true } } },
+      });
+
+      const targetLowers = new Set(normalized.map((entry) => entry.lower));
+      const keepMap = new Map<string, { interestId: string }>();
+      const removeIds: string[] = [];
+
+      for (const link of existing) {
+        const interestName = link.interest?.name ?? "";
+        const lower = interestName.toLowerCase();
+        if (targetLowers.has(lower)) {
+          keepMap.set(lower, { interestId: link.interestId });
+        } else {
+          removeIds.push(link.id);
+        }
+      }
+
+      if (removeIds.length) {
+        await tx.userInterest.deleteMany({ where: { id: { in: removeIds } } });
+      }
+
+      if (!normalized.length) {
+        return [] as string[];
+      }
+
+      const filters = normalized.map((entry) => ({
+        name: { equals: entry.value, mode: "insensitive" as const },
+      }));
+
+      let interestRecords = await tx.interest.findMany({
+        where: { OR: filters },
+      });
+
+      const interestByLower = new Map<string, { id: string; name: string }>();
+      for (const record of interestRecords) {
+        interestByLower.set(record.name.toLowerCase(), { id: record.id, name: record.name });
+      }
+
+      const toCreate = normalized
+        .filter((entry) => !interestByLower.has(entry.lower))
+        .map((entry) => ({ name: entry.value, createdById: userId }));
+
+      if (toCreate.length) {
+        await tx.interest.createMany({ data: toCreate, skipDuplicates: true });
+        interestRecords = await tx.interest.findMany({ where: { OR: filters } });
+        interestByLower.clear();
+        for (const record of interestRecords) {
+          interestByLower.set(record.name.toLowerCase(), { id: record.id, name: record.name });
+        }
+      }
+
+      const toLink = normalized
+        .filter((entry) => !keepMap.has(entry.lower))
+        .map((entry) => {
+          const interest = interestByLower.get(entry.lower);
+          if (!interest) return null;
+          return { userId, interestId: interest.id };
+        })
+        .filter((entry): entry is { userId: string; interestId: string } => Boolean(entry));
+
+      if (toLink.length) {
+        await tx.userInterest.createMany({ data: toLink, skipDuplicates: true });
+      }
+
+      return normalized.map((entry) => interestByLower.get(entry.lower)?.name ?? entry.value);
+    });
+
+    return NextResponse.json({ ok: true, interests: updatedNames });
+  } catch (error) {
+    console.error("[profile.interests]", error);
+    return NextResponse.json({ error: "Aktualisierung der Interessen fehlgeschlagen" }, { status: 500 });
+  }
+}

--- a/src/components/members/profile-interests-card.tsx
+++ b/src/components/members/profile-interests-card.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { Loader2, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+const MAX_INTERESTS = 30;
+const MIN_INTEREST_LENGTH = 2;
+
+function normalizeInterest(value: string) {
+  return value.trim();
+}
+
+function sortNormalized(values: string[]) {
+  return values
+    .map((value) => value.trim().toLowerCase())
+    .filter((value) => value.length > 0)
+    .sort();
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+export function ProfileInterestsCard() {
+  const [interests, setInterests] = useState<string[]>([]);
+  const [baseline, setBaseline] = useState<string[]>([]);
+  const [inputValue, setInputValue] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadInterests = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/profile/interests", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error("Failed to load interests");
+        }
+        const data = (await response.json()) as unknown;
+        const list = toStringArray((data as { interests?: unknown })?.interests);
+        if (!cancelled) {
+          setInterests(list);
+          setBaseline(list);
+        }
+      } catch (err) {
+        console.error("[profile.interests] load", err);
+        if (!cancelled) {
+          setError("Interessen konnten nicht geladen werden.");
+          setInterests([]);
+          setBaseline([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    void loadInterests();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const normalizedBaseline = useMemo(() => sortNormalized(baseline), [baseline]);
+  const normalizedCurrent = useMemo(() => sortNormalized(interests), [interests]);
+  const hasChanges = useMemo(() => {
+    if (normalizedBaseline.length !== normalizedCurrent.length) return true;
+    return normalizedBaseline.some((value, index) => value !== normalizedCurrent[index]);
+  }, [normalizedBaseline, normalizedCurrent]);
+
+  const handleAddInterest = () => {
+    const normalized = normalizeInterest(inputValue);
+    if (normalized.length < MIN_INTEREST_LENGTH) {
+      setError("Bitte gib mindestens zwei Zeichen ein.");
+      return;
+    }
+    if (interests.some((entry) => entry.trim().toLowerCase() === normalized.toLowerCase())) {
+      setError("Dieses Interesse hast du bereits hinzugefügt.");
+      return;
+    }
+    if (interests.length >= MAX_INTERESTS) {
+      setError(`Maximal ${MAX_INTERESTS} Interessen möglich.`);
+      return;
+    }
+    setInterests((prev) => [...prev, normalized]);
+    setInputValue("");
+    setError(null);
+  };
+
+  const handleRemoveInterest = (value: string) => {
+    setInterests((prev) => prev.filter((entry) => entry !== value));
+    setError(null);
+  };
+
+  const handleSubmit = async () => {
+    if (!hasChanges) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/profile/interests", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ interests }),
+      });
+      const data = (await response.json().catch(() => null)) as unknown;
+      if (!response.ok) {
+        const message = typeof (data as { error?: unknown })?.error === "string"
+          ? String((data as { error?: unknown }).error)
+          : "Speichern fehlgeschlagen.";
+        setError(message);
+        return;
+      }
+      const saved = toStringArray((data as { interests?: unknown })?.interests);
+      setBaseline(saved);
+      setInterests(saved);
+      setInputValue("");
+      toast.success("Interessen aktualisiert.");
+    } catch (err) {
+      console.error("[profile.interests] save", err);
+      setError("Netzwerkfehler – bitte später erneut versuchen.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleAddInterest();
+    }
+  };
+
+  return (
+    <Card className="border border-border/70">
+      <CardHeader className="space-y-2">
+        <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+          <Sparkles className="h-4 w-4" />
+          Interessen &amp; Talente
+        </div>
+        <CardTitle className="text-lg">Halte deine Interessen aktuell</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Diese Schlagworte helfen dem Team, dich passenden Projekten zuzuordnen. Du kannst sie hier jederzeit anpassen.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Interessen werden geladen …
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap gap-2">
+              {interests.length ? (
+                interests.map((interest) => (
+                  <Badge
+                    key={interest}
+                    variant="outline"
+                    className="flex items-center gap-2 border-primary/30 bg-primary/5 text-primary"
+                  >
+                    <span>{interest}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveInterest(interest)}
+                      className={cn(
+                        "rounded-full p-0.5 transition",
+                        saving ? "cursor-not-allowed text-primary/30" : "hover:bg-primary/10"
+                      )}
+                      disabled={saving}
+                      aria-label={`${interest} entfernen`}
+                    >
+                      ×
+                    </button>
+                  </Badge>
+                ))
+              ) : (
+                <span className="text-sm text-muted-foreground">
+                  Noch keine Interessen hinterlegt – ergänze deine ersten Schlagworte.
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <Input
+                value={inputValue}
+                onChange={(event) => {
+                  setInputValue(event.target.value);
+                  setError(null);
+                }}
+                onKeyDown={handleInputKeyDown}
+                placeholder="z.B. Impro, Tanz, Social Media …"
+                disabled={saving}
+              />
+              <Button type="button" onClick={handleAddInterest} disabled={saving}>
+                Hinzufügen
+              </Button>
+            </div>
+          </>
+        )}
+        <p className="text-xs text-muted-foreground">Maximal {MAX_INTERESTS} Interessen möglich.</p>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end border-t border-border/60 pt-4">
+          <Button type="button" onClick={handleSubmit} disabled={saving || loading || !hasChanges}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Speichern …
+              </>
+            ) : (
+              "Speichern"
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add a profile interests card so members can review and update their interest tags
- introduce `/api/profile/interests` to load and persist the editable interest list for the logged-in user

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d00da9d600832db0dfceb546e4f94a