### PR TITLE
Adjust allergen placeholder example for onboarding

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1587,7 +1587,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                   <Input
                     value={dietaryDraft.allergen}
                     onChange={(event) => setDietaryDraft((prev) => ({ ...prev, allergen: event.target.value }))}
-                    placeholder="z.B. Erdnüsse, Gluten, Vegan"
+                    placeholder="z.B. Erdnüsse, Gluten, Laktose"
                   />
                 </label>
                 <label className="space-y-1 text-sm">


### PR DESCRIPTION
## Summary
- update the dietary allergen placeholder example in the onboarding wizard to mention Laktose instead of Vegan for better relevance

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: Turbopack cannot resolve pdfkit/qrcode modules in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d0264e3ca4832dadeee38e156b5523