### PR TITLE
Fix role picker dropdown clipping in modal

### DIFF
--- a/src/components/members/members-table.tsx
+++ b/src/components/members/members-table.tsx
@@ -173,6 +173,7 @@ export function MembersTable({
                     title="Benutzer bearbeiten"
                     description="Rollen und Daten bearbeiten"
                     onClose={() => setOpenFor(null)}
+                    allowContentOverflow
                   >
                     <RoleManager
                       userId={u.id}

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 let openModalCount = 0;
 let savedBodyOverflow: string | null = null;
@@ -12,12 +13,14 @@ export function Modal({
   description,
   onClose,
   children,
+  allowContentOverflow = false,
 }: {
   open: boolean;
   title: string;
   description?: string;
   onClose: () => void;
   children: React.ReactNode;
+  allowContentOverflow?: boolean;
 }) {
   useEffect(() => {
     if (!open) return;
@@ -50,7 +53,10 @@ export function Modal({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-2xl rounded-lg bg-background shadow-xl border overflow-hidden"
+        className={cn(
+          "w-full max-w-2xl rounded-lg bg-background shadow-xl border",
+          allowContentOverflow ? "overflow-visible" : "overflow-hidden",
+        )}
         onClick={(event) => event.stopPropagation()}
       >
         <div className="flex items-center justify-between border-b px-6 py-4 bg-muted/30">


### PR DESCRIPTION
## Summary
- allow modal content to opt out of overflow clipping via a new `allowContentOverflow` flag
- enable overflow in the member edit modal so the role picker dropdown can render on top of surrounding content

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0363016e0832d96cae62614bb2e7b