### PR TITLE
Limit Docker publish workflow to environment tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,6 @@ jobs:
               GIT_COMMIT_SHA=${{ github.sha }}
             metadata_tags: |
               type=raw,value=dev
-              type=sha,prefix=dev-
           - environment: prod
             dockerfile: Dockerfile.prod
             build_args: |
@@ -53,7 +52,6 @@ jobs:
               GIT_COMMIT_SHA=${{ github.sha }}
             metadata_tags: |
               type=raw,value=prod
-              type=sha,prefix=prod-
     name: Build and Push Theater Website Image (${{ matrix.environment }})
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- update the Docker publish workflow to only push the stable dev and prod tags instead of commit-specific variants

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: Module not found: Can't resolve 'node-ical')*


------
https://chatgpt.com/codex/tasks/task_e_68d064637374832daaf986b3b66729fb