### PR TITLE
Prevent duplicate dietary entries during onboarding

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -587,17 +587,26 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
   }, [documentFile, form.photoConsent.consent, form.photoConsent.skipDocument, requiresDocument]);
 
   const handleAddDietary = () => {
-    if (!dietaryDraft.allergen.trim()) {
+    const trimmed = dietaryDraft.allergen.trim();
+    if (!trimmed) {
       setError("Bitte gib an, was du nicht verträgst.");
       return;
     }
+
+    const normalized = trimmed.toLocaleLowerCase("de-DE");
+    if (form.dietary.some((entry) => entry.allergen.trim().toLocaleLowerCase("de-DE") === normalized)) {
+      setError("Dieses Allergen hast du bereits eingetragen.");
+      return;
+    }
+
+    setError(null);
     setForm((prev) => ({
       ...prev,
       dietary: [
         ...prev.dietary,
         {
           id: createDietaryId(),
-          allergen: dietaryDraft.allergen.trim(),
+          allergen: trimmed,
           level: dietaryDraft.level,
           symptoms: dietaryDraft.symptoms.trim(),
           treatment: dietaryDraft.treatment.trim(),


### PR DESCRIPTION
## Summary
- deduplicate dietary restriction submissions on the onboarding API and surface a specific error when a duplicate slips through
- prevent users from adding the same allergen twice in the onboarding wizard so the form stays valid before submission

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d01b676b74832d8716aee639a1881e