### PR TITLE
Add music and props trades to onboarding options

### DIFF
--- a/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
+++ b/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
@@ -186,6 +186,10 @@ function humanizePreference(code: string) {
       return "Kostüm & Maske";
     case "crew_direction":
       return "Regieassistenz & Organisation";
+    case "crew_music":
+      return "Musik & Klang";
+    case "crew_props":
+      return "Requisite";
     default:
       return code;
   }

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -68,6 +68,16 @@ const crewOptions = [
     title: "Regieassistenz & Orga",
     description: "Abläufe koordinieren, Proben strukturieren, Teams im Hintergrund führen.",
   },
+  {
+    code: "crew_music",
+    title: "Musik & Klang",
+    description: "Arrangements entwickeln, Proben begleiten und Produktionen musikalisch tragen.",
+  },
+  {
+    code: "crew_props",
+    title: "Requisite",
+    description: "Requisiten gestalten, organisieren und für reibungslose Szenen sorgen.",
+  },
 ];
 
 const genderOptions = [


### PR DESCRIPTION
## Summary
- add Musik & Klang and Requisite crew options to the onboarding wizard
- ensure onboarding analytics labels cover the new crew preference codes

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d025278d40832d856051ad802d6c42