### PR TITLE
Update chronik backgrounds for 2019-2021 shows

### DIFF
--- a/src/data/chronik-altrossthal.json
+++ b/src/data/chronik-altrossthal.json
@@ -177,7 +177,8 @@
     "evidence_snippets": [
       "Im Sommer 2019 hatte sein Stück „Lysistrate’s Weber“ im Schlossparktheater Altroßthal Premiere."
     ],
-    "images": []
+    "images": [],
+    "posterUrl": "/images/P7070727.JPG"
   },
   {
     "year": 2020,
@@ -188,7 +189,8 @@
     "director": "Elke Zeh",
     "sources": [],
     "evidence_snippets": [],
-    "images": []
+    "images": [],
+    "posterUrl": "/images/IMG_2066.JPG"
   },
   {
     "year": 2021,
@@ -203,7 +205,8 @@
     "evidence_snippets": [
       "Seit nunmehr elf Jahren ... Sommertheater ... In diesem Jahr wird ... Elke Zeh ... „Robin Hood“ inszenieren."
     ],
-    "images": []
+    "images": [],
+    "posterUrl": "/images/IMG-20210629-WA0003.jpg"
   },
   {
     "year": 2022,


### PR DESCRIPTION
## Summary
- add the new chronik background image paths for Lysistrate’s Weber, Was ihr wollt, and Robin Hood in the Altroßthal data set

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0696a2b40832db7e48dcda8ad22cb