### PR TITLE
Update audience highlight details

### DIFF
--- a/src/app/ueber-uns/page.tsx
+++ b/src/app/ueber-uns/page.tsx
@@ -42,8 +42,13 @@ const highlights = [
   },
   {
     label: "Publikum",
-    value: "3.200",
-    detail: "begeisterte Gäste pro Saison",
+    value: "400+",
+    detail: "Gäste pro Aufführung",
+  },
+  {
+    label: "Aufführungen",
+    value: "4",
+    detail: "pro Saison",
   },
 ];
 


### PR DESCRIPTION
## Summary
- update the audience highlight to communicate 400+ guests per performance
- add a new highlight that notes there are four performances each season

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d02da51074832d90d9f1804d317e92