### PR TITLE
Fix Next.js 15 route typing regressions for mystery submissions

### DIFF
--- a/src/app/api/mystery/submissions/[id]/route.ts
+++ b/src/app/api/mystery/submissions/[id]/route.ts
@@ -10,7 +10,10 @@ const updateSchema = z.object({
   isCorrect: z.boolean(),
 });
 
-export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.mystery.tips");
   if (!allowed) {
@@ -20,6 +23,8 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
   if (!process.env.DATABASE_URL) {
     return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
   }
+
+  const { id } = await params;
 
   let payload: unknown;
   try {
@@ -36,7 +41,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
   }
 
   const submission = await prisma.mysteryTipSubmission.findUnique({
-    where: { id: params.id },
+    where: { id },
     include: { clue: { select: { points: true } }, tip: { select: { count: true } } },
   });
 

--- a/src/components/members/mystery/mystery-tip-manager.tsx
+++ b/src/components/members/mystery/mystery-tip-manager.tsx
@@ -80,7 +80,8 @@ export function MysteryTipManager({ clues, selectedClueId, submissions, scoreboa
     } else {
       params.delete("clue");
     }
-    const nextUrl = params.toString() ? `${pathname}?${params}` : pathname;
+    const basePath = pathname ?? "/";
+    const nextUrl = params.toString() ? `${basePath}?${params}` : basePath;
     router.push(nextUrl);
   }
 


### PR DESCRIPTION
## Summary
- adapt the mystery submission PATCH route to the updated Next.js 15 route handler context signature and await the resolved params
- tighten the mystery tips data helpers with an explicit Prisma include/type so relational fields stay typed, and simplify the aggregated count handling
- guard the mystery tip manager navigation against a null pathname when building the next URL

## Testing
- CI=1 pnpm lint
- CI=1 pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d064feca88832d840b1ffdf777b644