### PR TITLE
Add onboarding invite click insights

### DIFF
--- a/src/app/api/member-invites/route.ts
+++ b/src/app/api/member-invites/route.ts
@@ -68,7 +68,10 @@ export async function GET() {
     orderBy: { createdAt: "desc" },
     include: {
       createdBy: { select: { id: true, name: true, email: true } },
-      redemptions: { select: { id: true, completedAt: true } },
+      redemptions: {
+        select: { id: true, createdAt: true, completedAt: true },
+        orderBy: { createdAt: "desc" },
+      },
     },
   });
 
@@ -77,6 +80,7 @@ export async function GET() {
     const status = calculateInviteStatus(invite, now);
     const completed = invite.redemptions.filter((r) => r.completedAt).length;
     const pending = invite.redemptions.length - completed;
+    const recentClicks = invite.redemptions.slice(0, 3).map((entry) => entry.createdAt.toISOString());
     return {
       id: invite.id,
       label: invite.label,
@@ -95,6 +99,7 @@ export async function GET() {
       pendingSessions: pending,
       completedSessions: completed,
       shareUrl: status.isActive ? `/onboarding/${invite.tokenHash}` : null,
+      recentClicks,
     };
   });
 


### PR DESCRIPTION
## Summary
- include the last invite redemption timestamps in the member invite API payload
- surface a futuristic timeline of the most recent invite clicks in the invite manager, including relative time helpers and data normalization

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d04d383a0c832da76fcc56acf692c5