### PR TITLE
Add Meine Gewerke member view and dynamic navigation label

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -1,13 +1,33 @@
 import React from "react";
-import { MembersNav } from "@/components/members-nav";
+import { MembersNav, type AssignmentFocus } from "@/components/members-nav";
 import { requireAuth } from "@/lib/rbac";
 import { getUserPermissionKeys } from "@/lib/permissions";
 import { getActiveProduction } from "@/lib/active-production";
+import { prisma } from "@/lib/prisma";
 
 export default async function MembersLayout({ children }: { children: React.ReactNode }) {
   const session = await requireAuth();
   const permissions = await getUserPermissionKeys(session.user);
   const activeProduction = await getActiveProduction();
+
+  let assignmentFocus: AssignmentFocus = "none";
+  const userId = session.user?.id;
+  if (userId) {
+    const [rehearsalAssignments, departmentAssignments] = await Promise.all([
+      prisma.rehearsalAttendance.count({
+        where: { userId, rehearsal: { status: { not: "DRAFT" } } },
+      }),
+      prisma.departmentMembership.count({ where: { userId } }),
+    ]);
+
+    if (rehearsalAssignments > 0 && departmentAssignments > 0) {
+      assignmentFocus = "both";
+    } else if (departmentAssignments > 0) {
+      assignmentFocus = "departments";
+    } else if (rehearsalAssignments > 0) {
+      assignmentFocus = "rehearsals";
+    }
+  }
 
   return (
     <main className="w-full pb-12 pt-6 sm:pt-8">
@@ -15,7 +35,11 @@ export default async function MembersLayout({ children }: { children: React.Reac
         className="mx-auto flex w-full max-w-screen-2xl flex-col gap-6 px-4 sm:px-6 lg:grid lg:grid-cols-[280px_minmax(0,1fr)] lg:items-start lg:gap-10 lg:px-8 xl:grid-cols-[300px_minmax(0,1fr)] xl:gap-12 xl:px-10 2xl:grid-cols-[320px_minmax(0,1fr)] 2xl:gap-16 2xl:px-12"
       >
         <aside className="lg:sticky lg:top-28 lg:h-fit lg:self-start lg:max-h-[calc(100vh-7rem)] lg:overflow-y-auto lg:pr-2">
-          <MembersNav permissions={permissions} activeProduction={activeProduction ?? undefined} />
+          <MembersNav
+            permissions={permissions}
+            activeProduction={activeProduction ?? undefined}
+            assignmentFocus={assignmentFocus}
+          />
         </aside>
         <section className="min-w-0 space-y-8">{children}</section>
       </div>

--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -1,0 +1,489 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { addDays, format, formatDistance, startOfToday } from "date-fns";
+import { de } from "date-fns/locale/de";
+import { DepartmentMembershipRole, TaskStatus } from "@prisma/client";
+import type { ComponentProps } from "react";
+
+import { PageHeader } from "@/components/members/page-header";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+
+const ROLE_LABELS: Record<DepartmentMembershipRole, string> = {
+  lead: "Leitung",
+  member: "Mitglied",
+  deputy: "Vertretung",
+  guest: "Gast",
+};
+
+const ROLE_BADGE_VARIANTS: Record<DepartmentMembershipRole, ComponentProps<typeof Badge>["variant"]> = {
+  lead: "success",
+  member: "muted",
+  deputy: "info",
+  guest: "secondary",
+};
+
+const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  todo: "Offen",
+  doing: "In Arbeit",
+  done: "Erledigt",
+};
+
+const TASK_STATUS_BADGES: Record<TaskStatus, ComponentProps<typeof Badge>["variant"]> = {
+  todo: "muted",
+  doing: "info",
+  done: "success",
+};
+
+const TASK_STATUS_ORDER: Record<TaskStatus, number> = {
+  todo: 0,
+  doing: 1,
+  done: 2,
+};
+
+const PLANNING_FREEZE_DAYS = 7;
+const PLANNING_LOOKAHEAD_DAYS = 60;
+const DATE_KEY_FORMAT = "yyyy-MM-dd";
+
+function formatUserName(user: { name: string | null; email: string | null }) {
+  if (user.name && user.name.trim()) return user.name;
+  if (user.email) return user.email;
+  return "Unbekannt";
+}
+
+function getDueMeta(date: Date, reference: Date) {
+  return {
+    relative: formatDistance(date, reference, { addSuffix: true, locale: de }),
+    absolute: format(date, "EEEE, d. MMMM yyyy", { locale: de }),
+    isOverdue: date.getTime() < reference.getTime(),
+  };
+}
+
+type MeetingSuggestion = { key: string; date: Date; label: string; shortLabel: string };
+
+function findMeetingSuggestions(
+  memberIds: string[],
+  planningStart: Date,
+  planningEnd: Date,
+  blockedByUser: Map<string, Set<string>>,
+) {
+  if (memberIds.length === 0) return [] as MeetingSuggestion[];
+
+  const results: MeetingSuggestion[] = [];
+  let current = planningStart;
+  while (results.length < 3 && current <= planningEnd) {
+    const key = format(current, DATE_KEY_FORMAT);
+    const hasConflict = memberIds.some((id) => blockedByUser.get(id)?.has(key));
+    if (!hasConflict) {
+      results.push({
+        key,
+        date: new Date(current),
+        label: format(current, "EEEE, d. MMMM yyyy", { locale: de }),
+        shortLabel: format(current, "dd.MM.yyyy", { locale: de }),
+      });
+    }
+    current = addDays(current, 1);
+  }
+  return results;
+}
+
+function countBlockedDays(memberIds: string[], blockedByUser: Map<string, Set<string>>) {
+  const blocked = new Set<string>();
+  for (const memberId of memberIds) {
+    const entries = blockedByUser.get(memberId);
+    if (!entries) continue;
+    for (const key of entries) {
+      blocked.add(key);
+    }
+  }
+  return blocked.size;
+}
+
+export default async function MeineGewerkePage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.meine-gewerke");
+  if (!allowed) {
+    return <div className="text-sm text-red-600">Kein Zugriff auf die persönliche Gewerkeübersicht.</div>;
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    notFound();
+  }
+
+  const today = startOfToday();
+  const planningStart = addDays(today, PLANNING_FREEZE_DAYS);
+  const planningEnd = addDays(planningStart, PLANNING_LOOKAHEAD_DAYS);
+
+  const membershipsRaw = await prisma.departmentMembership.findMany({
+    where: { userId },
+    include: {
+      department: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          color: true,
+          slug: true,
+          memberships: {
+            include: {
+              user: { select: { id: true, name: true, email: true } },
+            },
+          },
+          tasks: {
+            where: { assigneeId: userId },
+            orderBy: { createdAt: "asc" },
+          },
+        },
+      },
+    },
+  });
+
+  const memberships = membershipsRaw.sort((a, b) =>
+    a.department.name.localeCompare(b.department.name, "de", { sensitivity: "base" }),
+  );
+
+  const memberIds = new Set<string>();
+  for (const membership of memberships) {
+    for (const entry of membership.department.memberships) {
+      memberIds.add(entry.userId);
+    }
+  }
+
+  const blockedDays = memberIds.size
+    ? await prisma.blockedDay.findMany({
+        where: {
+          userId: { in: Array.from(memberIds) },
+          date: { gte: today, lte: planningEnd },
+        },
+        orderBy: { date: "asc" },
+      })
+    : [];
+
+  const blockedByUser = new Map<string, Set<string>>();
+  for (const entry of blockedDays) {
+    const key = format(entry.date, DATE_KEY_FORMAT);
+    const existing = blockedByUser.get(entry.userId);
+    if (existing) {
+      existing.add(key);
+    } else {
+      blockedByUser.set(entry.userId, new Set([key]));
+    }
+  }
+
+  const taskTotals: Record<TaskStatus, number> = { todo: 0, doing: 0, done: 0 };
+  for (const membership of memberships) {
+    for (const task of membership.department.tasks) {
+      taskTotals[task.status] += 1;
+    }
+  }
+
+  const openTaskCount = taskTotals.todo + taskTotals.doing;
+  const freezeUntilLabel = format(planningStart, "d. MMMM yyyy", { locale: de });
+  const planningWindowLabel = format(planningEnd, "d. MMMM yyyy", { locale: de });
+  const now = new Date();
+
+  const headerActions = (
+    <>
+      <Button asChild size="sm" variant="outline">
+        <Link href="/mitglieder/sperrliste">Sperrliste</Link>
+      </Button>
+      <Button asChild size="sm">
+        <Link href="/mitglieder/produktionen/gewerke">Gewerke &amp; Teams</Link>
+      </Button>
+    </>
+  );
+
+  if (memberships.length === 0) {
+    return (
+      <div className="space-y-8">
+        <PageHeader
+          title="Meine Gewerke"
+          description="Sobald du einem Gewerk zugeordnet bist, findest du hier Aufgaben, Ansprechpartner:innen und Terminvorschläge."
+          actions={headerActions}
+        />
+
+        <Card className="border border-dashed border-border/60 bg-background/60">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold">Noch keine Gewerke</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm text-muted-foreground">
+            <p>Aktuell bist du keinem Gewerk zugeordnet. Sprich das Produktionsteam an, wenn du Verantwortung übernehmen möchtest.</p>
+            <p>
+              Du kannst jederzeit deine <Link href="/mitglieder/sperrliste" className="text-primary underline-offset-2 hover:underline">Sperrliste</Link> aktualisieren oder in der
+              <Link href="/mitglieder/produktionen/gewerke" className="ml-1 text-primary underline-offset-2 hover:underline">Gewerkübersicht</Link> stöbern.
+            </p>
+            <p>
+              Terminvorschläge berücksichtigen Sperrlisten nach dem Freeze bis {freezeUntilLabel} sowie den Planungshorizont bis {planningWindowLabel}.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const summaryStats = [
+    { label: "Gewerke", value: memberships.length, hint: "Aktive Zuordnungen" },
+    { label: "Aktive Aufgaben", value: openTaskCount, hint: "Status offen & in Arbeit" },
+    { label: "Abgeschlossen", value: taskTotals.done, hint: "Eigene erledigte Aufgaben" },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Meine Gewerke"
+        description="Behalte deine Zuständigkeiten im Blick, sieh offene Aufgaben und finde passende Terminfelder für dein Team."
+        actions={headerActions}
+      />
+
+      <Card className="border border-border/60 bg-background/60">
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold">Überblick</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Terminvorschläge berücksichtigen Sperrlisten ab dem Freeze am {freezeUntilLabel} bis zum Planungshorizont am {planningWindowLabel}.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-3">
+            {summaryStats.map((stat) => (
+              <div key={stat.label} className="rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">{stat.label}</p>
+                <p className="mt-1 text-2xl font-semibold text-foreground">{stat.value}</p>
+                {stat.hint ? <p className="text-xs text-muted-foreground">{stat.hint}</p> : null}
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+            <span>
+              Planungsfenster: {freezeUntilLabel} – {planningWindowLabel}
+            </span>
+            <Link href="/mitglieder/sperrliste" className="font-medium text-primary hover:text-primary/80">
+              Sperrliste aktualisieren
+            </Link>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-6">
+        {memberships.map((membership) => {
+          const { department } = membership;
+          const sortedMembers = [...department.memberships].sort((a, b) =>
+            formatUserName(a.user).localeCompare(formatUserName(b.user), "de", { sensitivity: "base" }),
+          );
+          const sortedTasks = [...department.tasks].sort((a, b) => {
+            const statusDiff = TASK_STATUS_ORDER[a.status] - TASK_STATUS_ORDER[b.status];
+            if (statusDiff !== 0) return statusDiff;
+            const dueA = a.dueAt ? a.dueAt.getTime() : Number.MAX_SAFE_INTEGER;
+            const dueB = b.dueAt ? b.dueAt.getTime() : Number.MAX_SAFE_INTEGER;
+            if (dueA !== dueB) return dueA - dueB;
+            return a.createdAt.getTime() - b.createdAt.getTime();
+          });
+          const activeTasks = sortedTasks.filter((task) => task.status !== "done");
+          const completedTasks = sortedTasks.filter((task) => task.status === "done");
+          const memberIdsForDepartment = department.memberships.map((entry) => entry.userId);
+          const meetingSuggestions = findMeetingSuggestions(
+            memberIdsForDepartment,
+            planningStart,
+            planningEnd,
+            blockedByUser,
+          );
+          const blockedDatesCount = countBlockedDays(memberIdsForDepartment, blockedByUser);
+
+          return (
+            <Card key={membership.id} className="space-y-6 border border-border/60 bg-background/70">
+              <CardHeader className="space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex items-start gap-3">
+                    <span
+                      className="mt-1 inline-block h-3 w-3 rounded-full border border-border/80"
+                      style={{ backgroundColor: department.color ?? "#94a3b8" }}
+                    />
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg font-semibold">{department.name}</CardTitle>
+                      {department.description ? (
+                        <p className="text-sm text-muted-foreground">{department.description}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                  <Button asChild size="sm" variant="outline">
+                    <Link href="/mitglieder/produktionen/gewerke">Team öffnen</Link>
+                  </Button>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <Badge variant={ROLE_BADGE_VARIANTS[membership.role]} size="sm">
+                    {ROLE_LABELS[membership.role]}
+                  </Badge>
+                  {membership.title ? (
+                    <Badge variant="outline" size="sm">
+                      {membership.title}
+                    </Badge>
+                  ) : null}
+                  {membership.note ? <span>Notiz: {membership.note}</span> : null}
+                </div>
+              </CardHeader>
+
+              <CardContent className="space-y-6">
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold">Teamübersicht</h3>
+                    <Badge variant="muted" size="sm">
+                      {sortedMembers.length} Personen
+                    </Badge>
+                  </div>
+                  <ul className="space-y-2">
+                    {sortedMembers.map((member) => {
+                      const isCurrentUser = member.userId === userId;
+                      return (
+                        <li
+                          key={member.id}
+                          className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-background/80 p-3 text-sm shadow-sm"
+                        >
+                          <div>
+                            <p className="font-medium">{formatUserName(member.user)}</p>
+                            {member.title ? (
+                              <p className="text-xs text-muted-foreground">{member.title}</p>
+                            ) : null}
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Badge variant={ROLE_BADGE_VARIANTS[member.role]} size="sm">
+                              {ROLE_LABELS[member.role]}
+                            </Badge>
+                            {isCurrentUser ? (
+                              <Badge variant="outline" size="sm">
+                                Du
+                              </Badge>
+                            ) : null}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+
+                <div className="space-y-3 rounded-lg border border-border/60 bg-background/80 p-4 shadow-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold">Terminvorschläge</h3>
+                    <Badge variant="muted" size="sm">
+                      {blockedDatesCount} blockierte Tage
+                    </Badge>
+                  </div>
+                  {meetingSuggestions.length ? (
+                    <ul className="grid gap-3 sm:grid-cols-2">
+                      {meetingSuggestions.map((suggestion) => (
+                        <li
+                          key={suggestion.key}
+                          className="rounded-md border border-border/60 bg-background p-3 text-sm shadow-sm"
+                        >
+                          <p className="font-medium">{suggestion.label}</p>
+                          <p className="text-xs text-muted-foreground">Frei für alle Mitglieder</p>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Aktuell gibt es keinen Termin ohne Sperrlisten-Konflikte. Prüfe deine Sperrtage und die deines Teams.
+                    </p>
+                  )}
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                    <span>
+                      Fenster: {freezeUntilLabel} – {planningWindowLabel}
+                    </span>
+                    <Link href="/mitglieder/sperrliste" className="font-medium text-primary hover:text-primary/80">
+                      Sperrliste öffnen
+                    </Link>
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold">Meine Aufgaben</h3>
+                    <Badge variant="muted" size="sm">
+                      {sortedTasks.length} Aufgaben
+                    </Badge>
+                  </div>
+                  {activeTasks.length ? (
+                    <ul className="space-y-3">
+                      {activeTasks.map((task) => {
+                        const dueMeta = task.dueAt ? getDueMeta(task.dueAt, now) : null;
+                        return (
+                          <li
+                            key={task.id}
+                            className="rounded-lg border border-border/60 bg-background/80 p-3 text-sm shadow-sm"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="space-y-2">
+                                <p className="font-medium text-foreground">{task.title}</p>
+                                {task.description ? (
+                                  <p className="text-xs text-muted-foreground">{task.description}</p>
+                                ) : null}
+                                {dueMeta ? (
+                                  <p
+                                    className={cn(
+                                      "text-xs",
+                                      dueMeta.isOverdue ? "text-destructive" : "text-muted-foreground",
+                                    )}
+                                  >
+                                    Fällig {dueMeta.relative} ({dueMeta.absolute})
+                                  </p>
+                                ) : null}
+                              </div>
+                              <Badge variant={TASK_STATUS_BADGES[task.status]} size="sm">
+                                {TASK_STATUS_LABELS[task.status]}
+                              </Badge>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Keine offenen Aufgaben in diesem Gewerk – du bist auf dem aktuellen Stand.
+                    </p>
+                  )}
+
+                  {completedTasks.length ? (
+                    <details className="group rounded-lg border border-border/50 bg-background/70 p-3 shadow-sm">
+                      <summary className="flex cursor-pointer items-center justify-between text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        <span>Abgeschlossene Aufgaben</span>
+                        <span className="text-[11px] text-muted-foreground group-open:hidden">Öffnen</span>
+                        <span className="hidden text-[11px] text-muted-foreground group-open:inline">Schließen</span>
+                      </summary>
+                      <ul className="mt-3 space-y-2 text-sm">
+                        {completedTasks.map((task) => {
+                          const dueMeta = task.dueAt ? getDueMeta(task.dueAt, now) : null;
+                          return (
+                            <li
+                              key={task.id}
+                              className="rounded-md border border-border/60 bg-background/80 p-3"
+                            >
+                              <div className="flex items-start justify-between gap-3">
+                                <div className="space-y-1">
+                                  <p className="font-medium text-foreground">{task.title}</p>
+                                  {dueMeta ? (
+                                    <p className="text-xs text-muted-foreground">Fällig war {dueMeta.absolute}</p>
+                                  ) : null}
+                                </div>
+                                <Badge variant={TASK_STATUS_BADGES[task.status]} size="sm">
+                                  {TASK_STATUS_LABELS[task.status]}
+                                </Badge>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </details>
+                  ) : null}
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -366,6 +366,7 @@ async function ensureProductionManager() {
 
 function revalidateDepartments(redirectPath?: string) {
   revalidatePath("/mitglieder/produktionen");
+  revalidatePath("/mitglieder/meine-gewerke");
   if (redirectPath && redirectPath !== "/mitglieder/produktionen") {
     revalidatePath(redirectPath);
   }

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -35,6 +35,7 @@ import {
   CalendarCog,
   UsersRound,
   ShieldCheck,
+  Hammer,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -149,6 +150,11 @@ const QUICK_ACTION_LINKS = [
     href: "/mitglieder/meine-proben",
     label: "Meine Proben",
     icon: CalendarCheck,
+  },
+  {
+    href: "/mitglieder/meine-gewerke",
+    label: "Meine Gewerke",
+    icon: Hammer,
   },
   {
     href: "/mitglieder/probenplanung",

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -8,51 +8,54 @@ import { cn } from "@/lib/utils";
 type Item = { href: string; label: string; permissionKey?: string };
 type Group = { label: string; items: Item[] };
 type ActiveProductionNavInfo = { id: string; title: string | null; year: number };
+export type AssignmentFocus = "none" | "rehearsals" | "departments" | "both";
 
-const groupedConfig: Group[] = [
+const GENERAL_ITEMS: Item[] = [
+  { href: "/mitglieder", label: "Dashboard", permissionKey: "mitglieder.dashboard" },
+  { href: "/mitglieder/profil", label: "Profil", permissionKey: "mitglieder.profil" },
+  { href: "/mitglieder/sperrliste", label: "Sperrliste", permissionKey: "mitglieder.sperrliste" },
+  { href: "/mitglieder/issues", label: "Feedback & Support", permissionKey: "mitglieder.issues" },
+];
+
+const ASSIGNMENT_ITEMS: Item[] = [
+  { href: "/mitglieder/meine-proben", label: "Meine Proben", permissionKey: "mitglieder.meine-proben" },
+  { href: "/mitglieder/meine-gewerke", label: "Meine Gewerke", permissionKey: "mitglieder.meine-gewerke" },
+  { href: "/mitglieder/probenplanung", label: "Probenplanung", permissionKey: "mitglieder.probenplanung" },
+];
+
+const PRODUCTION_ITEMS: Item[] = [
+  { href: "/mitglieder/produktionen", label: "Übersicht", permissionKey: "mitglieder.produktionen" },
+  { href: "/mitglieder/produktionen/gewerke", label: "Gewerke & Teams", permissionKey: "mitglieder.produktionen" },
   {
-    label: "Allgemein",
-    items: [
-      { href: "/mitglieder", label: "Dashboard", permissionKey: "mitglieder.dashboard" },
-      { href: "/mitglieder/profil", label: "Profil", permissionKey: "mitglieder.profil" },
-      { href: "/mitglieder/sperrliste", label: "Sperrliste", permissionKey: "mitglieder.sperrliste" },
-      { href: "/mitglieder/issues", label: "Feedback & Support", permissionKey: "mitglieder.issues" },
-    ],
+    href: "/mitglieder/produktionen/besetzung",
+    label: "Rollen & Besetzung",
+    permissionKey: "mitglieder.produktionen",
   },
   {
-    label: "Proben",
-    items: [
-      { href: "/mitglieder/meine-proben", label: "Meine Proben", permissionKey: "mitglieder.meine-proben" },
-      { href: "/mitglieder/probenplanung", label: "Probenplanung", permissionKey: "mitglieder.probenplanung" },
-    ],
-  },
-  {
-    label: "Produktion",
-    items: [
-      { href: "/mitglieder/produktionen", label: "Übersicht", permissionKey: "mitglieder.produktionen" },
-      { href: "/mitglieder/produktionen/gewerke", label: "Gewerke & Teams", permissionKey: "mitglieder.produktionen" },
-      {
-        href: "/mitglieder/produktionen/besetzung",
-        label: "Rollen & Besetzung",
-        permissionKey: "mitglieder.produktionen",
-      },
-      {
-        href: "/mitglieder/produktionen/szenen",
-        label: "Szenen & Breakdowns",
-        permissionKey: "mitglieder.produktionen",
-      },
-    ],
-  },
-  {
-    label: "Verwaltung",
-    items: [
-      { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", permissionKey: "mitglieder.rollenverwaltung" },
-      { href: "/mitglieder/onboarding-analytics", label: "Onboarding Analytics", permissionKey: "mitglieder.onboarding.analytics" },
-      { href: "/mitglieder/rechte", label: "Rechteverwaltung", permissionKey: "mitglieder.rechte" },
-      { href: "/mitglieder/fotoerlaubnisse", label: "Fotoerlaubnisse", permissionKey: "mitglieder.fotoerlaubnisse" },
-    ],
+    href: "/mitglieder/produktionen/szenen",
+    label: "Szenen & Breakdowns",
+    permissionKey: "mitglieder.produktionen",
   },
 ];
+
+const ADMIN_ITEMS: Item[] = [
+  { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", permissionKey: "mitglieder.rollenverwaltung" },
+  { href: "/mitglieder/onboarding-analytics", label: "Onboarding Analytics", permissionKey: "mitglieder.onboarding.analytics" },
+  { href: "/mitglieder/rechte", label: "Rechteverwaltung", permissionKey: "mitglieder.rechte" },
+  { href: "/mitglieder/fotoerlaubnisse", label: "Fotoerlaubnisse", permissionKey: "mitglieder.fotoerlaubnisse" },
+];
+
+function resolveAssignmentLabel(focus: AssignmentFocus, permissions: readonly string[] | Set<string>) {
+  if (focus === "both") return "Proben & Gewerke";
+  if (focus === "departments") return "Gewerke";
+  if (focus === "rehearsals") return "Proben";
+  const permissionSet = permissions instanceof Set ? permissions : new Set(permissions);
+  const canSeeRehearsals = permissionSet.has("mitglieder.meine-proben");
+  const canSeeDepartments = permissionSet.has("mitglieder.meine-gewerke");
+  if (canSeeRehearsals && canSeeDepartments) return "Proben & Gewerke";
+  if (canSeeDepartments) return "Gewerke";
+  return "Proben";
+}
 
 function isActive(pathname: string, href: string) {
   if (pathname === href) return true;
@@ -93,6 +96,18 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
           <path d="M4 20c0-2.761 2.239-5 5-5" />
           <path d="m15 5 2 2 4-4" />
           <path d="M14 9h6" />
+        </svg>
+      );
+    case "/mitglieder/meine-gewerke":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="5" y="4" width="14" height="16" rx="2" />
+          <path d="M9 2h6" />
+          <path d="M12 2v2" />
+          <path d="M8 10h8" />
+          <path d="M8 14h8" />
+          <path d="M8 18h5" />
+          <path d="m6 15 1.8 1.8L10 14" />
         </svg>
       );
     case "/mitglieder/sperrliste":
@@ -181,12 +196,29 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
 export function MembersNav({
   permissions,
   activeProduction,
+  assignmentFocus = "none",
 }: {
   permissions?: string[];
   activeProduction?: ActiveProductionNavInfo;
+  assignmentFocus?: AssignmentFocus;
 }) {
   const pathname = usePathname() ?? "";
   const router = useRouter();
+
+  const assignmentLabel = useMemo(
+    () => resolveAssignmentLabel(assignmentFocus, permissions ?? []),
+    [assignmentFocus, permissions],
+  );
+
+  const groupedConfig = useMemo<Group[]>(
+    () => [
+      { label: "Allgemein", items: GENERAL_ITEMS },
+      { label: assignmentLabel, items: ASSIGNMENT_ITEMS },
+      { label: "Produktion", items: PRODUCTION_ITEMS },
+      { label: "Verwaltung", items: ADMIN_ITEMS },
+    ],
+    [assignmentLabel],
+  );
 
   const { groups, flat } = useMemo(() => {
     const permissionSet = new Set(permissions ?? []);
@@ -198,7 +230,7 @@ export function MembersNav({
       .filter((g) => g.items.length > 0);
     const flat = groups.flatMap((g) => g.items);
     return { groups, flat } as { groups: Group[]; flat: Item[] };
-  }, [permissions]);
+  }, [groupedConfig, permissions]);
 
   const activeItem = useMemo(() => flat.find((item) => isActive(pathname, item.href)), [flat, pathname]);
   const activeHref = activeItem?.href ?? flat[0]?.href ?? "";

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -20,6 +20,11 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     label: "Eigene Probentermine einsehen",
     description: "Zugang zum Bereich \"Meine Proben\" mit persönlichen Terminen und Fristen.",
   },
+  {
+    key: "mitglieder.meine-gewerke",
+    label: "Eigene Gewerke einsehen",
+    description: "Zugang zum Bereich \"Meine Gewerke\" mit Aufgabenübersicht und Terminvorschlägen.",
+  },
   { key: "mitglieder.probenplanung", label: "Probenplanung verwalten" },
   {
     key: "mitglieder.produktionen",


### PR DESCRIPTION
## Summary
- make the members navigation aware of rehearsal/department assignments and expose the new "Meine Gewerke" entry
- add the "Meine Gewerke" page with personal department overview, task lists and scheduling suggestions
- register the new permission, update dashboard quick links and revalidate the personal view after department changes

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d03fdaee74832d9547fd97e07fbad4