### PR TITLE
feat: add mystery countdown and tip submissions

### DIFF
--- a/prisma/migrations/20260305120000_mystery_tips/migration.sql
+++ b/prisma/migrations/20260305120000_mystery_tips/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "public"."MysteryTip" (
+    "id" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "normalizedText" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MysteryTip_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MysteryTip_normalizedText_key" ON "public"."MysteryTip"("normalizedText");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -457,6 +457,15 @@ model Clue {
   @@index([showId, published, releaseAt])
 }
 
+model MysteryTip {
+  id             String   @id @default(cuid())
+  text           String
+  normalizedText String   @unique
+  count          Int      @default(1)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+}
+
 model Guess {
   id        String   @id @default(cuid())
   userId    String

--- a/src/app/api/mystery/tips/route.ts
+++ b/src/app/api/mystery/tips/route.ts
@@ -1,0 +1,90 @@
+import { prisma } from "@/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const tipSchema = z.object({
+  tip: z
+    .string()
+    .trim()
+    .min(3, "Dein Tipp sollte mindestens 3 Zeichen lang sein.")
+    .max(280, "Bitte kürze deinen Tipp auf höchstens 280 Zeichen."),
+});
+
+function normalizeTip(text: string) {
+  return text.trim().toLocaleLowerCase("de-DE");
+}
+
+export async function GET() {
+  try {
+    const tips = await prisma.mysteryTip.findMany({
+      orderBy: [
+        { count: "desc" },
+        { updatedAt: "desc" },
+        { createdAt: "asc" },
+      ],
+    });
+
+    return NextResponse.json({
+      tips: tips.map((tip) => ({
+        id: tip.id,
+        text: tip.text,
+        count: tip.count,
+        createdAt: tip.createdAt,
+        updatedAt: tip.updatedAt,
+      })),
+    });
+  } catch (error) {
+    console.error("Failed to load mystery tips", error);
+    return NextResponse.json({ error: "Konnte die Tipps gerade nicht laden." }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const parsed = tipSchema.safeParse(payload);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Ungültiger Tipp.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const trimmedTip = parsed.data.tip;
+  const normalizedText = normalizeTip(trimmedTip);
+
+  try {
+    const savedTip = await prisma.mysteryTip.upsert({
+      where: { normalizedText },
+      update: {
+        count: { increment: 1 },
+      },
+      create: {
+        text: trimmedTip,
+        normalizedText,
+      },
+    });
+
+    const created = savedTip.count === 1;
+
+    return NextResponse.json(
+      {
+        tip: {
+          id: savedTip.id,
+          text: savedTip.text,
+          count: savedTip.count,
+          createdAt: savedTip.createdAt,
+          updatedAt: savedTip.updatedAt,
+        },
+        created,
+      },
+      { status: created ? 201 : 200 }
+    );
+  } catch (error) {
+    console.error("Failed to save mystery tip", error);
+    return NextResponse.json({ error: "Dein Tipp konnte nicht gespeichert werden." }, { status: 500 });
+  }
+}

--- a/src/app/mystery/_components/countdown.tsx
+++ b/src/app/mystery/_components/countdown.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { Text } from "@/components/ui/typography";
+
+type CountdownProps = {
+  targetDate: string;
+  className?: string;
+};
+
+type CountdownState = {
+  totalMilliseconds: number;
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+};
+
+const MILLISECONDS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+
+function getTimeRemaining(targetTimestamp: number): CountdownState {
+  const now = Date.now();
+  const totalMilliseconds = Math.max(0, targetTimestamp - now);
+  const totalSeconds = Math.floor(totalMilliseconds / MILLISECONDS_PER_SECOND);
+
+  const days = Math.floor(totalSeconds / (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE));
+  const hours = Math.floor((totalSeconds % (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE)) / (MINUTES_PER_HOUR * SECONDS_PER_MINUTE));
+  const minutes = Math.floor((totalSeconds % (MINUTES_PER_HOUR * SECONDS_PER_MINUTE)) / SECONDS_PER_MINUTE);
+  const seconds = totalSeconds % SECONDS_PER_MINUTE;
+
+  return {
+    totalMilliseconds,
+    days,
+    hours,
+    minutes,
+    seconds,
+  };
+}
+
+function formatNumber(value: number) {
+  return value.toString().padStart(2, "0");
+}
+
+export function Countdown({ targetDate, className }: CountdownProps) {
+  const targetTimestamp = useMemo(() => new Date(targetDate).getTime(), [targetDate]);
+  const [state, setState] = useState<CountdownState>(() => getTimeRemaining(targetTimestamp));
+
+  useEffect(() => {
+    if (Number.isNaN(targetTimestamp)) {
+      return;
+    }
+
+    setState(getTimeRemaining(targetTimestamp));
+
+    const interval = window.setInterval(() => {
+      setState((previous) => {
+        const next = getTimeRemaining(targetTimestamp);
+        if (next.totalMilliseconds === 0 && previous.totalMilliseconds === 0) {
+          window.clearInterval(interval);
+        }
+        return next;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [targetTimestamp]);
+
+  if (Number.isNaN(targetTimestamp)) {
+    return <Text tone="destructive">Ungültiges Datum</Text>;
+  }
+
+  const timeParts = [
+    { label: "Tage", value: state.days },
+    { label: "Stunden", value: state.hours },
+    { label: "Minuten", value: state.minutes },
+    { label: "Sekunden", value: state.seconds },
+  ];
+
+  return (
+    <div className={cn("grid w-full grid-cols-2 gap-3 sm:grid-cols-4", className)} aria-live="polite">
+      {timeParts.map((part) => (
+        <div key={part.label} className="rounded-lg border border-border bg-card px-4 py-3 text-center shadow-sm">
+          <div className="text-3xl font-semibold tabular-nums sm:text-4xl">{formatNumber(part.value)}</div>
+          <Text variant="small" tone="muted" className="mt-1 uppercase tracking-[0.2em]">
+            {part.label}
+          </Text>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/mystery/_components/mystery-tips-board.tsx
+++ b/src/app/mystery/_components/mystery-tips-board.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Heading, Text } from "@/components/ui/typography";
+
+const MAX_TIP_LENGTH = 280;
+
+export type MysteryTip = {
+  id: string;
+  text: string;
+  count: number;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+};
+
+function sortTips(tips: MysteryTip[]) {
+  return [...tips].sort((a, b) => {
+    if (b.count !== a.count) {
+      return b.count - a.count;
+    }
+
+    const updatedA = new Date(a.updatedAt).getTime();
+    const updatedB = new Date(b.updatedAt).getTime();
+    if (updatedB !== updatedA) {
+      return updatedB - updatedA;
+    }
+
+    return a.text.localeCompare(b.text, "de-DE", { sensitivity: "base" });
+  });
+}
+
+type MysteryTipsBoardProps = {
+  initialTips?: MysteryTip[];
+};
+
+export function MysteryTipsBoard({ initialTips = [] }: MysteryTipsBoardProps) {
+  const [tips, setTips] = useState<MysteryTip[]>(() => sortTips(initialTips));
+  const [tipText, setTipText] = useState("");
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoading, setIsLoading] = useState(initialTips.length === 0);
+
+  const hasMinimumLength = useMemo(() => tipText.trim().length >= 3, [tipText]);
+
+  const refreshTips = useCallback(async () => {
+    setIsLoading(true);
+    setListError(null);
+    try {
+      const response = await fetch("/api/mystery/tips", { cache: "no-store" });
+      const payload = await response.json();
+      if (!response.ok) {
+        const message = typeof payload?.error === "string" ? payload.error : "Die Tipps konnten nicht geladen werden.";
+        throw new Error(message);
+      }
+      setTips(sortTips(payload.tips ?? []));
+    } catch (err) {
+      console.error("Failed to refresh mystery tips", err);
+      setListError(err instanceof Error ? err.message : "Unbekannter Fehler beim Laden.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setTips(sortTips(initialTips));
+    setListError(null);
+    if (initialTips.length === 0) {
+      refreshTips();
+    } else {
+      setIsLoading(false);
+    }
+  }, [initialTips, refreshTips]);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmed = tipText.trim();
+      if (trimmed.length < 3) {
+        setSubmissionError("Dein Tipp sollte mindestens 3 Zeichen lang sein.");
+        return;
+      }
+
+      setIsSubmitting(true);
+      setSubmissionError(null);
+
+      try {
+        const response = await fetch("/api/mystery/tips", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tip: trimmed }),
+        });
+        const payload = await response.json();
+        if (!response.ok) {
+          const message = typeof payload?.error === "string" ? payload.error : "Dein Tipp konnte nicht gespeichert werden.";
+          throw new Error(message);
+        }
+
+        setTips((previous) => {
+          const next = [...previous];
+          const index = next.findIndex((item) => item.id === payload.tip.id);
+          if (index !== -1) {
+            next[index] = {
+              ...next[index],
+              count: payload.tip.count,
+              updatedAt: payload.tip.updatedAt,
+            };
+          } else {
+            next.push(payload.tip);
+          }
+          return sortTips(next);
+        });
+        setTipText("");
+      } catch (err) {
+        console.error("Failed to submit mystery tip", err);
+        setSubmissionError(err instanceof Error ? err.message : "Unbekannter Fehler beim Speichern.");
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [tipText]
+  );
+
+  const remainingCharacters = MAX_TIP_LENGTH - tipText.length;
+
+  return (
+    <section className="space-y-6">
+      <Heading level="h2">Rätsel mit und gib uns deinen Tipp!</Heading>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Dein Tipp</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="mystery-tip">Was glaubst du, welches Stück wir spielen?</Label>
+                <Textarea
+                  id="mystery-tip"
+                  value={tipText}
+                  onChange={(event) => setTipText(event.target.value)}
+                  maxLength={MAX_TIP_LENGTH}
+                  rows={5}
+                  placeholder="Teile deinen Tipp mit der Theater-Community"
+                  aria-invalid={submissionError ? true : undefined}
+                  disabled={isSubmitting}
+                />
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{hasMinimumLength ? "Bereit zum Absenden" : "Mindestens 3 Zeichen"}</span>
+                  <span>{remainingCharacters} Zeichen übrig</span>
+                </div>
+              </div>
+              {submissionError && (
+                <Text tone="destructive" variant="small">
+                  {submissionError}
+                </Text>
+              )}
+              <div className="flex flex-wrap items-center gap-2">
+                <Button type="submit" disabled={isSubmitting || !hasMinimumLength}>
+                  {isSubmitting ? "Wird gesendet…" : "Tipp abschicken"}
+                </Button>
+                <Button type="button" variant="ghost" onClick={refreshTips} disabled={isLoading}>
+                  Aktualisieren
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Tipps der Community</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {listError && (
+              <Text tone="destructive" variant="small">
+                {listError}
+              </Text>
+            )}
+            {isLoading ? (
+              <Text tone="muted">Die Tipps werden geladen…</Text>
+            ) : tips.length === 0 ? (
+              <Text tone="muted">Noch keine Tipps vorhanden – sei die erste Person und teile deinen Verdacht!</Text>
+            ) : (
+              <ul className="space-y-3">
+                {tips.map((tip) => (
+                  <li key={tip.id} className="rounded-lg border border-border/60 bg-muted/10 px-4 py-3">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <Text className="text-left">{tip.text}</Text>
+                      <Badge variant="secondary">×{tip.count}</Badge>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/app/mystery/page.tsx
+++ b/src/app/mystery/page.tsx
@@ -1,8 +1,10 @@
 import { prisma } from "@/lib/prisma";
-import type { Clue, Prisma } from "@prisma/client";
+import type { Clue, MysteryTip as MysteryTipModel, Prisma } from "@prisma/client";
 import Image from "next/image";
-import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Heading, Text } from "@/components/ui/typography";
+import { Countdown } from "./_components/countdown";
+import { MysteryTipsBoard } from "./_components/mystery-tips-board";
 
 type ClueContent = {
   text?: string;
@@ -22,45 +24,153 @@ function parseClueContent(content: Prisma.JsonValue | null | undefined): ClueCon
   };
 }
 
+const FIRST_RIDDLE_RELEASE_ISO = "2025-10-15T10:00:00.000Z";
+const FIRST_RIDDLE_RELEASE = new Date(FIRST_RIDDLE_RELEASE_ISO);
+const FIRST_RIDDLE_RELEASE_LABEL = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "full",
+  timeStyle: "short",
+  timeZone: "Europe/Berlin",
+}).format(FIRST_RIDDLE_RELEASE);
+
+function renderClueBody(clue: Clue, content: ClueContent) {
+  if (clue.type === "image") {
+    return (
+      <div className="relative h-64 w-full">
+        <Image src={content.url ?? "/next.svg"} alt={content.alt ?? "Hinweis"} fill className="object-contain" />
+      </div>
+    );
+  }
+  if (clue.type === "text" || clue.type === "riddle") {
+    return <Text>{content.text ?? "Ein Rätsel wartet…"}</Text>;
+  }
+  return <Text>Ein Rätsel wartet…</Text>;
+}
+
 export const revalidate = 30;
 
 export default async function MysteryPage() {
   const now = new Date();
+  const isFirstRiddleReleased = now >= FIRST_RIDDLE_RELEASE;
   let clues: Clue[] = [];
-  try {
-    clues = await prisma.clue.findMany({
-      where: { published: true, releaseAt: { lte: now } },
-      orderBy: [{ index: "asc" }],
-    });
-  } catch {
-    clues = [];
+  let tips: MysteryTipModel[] = [];
+
+  if (process.env.DATABASE_URL) {
+    const [cluesResult, tipsResult] = await Promise.allSettled([
+      prisma.clue.findMany({
+        where: { published: true, releaseAt: { lte: now } },
+        orderBy: [{ index: "asc" }],
+      }),
+      prisma.mysteryTip.findMany({
+        orderBy: [
+          { count: "desc" },
+          { updatedAt: "desc" },
+          { createdAt: "asc" },
+        ],
+      }),
+    ]);
+
+    clues = cluesResult.status === "fulfilled" ? cluesResult.value : [];
+    tips = tipsResult.status === "fulfilled" ? tipsResult.value : [];
   }
 
+  const firstRiddle = clues.find((clue) => clue.index === 1) ?? null;
+  const remainingClues = firstRiddle ? clues.filter((clue) => clue.id !== firstRiddle.id) : clues;
+  const firstRiddleContent = firstRiddle ? parseClueContent(firstRiddle.content) : null;
+
+  const initialTips = tips.map((tip) => ({
+    id: tip.id,
+    text: tip.text,
+    count: tip.count,
+    createdAt: tip.createdAt.toISOString(),
+    updatedAt: tip.updatedAt.toISOString(),
+  }));
+
+  const showSilentMessage = !isFirstRiddleReleased && clues.length === 0;
+  const hasAdditionalClues = remainingClues.length > 0;
+
   return (
-    <div className="layout-container space-y-6 py-12">
+    <div className="layout-container space-y-10 py-12">
       <Heading level="h1">Das Geheimnis</Heading>
-      {clues.length === 0 && <Text tone="muted">Die Schatten sind noch still…</Text>}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {clues.map((c) => {
-          const content = parseClueContent(c.content);
-          return (
-            <Card key={c.id}>
-              <CardTitle className="p-4">
-                Hinweis {c.index} • {c.points} Punkte
-              </CardTitle>
-              <CardContent>
-                {c.type === "text" && <Text>{content.text}</Text>}
-                {c.type === "image" && (
-                  <div className="relative w-full h-64">
-                    <Image src={content.url ?? "/next.svg"} alt={content.alt ?? "Hinweis"} fill className="object-contain" />
-                  </div>
-                )}
-                {c.type !== "text" && c.type !== "image" && <Text>Ein Rätsel wartet…</Text>}
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+      <section className="space-y-6">
+        <div className="space-y-2">
+          {showSilentMessage && <Text tone="muted">Die Schatten sind noch still…</Text>}
+          <Text>
+            Jeden Monat kommt ein neues Rätsel hinzu, um den Titel des nächsten Stückes immer mehr aufzudecken.
+          </Text>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <Card>
+            <CardHeader>
+              <CardTitle>Nächstes Rätsel in</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {!isFirstRiddleReleased ? (
+                <>
+                  <Countdown targetDate={FIRST_RIDDLE_RELEASE_ISO} />
+                  <Text variant="small" tone="muted">
+                    Start am {FIRST_RIDDLE_RELEASE_LABEL}
+                  </Text>
+                </>
+              ) : (
+                <div className="space-y-2">
+                  <Text variant="lead" tone="success">
+                    Das erste Rätsel ist jetzt verfügbar!
+                  </Text>
+                  <Text variant="small" tone="muted">
+                    Veröffentlicht am {FIRST_RIDDLE_RELEASE_LABEL}
+                  </Text>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+          <Card className="flex flex-col">
+            <CardHeader>
+              <CardTitle>Das 1. Rätsel</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+              {isFirstRiddleReleased ? (
+                firstRiddle ? (
+                  <>
+                    {renderClueBody(firstRiddle, firstRiddleContent ?? {})}
+                    <Text variant="small" tone="muted">
+                      Hinweis {firstRiddle.index} • {firstRiddle.points} Punkte
+                    </Text>
+                  </>
+                ) : (
+                  <Text tone="muted">Das Rätsel wird gerade vorbereitet. Schau bald wieder vorbei.</Text>
+                )
+              ) : (
+                <Text className="text-2xl font-semibold text-muted-foreground">Das 1. Rätsel</Text>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+      <MysteryTipsBoard initialTips={initialTips} />
+      <section className="space-y-4">
+        <Heading level="h2">Bisher enthüllte Hinweise</Heading>
+        {hasAdditionalClues ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {remainingClues.map((clue) => {
+              const content = parseClueContent(clue.content);
+              return (
+                <Card key={clue.id}>
+                  <CardHeader>
+                    <CardTitle>
+                      Hinweis {clue.index} • {clue.points} Punkte
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {renderClueBody(clue, content)}
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        ) : (
+          <Text tone="muted">Weitere Hinweise folgen bald. Schau regelmäßig vorbei!</Text>
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a MysteryTip Prisma model and migration for tracking community guesses
- implement a GET/POST API for mystery tips with normalization and error handling
- enhance the mystery page with a countdown, first riddle reveal card, and a client-side tip board backed by new components

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d04d71a324832db72af2c85716ea8f