### PR TITLE
Add mystery tip scoreboard and management UI

### DIFF
--- a/prisma/migrations/20260602120000_mystery_tip_submissions/migration.sql
+++ b/prisma/migrations/20260602120000_mystery_tip_submissions/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "public"."MysteryTipSubmission" (
+    "id" TEXT NOT NULL,
+    "tipId" TEXT NOT NULL,
+    "clueId" TEXT,
+    "playerName" TEXT NOT NULL,
+    "tipText" TEXT NOT NULL,
+    "normalizedText" TEXT NOT NULL,
+    "isCorrect" BOOLEAN NOT NULL DEFAULT FALSE,
+    "score" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MysteryTipSubmission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MysteryTipSubmission_tipId_idx" ON "public"."MysteryTipSubmission"("tipId");
+CREATE INDEX "MysteryTipSubmission_clueId_idx" ON "public"."MysteryTipSubmission"("clueId");
+CREATE INDEX "MysteryTipSubmission_playerName_idx" ON "public"."MysteryTipSubmission"("playerName");
+
+-- AddForeignKey
+ALTER TABLE "public"."MysteryTipSubmission"
+  ADD CONSTRAINT "MysteryTipSubmission_tipId_fkey" FOREIGN KEY ("tipId") REFERENCES "public"."MysteryTip"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."MysteryTipSubmission"
+  ADD CONSTRAINT "MysteryTipSubmission_clueId_fkey" FOREIGN KEY ("clueId") REFERENCES "public"."Clue"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -452,6 +452,7 @@ model Clue {
   points    Int
   published Boolean  @default(false)
   show      Show     @relation(fields: [showId], references: [id], onDelete: Cascade)
+  tipSubmissions MysteryTipSubmission[]
 
   @@unique([showId, index], name: "showId_index")
   @@index([showId, published, releaseAt])
@@ -472,6 +473,26 @@ model MysteryTip {
   count          Int      @default(1)
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
+  submissions    MysteryTipSubmission[]
+}
+
+model MysteryTipSubmission {
+  id             String   @id @default(cuid())
+  tipId          String
+  clueId         String?
+  playerName     String
+  tipText        String
+  normalizedText String
+  isCorrect      Boolean  @default(false)
+  score          Int      @default(0)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  tip            MysteryTip @relation(fields: [tipId], references: [id], onDelete: Cascade)
+  clue           Clue?      @relation(fields: [clueId], references: [id], onDelete: SetNull)
+
+  @@index([clueId])
+  @@index([playerName])
+  @@index([tipId])
 }
 
 model Guess {

--- a/src/app/(members)/mitglieder/mystery/timer/page.tsx
+++ b/src/app/(members)/mitglieder/mystery/timer/page.tsx
@@ -1,13 +1,12 @@
 import { MysteryTimerManager } from "@/components/members/mystery/mystery-timer-manager";
-import { MysteryTipsTable } from "@/components/members/mystery/mystery-tips-table";
 import { Text } from "@/components/ui/typography";
 import {
   DEFAULT_MYSTERY_COUNTDOWN_ISO,
   DEFAULT_MYSTERY_EXPIRATION_MESSAGE,
+  MysterySettingsScope,
   resolveMysterySettings,
   readMysterySettings,
 } from "@/lib/mystery-settings";
-import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 
@@ -37,34 +36,17 @@ export default async function MysteryTimerPage() {
     );
   }
 
-  const [settingsRecord, tipRecords] = await Promise.all([
-    readMysterySettings(),
-    prisma.mysteryTip.findMany({
-      orderBy: [
-        { count: "desc" },
-        { updatedAt: "desc" },
-        { createdAt: "asc" },
-      ],
-    }),
-  ]);
+  const scope: MysterySettingsScope = "members";
+  const settingsRecord = await readMysterySettings(scope);
 
   const resolved = resolveMysterySettings(settingsRecord);
-
-  const tips = tipRecords.map((tip) => ({
-    id: tip.id,
-    text: tip.text,
-    normalizedText: tip.normalizedText,
-    count: tip.count,
-    createdAt: tip.createdAt.toISOString(),
-    updatedAt: tip.updatedAt.toISOString(),
-  }));
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold">Mystery-Timer</h1>
         <p className="text-sm text-foreground/70">
-          Verwalte Countdown, Hinweistext und erhalte einen Überblick über die häufigsten Community-Tipps.
+          Verwalte Countdown und Hinweistext für interne Planungen unabhängig vom öffentlichen Countdown.
         </p>
       </div>
 
@@ -80,7 +62,6 @@ export default async function MysteryTimerPage() {
         hasCustomMessage={resolved.hasCustomMessage}
       />
 
-      <MysteryTipsTable tips={tips} />
     </div>
   );
 }

--- a/src/app/(members)/mitglieder/mystery/tipps/page.tsx
+++ b/src/app/(members)/mitglieder/mystery/tipps/page.tsx
@@ -1,0 +1,91 @@
+import { MysteryTipManager } from "@/components/members/mystery/mystery-tip-manager";
+import { Heading, Text } from "@/components/ui/typography";
+import { getMysteryClueSummaries, getMysteryScoreboard, getMysterySubmissionsForClue } from "@/lib/mystery-tips";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+export default async function MysteryTipsAdminPage({
+  searchParams,
+}: {
+  searchParams?: { clue?: string };
+}) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.mystery.tips");
+  if (!allowed) {
+    return <div className="text-sm text-red-600">Kein Zugriff auf die Mystery-Tipps</div>;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <Heading level="h1">Mystery-Tipps</Heading>
+          <Text variant="small" tone="muted">
+            Die Datenbank ist nicht konfiguriert. Bitte hinterlege eine gültige <code>DATABASE_URL</code>, um die Tipps auszuwerten.
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  const [clueSummaries, scoreboard] = await Promise.all([
+    getMysteryClueSummaries(),
+    getMysteryScoreboard(),
+  ]);
+
+  const clues = clueSummaries.map((clue) => ({
+    id: clue.id,
+    index: clue.index,
+    points: clue.points,
+    label: `Hinweis ${clue.index}`,
+    releaseAt: clue.releaseAt ? clue.releaseAt.toISOString() : null,
+    published: clue.published,
+  }));
+
+  const availableClueIds = new Set(clues.map((clue) => clue.id));
+  let selectedClueId = searchParams?.clue && availableClueIds.has(searchParams.clue) ? searchParams.clue : null;
+  if (!selectedClueId && clues.length > 0) {
+    selectedClueId = clues[0].id;
+  }
+
+  const submissions = selectedClueId ? await getMysterySubmissionsForClue(selectedClueId) : [];
+
+  const submissionEntries = submissions.map((submission) => ({
+    id: submission.id,
+    playerName: submission.playerName,
+    tipText: submission.tipText,
+    normalizedText: submission.normalizedText,
+    isCorrect: submission.isCorrect,
+    score: submission.score,
+    tipCount: submission.tip.count,
+    cluePoints: submission.clue?.points ?? null,
+    createdAt: submission.createdAt.toISOString(),
+    updatedAt: submission.updatedAt.toISOString(),
+  }));
+
+  const scoreboardEntries = scoreboard.map((entry) => ({
+    playerName: entry.playerName,
+    totalScore: entry.totalScore,
+    correctCount: entry.correctCount,
+    totalSubmissions: entry.totalSubmissions,
+    lastUpdated: entry.lastUpdated ? entry.lastUpdated.toISOString() : null,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Heading level="h1">Mystery-Tipps</Heading>
+        <Text variant="small" tone="muted">
+          Analysiere Community-Tipps pro Rätsel und vergebe Punkte für richtige Ideen.
+        </Text>
+      </div>
+
+      <MysteryTipManager
+        clues={clues}
+        selectedClueId={selectedClueId ?? null}
+        submissions={submissionEntries}
+        scoreboard={scoreboardEntries}
+      />
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
+++ b/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
@@ -1,12 +1,14 @@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { collectOnboardingAnalytics } from "@/lib/onboarding-analytics";
+import { getMysteryScoreboard } from "@/lib/mystery-tips";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 
 const numberFormat = new Intl.NumberFormat("de-DE");
 const percentFormat = new Intl.NumberFormat("de-DE", { style: "percent", minimumFractionDigits: 0, maximumFractionDigits: 0 });
 const dateFormat = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+const dateTimeFormat = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" });
 
 export default async function OnboardingAnalyticsPage() {
   const session = await requireAuth();
@@ -16,6 +18,7 @@ export default async function OnboardingAnalyticsPage() {
   }
 
   const analytics = await collectOnboardingAnalytics();
+  const scoreboard = await getMysteryScoreboard();
   const totalFocus = analytics.completions.total || 1;
 
   return (
@@ -65,6 +68,43 @@ export default async function OnboardingAnalyticsPage() {
           </CardContent>
         </Card>
       </div>
+
+      <Card className="border border-border/70">
+        <CardHeader>
+          <CardTitle>Mystery Scoreboard</CardTitle>
+          <p className="text-sm text-muted-foreground">Top-Spieler:innen mit Punkten für richtige Rätsel-Ideen.</p>
+        </CardHeader>
+        <CardContent>
+          {scoreboard.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Noch keine Punkte vergeben.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-border text-sm">
+                <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Spielername</th>
+                    <th className="px-3 py-2 text-left">Punkte</th>
+                    <th className="px-3 py-2 text-left">Richtige Tipps</th>
+                    <th className="px-3 py-2 text-left">Zuletzt aktualisiert</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/70">
+                  {scoreboard.map((entry) => (
+                    <tr key={entry.playerName} className="bg-background/60">
+                      <td className="px-3 py-2 font-medium">{entry.playerName}</td>
+                      <td className="px-3 py-2 font-semibold">{numberFormat.format(entry.totalScore)}</td>
+                      <td className="px-3 py-2">{entry.correctCount}</td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {entry.lastUpdated ? dateTimeFormat.format(entry.lastUpdated) : "–"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Card className="border border-border/70">

--- a/src/app/api/mystery/settings/route.ts
+++ b/src/app/api/mystery/settings/route.ts
@@ -43,7 +43,7 @@ export async function GET() {
   }
 
   try {
-    const record = await readMysterySettings();
+    const record = await readMysterySettings("members");
     return NextResponse.json({ settings: serializeSettings(record) });
   } catch (error) {
     console.error("Failed to load mystery settings", error);
@@ -76,7 +76,7 @@ export async function PUT(request: NextRequest) {
   }
 
   try {
-    const saved = await saveMysterySettings({
+    const saved = await saveMysterySettings("members", {
       countdownTarget: parsed.data.countdownTarget,
       expirationMessage: parsed.data.expirationMessage,
     });

--- a/src/app/api/mystery/submissions/[id]/route.ts
+++ b/src/app/api/mystery/submissions/[id]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+import { getMysteryScoreboardEntry } from "@/lib/mystery-tips";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+const updateSchema = z.object({
+  isCorrect: z.boolean(),
+});
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.mystery.tips");
+  if (!allowed) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const parsed = updateSchema.safeParse(payload);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const message = issue?.message ?? "Ungültige Eingabe.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const submission = await prisma.mysteryTipSubmission.findUnique({
+    where: { id: params.id },
+    include: { clue: { select: { points: true } }, tip: { select: { count: true } } },
+  });
+
+  if (!submission) {
+    return NextResponse.json({ error: "Der Tipp konnte nicht gefunden werden." }, { status: 404 });
+  }
+
+  const nextScore = parsed.data.isCorrect ? submission.clue?.points ?? 1 : 0;
+
+  const updated = await prisma.mysteryTipSubmission.update({
+    where: { id: submission.id },
+    data: {
+      isCorrect: parsed.data.isCorrect,
+      score: nextScore,
+    },
+    include: {
+      tip: { select: { count: true } },
+      clue: { select: { id: true, index: true, points: true, releaseAt: true, published: true } },
+    },
+  });
+
+  const scoreboardEntry = await getMysteryScoreboardEntry(updated.playerName);
+
+  return NextResponse.json({
+    submission: {
+      id: updated.id,
+      playerName: updated.playerName,
+      tipText: updated.tipText,
+      normalizedText: updated.normalizedText,
+      isCorrect: updated.isCorrect,
+      score: updated.score,
+      tipCount: updated.tip.count,
+      cluePoints: updated.clue?.points ?? null,
+      createdAt: updated.createdAt.toISOString(),
+      updatedAt: updated.updatedAt.toISOString(),
+    },
+    scoreboardEntry: scoreboardEntry
+      ? {
+          playerName: scoreboardEntry.playerName,
+          totalScore: scoreboardEntry.totalScore,
+          correctCount: scoreboardEntry.correctCount,
+          totalSubmissions: scoreboardEntry.totalSubmissions,
+          lastUpdated: scoreboardEntry.lastUpdated ? scoreboardEntry.lastUpdated.toISOString() : null,
+        }
+      : null,
+  });
+}

--- a/src/app/mystery/_components/mystery-scoreboard.tsx
+++ b/src/app/mystery/_components/mystery-scoreboard.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Text } from "@/components/ui/typography";
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const NUMBER_FORMATTER = new Intl.NumberFormat("de-DE");
+
+type ScoreboardEntry = {
+  playerName: string;
+  totalScore: number;
+  correctCount: number;
+  lastUpdated: string | null;
+};
+
+export function MysteryScoreboard({ entries }: { entries: ScoreboardEntry[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Community-Scoreboard</CardTitle>
+        <Text variant="small" tone="muted">
+          Punkte gibt es für richtige Tipps pro Rätsel. Wer sammelt die meisten Treffer?
+        </Text>
+      </CardHeader>
+      <CardContent>
+        {entries.length === 0 ? (
+          <Text variant="small" tone="muted">Noch keine Punkte vergeben – reiche deinen Tipp ein und sichere dir den ersten Platz!</Text>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border text-left text-sm">
+              <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th scope="col" className="px-3 py-2 font-semibold">
+                    Spielername
+                  </th>
+                  <th scope="col" className="px-3 py-2 font-semibold">
+                    Punkte
+                  </th>
+                  <th scope="col" className="px-3 py-2 font-semibold">
+                    Richtige Tipps
+                  </th>
+                  <th scope="col" className="px-3 py-2 font-semibold">
+                    Zuletzt aktualisiert
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/70">
+                {entries.map((entry) => (
+                  <tr key={entry.playerName} className="bg-background/60">
+                    <td className="px-3 py-2 font-medium text-foreground">{entry.playerName}</td>
+                    <td className="px-3 py-2 font-semibold text-foreground">
+                      {NUMBER_FORMATTER.format(entry.totalScore)}
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">{entry.correctCount}</td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {entry.lastUpdated ? DATE_FORMATTER.format(new Date(entry.lastUpdated)) : "–"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -44,6 +44,11 @@ const MYSTERY_ITEMS: Item[] = [
     label: "Mystery-Timer",
     permissionKey: "mitglieder.mystery.timer",
   },
+  {
+    href: "/mitglieder/mystery/tipps",
+    label: "Mystery-Tipps",
+    permissionKey: "mitglieder.mystery.tips",
+  },
 ];
 
 const ADMIN_ITEMS: Item[] = [
@@ -198,6 +203,14 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
           <circle cx="12" cy="12" r="9" />
           <path d="M12 7v6l3 3" />
           <path d="M9 3h6" />
+        </svg>
+      );
+    case "/mitglieder/mystery/tipps":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="m2 12 9-9 4 4-9 9-4 4z" />
+          <path d="M12.5 5.5 18 11" />
+          <path d="M4 20h7" />
         </svg>
       );
     default:

--- a/src/components/members/mystery/mystery-tip-manager.tsx
+++ b/src/components/members/mystery/mystery-tip-manager.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Text } from "@/components/ui/typography";
+
+const TIMESTAMP_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const SCOREBOARD_FORMATTER = new Intl.NumberFormat("de-DE");
+
+function sortScoreboard(entries: MysteryTipManagerProps["scoreboard"]) {
+  return [...entries].sort((a, b) => {
+    if (b.totalScore !== a.totalScore) return b.totalScore - a.totalScore;
+    if (b.correctCount !== a.correctCount) return b.correctCount - a.correctCount;
+    if (b.totalSubmissions !== a.totalSubmissions) return b.totalSubmissions - a.totalSubmissions;
+    return a.playerName.localeCompare(b.playerName, "de-DE", { sensitivity: "base" });
+  });
+}
+
+type ClueOption = {
+  id: string;
+  label: string;
+  index: number;
+  points: number;
+  releaseAt: string | null;
+  published: boolean;
+};
+
+type SubmissionEntry = {
+  id: string;
+  playerName: string;
+  tipText: string;
+  normalizedText: string;
+  isCorrect: boolean;
+  score: number;
+  tipCount: number;
+  cluePoints: number | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ScoreboardEntry = {
+  playerName: string;
+  totalScore: number;
+  correctCount: number;
+  totalSubmissions: number;
+  lastUpdated: string | null;
+};
+
+type MysteryTipManagerProps = {
+  clues: ClueOption[];
+  selectedClueId: string | null;
+  submissions: SubmissionEntry[];
+  scoreboard: ScoreboardEntry[];
+};
+
+export function MysteryTipManager({ clues, selectedClueId, submissions, scoreboard }: MysteryTipManagerProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [items, setItems] = useState(submissions);
+  const [board, setBoard] = useState(() => sortScoreboard(scoreboard));
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const activeClue = useMemo(() => clues.find((clue) => clue.id === selectedClueId) ?? null, [clues, selectedClueId]);
+
+  function handleSelectClue(nextId: string) {
+    const params = new URLSearchParams(searchParams ? searchParams.toString() : "");
+    if (nextId) {
+      params.set("clue", nextId);
+    } else {
+      params.delete("clue");
+    }
+    const nextUrl = params.toString() ? `${pathname}?${params}` : pathname;
+    router.push(nextUrl);
+  }
+
+  function applyScoreboardUpdate(playerName: string, entry: ScoreboardEntry | null) {
+    setBoard((previous) => {
+      const filtered = previous.filter((item) => item.playerName !== playerName);
+      if (!entry) {
+        return filtered;
+      }
+      filtered.push(entry);
+      return sortScoreboard(filtered);
+    });
+  }
+
+  async function handleToggle(submissionId: string, nextState: boolean) {
+    setPendingId(submissionId);
+    setError(null);
+    try {
+      const response = await fetch(`/api/mystery/submissions/${submissionId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ isCorrect: nextState }),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        const message = typeof payload?.error === "string" ? payload.error : "Der Tipp konnte nicht aktualisiert werden.";
+        throw new Error(message);
+      }
+
+      let playerName = "";
+      setItems((previous) =>
+        previous.map((entry) => {
+          if (entry.id === submissionId) {
+            playerName = entry.playerName;
+            return {
+              ...entry,
+              isCorrect: payload.submission.isCorrect as boolean,
+              score: payload.submission.score as number,
+              tipCount: payload.submission.tipCount as number,
+              cluePoints: payload.submission.cluePoints as number | null,
+              updatedAt: payload.submission.updatedAt as string,
+            };
+          }
+          return entry;
+        }),
+      );
+
+      const scoreboardEntry = payload.scoreboardEntry
+        ? {
+            playerName: payload.scoreboardEntry.playerName as string,
+            totalScore: payload.scoreboardEntry.totalScore as number,
+            correctCount: payload.scoreboardEntry.correctCount as number,
+            totalSubmissions: payload.scoreboardEntry.totalSubmissions as number,
+            lastUpdated: payload.scoreboardEntry.lastUpdated as string | null,
+          }
+        : null;
+
+      const targetPlayer = scoreboardEntry?.playerName ?? playerName;
+      if (targetPlayer) {
+        applyScoreboardUpdate(targetPlayer, scoreboardEntry);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler beim Aktualisieren.");
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Punktestand</CardTitle>
+          <Text variant="small" tone="muted">
+            Punkte werden automatisch anhand der Rätsel-Punkte vergeben, sobald ein Tipp als richtig markiert wird.
+          </Text>
+        </CardHeader>
+        <CardContent>
+          {board.length === 0 ? (
+            <Text variant="small" tone="muted">Noch keine Punkte vergeben.</Text>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-border text-sm">
+                <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Spielername</th>
+                    <th className="px-3 py-2 text-left">Punkte</th>
+                    <th className="px-3 py-2 text-left">Richtige Tipps</th>
+                    <th className="px-3 py-2 text-left">Letztes Update</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/70">
+                  {board.map((entry) => (
+                    <tr key={entry.playerName} className="bg-background/60">
+                      <td className="px-3 py-2 font-medium">{entry.playerName}</td>
+                      <td className="px-3 py-2 font-semibold">{SCOREBOARD_FORMATTER.format(entry.totalScore)}</td>
+                      <td className="px-3 py-2">{entry.correctCount}</td>
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {entry.lastUpdated ? TIMESTAMP_FORMATTER.format(new Date(entry.lastUpdated)) : "–"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Tipps nach Rätsel</CardTitle>
+          <Text variant="small" tone="muted">
+            Wähle ein Rätsel, um die abgegebenen Tipps zu prüfen und bei korrekter Lösung Punkte zu vergeben.
+          </Text>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {clues.length > 0 ? (
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-1">
+                <Text variant="small" tone="muted">Rätsel auswählen</Text>
+                <Select value={selectedClueId ?? clues[0]?.id ?? ""} onValueChange={handleSelectClue}>
+                  <SelectTrigger className="w-72">
+                    <SelectValue placeholder="Rätsel wählen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {clues.map((clue) => (
+                      <SelectItem key={clue.id} value={clue.id}>
+                        {clue.label} · {clue.points} Punkte
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {activeClue && (
+                <Badge variant="outline">
+                  {activeClue.points} Punkte · {activeClue.published ? "Veröffentlicht" : "Entwurf"}
+                </Badge>
+              )}
+            </div>
+          ) : (
+            <Text variant="small" tone="muted">Noch keine Rätsel angelegt.</Text>
+          )}
+
+          {error && <Text tone="destructive">{error}</Text>}
+
+          {items.length === 0 ? (
+            <Text variant="small" tone="muted">Keine Tipps für dieses Rätsel vorhanden.</Text>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-border text-sm">
+                <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Spielername</th>
+                    <th className="px-3 py-2 text-left">Tipp</th>
+                    <th className="px-3 py-2 text-left">Stimmen</th>
+                    <th className="px-3 py-2 text-left">Status</th>
+                    <th className="px-3 py-2 text-left">Aktion</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/70">
+                  {items.map((item) => {
+                    const isActive = pendingId === item.id;
+                    return (
+                      <tr key={item.id} className="bg-background/60 align-top">
+                        <td className="px-3 py-2 font-medium">{item.playerName}</td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          <div className="whitespace-pre-wrap break-words">{item.tipText}</div>
+                        </td>
+                        <td className="px-3 py-2">
+                          <Badge variant="secondary">×{item.tipCount}</Badge>
+                        </td>
+                        <td className="px-3 py-2">
+                          {item.isCorrect ? (
+                            <span className="inline-flex items-center gap-2 text-foreground">
+                              <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden />
+                              Richtig · {item.score} Punkte
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center gap-2 text-muted-foreground">
+                              <span className="h-2 w-2 rounded-full bg-muted-foreground/40" aria-hidden />
+                              Offen
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-3 py-2">
+                          <Button
+                            variant={item.isCorrect ? "outline" : "default"}
+                            size="sm"
+                            disabled={isActive}
+                            onClick={() => handleToggle(item.id, !item.isCorrect)}
+                          >
+                            {isActive
+                              ? "Aktualisiere…"
+                              : item.isCorrect
+                              ? "Als falsch markieren"
+                              : "Als richtig markieren"}
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/mystery-tips.ts
+++ b/src/lib/mystery-tips.ts
@@ -1,0 +1,142 @@
+import { prisma } from "@/lib/prisma";
+
+export type MysteryScoreboardEntry = {
+  playerName: string;
+  totalScore: number;
+  correctCount: number;
+  totalSubmissions: number;
+  lastUpdated: Date | null;
+};
+
+export async function getMysteryScoreboard(limit?: number): Promise<MysteryScoreboardEntry[]> {
+  if (!process.env.DATABASE_URL) {
+    return [];
+  }
+  const totals = await prisma.mysteryTipSubmission.groupBy({
+    by: ["playerName"],
+    _sum: { score: true },
+    _count: { _all: true },
+    _max: { updatedAt: true },
+  });
+
+  const correctCounts = await prisma.mysteryTipSubmission.groupBy({
+    by: ["playerName"],
+    _count: { _all: true },
+    where: { isCorrect: true },
+  });
+
+  const correctMap = new Map<string, number>();
+  for (const entry of correctCounts) {
+    correctMap.set(entry.playerName, entry._count._all ?? 0);
+  }
+
+  const scoreboard = totals
+    .map<MysteryScoreboardEntry | null>((entry) => {
+      const playerName = entry.playerName.trim();
+      const totalScore = entry._sum.score ?? 0;
+      const totalSubmissions = entry._count._all ?? 0;
+      if (!playerName || totalScore <= 0) {
+        return null;
+      }
+      return {
+        playerName,
+        totalScore,
+        totalSubmissions,
+        correctCount: correctMap.get(playerName) ?? 0,
+        lastUpdated: entry._max.updatedAt ?? null,
+      };
+    })
+    .filter((entry): entry is MysteryScoreboardEntry => Boolean(entry));
+
+  scoreboard.sort((a, b) => {
+    if (b.totalScore !== a.totalScore) return b.totalScore - a.totalScore;
+    if (b.correctCount !== a.correctCount) return b.correctCount - a.correctCount;
+    if (b.totalSubmissions !== a.totalSubmissions) return b.totalSubmissions - a.totalSubmissions;
+    return a.playerName.localeCompare(b.playerName, "de-DE", { sensitivity: "base" });
+  });
+
+  if (typeof limit === "number" && limit > 0) {
+    return scoreboard.slice(0, limit);
+  }
+
+  return scoreboard;
+}
+
+export async function getMysteryScoreboardEntry(playerName: string): Promise<MysteryScoreboardEntry | null> {
+  const trimmed = playerName.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return null;
+  }
+
+  const [totals, correctCount] = await Promise.all([
+    prisma.mysteryTipSubmission.aggregate({
+      where: { playerName: trimmed },
+      _sum: { score: true },
+      _count: true,
+      _max: { updatedAt: true },
+    }),
+    prisma.mysteryTipSubmission.count({ where: { playerName: trimmed, isCorrect: true } }),
+  ]);
+
+  const totalScore = totals._sum.score ?? 0;
+  if (totalScore <= 0) {
+    return null;
+  }
+
+  const totalSubmissions = typeof totals._count === "number" ? totals._count : totals._count?._all ?? 0;
+
+  return {
+    playerName: trimmed,
+    totalScore,
+    correctCount,
+    totalSubmissions,
+    lastUpdated: totals._max.updatedAt ?? null,
+  };
+}
+
+export async function getMysteryClueSummaries() {
+  if (!process.env.DATABASE_URL) {
+    return [] as Awaited<ReturnType<typeof prisma.clue.findMany>>;
+  }
+  return prisma.clue.findMany({
+    orderBy: [{ index: "asc" }],
+    select: {
+      id: true,
+      index: true,
+      points: true,
+      releaseAt: true,
+      published: true,
+    },
+  });
+}
+
+export async function getMysterySubmissionsForClue(clueId: string) {
+  if (!process.env.DATABASE_URL) {
+    return [] as Awaited<ReturnType<typeof prisma.mysteryTipSubmission.findMany>>;
+  }
+  return prisma.mysteryTipSubmission.findMany({
+    where: { clueId },
+    include: {
+      tip: {
+        select: {
+          text: true,
+          count: true,
+        },
+      },
+      clue: {
+        select: {
+          id: true,
+          index: true,
+          points: true,
+          releaseAt: true,
+          published: true,
+        },
+      },
+    },
+    orderBy: [{ createdAt: "desc" }],
+  });
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -44,6 +44,11 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     label: "Mystery-Timer verwalten",
     description: "Countdown und Hinweistext für das öffentliche Geheimnis pflegen.",
   },
+  {
+    key: "mitglieder.mystery.tips",
+    label: "Mystery-Tipps verwalten",
+    description: "Community-Tipps nach Rätsel auswerten und Punkte für richtige Ideen vergeben.",
+  },
   { key: "mitglieder.sperrliste", label: "Sperrliste pflegen" },
   {
     key: "mitglieder.fotoerlaubnisse",


### PR DESCRIPTION
## Summary
- add a dedicated `MysteryTipSubmission` model, migration, and helper utilities to track player names and mystery tip scoring
- extend the mystery API to capture player information, expose a scoring update endpoint, and surface aggregated results
- introduce a member-facing tips management page with filtering, scoreboard, and correct-guess toggles plus wire the public mystery page to require riddle selection and show a scoreboard

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: Turbopack cannot resolve optional dependency `node-ical` in src/lib/holidays.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d05eedf230832d83271e74a2ea8e25