### PR TITLE
Enable drag-and-drop ordering for permission roles

### DIFF
--- a/prisma/migrations/20250320120000_app_role_sort_order/migration.sql
+++ b/prisma/migrations/20250320120000_app_role_sort_order/migration.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "public"."AppRole"
+  ADD COLUMN "sortIndex" INTEGER NOT NULL DEFAULT 0;
+
+WITH ordered AS (
+  SELECT "id", ROW_NUMBER() OVER (ORDER BY "name" ASC) - 1 AS rn
+  FROM "public"."AppRole"
+  WHERE "isSystem" = false
+)
+UPDATE "public"."AppRole" AS r
+SET "sortIndex" = ordered.rn
+FROM ordered
+WHERE r."id" = ordered."id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -563,6 +563,7 @@ model AppRole {
   name       String  @unique
   isSystem   Boolean @default(false)
   systemRole Role?
+  sortIndex  Int     @default(0)
   grants     AppRolePermission[]
   users      UserAppRole[]
 }

--- a/src/app/api/permissions/definitions/route.ts
+++ b/src/app/api/permissions/definitions/route.ts
@@ -18,7 +18,10 @@ export async function GET() {
   await Promise.all([ensureSystemRoles(), ensurePermissionDefinitions()]);
 
   const [roles, permissions, grants] = await Promise.all([
-    prisma.appRole.findMany({ where: { isSystem: false }, orderBy: { name: "asc" } }),
+    prisma.appRole.findMany({
+      where: { isSystem: false },
+      orderBy: [{ sortIndex: "asc" }, { name: "asc" }],
+    }),
     prisma.permission.findMany({ where: { key: { in: DEFAULT_PERMISSION_DEFINITIONS.map((def) => def.key) } } }),
     prisma.appRolePermission.findMany({ select: { roleId: true, permission: { select: { key: true } } } }),
   ]);

--- a/src/app/api/permissions/roles/order/route.ts
+++ b/src/app/api/permissions/roles/order/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+export async function PUT(request: NextRequest) {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.rechte"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = (await request.json().catch(() => null)) as { roleIds?: unknown } | null;
+  if (!body || !Array.isArray(body.roleIds) || !body.roleIds.every((id) => typeof id === "string")) {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const roleIds = body.roleIds;
+  if (roleIds.length === 0) {
+    return NextResponse.json({ ok: true });
+  }
+
+  const uniqueIds = new Set(roleIds);
+  if (uniqueIds.size !== roleIds.length) {
+    return NextResponse.json({ error: "Rollen dürfen nur einmal vorkommen" }, { status: 400 });
+  }
+
+  const existing = await prisma.appRole.findMany({
+    where: { id: { in: roleIds }, isSystem: false },
+    select: { id: true },
+  });
+  const existingIds = new Set(existing.map((role) => role.id));
+  const missing = roleIds.filter((id) => !existingIds.has(id));
+  if (missing.length > 0) {
+    return NextResponse.json({ error: "Unbekannte Rollen können nicht sortiert werden" }, { status: 400 });
+  }
+
+  await prisma.$transaction(
+    roleIds.map((id, index) =>
+      prisma.appRole.update({
+        where: { id },
+        data: { sortIndex: index },
+      }),
+    ),
+  );
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/permissions/roles/route.ts
+++ b/src/app/api/permissions/roles/route.ts
@@ -9,7 +9,10 @@ export async function GET() {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
   await Promise.all([ensureSystemRoles(), ensurePermissionDefinitions()]);
-  const roles = await prisma.appRole.findMany({ where: { isSystem: false }, orderBy: { name: "asc" } });
+  const roles = await prisma.appRole.findMany({
+    where: { isSystem: false },
+    orderBy: [{ sortIndex: "asc" }, { name: "asc" }],
+  });
   return NextResponse.json({ roles });
 }
 
@@ -22,7 +25,16 @@ export async function POST(request: NextRequest) {
   if (!body || typeof body.name !== "string" || !body.name.trim()) {
     return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
   }
-  const created = await prisma.appRole.create({ data: { name: body.name.trim(), isSystem: false } });
+  const trimmed = body.name.trim();
+  const result = await prisma.$transaction(async (tx) => {
+    const maxSortIndex = await tx.appRole.aggregate({
+      where: { isSystem: false },
+      _max: { sortIndex: true },
+    });
+    const nextIndex = (maxSortIndex._max.sortIndex ?? -1) + 1;
+    return tx.appRole.create({ data: { name: trimmed, isSystem: false, sortIndex: nextIndex } });
+  });
+  const created = result;
   return NextResponse.json({ ok: true, role: created });
 }
 


### PR DESCRIPTION
## Summary
- add a persistent `sortIndex` for custom roles via Prisma schema and migration
- update the permissions API to respect and update role order, including a dedicated reorder endpoint
- enhance the permission matrix UI with drag-and-drop column sorting that persists new orders and handles errors gracefully

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d00f05fff4832db2a0b8e20224632f