### PR TITLE
Add marketing option to onboarding wizard

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,7 +18,7 @@ const nextConfig: NextConfig = {
     ],
   },
   // Next.js 15+: serverComponentsExternalPackages moved to serverExternalPackages
-  serverExternalPackages: ["bcryptjs"],
+  serverExternalPackages: ["bcryptjs", "pdfkit", "qrcode"],
 };
 
 export default nextConfig;

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -165,6 +165,12 @@ async function main() {
       color: "#16a34a",
       description: "Requisitenbeschaffung, Vorbereitung und Pflege.",
     },
+    {
+      slug: "werbung-social",
+      name: "Werbung & Social Media",
+      color: "#ec4899",
+      description: "Kommunikation, Öffentlichkeitsarbeit und Social Media.",
+    },
   ];
 
   for (const dept of departmentSeeds) {

--- a/src/app/ueber-uns/page.tsx
+++ b/src/app/ueber-uns/page.tsx
@@ -120,7 +120,7 @@ const engagement = [
   {
     title: "Mitmachen",
     description:
-      "Ob Schauspiel, Kostüm, Floristik, Metallwerkstatt oder Gästebetreuung – wir freuen uns über neue Gesichter, die mit uns die Sommertheater-Momente gestalten.",
+      "Ob Schauspiel, Kostüm, Floristik, Metallwerkstatt, Werbung & Social Media oder Gästebetreuung – wir freuen uns über neue Gesichter, die mit uns die Sommertheater-Momente gestalten.",
     action: {
       label: "Schreib uns",
       href: "mailto:ensemble@sommertheater-altrossthal.de",

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -68,6 +68,11 @@ const crewOptions = [
     title: "Regieassistenz & Orga",
     description: "Abläufe koordinieren, Proben strukturieren, Teams im Hintergrund führen.",
   },
+  {
+    code: "crew_marketing",
+    title: "Werbung & Social Media",
+    description: "Kampagnen planen, Content erstellen und unsere Produktionen sichtbar machen.",
+  },
 ];
 
 const genderOptions = [


### PR DESCRIPTION
## Summary
- add the core department seed for "Werbung & Social Media" including color and description
- extend the public "Über uns" copy so the new department is mentioned when inviting people to join
- extend the onboarding wizard with the crew preference "Werbung & Social Media" so newcomers can choose the team during signup
- mark `pdfkit` and `qrcode` as external server packages so the Turbopack build succeeds with the PDF tooling

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0255d2158832da98c74a68eb48539