### PR TITLE
feat(sperrliste): annotate calendar with Saxony school holidays

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/theater?schema=public
 # Mirror to the client to avoid hydration mismatches ("1" enables dev-only login)
 NEXT_PUBLIC_AUTH_DEV_NO_DB=0
 
+# Optional: ICS feed for sächsische Schulferien. Wird genutzt, um die Sperrliste zu annotieren.
+#SAXONY_HOLIDAYS_ICS_URL=https://www.schulferien.org/media/ical/deutschland/ferien_sachsen.ics
+
 # Realtime service authentication
 REALTIME_AUTH_TOKEN=replace-with-realtime-token
 REALTIME_SERVER_TOKEN=replace-with-realtime-token

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
     "next-auth": "^4.24.11",
+    "node-ical": "^0.21.0",
     "nodemailer": "^6.9.12",
     "pdfkit": "^0.17.2",
     "postcss": "^8.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       next-auth:
         specifier: ^4.24.11
         version: 4.24.11(next@15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@6.10.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      node-ical:
+        specifier: ^0.21.0
+        version: 0.21.0
       nodemailer:
         specifier: ^6.9.12
         version: 6.10.1
@@ -2674,6 +2677,9 @@ packages:
   moment-timezone@0.5.48:
     resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
 
+  moment-timezone@0.6.0:
+    resolution: {integrity: sha512-ldA5lRNm3iJCWZcBCab4pnNL3HSZYXVb/3TYr75/1WCTWYuTqYUb5f/S384pncYjJ88lbO8Z4uPDvmoluHJc8Q==}
+
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
@@ -2734,6 +2740,10 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-ical@0.21.0:
+    resolution: {integrity: sha512-69YB4OnngmGJjGKR5PudfiWEDsjFWi6w2dgHsiyDUaFRiR/3uX4VZG0SjkkiaKrvMFcuqwsoUImfRcoLTVr6uQ==}
+    engines: {node: '>=18'}
 
   nodemailer@6.10.1:
     resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
@@ -3088,6 +3098,9 @@ packages:
     resolution: {integrity: sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -6040,6 +6053,10 @@ snapshots:
     dependencies:
       moment: 2.30.1
 
+  moment-timezone@0.6.0:
+    dependencies:
+      moment: 2.30.1
+
   moment@2.30.1: {}
 
   ms@2.1.3: {}
@@ -6093,6 +6110,11 @@ snapshots:
       - babel-plugin-macros
 
   node-fetch-native@1.6.7: {}
+
+  node-ical@0.21.0:
+    dependencies:
+      moment-timezone: 0.6.0
+      rrule: 2.8.1
 
   nodemailer@6.10.1: {}
 
@@ -6487,6 +6509,10 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.50.2
       '@rollup/rollup-win32-x64-msvc': 4.50.2
       fsevents: 2.3.3
+
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.8.1
 
   run-parallel@1.2.0:
     dependencies:

--- a/src/app/(members)/mitglieder/sperrliste/page.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page.tsx
@@ -5,6 +5,7 @@ import { hasPermission } from "@/lib/permissions";
 import { addDays, format } from "date-fns";
 import { de } from "date-fns/locale/de";
 import { BlockCalendar } from "./block-calendar";
+import { getSaxonySchoolHolidayRanges } from "@/lib/holidays";
 
 type BlockedDayDTO = {
   id: string;
@@ -29,6 +30,8 @@ export default async function SperrlistePage() {
     orderBy: { date: "asc" },
   });
 
+  const holidayRanges = await getSaxonySchoolHolidayRanges();
+
   const initialBlockedDays: BlockedDayDTO[] = blockedDays.map((entry) => ({
     id: entry.id,
     date: format(entry.date, "yyyy-MM-dd"),
@@ -48,7 +51,7 @@ export default async function SperrlistePage() {
         dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200">
         Hinweis: Aus Planungsgründen können Sperrtermine erst ab {format(freezeUntil, "EEEE, d. MMMM yyyy", { locale: de })} eingetragen werden.
       </div>
-      <BlockCalendar initialBlockedDays={initialBlockedDays} />
+      <BlockCalendar initialBlockedDays={initialBlockedDays} holidays={holidayRanges} />
     </div>
   );
 }

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -1,0 +1,139 @@
+import { unstable_cache } from "next/cache";
+import ical, { type VEvent } from "node-ical";
+import { addDays, format } from "date-fns";
+
+import type { HolidayRange } from "@/types/holidays";
+
+export type { HolidayRange } from "@/types/holidays";
+
+const DEFAULT_SAXONY_HOLIDAY_FEED =
+  "https://www.schulferien.org/media/ical/deutschland/ferien_sachsen.ics";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function normaliseSummary(value: unknown) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : "";
+}
+
+function ensureDate(value: unknown) {
+  if (!(value instanceof Date)) {
+    return null;
+  }
+  const time = value.getTime();
+  if (Number.isNaN(time)) {
+    return null;
+  }
+  return value;
+}
+
+function resolveInclusiveEnd(start: Date, rawEnd: Date | null, isDateOnly: boolean) {
+  if (!rawEnd) {
+    return start;
+  }
+
+  if (isDateOnly || (rawEnd as Date & { dateOnly?: boolean }).dateOnly) {
+    const adjusted = new Date(rawEnd.getTime() - DAY_IN_MS);
+    if (adjusted.getTime() < start.getTime()) {
+      return start;
+    }
+    return adjusted;
+  }
+
+  return rawEnd;
+}
+
+function toRange(event: VEvent): HolidayRange | null {
+  const start = ensureDate(event.start);
+  if (!start) {
+    return null;
+  }
+
+  const end = resolveInclusiveEnd(start, ensureDate(event.end), event.datetype === "date");
+  const summary = normaliseSummary(event.summary);
+
+  const startDate = format(start, "yyyy-MM-dd");
+  const endDate = format(end, "yyyy-MM-dd");
+
+  const uid = normaliseSummary(event.uid);
+  const id = uid || `${startDate}-${endDate}-${summary || "ferien"}`;
+
+  return {
+    id,
+    title: summary || "Ferien",
+    startDate,
+    endDate,
+  };
+}
+
+function parseHolidayRanges(body: string) {
+  const parsed = ical.sync.parseICS(body);
+  const ranges: HolidayRange[] = [];
+
+  for (const component of Object.values(parsed)) {
+    if (!component || component.type !== "VEVENT") {
+      continue;
+    }
+    const range = toRange(component);
+    if (range) {
+      ranges.push(range);
+    }
+  }
+
+  ranges.sort((a, b) => a.startDate.localeCompare(b.startDate));
+
+  return ranges;
+}
+
+async function fetchHolidayFeed() {
+  const source = process.env.SAXONY_HOLIDAYS_ICS_URL || DEFAULT_SAXONY_HOLIDAY_FEED;
+
+  if (!source) {
+    return [] as HolidayRange[];
+  }
+
+  try {
+    const response = await fetch(source, {
+      headers: {
+        Accept: "text/calendar, text/plain;q=0.9,*/*;q=0.1",
+        "User-Agent":
+          "Theaterverein Kalenderbot/1.0 (+https://devtheater.beegreenx.de)",
+        Referer: "https://devtheater.beegreenx.de/mitglieder/sperrliste",
+      },
+      next: { revalidate: 60 * 60 * 12 },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Unexpected response: ${response.status}`);
+    }
+
+    const body = await response.text();
+
+    if (!body.trim()) {
+      throw new Error("Ferien-Kalender lieferte keine Daten");
+    }
+
+    return parseHolidayRanges(body);
+  } catch (error) {
+    console.error("[holidays] feed fetch failed", error);
+    return [] as HolidayRange[];
+  }
+}
+
+export const getSaxonySchoolHolidayRanges = unstable_cache(
+  async () => {
+    const ranges = await fetchHolidayFeed();
+
+    const thresholdStart = format(addDays(new Date(), -365), "yyyy-MM-dd");
+    const thresholdEnd = format(addDays(new Date(), 365 * 3), "yyyy-MM-dd");
+
+    return ranges.filter(
+      (range) => range.endDate >= thresholdStart && range.startDate <= thresholdEnd,
+    );
+  },
+  ["saxony-school-holidays"],
+  { revalidate: 60 * 60 * 12 },
+);

--- a/src/types/holidays.ts
+++ b/src/types/holidays.ts
@@ -1,0 +1,18 @@
+export type HolidayRange = {
+  /**
+   * Stable identifier from the calendar feed. Defaults to a composite key when the feed does not provide a UID.
+   */
+  id: string;
+  /**
+   * Display label for the holiday period (e.g. "Sommerferien").
+   */
+  title: string;
+  /**
+   * Inclusive ISO date (yyyy-MM-dd) of the first day covered by the holiday.
+   */
+  startDate: string;
+  /**
+   * Inclusive ISO date (yyyy-MM-dd) of the last day covered by the holiday.
+   */
+  endDate: string;
+};


### PR DESCRIPTION
## Summary
- fetch Saxony school holiday ranges from an ICS feed and cache them on the server
- surface the holiday data in the Sperrliste by highlighting calendar days and listing upcoming periods
- document the optional ICS feed URL in the environment template

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d059ca6bc0832d93b4e27dfd3f9fbb