### PR TITLE
Update Chronik backgrounds for Bunbury and Aladin

### DIFF
--- a/src/app/chronik/fullframes.tsx
+++ b/src/app/chronik/fullframes.tsx
@@ -2,6 +2,8 @@
 import Image from "next/image";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { PosterSlideshow } from "./poster-slideshow";
+
 type ChronikMeta = {
   author?: string | null;
   director?: string | null;
@@ -16,7 +18,7 @@ type ChronikItem = {
   year: number;
   title?: string | null;
   synopsis?: string | null;
-  posterUrl?: string | null;
+  posterUrl?: string | string[] | null;
   meta?: ChronikMeta | null;
 };
 
@@ -24,6 +26,17 @@ function toStringArray(value: unknown, limit?: number) {
   if (!Array.isArray(value)) return [] as string[];
   const entries = value.filter((entry): entry is string => typeof entry === "string");
   return typeof limit === "number" ? entries.slice(0, limit) : entries;
+}
+
+function toPosterSources(value: ChronikItem["posterUrl"]) {
+  if (!value) {
+    return [] as string[];
+  }
+
+  const sources = Array.isArray(value) ? value : [value];
+  return sources
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry): entry is string => entry.length > 0);
 }
 
 export function ChronikFullframes({ items }: { items: ChronikItem[] }) {
@@ -111,25 +124,23 @@ export function ChronikFullframes({ items }: { items: ChronikItem[] }) {
           const meta: ChronikMeta = s.meta ?? {};
           const sources = toStringArray(meta.sources, 3);
           const gallery = toStringArray(meta.gallery, 6);
-          return (
-            <section
-              key={s.id}
-              id={s.id}
-              data-id={s.id}
+          const posterSources = toPosterSources(s.posterUrl);
+        return (
+          <section
+            key={s.id}
+            id={s.id}
+            data-id={s.id}
               ref={(el) => { sectionRefs.current[s.id] = el; }}
               className="relative min-h-screen grid place-items-stretch overflow-hidden snap-start"
             >
               {/* Background image */}
-              {s.posterUrl && (
-                <div className="absolute inset-0 -z-10">
-                  <Image
-                    src={s.posterUrl}
-                    alt={s.title ?? String(s.year)}
-                    fill
-                    className="object-cover"
-                    priority={idx === 0}
-                  />
-                </div>
+              {posterSources.length > 0 && (
+                <PosterSlideshow
+                  sources={posterSources}
+                  alt={s.title ?? String(s.year)}
+                  priority={idx === 0}
+                  className="-z-10"
+                />
               )}
               {/* Mystic overlays for readability */}
               <div className="absolute inset-0 -z-0 bg-gradient-to-b from-background/80 via-background/60 to-background/80" />
@@ -179,9 +190,9 @@ export function ChronikFullframes({ items }: { items: ChronikItem[] }) {
                         </div>
                       );
                     })
-                  ) : s.posterUrl ? (
+                  ) : posterSources.length > 0 ? (
                     <div className="relative col-span-2 sm:col-span-3 h-56 md:h-72 rounded overflow-hidden border border-border/40">
-                      <Image src={s.posterUrl} alt={s.title ?? String(s.year)} fill className="object-cover" />
+                      <Image src={posterSources[0]} alt={s.title ?? String(s.year)} fill className="object-cover" />
                     </div>
                   ) : null}
                 </div>

--- a/src/app/chronik/poster-slideshow.tsx
+++ b/src/app/chronik/poster-slideshow.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+type PosterSlideshowProps = {
+  sources: string[];
+  alt: string;
+  priority?: boolean;
+  intervalMs?: number;
+  className?: string;
+};
+
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handler = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+    mediaQuery.addEventListener?.("change", handler);
+
+    return () => mediaQuery.removeEventListener?.("change", handler);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+export function PosterSlideshow({
+  sources,
+  alt,
+  priority = false,
+  intervalMs = 8000,
+  className,
+}: PosterSlideshowProps) {
+  const sanitizedSources = useMemo(() => {
+    const unique = new Set<string>();
+    return sources
+      .map((src) => (typeof src === "string" ? src.trim() : ""))
+      .filter((src) => {
+        if (!src) return false;
+        if (unique.has(src)) return false;
+        unique.add(src);
+        return true;
+      });
+  }, [sources]);
+
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (activeIndex >= sanitizedSources.length) {
+      setActiveIndex(0);
+    }
+  }, [activeIndex, sanitizedSources.length]);
+
+  useEffect(() => {
+    if (sanitizedSources.length <= 1 || prefersReducedMotion) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setActiveIndex((current) => (current + 1) % sanitizedSources.length);
+    }, Math.max(intervalMs, 2000));
+
+    return () => window.clearInterval(interval);
+  }, [sanitizedSources.length, prefersReducedMotion, intervalMs]);
+
+  if (sanitizedSources.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("absolute inset-0", className)}>
+      {sanitizedSources.map((src, index) => (
+        <Image
+          key={`${src}-${index}`}
+          src={src}
+          alt={alt}
+          fill
+          priority={priority && index === 0}
+          className={cn(
+            "object-cover transition-opacity duration-1000 ease-in-out",
+            index === activeIndex ? "opacity-100" : "opacity-0",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+

--- a/src/app/chronik/stacked.tsx
+++ b/src/app/chronik/stacked.tsx
@@ -1,6 +1,7 @@
 "use client";
-import Image from "next/image";
 import { Heading, Text } from "@/components/ui/typography";
+
+import { PosterSlideshow } from "./poster-slideshow";
 
 type ChronikCastEntry = {
   role: string;
@@ -22,7 +23,7 @@ type ChronikItem = {
   year: number;
   title?: string | null;
   synopsis?: string | null;
-  posterUrl?: string | null;
+  posterUrl?: string | string[] | null;
   meta?: ChronikMeta | null;
 };
 
@@ -65,6 +66,17 @@ function formatPlayerName(name: string) {
   return `${firstNames} ${lastInitial}.`;
 }
 
+function toPosterSources(value: ChronikItem["posterUrl"]) {
+  if (!value) {
+    return [] as string[];
+  }
+
+  const sources = Array.isArray(value) ? value : [value];
+  return sources
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry): entry is string => entry.length > 0);
+}
+
 export function ChronikStacked({ items }: { items: ChronikItem[] }) {
   const sorted = [...items].sort((a, b) => b.year - a.year);
 
@@ -74,6 +86,7 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
         const meta: ChronikMeta = s.meta ?? {};
         const sources = toStringArray(meta.sources);
         const castEntries = toCastEntries(meta.cast);
+        const posterSources = toPosterSources(s.posterUrl);
         return (
           <section
             key={s.id}
@@ -81,12 +94,10 @@ export function ChronikStacked({ items }: { items: ChronikItem[] }) {
             className="group relative overflow-hidden rounded-2xl border border-border/60 shadow-2xl transition-all duration-500 hover:scale-[1.02] hover:shadow-3xl sm:rounded-3xl"
           >
             <div className="relative h-[60vh] sm:h-[70vh] lg:h-[75vh] xl:h-[65vh] 2xl:h-[60vh] w-full max-h-[800px]">
-              {s.posterUrl && (
-                <Image
-                  src={s.posterUrl}
+              {posterSources.length > 0 && (
+                <PosterSlideshow
+                  sources={posterSources}
                   alt={s.title ?? String(s.year)}
-                  fill
-                  className="object-cover"
                   priority={idx === 0}
                 />
               )}


### PR DESCRIPTION
## Summary
- add a reusable poster slideshow component to support cycling hero images in the Chronik
- override the Bunbury and Aladin entries to use the new flyer and alternating stage imagery
- update the Chronik stacked and fullframe layouts to consume the slideshow posters

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0474e66f8832daf4cf4a01f5a582e