### PR TITLE
Improve mobile onboarding layout and form inputs

### DIFF
--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -58,7 +58,7 @@ export default async function OnboardingInvitePage({ params }: { params: { token
   });
 
   return (
-    <div className="mx-auto w-full max-w-5xl py-12">
+    <div className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 sm:py-12 lg:px-8">
       <OnboardingWizard
         sessionToken={redemption.sessionToken}
         invite={{

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -852,18 +852,18 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
   }, [invite.expiresAt]);
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6 sm:space-y-8">
       <Card className="border border-border/70 bg-gradient-to-br from-background to-background/70">
         <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <CardTitle className="text-2xl font-semibold">Dein Einstieg ins Theater</CardTitle>
+            <CardTitle className="text-xl font-semibold sm:text-2xl">Dein Einstieg ins Theater</CardTitle>
             <p className="text-sm text-muted-foreground">
               Einladung erstellt {inviteCreatedAt ? `am ${inviteCreatedAt}` : "vor Kurzem"}
               {invite.createdBy ? ` von ${invite.createdBy}` : ""}.
               {inviteExpiresAt ? ` Gültig bis ${inviteExpiresAt}.` : ""}
             </p>
           </div>
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground sm:flex-nowrap">
             <Badge variant="outline">Link-ID gesichert</Badge>
             {invite.remainingUses !== null ? (
               <span>{invite.remainingUses} von {invite.remainingUses + invite.usageCount} Plätzen frei</span>
@@ -878,7 +878,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
         aria-label="Onboarding-Fortschritt"
         className="max-w-full overflow-x-auto rounded-xl border border-border/60 bg-background/80 px-3 py-2 shadow-sm sm:overflow-visible sm:border-none sm:bg-transparent sm:px-0 sm:py-0 sm:shadow-none"
       >
-        <ol className="flex min-w-max list-none items-center gap-3 sm:min-w-0 sm:flex-wrap">
+        <ol className="flex list-none flex-wrap items-center gap-3 md:flex-nowrap">
           {steps.map((item, index) => {
             const isActive = index === step;
             const isComplete = index < step;
@@ -890,7 +890,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                   onClick={() => goToStep(index)}
                   disabled={isFuture}
                   className={cn(
-                    "group flex shrink-0 flex-col items-center gap-1 rounded-lg bg-transparent px-2 py-1 text-center focus-visible:outline-none sm:flex-row sm:items-center sm:gap-2 sm:px-0 sm:py-0 sm:text-left",
+                    "group flex shrink-0 flex-col items-center gap-1 rounded-lg bg-transparent px-2 py-1 text-center focus-visible:outline-none md:flex-row md:items-center md:gap-2 md:px-0 md:py-0 md:text-left",
                     isComplete ? "cursor-pointer" : "cursor-default",
                   )}
                   aria-current={isActive ? "step" : undefined}
@@ -914,7 +914,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                   </span>
                   <span
                     className={cn(
-                      "text-xs font-medium sm:text-sm",
+                      "text-xs font-medium md:text-sm",
                       isActive ? "text-foreground" : "text-muted-foreground",
                     )}
                     aria-hidden
@@ -923,7 +923,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                   </span>
                 </button>
                 {index < steps.length - 1 && (
-                  <div className="hidden h-px w-10 shrink-0 bg-border sm:block" aria-hidden />
+                  <div className="hidden h-px w-10 shrink-0 bg-border md:block" aria-hidden />
                 )}
               </li>
             );
@@ -933,9 +933,9 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
 
       {step === 0 && (
         <Card className="border border-border/70 bg-background/80 shadow-xl">
-          <CardContent className="space-y-6 p-8 text-center">
-            <h2 className="text-3xl font-semibold">Willkommen im Zukunftstheater</h2>
-            <p className="text-muted-foreground">
+          <CardContent className="space-y-5 px-5 py-6 text-center sm:space-y-6 sm:px-8 sm:py-8">
+            <h2 className="text-2xl font-semibold sm:text-3xl">Willkommen im Zukunftstheater</h2>
+            <p className="text-sm text-muted-foreground sm:text-base">
               Schön, dass du da bist! Nimm dir 10 Minuten Zeit, such dir einen ruhigen Ort und lass uns gemeinsam herausfinden, wie du
               dich auf der Bühne oder hinter den Kulissen einbringen möchtest.
             </p>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...pr
     <input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-card px-3 py-2 text-sm shadow-sm transition",
+        "flex h-10 w-full rounded-md border border-input bg-card px-3 py-2 text-base shadow-sm transition md:text-sm",
         "placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
         className

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring md:text-sm",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    className={cn("px-2 py-1.5 text-base font-semibold md:text-sm", className)}
     {...props}
   />
 ));
@@ -78,7 +78,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-base outline-none focus:bg-accent focus:text-accent-foreground md:text-sm",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     <textarea
       ref={ref}
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- add responsive padding to the onboarding page and welcome step to improve the mobile layout
- update the onboarding wizard header and stepper to wrap gracefully on small screens
- raise the base font size of inputs, textareas, and selects to prevent mobile browsers from zooming on focus

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d019c10f38832da836e7021393b7b5