### PR TITLE
Add rotating Schulkatze gallery

### DIFF
--- a/src/app/unsere-schulkatze/image-rotator.tsx
+++ b/src/app/unsere-schulkatze/image-rotator.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+type SchulkatzeImageRotatorProps = {
+  images: string[];
+  alt: string;
+  interval?: number;
+  sizes?: string;
+  className?: string;
+};
+
+const DEFAULT_INTERVAL = 6000;
+const MINIMUM_INTERVAL = 2000;
+const DEFAULT_SIZES = "(min-width: 1024px) 320px, (min-width: 768px) 40vw, 90vw";
+
+export function SchulkatzeImageRotator({
+  images,
+  alt,
+  interval = DEFAULT_INTERVAL,
+  sizes = DEFAULT_SIZES,
+  className,
+}: SchulkatzeImageRotatorProps) {
+  const validImages = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          images.filter((src) => typeof src === "string" && src.trim().length > 0)
+        )
+      ),
+    [images]
+  );
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [validImages.length]);
+
+  useEffect(() => {
+    if (validImages.length <= 1) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    if (mediaQuery.matches) {
+      return;
+    }
+
+    const rotationInterval = window.setInterval(() => {
+      setCurrentIndex((previousIndex) => {
+        const nextIndex = previousIndex + 1;
+        return nextIndex >= validImages.length ? 0 : nextIndex;
+      });
+    }, Math.max(MINIMUM_INTERVAL, interval));
+
+    return () => {
+      window.clearInterval(rotationInterval);
+    };
+  }, [validImages.length, interval]);
+
+  if (validImages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("relative aspect-[3/4] w-full", className)}>
+      {validImages.map((src, index) => (
+        <Image
+          key={src}
+          src={src}
+          alt={alt}
+          fill
+          sizes={sizes}
+          priority={index === 0}
+          className={cn(
+            "object-cover transition-opacity duration-700 ease-in-out",
+            index === currentIndex ? "opacity-100" : "opacity-0"
+          )}
+          aria-hidden={index !== currentIndex}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/unsere-schulkatze/page.tsx
+++ b/src/app/unsere-schulkatze/page.tsx
@@ -1,13 +1,40 @@
+import { readdirSync } from "node:fs";
+import path from "node:path";
+
 import type { Metadata } from "next";
 import type { LucideIcon } from "lucide-react";
 import { Cat, Fish, Heart, MoonStar, PawPrint, ShieldCheck, Sun, Users } from "lucide-react";
-import Image from "next/image";
 
 import { Card } from "@/components/ui/card";
 import { TextLink } from "@/components/ui/text-link";
 import { Heading, Text } from "@/components/ui/typography";
 
 import { DieterEncountersSection } from "./encounters-section";
+import { SchulkatzeImageRotator } from "./image-rotator";
+
+const SUPPORTED_IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif", ".avif"]);
+
+function resolveSchulkatzeImages(): string[] {
+  const directory = path.join(process.cwd(), "public", "images", "katze");
+
+  try {
+    const files = readdirSync(directory, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => entry.name)
+      .filter((name) => SUPPORTED_IMAGE_EXTENSIONS.has(path.extname(name).toLowerCase()))
+      .sort((a, b) => a.localeCompare(b));
+
+    if (files.length > 0) {
+      return Array.from(new Set(files)).map((name) => `/images/katze/${name}`);
+    }
+  } catch {
+    // Wenn das Verzeichnis nicht gelesen werden kann, nutzen wir den Fallback weiter unten.
+  }
+
+  return ["/images/katze/IMG_8370.JPEG"];
+}
+
+const schulkatzeImages = resolveSchulkatzeImages();
 
 export const metadata: Metadata = {
   title: "Unsere Schulkatze",
@@ -154,16 +181,10 @@ export default function SchulkatzePage() {
             </Text>
           </div>
           <figure className="relative mx-auto max-w-sm overflow-hidden rounded-3xl border border-border bg-background shadow-lg">
-            <div className="relative aspect-[3/4]">
-              <Image
-                src="/images/katze/IMG_8370.JPEG"
-                alt="Schulkatze Dieter Dennis von Altroßthal, graug getigert, sitzt aufmerksam im Schulhof."
-                fill
-                className="object-cover"
-                sizes="(min-width: 1024px) 320px, (min-width: 768px) 40vw, 90vw"
-                priority
-              />
-            </div>
+            <SchulkatzeImageRotator
+              images={schulkatzeImages}
+              alt="Schulkatze Dieter Dennis von Altroßthal, graug getigert, sitzt aufmerksam im Schulhof."
+            />
             <figcaption className="border-t border-border bg-background px-4 py-3 text-sm text-muted-foreground">
               Dieter Dennis von Altroßthal war über viele Jahre Teil unserer Schulgemeinschaft.
             </figcaption>


### PR DESCRIPTION
## Summary
- add a rotating image component for the Schulkatze portrait that fades between the available cat photos
- collect supported image files from `public/images/katze` on the server and pass them to the client rotator with a graceful fallback

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d05b13b56c832da584a756b657f089