### PR TITLE
Add missing member onboarding profile columns

### DIFF
--- a/prisma/migrations/20260109120000_member_onboarding_optional_fields/migration.sql
+++ b/prisma/migrations/20260109120000_member_onboarding_optional_fields/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "public"."MemberOnboardingProfile"
+    ADD COLUMN "gender" TEXT,
+    ADD COLUMN "memberSinceYear" INTEGER,
+    ADD COLUMN "dietaryPreference" TEXT,
+    ADD COLUMN "dietaryPreferenceStrictness" TEXT;


### PR DESCRIPTION
## Summary
- add a Prisma migration to extend `MemberOnboardingProfile` with the optional fields used by the onboarding flow

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d023bd20d8832d8f113b2f016e796d