### PR TITLE
Refine member tooling for split names

### DIFF
--- a/prisma/migrations/20260110120000_split_user_names/migration.sql
+++ b/prisma/migrations/20260110120000_split_user_names/migration.sql
@@ -1,0 +1,36 @@
+ALTER TABLE "User" ADD COLUMN "firstName" TEXT;
+ALTER TABLE "User" ADD COLUMN "lastName" TEXT;
+
+WITH prepared AS (
+  SELECT
+    id,
+    NULLIF(BTRIM(name), '') AS trimmed_name,
+    CASE
+      WHEN name IS NULL OR BTRIM(name) = '' THEN ARRAY[]::text[]
+      ELSE regexp_split_to_array(BTRIM(name), '\\s+')
+    END AS parts
+  FROM "User"
+)
+UPDATE "User" AS u
+SET
+  "firstName" = CASE
+    WHEN p.trimmed_name IS NULL THEN NULL
+    WHEN POSITION(',' IN p.trimmed_name) > 0 THEN NULLIF(BTRIM(split_part(p.trimmed_name, ',', 2)), '')
+    WHEN COALESCE(array_length(p.parts, 1), 0) >= 1 THEN NULLIF(BTRIM(p.parts[1]), '')
+    ELSE NULL
+  END,
+  "lastName" = CASE
+    WHEN p.trimmed_name IS NULL THEN NULL
+    WHEN POSITION(',' IN p.trimmed_name) > 0 THEN NULLIF(BTRIM(split_part(p.trimmed_name, ',', 1)), '')
+    WHEN COALESCE(array_length(p.parts, 1), 0) > 1 THEN NULLIF(
+      BTRIM(array_to_string(p.parts[2:COALESCE(array_length(p.parts, 1), 0)], ' ')),
+      ''
+    )
+    ELSE NULL
+  END
+FROM prepared AS p
+WHERE p.id = u.id;
+
+UPDATE "User"
+SET "name" = NULLIF(BTRIM(concat_ws(' ', "firstName", "lastName")), '')
+WHERE "firstName" IS NOT NULL OR "lastName" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,6 +194,8 @@ enum IssueVisibility {
 
 model User {
   id        String   @id @default(cuid())
+  firstName String?
+  lastName  String?
   name      String?
   email     String?  @unique
   role      Role     @default(member)

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -7,6 +7,38 @@ import {
 import bcrypt from "bcryptjs";
 const prisma = new PrismaClient();
 
+function splitFullName(value) {
+  if (!value) return { firstName: null, lastName: null };
+  const trimmed = value.trim();
+  if (!trimmed) return { firstName: null, lastName: null };
+  if (trimmed.includes(",")) {
+    const [lastPart, firstPart] = trimmed.split(",", 2);
+    return {
+      firstName: (firstPart ?? "").trim() || null,
+      lastName: (lastPart ?? "").trim() || null,
+    };
+  }
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { firstName: null, lastName: null };
+  if (parts.length === 1) return { firstName: parts[0], lastName: null };
+  const [first, ...rest] = parts;
+  return {
+    firstName: first,
+    lastName: rest.join(" ") || null,
+  };
+}
+
+function combineName(firstName, lastName) {
+  const parts = [];
+  if (typeof firstName === "string" && firstName.trim()) {
+    parts.push(firstName.trim());
+  }
+  if (typeof lastName === "string" && lastName.trim()) {
+    parts.push(lastName.trim());
+  }
+  return parts.length ? parts.join(" ") : null;
+}
+
 async function main() {
   // --- Chronik: use ONLY the provided Altroßthal data below ---
 
@@ -96,12 +128,24 @@ async function main() {
   const defaultPasswordHash = await bcrypt.hash("password", 10);
 
   for (let i = 0; i < emails.length; i++) {
+    const friendlyName = emails[i].split("@")[0] ?? "";
+    const normalizedName = friendlyName.replace(/[._-]+/g, " ");
+    const { firstName, lastName } = splitFullName(normalizedName);
+    const displayName = combineName(firstName, lastName);
+
     await prisma.user.upsert({
       where: { email: emails[i] },
-      update: { passwordHash: defaultPasswordHash },
+      update: {
+        firstName,
+        lastName,
+        name: displayName,
+        passwordHash: defaultPasswordHash,
+      },
       create: {
         email: emails[i],
-        name: emails[i].split("@")[0],
+        firstName,
+        lastName,
+        name: displayName,
         role: roles[i],
         passwordHash: defaultPasswordHash,
       },

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/page.tsx
@@ -5,6 +5,7 @@ import { sortRoles, type Role } from "@/lib/roles";
 import { hasPermission } from "@/lib/permissions";
 import { MembersTable } from "@/components/members/members-table";
 import { MemberInviteManager } from "@/components/members/member-invite-manager";
+import { combineNameParts } from "@/lib/names";
 
 export default async function MitgliederVerwaltungPage() {
   const session = await requireAuth();
@@ -22,6 +23,8 @@ export default async function MitgliederVerwaltungPage() {
       select: {
         id: true,
         email: true,
+        firstName: true,
+        lastName: true,
         name: true,
         role: true,
         roles: { select: { role: true } },
@@ -41,7 +44,9 @@ export default async function MitgliederVerwaltungPage() {
     return {
       id: user.id,
       email: user.email,
-      name: user.name,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      name: combineNameParts(user.firstName, user.lastName) ?? user.name,
       roles: combined,
       customRoles: user.appRoles.map((ar) => ar.role),
       avatarSource: user.avatarSource,

--- a/src/app/(members)/mitglieder/proben/[rehearsalId]/page.tsx
+++ b/src/app/(members)/mitglieder/proben/[rehearsalId]/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
+import { getUserDisplayName } from "@/lib/names";
 
 const STATUS_LABELS: Record<string, string> = {
   PLANNED: "Geplant",
@@ -42,8 +43,16 @@ function sanitizeDescription(html: string | null | undefined) {
   });
 }
 
-function displayName(user: { name: string | null; email: string | null }) {
-  return user.name?.trim() || user.email?.trim() || "Unbekannt";
+type DisplayUser = {
+  firstName?: string | null;
+  lastName?: string | null;
+  name: string | null;
+  email: string | null;
+};
+
+function displayName(user?: DisplayUser | null) {
+  if (!user) return "Unbekannt";
+  return getUserDisplayName(user, "Unbekannt");
 }
 
 export default async function RehearsalDetailPage({ params }: { params: { rehearsalId: string } }) {
@@ -65,6 +74,8 @@ export default async function RehearsalDetailPage({ params }: { params: { rehear
           user: {
             select: {
               id: true,
+              firstName: true,
+              lastName: true,
               name: true,
               email: true,
               roles: { select: { role: true } },
@@ -74,7 +85,7 @@ export default async function RehearsalDetailPage({ params }: { params: { rehear
       },
       attendance: {
         include: {
-          user: { select: { id: true, name: true, email: true } },
+          user: { select: { id: true, firstName: true, lastName: true, name: true, email: true } },
         },
       },
     },

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
@@ -25,6 +25,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
 import { cn } from "@/lib/utils";
+import { getUserDisplayName } from "@/lib/names";
 import { toast } from "sonner";
 
 import { createRehearsalDraftAction, deleteRehearsalAction } from "./actions";
@@ -60,7 +61,13 @@ export type CalendarBlockedDay = {
   date: string;
   dateKey: string;
   reason: string | null;
-  user: { id: string; name: string | null; email: string | null };
+  user: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    name: string | null;
+    email: string | null;
+  };
 };
 
 export type CalendarRehearsal = {
@@ -125,8 +132,8 @@ export function RehearsalCalendar({
     }
     for (const [, list] of map) {
       list.sort((a, b) => {
-        const nameA = (a.user.name ?? a.user.email ?? "").toLowerCase();
-        const nameB = (b.user.name ?? b.user.email ?? "").toLowerCase();
+        const nameA = getUserDisplayName(a.user, "").toLowerCase();
+        const nameB = getUserDisplayName(b.user, "").toLowerCase();
         return nameA.localeCompare(nameB);
       });
     }
@@ -466,7 +473,7 @@ export function RehearsalCalendar({
             {selectedDayBlocked.length ? (
               <ul className="space-y-2">
                 {selectedDayBlocked.map((entry) => {
-                  const displayName = entry.user.name ?? entry.user.email ?? "Mitglied";
+                  const displayName = getUserDisplayName(entry.user, "Mitglied");
                   return (
                     <li key={entry.id} className="rounded-2xl border border-border/60 bg-card/70 px-3 py-2">
                       <div className="text-sm font-medium text-foreground">{displayName}</div>
@@ -623,7 +630,7 @@ export function RehearsalCalendar({
             {selectedDayBlocked.length ? (
               <ul className="mt-4 space-y-3">
                 {selectedDayBlocked.map((entry) => {
-                  const displayName = entry.user.name ?? entry.user.email ?? "Mitglied";
+                  const displayName = getUserDisplayName(entry.user, "Mitglied");
                   return (
                     <li
                       key={entry.id}

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
@@ -8,6 +8,7 @@ import { EditIcon, TrashIcon } from "@/components/ui/icons";
 import { toast } from "sonner";
 import { deleteRehearsalAction } from "./actions";
 import type { RehearsalLite } from "./rehearsal-list";
+import { combineNameParts, getUserDisplayName } from "@/lib/names";
 
 const dateFormatter = new Intl.DateTimeFormat("de-DE", {
   dateStyle: "full",
@@ -19,9 +20,16 @@ const timeFormatter = new Intl.DateTimeFormat("de-DE", {
   timeZone: "Europe/Berlin",
 });
 
-function displayName(user?: { name: string | null; email: string | null }) {
+type DisplayUser = {
+  firstName?: string | null;
+  lastName?: string | null;
+  name?: string | null;
+  email?: string | null;
+};
+
+function displayName(user?: DisplayUser | null) {
   if (!user) return "Unbekannt";
-  return user.name?.trim() || user.email?.trim() || "Unbekannt";
+  return getUserDisplayName(user, "Unbekannt");
 }
 
 function ResponseColumn({
@@ -30,7 +38,7 @@ function ResponseColumn({
   emptyText,
 }: {
   title: string;
-  people: Array<{ id: string; name: string | null; email: string | null }>;
+  people: Array<{ id: string; firstName: string | null; lastName: string | null; name: string | null; email: string | null }>;
   emptyText: string;
 }) {
   return (
@@ -157,8 +165,13 @@ export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: 
             title="Zusagen"
             people={yes.map((entry) => ({
               id: entry.user.id,
-              name: entry.user.name,
-              email: entry.user.email,
+              firstName: entry.user.firstName ?? null,
+              lastName: entry.user.lastName ?? null,
+              name:
+                combineNameParts(entry.user.firstName, entry.user.lastName) ??
+                entry.user.name ??
+                null,
+              email: entry.user.email ?? null,
             }))}
             emptyText="Noch keine Zusagen."
           />
@@ -166,8 +179,13 @@ export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: 
             title="Absagen"
             people={no.map((entry) => ({
               id: entry.user.id,
-              name: entry.user.name,
-              email: entry.user.email,
+              firstName: entry.user.firstName ?? null,
+              lastName: entry.user.lastName ?? null,
+              name:
+                combineNameParts(entry.user.firstName, entry.user.lastName) ??
+                entry.user.name ??
+                null,
+              email: entry.user.email ?? null,
             }))}
             emptyText="Noch keine Absagen."
           />
@@ -175,8 +193,13 @@ export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: 
             title="Offen"
             people={pending.map((recipient) => ({
               id: recipient.user.id,
-              name: recipient.user.name,
-              email: recipient.user.email,
+              firstName: recipient.user.firstName ?? null,
+              lastName: recipient.user.lastName ?? null,
+              name:
+                combineNameParts(recipient.user.firstName, recipient.user.lastName) ??
+                recipient.user.name ??
+                null,
+              email: recipient.user.email ?? null,
             }))}
             emptyText={notification ? "Alle haben reagiert." : "Es wurde noch keine Benachrichtigung verschickt."}
           />

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
@@ -5,8 +5,15 @@ import { RehearsalCardWithActions } from "./rehearsal-card-with-actions";
 import { format } from "date-fns";
 import { de } from "date-fns/locale/de";
 import { Button } from "@/components/ui/button";
+import { getUserDisplayName } from "@/lib/names";
 
-type UserLite = { id: string; name: string | null; email: string | null };
+type UserLite = {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  name: string | null;
+  email: string | null;
+};
 type AttendanceLite = { status: string; userId: string; user: UserLite };
 type RecipientLite = { userId: string; user: UserLite };
 type NotificationLite = { recipients: RecipientLite[] };
@@ -34,7 +41,15 @@ export function RehearsalList({ initial }: { initial: RehearsalLite[] }) {
       if (!q) return true;
       return (
         r.title.toLowerCase().includes(q) ||
-        r.location.toLowerCase().includes(q)
+        r.location.toLowerCase().includes(q) ||
+        r.attendance.some((entry) =>
+          getUserDisplayName(entry.user, "").toLowerCase().includes(q)
+        ) ||
+        r.notifications.some((notification) =>
+          notification.recipients.some((recipient) =>
+            getUserDisplayName(recipient.user, "").toLowerCase().includes(q)
+          )
+        )
       );
     });
   }, [initial, query, onlyUpcoming]);

--- a/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProduction } from "@/lib/active-production";
+import { getUserDisplayName } from "@/lib/names";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -38,10 +39,16 @@ const CASTING_ORDER: CharacterCastingType[] = [
 const selectSmallClassName =
   "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
-function formatUserName(user: { name: string | null; email: string | null }) {
-  if (user.name && user.name.trim()) return user.name;
-  if (user.email) return user.email;
-  return "Unbekannt";
+type DisplayUser = {
+  firstName?: string | null;
+  lastName?: string | null;
+  name: string | null;
+  email: string | null;
+};
+
+function formatUserName(user?: DisplayUser | null) {
+  if (!user) return "Unbekannt";
+  return getUserDisplayName(user, "Unbekannt");
 }
 
 export default async function ProduktionsBesetzungPage() {
@@ -86,7 +93,7 @@ export default async function ProduktionsBesetzungPage() {
         { name: "asc" },
         { email: "asc" },
       ],
-      select: { id: true, name: true, email: true },
+      select: { id: true, firstName: true, lastName: true, name: true, email: true },
     }),
     prisma.show.findUnique({
       where: { id: activeProduction.id },
@@ -110,7 +117,7 @@ export default async function ProduktionsBesetzungPage() {
                 id: true,
                 type: true,
                 notes: true,
-                user: { select: { id: true, name: true, email: true } },
+                user: { select: { id: true, firstName: true, lastName: true, name: true, email: true } },
               },
             },
           },

--- a/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProduction } from "@/lib/active-production";
+import { getUserDisplayName } from "@/lib/names";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -27,10 +28,16 @@ const ROLE_LABELS: Record<DepartmentMembershipRole, string> = {
   guest: "Gast",
 };
 
-function formatUserName(user: { name: string | null; email: string | null }) {
-  if (user.name && user.name.trim()) return user.name;
-  if (user.email) return user.email;
-  return "Unbekannt";
+type DisplayUser = {
+  firstName?: string | null;
+  lastName?: string | null;
+  name: string | null;
+  email: string | null;
+};
+
+function formatUserName(user?: DisplayUser | null) {
+  if (!user) return "Unbekannt";
+  return getUserDisplayName(user, "Unbekannt");
 }
 
 const selectClassName =
@@ -56,7 +63,7 @@ export default async function ProduktionsGewerkePage() {
       include: {
         memberships: {
           include: {
-            user: { select: { id: true, name: true, email: true } },
+            user: { select: { id: true, firstName: true, lastName: true, name: true, email: true } },
           },
           orderBy: { createdAt: "asc" },
         },
@@ -67,7 +74,7 @@ export default async function ProduktionsGewerkePage() {
         { name: "asc" },
         { email: "asc" },
       ],
-      select: { id: true, name: true, email: true },
+      select: { id: true, firstName: true, lastName: true, name: true, email: true },
     }),
     getActiveProduction(),
   ]);

--- a/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProduction } from "@/lib/active-production";
+import { getUserDisplayName } from "@/lib/names";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -36,10 +37,16 @@ const selectClassName =
 const selectSmallClassName =
   "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
-function formatUserName(user: { name: string | null; email: string | null }) {
-  if (user.name && user.name.trim()) return user.name;
-  if (user.email) return user.email;
-  return "Unbekannt";
+type DisplayUser = {
+  firstName?: string | null;
+  lastName?: string | null;
+  name: string | null;
+  email: string | null;
+};
+
+function formatUserName(user?: DisplayUser | null) {
+  if (!user) return "Unbekannt";
+  return getUserDisplayName(user, "Unbekannt");
 }
 
 export default async function ProduktionsSzenenPage() {
@@ -84,7 +91,7 @@ export default async function ProduktionsSzenenPage() {
         { name: "asc" },
         { email: "asc" },
       ],
-      select: { id: true, name: true, email: true },
+      select: { id: true, firstName: true, lastName: true, name: true, email: true },
     }),
     prisma.department.findMany({
       orderBy: { name: "asc" },
@@ -134,7 +141,7 @@ export default async function ProduktionsSzenenPage() {
                 neededBy: true,
                 department: { select: { id: true, name: true, slug: true, color: true } },
                 assignedToId: true,
-                assignedTo: { select: { id: true, name: true, email: true } },
+                assignedTo: { select: { id: true, firstName: true, lastName: true, name: true, email: true } },
               },
             },
           },

--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -67,6 +67,8 @@ export default async function ProfilePage() {
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: {
+      firstName: true,
+      lastName: true,
       name: true,
       email: true,
       role: true,
@@ -94,6 +96,8 @@ export default async function ProfilePage() {
         <div className="space-y-6">
           <ProfileSummaryCard
             userId={userId}
+            firstName={user.firstName}
+            lastName={user.lastName}
             name={user.name}
             email={user.email}
             roles={roles}
@@ -185,6 +189,8 @@ export default async function ProfilePage() {
             <CardContent className="space-y-0">
               <ProfileForm
                 userId={userId}
+                initialFirstName={user.firstName}
+                initialLastName={user.lastName}
                 initialName={user.name}
                 initialEmail={user.email}
                 initialAvatarSource={user.avatarSource}

--- a/src/app/api/members/roles/route.ts
+++ b/src/app/api/members/roles/route.ts
@@ -90,6 +90,8 @@ export async function PUT(request: NextRequest) {
       },
       select: {
         id: true,
+        firstName: true,
+        lastName: true,
         email: true,
         name: true,
         role: true,
@@ -105,6 +107,8 @@ export async function PUT(request: NextRequest) {
       user: {
         id: updated.id,
         email: updated.email,
+        firstName: updated.firstName,
+        lastName: updated.lastName,
         name: updated.name,
         roles: allRoles,
         customRoles: updated.appRoles.map((ar) => ar.role),

--- a/src/components/members/members-table.tsx
+++ b/src/components/members/members-table.tsx
@@ -8,16 +8,23 @@ import { ROLE_BADGE_VARIANTS, ROLE_LABELS, sortRoles, type Role } from "@/lib/ro
 import { RoleManager } from "@/components/members/role-manager";
 import { UserAvatar } from "@/components/user-avatar";
 import type { AvatarSource } from "@/components/user-avatar";
+import { combineNameParts } from "@/lib/names";
 
 export type MembersTableUser = {
   id: string;
   email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
   name?: string | null;
   roles: Role[];
   customRoles: { id: string; name: string }[];
   avatarSource?: AvatarSource | null;
   avatarUpdatedAt?: string | number | Date | null;
 };
+
+function getDisplayName(user: MembersTableUser): string {
+  return combineNameParts(user.firstName, user.lastName) ?? user.name ?? "";
+}
 
 export function MembersTable({
   users,
@@ -41,9 +48,9 @@ export function MembersTable({
     const q = query.trim().toLowerCase();
     if (!q) return rows;
     return rows.filter((r) => {
-      const name = r.name ?? "";
-      const email = r.email ?? "";
-      return name.toLowerCase().includes(q) || email.toLowerCase().includes(q);
+      const name = getDisplayName(r).toLowerCase();
+      const email = (r.email ?? "").toLowerCase();
+      return name.includes(q) || email.includes(q);
     });
   }, [rows, query]);
 
@@ -64,6 +71,7 @@ export function MembersTable({
       <div className="space-y-2 sm:hidden">
         {filteredRows.map((u) => {
           const sorted = sortRoles(u.roles);
+          const displayName = getDisplayName(u);
           return (
             <div key={u.id} className="rounded-md border bg-card p-3">
               <div className="flex items-start justify-between">
@@ -71,14 +79,16 @@ export function MembersTable({
                   <UserAvatar
                     userId={u.id}
                     email={u.email}
-                    name={u.name}
+                    firstName={u.firstName}
+                    lastName={u.lastName}
+                    name={displayName}
                     size={40}
                     className="h-10 w-10"
                     avatarSource={u.avatarSource}
                     avatarUpdatedAt={u.avatarUpdatedAt}
                   />
                   <div>
-                    <div className="font-medium">{u.name || "—"}</div>
+                    <div className="font-medium">{displayName || "—"}</div>
                     <div className="text-xs text-muted-foreground">{u.email || "—"}</div>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {sorted.map((r) => (
@@ -119,6 +129,7 @@ export function MembersTable({
         <tbody>
           {filteredRows.map((u) => {
             const sorted = sortRoles(u.roles);
+            const displayName = getDisplayName(u);
             return (
               <tr key={u.id} className="border-b hover:bg-accent/10">
                 <td className="px-3 py-2 whitespace-nowrap">
@@ -126,14 +137,16 @@ export function MembersTable({
                     <UserAvatar
                       userId={u.id}
                       email={u.email}
-                      name={u.name}
+                      firstName={u.firstName}
+                      lastName={u.lastName}
+                      name={displayName}
                       size={32}
                       className="h-8 w-8"
                       avatarSource={u.avatarSource}
                       avatarUpdatedAt={u.avatarUpdatedAt}
                     />
                     <div>
-                      <div className="font-medium">{u.name || "—"}</div>
+                      <div className="font-medium">{displayName || "—"}</div>
                       <div className="text-xs text-muted-foreground">{u.email || "—"}</div>
                     </div>
                   </div>
@@ -177,7 +190,9 @@ export function MembersTable({
                     <RoleManager
                       userId={u.id}
                       email={u.email}
-                      name={u.name}
+                      firstName={u.firstName}
+                      lastName={u.lastName}
+                      name={displayName}
                       initialRoles={u.roles}
                       canEditOwner={canEditOwner}
                       availableCustomRoles={availableCustomRoles}
@@ -195,14 +210,21 @@ export function MembersTable({
                           ),
                         );
                       }}
-                      onUserUpdated={({ email, name }) => {
+                      onUserUpdated={({ email, firstName, lastName, name }) => {
                         setRows((prev) =>
                           prev.map((row) =>
                             row.id === u.id
                               ? {
                                   ...row,
                                   email: email ?? row.email,
-                                  name: name ?? row.name,
+                                  firstName: firstName !== undefined ? firstName : row.firstName,
+                                  lastName: lastName !== undefined ? lastName : row.lastName,
+                                  name:
+                                    name ??
+                                    combineNameParts(
+                                      firstName !== undefined ? firstName : row.firstName,
+                                      lastName !== undefined ? lastName : row.lastName,
+                                    ) ?? row.name,
                                 }
                               : row,
                           ),

--- a/src/components/members/profile-summary-card.tsx
+++ b/src/components/members/profile-summary-card.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { UserAvatar, type AvatarSource } from "@/components/user-avatar";
 import { ROLE_LABELS, type Role } from "@/lib/roles";
 import { cn } from "@/lib/utils";
+import { getUserDisplayName } from "@/lib/names";
 
 const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
 
@@ -33,7 +34,9 @@ function formatUpdatedAt(value: string | null | undefined) {
 
 export interface ProfileSummaryCardProps {
   userId: string;
-  name: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  name?: string | null;
   email: string | null;
   roles: Role[];
   avatarSource: AvatarSource | string | null;
@@ -42,13 +45,15 @@ export interface ProfileSummaryCardProps {
 
 export function ProfileSummaryCard({
   userId,
+  firstName,
+  lastName,
   name,
   email,
   roles,
   avatarSource,
   avatarUpdatedAt,
 }: ProfileSummaryCardProps) {
-  const displayName = name?.trim() ? name.trim() : "Unbenanntes Profil";
+  const displayName = getUserDisplayName({ firstName, lastName, name, email }, "") || "Unbenanntes Profil";
   const normalizedEmail = email?.trim() ?? "";
   const hasEmail = Boolean(normalizedEmail);
   const normalizedSource = normalizeAvatarSource(avatarSource);
@@ -63,15 +68,17 @@ export function ProfileSummaryCard({
       <CardHeader className="space-y-4">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-4">
-            <UserAvatar
-              userId={userId}
-              name={name}
-              email={email}
-              avatarSource={avatarSource}
-              avatarUpdatedAt={avatarUpdatedAt}
-              size={76}
-              className="h-[76px] w-[76px] border-border/80 text-xl shadow-sm"
-            />
+          <UserAvatar
+            userId={userId}
+            firstName={firstName}
+            lastName={lastName}
+            name={displayName}
+            email={email}
+            avatarSource={avatarSource}
+            avatarUpdatedAt={avatarUpdatedAt}
+            size={76}
+            className="h-[76px] w-[76px] border-border/80 text-xl shadow-sm"
+          />
             <div className="space-y-1.5">
               <CardTitle className="text-xl font-semibold leading-tight text-foreground">{displayName}</CardTitle>
               <p className="text-sm text-muted-foreground">{rolesSummary}</p>

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -303,7 +303,8 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
   const [customCrewError, setCustomCrewError] = useState<string | null>(null);
 
   const [form, setForm] = useState({
-    name: "",
+    firstName: "",
+    lastName: "",
     email: "",
     password: "",
     passwordConfirm: "",
@@ -676,8 +677,12 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
       return;
     }
     if (step === 1) {
-      if (!form.name.trim()) {
-        setError("Bitte gib deinen Namen ein.");
+      if (!form.firstName.trim()) {
+        setError("Bitte gib deinen Vornamen ein.");
+        return;
+      }
+      if (!form.lastName.trim()) {
+        setError("Bitte gib deinen Nachnamen ein.");
         return;
       }
       if (!form.email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
@@ -791,7 +796,8 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
       const memberSinceYear = Number.isFinite(parsedYear) ? parsedYear : null;
       const payload = {
         sessionToken,
-        name: form.name.trim(),
+        firstName: form.firstName.trim(),
+        lastName: form.lastName.trim(),
         email: form.email.trim(),
         password: form.password,
         background: form.background.trim(),
@@ -990,10 +996,24 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
           <CardContent className="space-y-4">
             <div className="grid gap-4 md:grid-cols-2">
               <label className="space-y-1 text-sm">
-                <span className="font-medium">Name</span>
-                <Input value={form.name} onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))} placeholder="Vorname Nachname" />
+                <span className="font-medium">Vorname</span>
+                <Input
+                  value={form.firstName}
+                  onChange={(event) => setForm((prev) => ({ ...prev, firstName: event.target.value }))}
+                  placeholder="Vorname"
+                  autoComplete="given-name"
+                />
               </label>
               <label className="space-y-1 text-sm">
+                <span className="font-medium">Nachname</span>
+                <Input
+                  value={form.lastName}
+                  onChange={(event) => setForm((prev) => ({ ...prev, lastName: event.target.value }))}
+                  placeholder="Nachname"
+                  autoComplete="family-name"
+                />
+              </label>
+              <label className="space-y-1 text-sm md:col-span-2">
                 <span className="font-medium">E-Mail</span>
                 <Input
                   type="email"
@@ -1689,7 +1709,11 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                 <dl className="mt-3 grid gap-3 text-sm">
                   <div className="flex items-center justify-between">
                     <dt className="text-muted-foreground">Name</dt>
-                    <dd className="font-medium text-foreground">{form.name || "–"}</dd>
+                    <dd className="font-medium text-foreground">
+                      {form.firstName || form.lastName
+                        ? [form.firstName, form.lastName].filter(Boolean).join(" ")
+                        : "–"}
+                    </dd>
                   </div>
                   <div className="flex items-center justify-between">
                     <dt className="text-muted-foreground">E-Mail</dt>

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 import { getGravatarUrl } from "@/lib/gravatar";
 import { cn } from "@/lib/utils";
+import { getNameInitials, getUserDisplayName } from "@/lib/names";
 import type { CSSProperties } from "react";
 
 export type AvatarSource = "GRAVATAR" | "UPLOAD" | "INITIALS";
@@ -33,26 +34,11 @@ function getVersionKey(value?: string | number | Date | null): string | undefine
   return Number.isNaN(parsed) ? undefined : String(parsed);
 }
 
-function computeInitials(name?: string | null, email?: string | null): string {
-  const trimmedName = name?.trim();
-  if (trimmedName) {
-    const parts = trimmedName.split(/\s+/).filter(Boolean);
-    if (parts.length >= 2) {
-      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-    }
-    return trimmedName.slice(0, 2).toUpperCase();
-  }
-  const trimmedEmail = email?.trim();
-  if (trimmedEmail) {
-    const local = trimmedEmail.split("@")[0];
-    return local.slice(0, 2).toUpperCase() || trimmedEmail[0]?.toUpperCase() || "?";
-  }
-  return "?";
-}
-
 export type UserAvatarProps = {
   userId?: string;
   email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
   name?: string | null;
   size?: number;
   className?: string;
@@ -66,6 +52,8 @@ export type UserAvatarProps = {
 export default function UserAvatar({
   userId,
   email,
+  firstName,
+  lastName,
   name,
   size = 40,
   className,
@@ -76,9 +64,8 @@ export default function UserAvatar({
   previewUrl,
 }: UserAvatarProps) {
   const displaySize = Math.max(1, Math.round(size));
-  const trimmedName = name?.trim() || undefined;
   const trimmedEmail = email?.trim() || undefined;
-  const label = trimmedName || trimmedEmail || undefined;
+  const label = getUserDisplayName({ firstName, lastName, name, email }, "") || undefined;
   const normalized = normalizeSource(avatarSource);
 
   const [gravatarFailed, setGravatarFailed] = useState(false);
@@ -137,7 +124,7 @@ export default function UserAvatar({
   }
 
   // Default to initials (or when Gravatar failed or no source available)
-  const initials = computeInitials(name, email);
+  const initials = getNameInitials({ firstName, lastName, name, email });
   return (
     <div
       className={cn("inline-flex items-center justify-center rounded-full border border-border bg-muted", className)}

--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { UserAvatar } from "@/components/user-avatar";
+import { getUserDisplayName } from "@/lib/names";
 
 export function UserNav({ className }: { className?: string }) {
   const { data: session, status } = useSession();
@@ -55,7 +56,15 @@ export function UserNav({ className }: { className?: string }) {
     );
   }
 
-  const name = session.user.name ?? session.user.email ?? "";
+  const name = getUserDisplayName(
+    {
+      firstName: session.user.firstName,
+      lastName: session.user.lastName,
+      name: session.user.name,
+      email: session.user.email,
+    },
+    "",
+  );
   const role = session.user.role;
   async function onLogout() {
     try {
@@ -79,7 +88,9 @@ export function UserNav({ className }: { className?: string }) {
         <UserAvatar
           userId={session.user.id}
           email={session.user.email}
-          name={session.user.name}
+          firstName={session.user.firstName}
+          lastName={session.user.lastName}
+          name={name}
           size={28}
           className="h-7 w-7 select-none"
           avatarSource={session.user.avatarSource}

--- a/src/lib/email/rehearsal-reminders.ts
+++ b/src/lib/email/rehearsal-reminders.ts
@@ -1,7 +1,8 @@
-import type { PrismaClient, User, Rehearsal } from '@prisma/client';
-import { render } from '@react-email/render';
-import { sendEmail } from './email-service';
-import { RehearsalReminderEmail } from './templates/rehearsal-reminder';
+import type { PrismaClient, User, Rehearsal } from "@prisma/client";
+import { render } from "@react-email/render";
+import { sendEmail } from "./email-service";
+import { RehearsalReminderEmail } from "./templates/rehearsal-reminder";
+import { getUserDisplayName } from "@/lib/names";
 
 export async function sendRehearsalReminders(prisma: PrismaClient) {
   const oneWeekFromNow = new Date();
@@ -42,8 +43,8 @@ async function findUsersWithoutResponse(
     where: {
       id: { notIn: respondedUserIds },
       AND: [
-        { role: { notIn: ['admin', 'owner'] } },
-        { roles: { none: { role: { in: ['admin', 'owner'] } } } },
+        { role: { notIn: ["admin", "owner"] } },
+        { roles: { none: { role: { in: ["admin", "owner"] } } } },
       ],
     },
   });
@@ -62,10 +63,19 @@ async function sendRemindersForRehearsal(
     if (!user.email) continue;
 
     const registrationLink = `${process.env.NEXT_PUBLIC_BASE_URL}/proben/${rehearsal.id}`;
+    const userName = getUserDisplayName(
+      {
+        firstName: user.firstName,
+        lastName: user.lastName,
+        name: user.name,
+        email: user.email,
+      },
+      "Theatermitglied",
+    );
 
     const emailHtml = await render(
       RehearsalReminderEmail({
-        userName: user.name || 'Theatermitglied',
+        userName,
         rehearsalTitle: rehearsal.title,
         rehearsalDate: rehearsal.start,
         rehearsalLocation: rehearsal.location,

--- a/src/lib/names.ts
+++ b/src/lib/names.ts
@@ -1,0 +1,95 @@
+export type MaybeString = string | null | undefined;
+export function trimToNull(value: MaybeString): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function combineNameParts(firstName?: MaybeString, lastName?: MaybeString): string | null {
+  const first = trimToNull(firstName);
+  const last = trimToNull(lastName);
+  if (!first && !last) return null;
+  return [first, last].filter(Boolean).join(" ");
+}
+
+export function getUserFullName(user: {
+  firstName?: MaybeString;
+  lastName?: MaybeString;
+  name?: MaybeString;
+}): string | null {
+  return combineNameParts(user.firstName, user.lastName) ?? trimToNull(user.name);
+}
+
+export function getUserDisplayName(
+  user: {
+    firstName?: MaybeString;
+    lastName?: MaybeString;
+    name?: MaybeString;
+    email?: MaybeString;
+  },
+  fallback = "Unbekannt",
+): string {
+  return getUserFullName(user) ?? trimToNull(user.email) ?? fallback;
+}
+
+function initialsFromSegments(segments: string[]): string | null {
+  if (segments.length === 0) return null;
+  if (segments.length >= 2) {
+    const first = Array.from(segments[0] ?? "").shift();
+    const last = Array.from(segments[segments.length - 1] ?? "").shift();
+    if (first && last) return `${first}${last}`.toUpperCase();
+  }
+  const joined = segments[0] ?? "";
+  const letters = Array.from(joined).slice(0, 2).join("");
+  return letters ? letters.toUpperCase() : null;
+}
+
+export function getNameInitials(params: {
+  firstName?: MaybeString;
+  lastName?: MaybeString;
+  name?: MaybeString;
+  email?: MaybeString;
+}): string {
+  const first = trimToNull(params.firstName);
+  const last = trimToNull(params.lastName);
+  const fromParts = initialsFromSegments([first, last].filter(Boolean) as string[]);
+  if (fromParts) return fromParts;
+
+  const fallbackName = trimToNull(params.name);
+  if (fallbackName) {
+    const nameInitials = initialsFromSegments(fallbackName.split(/\s+/).filter(Boolean));
+    if (nameInitials) return nameInitials;
+  }
+
+  const trimmedEmail = trimToNull(params.email);
+  if (trimmedEmail) {
+    const local = trimmedEmail.split("@")[0];
+    const emailInitials = initialsFromSegments([local].filter(Boolean));
+    if (emailInitials) return emailInitials;
+  }
+
+  return "?";
+}
+
+export function splitFullName(fullName: MaybeString): { firstName: string | null; lastName: string | null } {
+  const trimmed = trimToNull(fullName);
+  if (!trimmed) return { firstName: null, lastName: null };
+
+  if (trimmed.includes(",")) {
+    const [lastPart, firstPart] = trimmed.split(",", 2);
+    return {
+      firstName: trimToNull(firstPart),
+      lastName: trimToNull(lastPart),
+    };
+  }
+
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return { firstName: null, lastName: null };
+  if (parts.length === 1) return { firstName: parts[0] ?? null, lastName: null };
+
+  const [first, ...rest] = parts;
+  return {
+    firstName: first ?? null,
+    lastName: rest.join(" ") || null,
+  };
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -5,6 +5,8 @@ declare module "next-auth" {
   interface Session {
     user?: {
       id: string;
+      firstName?: string | null;
+      lastName?: string | null;
       name?: string | null;
       email?: string | null;
       role?: Role;
@@ -15,6 +17,8 @@ declare module "next-auth" {
     };
   }
   interface User {
+    firstName?: string | null;
+    lastName?: string | null;
     role?: Role;
     roles?: Role[];
     avatarSource?: AvatarSource | null;


### PR DESCRIPTION
## Summary
- adopt the new first/last name fields across the production management pages so dropdowns and assignments show correct display names
- update rehearsal detail, planning calendar, and list views to normalise member names and filter by the combined label
- ensure admin APIs and reminder emails recompute display names from split fields when serialising responses

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d03436cb04832dbb1292879da404e2