### PR TITLE
Add icon guidelines and enhance button symbols

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -80,6 +80,26 @@ Weitere Layout-Konstanten:
 - **Varianten:** `primary` (alias `default`), `secondary`, `accent`, `outline`, `ghost`, `subtle`, `link`, `destructive`, `success`, `info`.
 - **States:** Hover reduziert Deckkraft bzw. hebt Konturen hervor; `focus-visible` nutzt `ring` + Offset, `disabled` setzt `opacity-60` und deaktiviert Pointer Events.
 - **Sizes:** `xs`–`xl` plus `icon`, alle auf das 8pt-Raster abgestimmt.
+- **Icons:** Buttons besitzen standardmäßig `inline-flex` + `gap-2`. Platziere führende oder nachgestellte Icons direkt in der Button-Children-Hierarchie (z. B. `<Sparkles className="h-4 w-4" aria-hidden />`). Auf XS-Screens dürfen Labels zugunsten eines Icons mit `sr-only sm:not-sr-only` ausgeblendet werden, solange ein `title` oder das Screenreader-Label erhalten bleibt.
+
+### Symbolsprache & Icon-Buttons
+
+- **Quelle:** Alle Icons stammen aus `lucide-react`. Nutze `import type { LucideIcon }` für konfigurierbare Icon-Props.
+- **Größen:** In Buttons `size="sm"` bis `"lg"` funktionieren Icons mit `className="h-4 w-4"`. Für `size="xl"` darf `h-5 w-5` verwendet werden.
+- **Textersatz:** Für kompakte Quick-Actions oder Toolbars sind reine Icon-Buttons erlaubt (`size="icon"`). Kombiniere Icon + `span.sr-only`, um den Text nur für Screenreader bereitzustellen.
+- **Responsives Labeling:** Möchtest du Labels ab einer bestimmten Breite wiedergeben, nutze `className="sr-only sm:not-sr-only"` für den Text und vergib zusätzlich `title="…"` am Button/Link.
+- **Abstände:** Bei Buttons mit Icon und Text kein zusätzliches Padding setzen – die Komponenten bringen bereits konsistente `gap`- und Paddingwerte mit. Für Sonderfälle kann ein Wrapper-`span` die Reihenfolge oder Animationen steuern.
+- **Beispiel:**
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { CalendarCog } from "lucide-react";
+
+<Button variant="outline" size="sm" title="Probenplanung öffnen">
+  <CalendarCog aria-hidden className="h-4 w-4" />
+  <span className="sr-only sm:not-sr-only">Probenplanung</span>
+</Button>;
+```
 
 ### TextLink (`@/components/ui/text-link`)
 - Variants: `default` (primär), `subtle`, `muted`, `ghost`, `accent`, `button`.

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,9 +1,11 @@
 "use client";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { Heading, Text } from "@/components/ui/typography";
 import { HeroRotator } from "@/components/hero-rotator";
-import { useEffect, useState } from "react";
+import { BookOpen, Sparkles } from "lucide-react";
 
 export function Hero({ images }: { images: string[] }) {
   const [scrollY, setScrollY] = useState(0);
@@ -88,7 +90,10 @@ export function Hero({ images }: { images: string[] }) {
                   size="xl"
                   className="px-8 py-5 text-base font-semibold tracking-wide md:px-10 md:text-lg"
                 >
-                  <Link href="/mystery">Das Geheimnis entdecken</Link>
+                  <Link href="/mystery" title="Geheimnis entdecken">
+                    <Sparkles aria-hidden className="h-5 w-5" />
+                    <span>Das Geheimnis entdecken</span>
+                  </Link>
                 </Button>
                 <Button
                   variant="outline"
@@ -96,7 +101,10 @@ export function Hero({ images }: { images: string[] }) {
                   size="xl"
                   className="border-white/50 bg-white/10 px-8 py-5 text-base font-semibold text-white shadow-lg backdrop-blur md:px-10 md:text-lg"
                 >
-                  <Link href="/chronik">Chronik</Link>
+                  <Link href="/chronik" title="Chronik öffnen">
+                    <BookOpen aria-hidden className="h-5 w-5" />
+                    <span>Chronik</span>
+                  </Link>
                 </Button>
               </div>
             </div>

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -30,7 +30,13 @@ import {
   Bell,
   CheckCircle2,
   Sparkles,
+  UserRound,
+  CalendarCheck,
+  CalendarCog,
+  UsersRound,
+  ShieldCheck,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface RecentActivity {
@@ -125,6 +131,44 @@ const DIETARY_LEVEL_LABELS: Record<string, string> = {
   SEVERE: "Stark",
   LETHAL: "Kritisch",
 };
+
+type QuickActionLink = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  roles?: string[];
+};
+
+const QUICK_ACTION_LINKS = [
+  {
+    href: "/mitglieder/profil",
+    label: "Profil öffnen",
+    icon: UserRound,
+  },
+  {
+    href: "/mitglieder/meine-proben",
+    label: "Meine Proben",
+    icon: CalendarCheck,
+  },
+  {
+    href: "/mitglieder/probenplanung",
+    label: "Probenplanung",
+    icon: CalendarCog,
+    roles: ["board", "admin", "tech", "owner"],
+  },
+  {
+    href: "/mitglieder/mitgliederverwaltung",
+    label: "Mitgliederverwaltung",
+    icon: UsersRound,
+    roles: ["admin", "owner"],
+  },
+  {
+    href: "/mitglieder/rechte",
+    label: "Rechteverwaltung",
+    icon: ShieldCheck,
+    roles: ["admin", "owner"],
+  },
+] satisfies QuickActionLink[];
 
 type OverviewStatsPayload = {
   totalMembers?: unknown;
@@ -768,18 +812,21 @@ export function MembersDashboard() {
                 {(() => {
                   const userRoles = (session?.user?.roles as string[] | undefined) ?? (session?.user?.role ? [session.user.role] : []);
                   const roleSet = new Set(userRoles);
-                  const links = [
-                    { href: "/mitglieder/profil", label: "Profil öffnen" },
-                    { href: "/mitglieder/meine-proben", label: "Meine Proben" },
-                    { href: "/mitglieder/probenplanung", label: "Probenplanung", roles: ["board", "admin", "tech", "owner"] },
-                    { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", roles: ["admin", "owner"] },
-                    { href: "/mitglieder/rechte", label: "Rechteverwaltung", roles: ["admin", "owner"] },
-                  ].filter((l: { href: string; label: string; roles?: string[] }) => !l.roles || l.roles.some((r) => roleSet.has(r)));
-                  return links.map((l) => (
-                    <Button asChild key={l.href} variant="outline" size="sm">
-                      <Link href={l.href}>{l.label}</Link>
-                    </Button>
-                  ));
+                  const links = QUICK_ACTION_LINKS.filter(
+                    (link) => !link.roles || link.roles.some((role) => roleSet.has(role))
+                  );
+
+                  return links.map((link) => {
+                    const Icon = link.icon;
+                    return (
+                      <Button asChild key={link.href} variant="outline" size="sm">
+                        <Link href={link.href} title={link.label}>
+                          <Icon aria-hidden className="h-4 w-4" />
+                          <span className="sr-only sm:not-sr-only">{link.label}</span>
+                        </Link>
+                      </Button>
+                    );
+                  });
                 })()}
               </div>
             </CardContent>

--- a/src/components/production/workspace-empty-state.tsx
+++ b/src/components/production/workspace-empty-state.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { ArrowRightCircle } from "lucide-react";
 
 type ProductionWorkspaceEmptyStateProps = {
   title: string;
@@ -23,8 +24,11 @@ export function ProductionWorkspaceEmptyState({
         <p className="text-sm text-muted-foreground">{description}</p>
       </CardHeader>
       <CardContent>
-        <Button asChild>
-          <Link href={actionHref}>{actionLabel}</Link>
+        <Button asChild title={actionLabel}>
+          <Link href={actionHref}>
+            <ArrowRightCircle aria-hidden className="h-4 w-4" />
+            <span className="sr-only sm:not-sr-only">{actionLabel}</span>
+          </Link>
         </Button>
       </CardContent>
     </Card>

--- a/src/components/production/workspace-header.tsx
+++ b/src/components/production/workspace-header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Clapperboard } from "lucide-react";
 
 import { ProductionWorkspaceNav } from "./workspace-nav";
 
@@ -92,7 +93,10 @@ export function ProductionWorkspaceHeader({
               Ohne aktive Produktion fehlen Rollen, Szenen und Aufgaben. Wähle eine Produktion aus oder lege eine neue an, um loszulegen.
             </p>
             <Button asChild size="sm" variant="outline" className="ml-auto">
-              <Link href="/mitglieder/produktionen">Produktion auswählen</Link>
+              <Link href="/mitglieder/produktionen" title="Produktion auswählen">
+                <Clapperboard aria-hidden className="h-4 w-4" />
+                <span>Produktion auswählen</span>
+              </Link>
             </Button>
           </CardContent>
         )}


### PR DESCRIPTION
## Summary
- expand the button guidelines with icon usage patterns and responsive labelling rules
- add lucide icons to the hero call-to-action buttons for clearer visual affordances
- apply icon-forward buttons to members dashboard quick actions and production workspace prompts, hiding labels on small screens where appropriate

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d01868b900832d8b283e4b90a59a19