### PR TITLE
Adjust campus wording to school terminology

### DIFF
--- a/src/app/ueber-uns/page.tsx
+++ b/src/app/ueber-uns/page.tsx
@@ -67,7 +67,7 @@ const signature = [
   },
   {
     icon: Trees,
-    title: "Campus voller Gewerke",
+    title: "Schulgelände voller Gewerke",
     description:
       "Schüler:innen des BSZ Altroßthal bringen Floristik, Holz- und Metallbau ein – so wachsen Bühne, Kostüm und Szenografie Hand in Hand.",
   },

--- a/src/app/unsere-schulkatze/page.tsx
+++ b/src/app/unsere-schulkatze/page.tsx
@@ -52,7 +52,7 @@ const highlights: Highlight[] = [
     icon: MoonStar,
     title: "Uralter Bekannter",
     description:
-      "Niemand konnte genau sagen, wann er eingezogen ist. Gefühlt streifte er schon seit über fünfzehn, zwanzig Jahren durch den Campus.",
+      "Niemand konnte genau sagen, wann er eingezogen ist. Gefühlt streifte er schon seit über fünfzehn, zwanzig Jahren über das Schulgelände.",
   },
   {
     icon: Heart,
@@ -105,7 +105,7 @@ const careCircle: Supporter[] = [
 ];
 
 const lessons: string[] = [
-  "Tiere, die unseren Campus begleiten, brauchen feste Bezugspersonen und klare Absprachen – Dieter hat uns das gelehrt.",
+  "Tiere, die unsere Schule begleiten, brauchen feste Bezugspersonen und klare Absprachen – Dieter hat uns das gelehrt.",
   "Gemeinsame Rituale schaffen Vertrauen, besonders wenn ein Vierbeiner über so viele Jahre Teil der Gemeinschaft ist.",
   "In Abschiedsmomenten hilft es, Erinnerungen zu teilen und Orte des Gedenkens zu schaffen.",
   "Wer künftig eine Schulkatze willkommen heißt, sollte an Dieters Bedürfnisse denken: Ruhe, Respekt und Zeit.",
@@ -140,7 +140,7 @@ export default function SchulkatzePage() {
             </Heading>
             <Text variant="bodyLg" tone="muted" className="mt-4">
               Dieter Dennis von Altroßthal – von allen nur Dieter genannt – war unsere graug getigerte Schulkatze. Über Generationen hinweg
-              streifte er durch den Campus und wurde zum vertrauten Gesicht des BSZ Altrossthal.
+              streifte er über das Schulgelände und wurde zum vertrauten Gesicht des BSZ Altrossthal.
             </Text>
             <Text tone="muted">
               Niemand wusste genau, seit wann er da war; gefühlt waren es weit über fünfzehn Jahre. Seine stille Präsenz begleitete Unterricht,
@@ -281,7 +281,7 @@ export default function SchulkatzePage() {
             In Erinnerung an Dieter
           </Heading>
           <Text variant="bodyLg" tone="muted" align="center">
-            Dieter hat Generationen von Schüler:innen begleitet und unserem Campus ein unverwechselbares Gefühl von Heimat gegeben.
+            Dieter hat Generationen von Schüler:innen begleitet und unserer Schule ein unverwechselbares Gefühl von Heimat gegeben.
             Seine Geschichte erinnert uns daran, wie wertvoll Fürsorge und Gemeinschaft sind.
           </Text>
           <Text tone="muted" align="center">

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -18,7 +18,7 @@ export const primaryNavigation: NavigationItem[] = [
   {
     label: "Unsere Schulkatze",
     href: "/unsere-schulkatze",
-    description: "Lerne Minna kennen – Pausenbegleiterin und Herz unseres Campus.",
+    description: "Lerne Minna kennen – Pausenbegleiterin und Herz unserer Schule.",
   },
   {
     label: "Chronik",


### PR DESCRIPTION
## Summary
- replace "Campus" wording with school-focused terminology in the navigation and about page
- update the Schulkatze story so every reference uses Schule oder Schulgelände instead of Campus

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d052cdd158832d96f867c399a01ed0