### PR TITLE
Move Sperrliste link to Allgemein nav group

### DIFF
--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -15,6 +15,7 @@ const groupedConfig: Group[] = [
     items: [
       { href: "/mitglieder", label: "Dashboard", permissionKey: "mitglieder.dashboard" },
       { href: "/mitglieder/profil", label: "Profil", permissionKey: "mitglieder.profil" },
+      { href: "/mitglieder/sperrliste", label: "Sperrliste", permissionKey: "mitglieder.sperrliste" },
       { href: "/mitglieder/issues", label: "Feedback & Support", permissionKey: "mitglieder.issues" },
     ],
   },
@@ -23,7 +24,6 @@ const groupedConfig: Group[] = [
     items: [
       { href: "/mitglieder/meine-proben", label: "Meine Proben", permissionKey: "mitglieder.meine-proben" },
       { href: "/mitglieder/probenplanung", label: "Probenplanung", permissionKey: "mitglieder.probenplanung" },
-      { href: "/mitglieder/sperrliste", label: "Sperrliste", permissionKey: "mitglieder.sperrliste" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- move the Sperrliste navigation entry from the "Proben" section into the "Allgemein" group so it appears with the general member links

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d035c63bc0832d81b75a89f34b0b1a