### PR TITLE
Enable dynamic rendering for Chronik page

### DIFF
--- a/src/app/chronik/page.tsx
+++ b/src/app/chronik/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { prisma } from "@/lib/prisma";
 import type { Prisma, Show } from "@prisma/client";
 import { Heading, Text } from "@/components/ui/typography";


### PR DESCRIPTION
## Summary
- force the Chronik route to render dynamically so production requests hit the database instead of build-time output

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d03fa9c144832d95dab39fd2d86c66