### PR TITLE
Add finance management module

### DIFF
--- a/prisma/migrations/20260602120000_finance_module/migration.sql
+++ b/prisma/migrations/20260602120000_finance_module/migration.sql
@@ -1,0 +1,94 @@
+-- Create new enums for finance entries
+CREATE TYPE "public"."FinanceEntryKind" AS ENUM ('general', 'invoice', 'donation');
+CREATE TYPE "public"."FinanceEntryStatus" AS ENUM ('draft', 'pending', 'approved', 'paid', 'cancelled');
+
+-- Extend FinanceEntry with richer bookkeeping fields
+ALTER TABLE "public"."FinanceEntry"
+  ADD COLUMN "kind" "public"."FinanceEntryKind" NOT NULL DEFAULT 'general',
+  ADD COLUMN "status" "public"."FinanceEntryStatus" NOT NULL DEFAULT 'draft',
+  ADD COLUMN "title" TEXT,
+  ADD COLUMN "description" TEXT,
+  ADD COLUMN "currency" TEXT NOT NULL DEFAULT 'EUR',
+  ADD COLUMN "bookingDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN "dueDate" TIMESTAMP(3),
+  ADD COLUMN "paidAt" TIMESTAMP(3),
+  ADD COLUMN "invoiceNumber" TEXT,
+  ADD COLUMN "vendor" TEXT,
+  ADD COLUMN "memberPaidById" TEXT,
+  ADD COLUMN "donationSource" TEXT,
+  ADD COLUMN "donorContact" TEXT,
+  ADD COLUMN "tags" JSONB,
+  ADD COLUMN "budgetId" TEXT,
+  ADD COLUMN "createdById" TEXT NOT NULL,
+  ADD COLUMN "approvedById" TEXT,
+  ADD COLUMN "approvedAt" TIMESTAMP(3),
+  ADD COLUMN "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "public"."FinanceEntry" SET "title" = COALESCE("title", 'Finanzbuchung');
+ALTER TABLE "public"."FinanceEntry" ALTER COLUMN "title" SET NOT NULL;
+ALTER TABLE "public"."FinanceEntry" ALTER COLUMN "visibilityScope" SET DEFAULT 'finance';
+
+-- Create finance budgets table
+CREATE TABLE "public"."FinanceBudget" (
+    "id" TEXT NOT NULL,
+    "showId" TEXT,
+    "category" TEXT NOT NULL,
+    "plannedAmount" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "currency" TEXT NOT NULL DEFAULT 'EUR',
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FinanceBudget_pkey" PRIMARY KEY ("id")
+);
+
+-- Create attachments table for finance entries
+CREATE TABLE "public"."FinanceAttachment" (
+    "id" TEXT NOT NULL,
+    "entryId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "url" TEXT,
+    "mimeType" TEXT,
+    "size" INTEGER,
+    "meta" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FinanceAttachment_pkey" PRIMARY KEY ("id")
+);
+
+-- Create status log table for finance entries
+CREATE TABLE "public"."FinanceLog" (
+    "id" TEXT NOT NULL,
+    "entryId" TEXT NOT NULL,
+    "changedById" TEXT,
+    "fromStatus" "public"."FinanceEntryStatus",
+    "toStatus" "public"."FinanceEntryStatus" NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FinanceLog_pkey" PRIMARY KEY ("id")
+);
+
+-- Create supporting indexes
+CREATE INDEX "FinanceEntry_showId_status_idx" ON "public"."FinanceEntry"("showId", "status");
+CREATE INDEX "FinanceEntry_budgetId_idx" ON "public"."FinanceEntry"("budgetId");
+CREATE INDEX "FinanceEntry_memberPaidById_bookingDate_idx" ON "public"."FinanceEntry"("memberPaidById", "bookingDate");
+CREATE INDEX "FinanceAttachment_entryId_idx" ON "public"."FinanceAttachment"("entryId");
+CREATE INDEX "FinanceBudget_showId_category_idx" ON "public"."FinanceBudget"("showId", "category");
+CREATE INDEX "FinanceLog_entryId_idx" ON "public"."FinanceLog"("entryId");
+CREATE INDEX "FinanceLog_changedById_idx" ON "public"."FinanceLog"("changedById");
+
+-- Wire up foreign keys
+ALTER TABLE "public"."FinanceBudget"
+  ADD CONSTRAINT "FinanceBudget_showId_fkey" FOREIGN KEY ("showId") REFERENCES "public"."Show"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "public"."FinanceEntry"
+  ADD CONSTRAINT "FinanceEntry_budgetId_fkey" FOREIGN KEY ("budgetId") REFERENCES "public"."FinanceBudget"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "FinanceEntry_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "FinanceEntry_approvedById_fkey" FOREIGN KEY ("approvedById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "FinanceEntry_memberPaidById_fkey" FOREIGN KEY ("memberPaidById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "public"."FinanceAttachment"
+  ADD CONSTRAINT "FinanceAttachment_entryId_fkey" FOREIGN KEY ("entryId") REFERENCES "public"."FinanceEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."FinanceLog"
+  ADD CONSTRAINT "FinanceLog_entryId_fkey" FOREIGN KEY ("entryId") REFERENCES "public"."FinanceEntry"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "FinanceLog_changedById_fkey" FOREIGN KEY ("changedById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -154,6 +154,20 @@ enum FinanceType {
   expense
 }
 
+enum FinanceEntryKind {
+  general
+  invoice
+  donation
+}
+
+enum FinanceEntryStatus {
+  draft
+  pending
+  approved
+  paid
+  cancelled
+}
+
 enum VisibilityScope {
   board
   finance
@@ -243,6 +257,10 @@ model User {
   issuesCreated          Issue[]                @relation("IssueCreatedBy")
   issuesUpdated          Issue[]                @relation("IssueUpdatedBy")
   issueComments          IssueComment[]         @relation("IssueCommentAuthor")
+  financeEntriesCreated  FinanceEntry[]         @relation("FinanceEntryCreatedBy")
+  financeEntriesApproved FinanceEntry[]         @relation("FinanceEntryApprovedBy")
+  financeEntriesPaidFor  FinanceEntry[]         @relation("FinanceEntryMemberPaidBy")
+  financeLogsAuthored    FinanceLog[]           @relation("FinanceLogChangedBy")
 }
 
 model Account {
@@ -300,6 +318,7 @@ model Show {
   clues      Clue[]
   rehearsals Rehearsal[]
   finance    FinanceEntry[]
+  budgets    FinanceBudget[]
   guesses    Guess[]
   proposals  RehearsalProposal[]
   characters Character[]
@@ -760,13 +779,88 @@ model InventoryItem {
 }
 
 model FinanceEntry {
-  id              String          @id @default(cuid())
+  id              String             @id @default(cuid())
   type            FinanceType
+  kind            FinanceEntryKind   @default(general)
+  status          FinanceEntryStatus @default(draft)
+  title           String
+  description     String?
   amount          Float
+  currency        String             @default("EUR")
   category        String?
+  bookingDate     DateTime           @default(now())
+  dueDate         DateTime?
+  paidAt          DateTime?
+  invoiceNumber   String?
+  vendor          String?
+  memberPaidById  String?
+  donationSource  String?
+  donorContact    String?
+  tags            Json?
   showId          String?
-  visibilityScope VisibilityScope
-  show            Show?           @relation(fields: [showId], references: [id])
+  budgetId        String?
+  visibilityScope VisibilityScope    @default(finance)
+  createdById     String
+  approvedById    String?
+  approvedAt      DateTime?
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
+
+  show           Show?          @relation(fields: [showId], references: [id], onDelete: SetNull)
+  budget         FinanceBudget? @relation(fields: [budgetId], references: [id], onDelete: SetNull)
+  createdBy      User           @relation("FinanceEntryCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
+  approvedBy     User?          @relation("FinanceEntryApprovedBy", fields: [approvedById], references: [id], onDelete: SetNull)
+  memberPaidBy   User?          @relation("FinanceEntryMemberPaidBy", fields: [memberPaidById], references: [id], onDelete: SetNull)
+  attachments    FinanceAttachment[]
+  logs           FinanceLog[]
+
+  @@index([showId, status])
+  @@index([budgetId])
+  @@index([memberPaidById, bookingDate])
+}
+
+model FinanceAttachment {
+  id        String        @id @default(cuid())
+  entryId   String
+  filename  String
+  url       String?
+  mimeType  String?
+  size      Int?
+  meta      Json?
+  createdAt DateTime      @default(now())
+  entry     FinanceEntry  @relation(fields: [entryId], references: [id], onDelete: Cascade)
+
+  @@index([entryId])
+}
+
+model FinanceBudget {
+  id            String         @id @default(cuid())
+  showId        String?
+  category      String
+  plannedAmount Float          @default(0)
+  currency      String         @default("EUR")
+  notes         String?
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+  show          Show?          @relation(fields: [showId], references: [id], onDelete: SetNull)
+  entries       FinanceEntry[]
+
+  @@index([showId, category])
+}
+
+model FinanceLog {
+  id          String             @id @default(cuid())
+  entryId     String
+  changedById String?
+  fromStatus  FinanceEntryStatus?
+  toStatus    FinanceEntryStatus
+  note        String?
+  createdAt   DateTime           @default(now())
+  entry       FinanceEntry       @relation(fields: [entryId], references: [id], onDelete: Cascade)
+  changedBy   User?              @relation("FinanceLogChangedBy", fields: [changedById], references: [id], onDelete: SetNull)
+
+  @@index([entryId])
+  @@index([changedById])
 }
 
 model Notification {

--- a/src/app/(members)/mitglieder/finanzen/[[...section]]/page.tsx
+++ b/src/app/(members)/mitglieder/finanzen/[[...section]]/page.tsx
@@ -1,0 +1,186 @@
+import type { FinanceEntryStatus } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { FinanceOverview } from "@/components/members/finance/finance-overview";
+import {
+  createEmptyFinanceSummary,
+  mapFinanceBudget,
+  mapFinanceEntry,
+  resolveAllowedVisibilityScopes,
+  type FinanceBudgetWithMeta,
+  type FinanceEntryWithRelations,
+} from "@/app/api/finance/utils";
+import { PageHeader } from "@/components/members/page-header";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_STATUS_FILTER: FinanceEntryStatus[] = ["draft", "pending", "approved", "paid"];
+const VALID_SECTIONS = new Set(["dashboard", "buchungen", "budgets", "export"]);
+
+interface PageProps {
+  params: { section?: string[] };
+}
+
+export default async function FinancePage({ params }: PageProps) {
+  const session = await requireAuth();
+  const [canView, canManage, canApprove, canExport] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen"),
+    hasPermission(session.user, "mitglieder.finanzen.manage"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+    hasPermission(session.user, "mitglieder.finanzen.export"),
+  ]);
+
+  if (!canView) {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Finanzen" description="Du hast keine Berechtigung für diesen Bereich." />
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-6 text-sm text-destructive">
+          Für den Finanzbereich benötigst du eine entsprechende Rolle.
+        </div>
+      </div>
+    );
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+  const requestedSection = params.section?.[0] ?? "dashboard";
+  const activeSection = VALID_SECTIONS.has(requestedSection)
+    ? (requestedSection as "dashboard" | "buchungen" | "budgets" | "export")
+    : "dashboard";
+
+  const entriesPromise = prisma.financeEntry.findMany({
+    where: {
+      visibilityScope: { in: allowedScopes },
+      status: { in: DEFAULT_STATUS_FILTER },
+    },
+    orderBy: { bookingDate: "desc" },
+    take: 200,
+    include: {
+      show: { select: { id: true, title: true, year: true } },
+      budget: { include: { show: { select: { id: true, title: true, year: true } } } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      approvedBy: { select: { id: true, name: true, email: true } },
+      memberPaidBy: { select: { id: true, name: true, email: true } },
+      attachments: true,
+      logs: {
+        include: { changedBy: { select: { id: true, name: true, email: true } } },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  const budgetsPromise = prisma.financeBudget.findMany({
+    orderBy: [{ show: { year: "desc" } }, { category: "asc" }],
+    include: { show: { select: { id: true, title: true, year: true } } },
+  });
+
+  const summaryPromise = (async () => {
+    const [totals, pending, donations] = await Promise.all([
+      prisma.financeEntry.groupBy({
+        by: ["type"],
+        where: { visibilityScope: { in: allowedScopes }, status: { in: ["pending", "approved", "paid"] } },
+        _sum: { amount: true },
+      }),
+      prisma.financeEntry.aggregate({
+        where: {
+          kind: "invoice",
+          status: { in: ["pending", "approved"] },
+          visibilityScope: { in: allowedScopes },
+        },
+        _sum: { amount: true },
+        _count: { _all: true },
+      }),
+      prisma.financeEntry.aggregate({
+        where: {
+          kind: "donation",
+          status: { in: ["approved", "paid"] },
+          visibilityScope: { in: allowedScopes },
+        },
+        _sum: { amount: true },
+      }),
+    ]);
+
+    const summary = createEmptyFinanceSummary();
+    for (const entry of totals) {
+      const sum = entry._sum.amount ?? 0;
+      if (entry.type === "income") {
+        summary.totalIncome += sum;
+      } else if (entry.type === "expense") {
+        summary.totalExpense += sum;
+      }
+    }
+    summary.pendingInvoices = pending._count._all ?? 0;
+    summary.pendingAmount = pending._sum.amount ?? 0;
+    summary.donationTotal = donations._sum.amount ?? 0;
+    return summary;
+  })();
+
+  const [entriesRaw, budgetsRaw, summary, shows, members] = await Promise.all([
+    entriesPromise,
+    budgetsPromise,
+    summaryPromise,
+    prisma.show.findMany({
+      orderBy: { year: "desc" },
+      select: { id: true, title: true, year: true },
+    }),
+    prisma.user.findMany({
+      orderBy: [{ name: "asc" }, { email: "asc" }],
+      select: { id: true, name: true, email: true },
+    }),
+  ]);
+
+  const budgetIds = budgetsRaw.map((budget) => budget.id);
+  const budgetAggregates = budgetIds.length
+    ? await prisma.financeEntry.groupBy({
+        by: ["budgetId", "type"],
+        where: {
+          budgetId: { in: budgetIds },
+          status: { in: ["approved", "paid"] },
+          visibilityScope: { in: allowedScopes },
+        },
+        _sum: { amount: true },
+        _count: { _all: true },
+      })
+    : [];
+
+  const totals = new Map<string, { amount: number; count: number }>();
+  for (const aggregate of budgetAggregates) {
+    if (!aggregate.budgetId) continue;
+    const current = totals.get(aggregate.budgetId) ?? { amount: 0, count: 0 };
+    const sum = aggregate._sum.amount ?? 0;
+    const signed = aggregate.type === "expense" ? sum : -sum;
+    current.amount += signed;
+    current.count += aggregate._count._all ?? 0;
+    totals.set(aggregate.budgetId, current);
+  }
+
+  const budgets: FinanceBudgetWithMeta[] = budgetsRaw.map((budget) => {
+    const info = totals.get(budget.id) ?? { amount: 0, count: 0 };
+    return {
+      ...budget,
+      actualAmount: info.amount,
+      entryCount: info.count,
+    };
+  });
+
+  const entries = entriesRaw.map((entry) => mapFinanceEntry(entry as FinanceEntryWithRelations));
+  const budgetDtos = budgets.map((budget) => mapFinanceBudget(budget));
+
+  const showOptions = shows.map((show) => ({ id: show.id, title: show.title, year: show.year }));
+  const memberOptions = members.map((member) => ({ id: member.id, name: member.name, email: member.email }));
+
+  return (
+    <FinanceOverview
+      initialEntries={entries}
+      initialSummary={summary}
+      initialBudgets={budgetDtos}
+      showOptions={showOptions}
+      memberOptions={memberOptions}
+      canManage={canManage}
+      canApprove={canApprove}
+      canExport={canExport}
+      allowedScopes={allowedScopes}
+      activeSection={activeSection}
+    />
+  );
+}

--- a/src/app/api/finance/[id]/route.ts
+++ b/src/app/api/finance/[id]/route.ts
@@ -1,0 +1,319 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import type { Prisma, VisibilityScope } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { mapFinanceEntry, resolveAllowedVisibilityScopes, type FinanceEntryWithRelations } from "../utils";
+
+function parseDate(input: unknown): Date | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.valueOf()) ? null : parsed;
+}
+
+function ensureAllowedScope(requested: VisibilityScope | undefined, allowed: readonly VisibilityScope[]): VisibilityScope {
+  if (requested && allowed.includes(requested)) {
+    return requested;
+  }
+  return allowed[0] ?? "finance";
+}
+
+async function loadEntry(id: string) {
+  return prisma.financeEntry.findUnique({
+    where: { id },
+    include: {
+      show: { select: { id: true, title: true, year: true } },
+      budget: { include: { show: { select: { id: true, title: true, year: true } } } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      approvedBy: { select: { id: true, name: true, email: true } },
+      memberPaidBy: { select: { id: true, name: true, email: true } },
+      attachments: true,
+      logs: {
+        include: { changedBy: { select: { id: true, name: true, email: true } } },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+}
+
+export async function GET(_: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const session = await requireAuth();
+  const [canView, canApprove] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+  ]);
+
+  if (!canView) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const entry = await loadEntry(id);
+  if (!entry) {
+    return NextResponse.json({ error: "Eintrag nicht gefunden" }, { status: 404 });
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+  if (!allowedScopes.includes(entry.visibilityScope)) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  return NextResponse.json({ entry: mapFinanceEntry(entry as FinanceEntryWithRelations) });
+}
+
+const attachmentSchema = z.object({
+  filename: z.string().min(1).max(160),
+  url: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length ? value : null))
+    .refine((value) => !value || /^https?:\/\//.test(value), {
+      message: "Anhänge benötigen eine gültige URL",
+    }),
+  mimeType: z
+    .string()
+    .trim()
+    .max(120)
+    .optional()
+    .transform((value) => (value && value.length ? value : null)),
+  size: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .transform((value) => (typeof value === "number" ? value : null)),
+});
+
+const updateSchema = z
+  .object({
+    title: z.string().min(3).max(200).optional(),
+    description: z.string().max(4000).optional().nullable(),
+    amount: z.number().finite().nonnegative().optional(),
+    currency: z.string().trim().min(1).max(10).optional(),
+    type: z.enum(["income", "expense"] as const).optional(),
+    kind: z.enum(["general", "invoice", "donation"] as const).optional(),
+    status: z.enum(["draft", "pending", "approved", "paid", "cancelled"] as const).optional(),
+    category: z.string().max(120).optional().nullable(),
+    bookingDate: z.string().optional(),
+    dueDate: z.string().optional().nullable(),
+    paidAt: z.string().optional().nullable(),
+    invoiceNumber: z.string().max(120).optional().nullable(),
+    vendor: z.string().max(160).optional().nullable(),
+    memberPaidById: z.string().optional().nullable(),
+    donationSource: z.string().max(160).optional().nullable(),
+    donorContact: z.string().max(200).optional().nullable(),
+    tags: z.any().optional(),
+    showId: z.string().optional().nullable(),
+    budgetId: z.string().optional().nullable(),
+    visibilityScope: z.enum(["finance", "board"] as const).optional(),
+    attachments: z.array(attachmentSchema).optional(),
+  })
+  .strict();
+
+export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const session = await requireAuth();
+  const [canManage, canApprove] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen.manage"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+  ]);
+
+  if (!canManage) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Nutzer unbekannt" }, { status: 400 });
+  }
+
+  const entry = await loadEntry(id);
+  if (!entry) {
+    return NextResponse.json({ error: "Eintrag nicht gefunden" }, { status: 404 });
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+  if (!allowedScopes.includes(entry.visibilityScope)) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const json = await request.json().catch(() => null);
+  const parsed = updateSchema.safeParse(json);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Ungültige Eingabe";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const payload = parsed.data;
+  const data: Prisma.FinanceEntryUpdateInput = {};
+  let newStatusLog: Prisma.FinanceLogCreateWithoutEntryInput | null = null;
+
+  if (payload.title !== undefined) {
+    data.title = payload.title.trim();
+  }
+  if (payload.description !== undefined) {
+    data.description = payload.description?.trim() ?? null;
+  }
+  if (payload.amount !== undefined) {
+    data.amount = payload.amount;
+  }
+  if (payload.currency !== undefined) {
+    data.currency = payload.currency.toUpperCase();
+  }
+  if (payload.type !== undefined) {
+    data.type = payload.type;
+  }
+  if (payload.kind !== undefined) {
+    data.kind = payload.kind;
+  }
+  if (payload.category !== undefined) {
+    data.category = payload.category?.trim() ?? null;
+  }
+  if (payload.invoiceNumber !== undefined) {
+    data.invoiceNumber = payload.invoiceNumber?.trim() ?? null;
+  }
+  if (payload.vendor !== undefined) {
+    data.vendor = payload.vendor?.trim() ?? null;
+  }
+  if (payload.memberPaidById !== undefined) {
+    data.memberPaidBy = payload.memberPaidById
+      ? { connect: { id: payload.memberPaidById } }
+      : { disconnect: true };
+  }
+  if (payload.donationSource !== undefined) {
+    data.donationSource = payload.donationSource?.trim() ?? null;
+  }
+  if (payload.donorContact !== undefined) {
+    data.donorContact = payload.donorContact?.trim() ?? null;
+  }
+  if (payload.tags !== undefined) {
+    data.tags = payload.tags;
+  }
+  if (payload.showId !== undefined) {
+    data.show = payload.showId ? { connect: { id: payload.showId } } : { disconnect: true };
+  }
+  if (payload.budgetId !== undefined) {
+    data.budget = payload.budgetId ? { connect: { id: payload.budgetId } } : { disconnect: true };
+  }
+  if (payload.bookingDate !== undefined) {
+    const parsedDate = parseDate(payload.bookingDate);
+    if (!parsedDate) {
+      return NextResponse.json({ error: "Ungültiges Buchungsdatum" }, { status: 400 });
+    }
+    data.bookingDate = parsedDate;
+  }
+  if (payload.dueDate !== undefined) {
+    const parsedDate = parseDate(payload.dueDate);
+    data.dueDate = parsedDate;
+  }
+  if (payload.visibilityScope !== undefined) {
+    const nextScope = ensureAllowedScope(payload.visibilityScope as VisibilityScope, allowedScopes);
+    data.visibilityScope = nextScope;
+  }
+
+  if (payload.status !== undefined) {
+    if ((payload.status === "approved" || payload.status === "paid") && !canApprove) {
+      return NextResponse.json({ error: "Freigabe-Rechte erforderlich" }, { status: 403 });
+    }
+    if (payload.status !== entry.status) {
+      data.status = payload.status;
+      data.approvedBy =
+        payload.status === "approved" || payload.status === "paid"
+          ? { connect: { id: userId } }
+          : { disconnect: true };
+      data.approvedAt = payload.status === "approved" || payload.status === "paid" ? new Date() : null;
+      if (payload.status === "paid") {
+        data.paidAt = parseDate(payload.paidAt) ?? new Date();
+      } else {
+        data.paidAt = payload.paidAt !== undefined ? parseDate(payload.paidAt) : null;
+      }
+      newStatusLog = {
+        fromStatus: entry.status,
+        toStatus: payload.status,
+        changedBy: { connect: { id: userId } },
+        note: null,
+      };
+    }
+  }
+
+  if (payload.paidAt !== undefined && data.paidAt === undefined) {
+    const parsedDate = parseDate(payload.paidAt);
+    data.paidAt = parsedDate;
+  }
+
+  if (payload.attachments) {
+    data.attachments = {
+      deleteMany: {},
+      create: payload.attachments.map((attachment) => ({
+        filename: attachment.filename.trim(),
+        url: attachment.url,
+        mimeType: attachment.mimeType,
+        size: attachment.size ?? null,
+      })),
+    };
+  }
+
+  if (Object.keys(data).length === 0 && !newStatusLog) {
+    return NextResponse.json({ error: "Keine Änderungen übermittelt" }, { status: 400 });
+  }
+
+  if (newStatusLog) {
+    data.logs = { create: newStatusLog };
+  }
+
+  try {
+    const updated = await prisma.financeEntry.update({
+      where: { id },
+      data,
+      include: {
+        show: { select: { id: true, title: true, year: true } },
+        budget: { include: { show: { select: { id: true, title: true, year: true } } } },
+        createdBy: { select: { id: true, name: true, email: true } },
+        approvedBy: { select: { id: true, name: true, email: true } },
+        memberPaidBy: { select: { id: true, name: true, email: true } },
+        attachments: true,
+        logs: {
+          include: { changedBy: { select: { id: true, name: true, email: true } } },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    return NextResponse.json({ entry: mapFinanceEntry(updated as FinanceEntryWithRelations) });
+  } catch (error) {
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: "Eintrag konnte nicht aktualisiert werden" }, { status: 400 });
+  }
+}
+
+export async function DELETE(_: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const session = await requireAuth();
+  const [canManage, canApprove] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen.manage"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+  ]);
+
+  if (!canManage) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const entry = await loadEntry(id);
+  if (!entry) {
+    return NextResponse.json({ error: "Eintrag nicht gefunden" }, { status: 404 });
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+  if (!allowedScopes.includes(entry.visibilityScope)) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  await prisma.financeEntry.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/finance/budgets/[id]/route.ts
+++ b/src/app/api/finance/budgets/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { mapFinanceBudget } from "../../utils";
+
+const updateSchema = z
+  .object({
+    category: z.string().min(2).max(120).optional(),
+    plannedAmount: z.number().finite().nonnegative().optional(),
+    currency: z.string().trim().min(1).max(10).optional(),
+    notes: z.string().max(400).optional().nullable(),
+    showId: z.string().optional().nullable(),
+  })
+  .strict();
+
+export async function PATCH(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const session = await requireAuth();
+  const canManage = await hasPermission(session.user, "mitglieder.finanzen.manage");
+  if (!canManage) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const json = await request.json().catch(() => null);
+  const parsed = updateSchema.safeParse(json);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Ungültige Eingabe";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const payload = parsed.data;
+  if (!Object.keys(payload).length) {
+    return NextResponse.json({ error: "Keine Änderungen übermittelt" }, { status: 400 });
+  }
+
+  const updated = await prisma.financeBudget.update({
+    where: { id },
+    data: {
+      category: payload.category?.trim(),
+      plannedAmount: payload.plannedAmount,
+      currency: payload.currency?.toUpperCase(),
+      notes: payload.notes?.trim() ?? null,
+      showId: payload.showId ?? null,
+    },
+    include: { show: { select: { id: true, title: true, year: true } } },
+  });
+
+  const aggregates = await prisma.financeEntry.aggregate({
+    where: { budgetId: id, status: { in: ["approved", "paid"] } },
+    _sum: { amount: true },
+    _count: { _all: true },
+  });
+
+  const actualAmount = aggregates._sum.amount ?? 0;
+  const entryCount = aggregates._count._all ?? 0;
+
+  return NextResponse.json({ budget: mapFinanceBudget({ ...updated, actualAmount, entryCount }) });
+}
+
+export async function DELETE(_: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const session = await requireAuth();
+  const canManage = await hasPermission(session.user, "mitglieder.finanzen.manage");
+  if (!canManage) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const usage = await prisma.financeEntry.count({ where: { budgetId: id } });
+  if (usage > 0) {
+    return NextResponse.json({ error: "Budget enthält Buchungen und kann nicht gelöscht werden." }, { status: 400 });
+  }
+
+  await prisma.financeBudget.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/finance/budgets/route.ts
+++ b/src/app/api/finance/budgets/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { mapFinanceBudget, resolveAllowedVisibilityScopes, type FinanceBudgetWithMeta } from "../utils";
+
+const budgetSchema = z.object({
+  category: z.string().min(2).max(120),
+  plannedAmount: z.number().finite().nonnegative(),
+  currency: z.string().trim().min(1).max(10).default("EUR"),
+  notes: z.string().max(400).optional().nullable(),
+  showId: z.string().optional().nullable(),
+});
+
+export async function GET() {
+  const session = await requireAuth();
+  const [canView, canApprove] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+  ]);
+
+  if (!canView) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+
+  const budgetsRaw = await prisma.financeBudget.findMany({
+    orderBy: [{ show: { year: "desc" } }, { category: "asc" }],
+    include: { show: { select: { id: true, title: true, year: true } } },
+  });
+
+  if (!budgetsRaw.length) {
+    return NextResponse.json({ budgets: [] });
+  }
+
+  const budgetIds = budgetsRaw.map((budget) => budget.id);
+  const aggregates = await prisma.financeEntry.groupBy({
+    by: ["budgetId", "type"],
+    where: {
+      budgetId: { in: budgetIds },
+      status: { in: ["approved", "paid"] },
+      visibilityScope: { in: allowedScopes },
+    },
+    _sum: { amount: true },
+    _count: { _all: true },
+  });
+
+  const totals = new Map<string, { amount: number; count: number }>();
+  for (const aggregate of aggregates) {
+    if (!aggregate.budgetId) continue;
+    const current = totals.get(aggregate.budgetId) ?? { amount: 0, count: 0 };
+    const sum = aggregate._sum.amount ?? 0;
+    const signed = aggregate.type === "expense" ? sum : -sum;
+    current.amount += signed;
+    current.count += aggregate._count._all ?? 0;
+    totals.set(aggregate.budgetId, current);
+  }
+
+  const budgets: FinanceBudgetWithMeta[] = budgetsRaw.map((budget) => {
+    const info = totals.get(budget.id) ?? { amount: 0, count: 0 };
+    return {
+      ...budget,
+      actualAmount: info.amount,
+      entryCount: info.count,
+    };
+  });
+
+  return NextResponse.json({ budgets: budgets.map(mapFinanceBudget) });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await requireAuth();
+  const canManage = await hasPermission(session.user, "mitglieder.finanzen.manage");
+  if (!canManage) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const json = await request.json().catch(() => null);
+  const parsed = budgetSchema.safeParse(json);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Ungültige Eingabe";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const payload = parsed.data;
+  const budget = await prisma.financeBudget.create({
+    data: {
+      category: payload.category.trim(),
+      plannedAmount: payload.plannedAmount,
+      currency: payload.currency.toUpperCase(),
+      notes: payload.notes?.trim() ?? null,
+      showId: payload.showId ?? null,
+    },
+    include: { show: { select: { id: true, title: true, year: true } } },
+  });
+
+  return NextResponse.json({ budget: mapFinanceBudget({ ...budget, actualAmount: 0, entryCount: 0 }) }, { status: 201 });
+}

--- a/src/app/api/finance/export/route.ts
+++ b/src/app/api/finance/export/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from "next/server";
+import type { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { FINANCE_EXPORT_FILENAME, isFinanceEntryKind, isFinanceEntryStatus, isFinanceType } from "@/lib/finance";
+import { mapFinanceEntry, resolveAllowedVisibilityScopes } from "../utils";
+
+function parseDate(input: string | null): Date | null {
+  if (!input) return null;
+  const parsed = new Date(input);
+  return Number.isNaN(parsed.valueOf()) ? null : parsed;
+}
+
+function escapeCsv(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (!/[",\n]/.test(str)) return str;
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+export async function GET(request: Request) {
+  const session = await requireAuth();
+  const [canView, canApprove, canExport] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+    hasPermission(session.user, "mitglieder.finanzen.export"),
+  ]);
+
+  if (!canView || !canExport) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+  const url = new URL(request.url);
+  const statusParam = url.searchParams.get("status");
+  const kindParam = url.searchParams.get("kind");
+  const typeParam = url.searchParams.get("type");
+  const showParam = url.searchParams.get("showId");
+  const fromParam = url.searchParams.get("from");
+  const toParam = url.searchParams.get("to");
+
+  const where: Prisma.FinanceEntryWhereInput = {
+    visibilityScope: { in: allowedScopes },
+  };
+
+  if (statusParam && isFinanceEntryStatus(statusParam)) {
+    where.status = statusParam;
+  }
+  if (kindParam && isFinanceEntryKind(kindParam)) {
+    where.kind = kindParam;
+  }
+  if (typeParam && isFinanceType(typeParam)) {
+    where.type = typeParam;
+  }
+  if (showParam) {
+    where.showId = showParam;
+  }
+
+  const fromDate = parseDate(fromParam);
+  const toDate = parseDate(toParam);
+  if (fromDate || toDate) {
+    where.bookingDate = {};
+    if (fromDate) where.bookingDate.gte = fromDate;
+    if (toDate) where.bookingDate.lte = toDate;
+  }
+
+  const entries = await prisma.financeEntry.findMany({
+    where,
+    orderBy: { bookingDate: "asc" },
+    include: {
+      show: { select: { id: true, title: true, year: true } },
+      budget: { include: { show: { select: { id: true, title: true, year: true } } } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      approvedBy: { select: { id: true, name: true, email: true } },
+      memberPaidBy: { select: { id: true, name: true, email: true } },
+      attachments: true,
+      logs: {
+        include: { changedBy: { select: { id: true, name: true, email: true } } },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  const rows = entries.map((entry) => mapFinanceEntry(entry));
+
+  const header = [
+    "ID",
+    "Titel",
+    "Art",
+    "Typ",
+    "Status",
+    "Betrag",
+    "Währung",
+    "Kategorie",
+    "Buchungsdatum",
+    "Fälligkeit",
+    "Bezahlt am",
+    "Rechnungsnummer",
+    "Anbieter",
+    "Mitglied",
+    "Spendenquelle",
+    "Spenderkontakt",
+    "Show",
+    "Budget",
+    "Sichtbarkeit",
+    "Anhänge",
+  ];
+
+  const csvLines = [header.map(escapeCsv).join(",")];
+
+  for (const entry of rows) {
+    const attachments = entry.attachments.map((attachment) => attachment.url ?? attachment.filename).filter(Boolean).join(" | ");
+    csvLines.push(
+      [
+        entry.id,
+        entry.title,
+        entry.kind,
+        entry.type,
+        entry.status,
+        entry.amount.toFixed(2),
+        entry.currency,
+        entry.category ?? "",
+        entry.bookingDate,
+        entry.dueDate ?? "",
+        entry.paidAt ?? "",
+        entry.invoiceNumber ?? "",
+        entry.vendor ?? "",
+        entry.memberPaidBy?.name ?? entry.memberPaidBy?.email ?? "",
+        entry.donationSource ?? "",
+        entry.donorContact ?? "",
+        entry.show ? `${entry.show.year ?? ""} ${entry.show.title ?? ""}`.trim() : "",
+        entry.budget ? `${entry.budget.category}` : "",
+        entry.visibilityScope,
+        attachments,
+      ]
+        .map(escapeCsv)
+        .join(","),
+    );
+  }
+
+  const csvContent = csvLines.join("\n");
+
+  return new NextResponse(csvContent, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename=${FINANCE_EXPORT_FILENAME}`,
+    },
+  });
+}

--- a/src/app/api/finance/route.ts
+++ b/src/app/api/finance/route.ts
@@ -1,0 +1,286 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import type { FinanceEntryStatus, Prisma, VisibilityScope } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { isFinanceEntryKind, isFinanceEntryStatus, isFinanceType } from "@/lib/finance";
+import {
+  mapFinanceEntry,
+  resolveAllowedVisibilityScopes,
+  type FinanceEntryWithRelations,
+} from "./utils";
+
+const MAX_RESULTS = 200;
+const DEFAULT_STATUS_FILTER: FinanceEntryStatus[] = ["draft", "pending", "approved", "paid"];
+
+function parseDate(input: unknown): Date | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.valueOf()) ? null : parsed;
+}
+
+function ensureAllowedScope(requested: VisibilityScope | undefined, allowed: readonly VisibilityScope[]): VisibilityScope {
+  if (requested && allowed.includes(requested)) {
+    return requested;
+  }
+  return allowed[0] ?? "finance";
+}
+
+export async function GET(request: NextRequest) {
+  const session = await requireAuth();
+  const [canView, canApprove] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+  ]);
+
+  if (!canView) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+  const url = request.nextUrl;
+  const statusParam = url.searchParams.get("status");
+  const kindParam = url.searchParams.get("kind");
+  const typeParam = url.searchParams.get("type");
+  const showParam = url.searchParams.get("showId");
+  const budgetParam = url.searchParams.get("budgetId");
+  const searchParam = url.searchParams.get("q");
+  const fromParam = url.searchParams.get("from");
+  const toParam = url.searchParams.get("to");
+
+  const where: Prisma.FinanceEntryWhereInput = {
+    visibilityScope: { in: allowedScopes },
+    status: { in: DEFAULT_STATUS_FILTER },
+  };
+
+  if (statusParam && isFinanceEntryStatus(statusParam)) {
+    where.status = statusParam;
+  }
+
+  if (kindParam && isFinanceEntryKind(kindParam)) {
+    where.kind = kindParam;
+  }
+
+  if (typeParam && isFinanceType(typeParam)) {
+    where.type = typeParam;
+  }
+
+  if (showParam) {
+    where.showId = showParam;
+  }
+
+  if (budgetParam) {
+    where.budgetId = budgetParam;
+  }
+
+  const fromDate = parseDate(fromParam);
+  const toDate = parseDate(toParam);
+  if (fromDate || toDate) {
+    where.bookingDate = {};
+    if (fromDate) {
+      where.bookingDate.gte = fromDate;
+    }
+    if (toDate) {
+      where.bookingDate.lte = toDate;
+    }
+  }
+
+  if (searchParam && searchParam.trim()) {
+    const term = searchParam.trim();
+    where.OR = [
+      { title: { contains: term, mode: "insensitive" } },
+      { description: { contains: term, mode: "insensitive" } },
+      { invoiceNumber: { contains: term, mode: "insensitive" } },
+      { vendor: { contains: term, mode: "insensitive" } },
+      { donationSource: { contains: term, mode: "insensitive" } },
+    ];
+  }
+
+  const entries = await prisma.financeEntry.findMany({
+    where,
+    orderBy: { bookingDate: "desc" },
+    take: MAX_RESULTS,
+    include: {
+      show: { select: { id: true, title: true, year: true } },
+      budget: { include: { show: { select: { id: true, title: true, year: true } } } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      approvedBy: { select: { id: true, name: true, email: true } },
+      memberPaidBy: { select: { id: true, name: true, email: true } },
+      attachments: true,
+      logs: {
+        include: {
+          changedBy: { select: { id: true, name: true, email: true } },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  return NextResponse.json({ entries: entries.map(mapFinanceEntry) });
+}
+
+const attachmentSchema = z.object({
+  filename: z.string().min(1).max(160),
+  url: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value && value.length ? value : null))
+    .refine((value) => !value || /^https?:\/\//.test(value), {
+      message: "Anhänge benötigen eine gültige URL",
+    }),
+  mimeType: z
+    .string()
+    .trim()
+    .max(120)
+    .optional()
+    .transform((value) => (value && value.length ? value : null)),
+  size: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .transform((value) => (typeof value === "number" ? value : null)),
+});
+
+const payloadSchema = z.object({
+  title: z.string().min(3).max(200),
+  description: z.string().max(4000).optional().nullable(),
+  amount: z.number().finite().nonnegative(),
+  currency: z.string().trim().min(1).max(10).default("EUR"),
+  type: z.enum(["income", "expense"] as const),
+  kind: z.enum(["general", "invoice", "donation"] as const).default("general"),
+  status: z.enum(["draft", "pending", "approved", "paid", "cancelled"] as const).optional(),
+  category: z.string().max(120).optional().nullable(),
+  bookingDate: z.string().optional(),
+  dueDate: z.string().optional().nullable(),
+  paidAt: z.string().optional().nullable(),
+  invoiceNumber: z.string().max(120).optional().nullable(),
+  vendor: z.string().max(160).optional().nullable(),
+  memberPaidById: z.string().optional().nullable(),
+  donationSource: z.string().max(160).optional().nullable(),
+  donorContact: z.string().max(200).optional().nullable(),
+  tags: z.any().optional(),
+  showId: z.string().optional().nullable(),
+  budgetId: z.string().optional().nullable(),
+  visibilityScope: z.enum(["finance", "board"] as const).optional(),
+  attachments: z.array(attachmentSchema).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await requireAuth();
+  const [canManage, canApprove] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen.manage"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+  ]);
+
+  if (!canManage) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Nutzer unbekannt" }, { status: 400 });
+  }
+
+  const json = await request.json().catch(() => null);
+  const parsed = payloadSchema.safeParse(json);
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Ungültige Eingabe";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const payload = parsed.data;
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+  const status = payload.status ?? (payload.kind === "invoice" ? "pending" : payload.kind === "donation" ? "approved" : "draft");
+
+  if ((status === "approved" || status === "paid") && !canApprove) {
+    return NextResponse.json({ error: "Freigabe-Rechte erforderlich" }, { status: 403 });
+  }
+
+  if (payload.kind === "invoice" && !payload.memberPaidById) {
+    return NextResponse.json({ error: "Für Rechnungen muss ein zahlendes Mitglied angegeben werden." }, { status: 400 });
+  }
+
+  if (payload.kind === "donation" && !payload.donationSource) {
+    return NextResponse.json({ error: "Spenden benötigen eine Quelle." }, { status: 400 });
+  }
+
+  const bookingDate = parseDate(payload.bookingDate) ?? new Date();
+  const dueDate = parseDate(payload.dueDate);
+  const paidAt = status === "paid" ? parseDate(payload.paidAt) ?? new Date() : parseDate(payload.paidAt);
+
+  const visibilityScope = ensureAllowedScope(payload.visibilityScope as VisibilityScope | undefined, allowedScopes);
+
+  try {
+    const entry = await prisma.financeEntry.create({
+      data: {
+        title: payload.title.trim(),
+        description: payload.description?.trim() ?? null,
+        amount: payload.amount,
+        currency: payload.currency.toUpperCase(),
+        type: payload.type,
+        kind: payload.kind,
+        status,
+        category: payload.category?.trim() ?? null,
+        bookingDate,
+        dueDate,
+        paidAt: status === "paid" ? paidAt : null,
+        invoiceNumber: payload.invoiceNumber?.trim() ?? null,
+        vendor: payload.vendor?.trim() ?? null,
+        memberPaidById: payload.memberPaidById ?? null,
+        donationSource: payload.donationSource?.trim() ?? null,
+        donorContact: payload.donorContact?.trim() ?? null,
+        tags: payload.tags ?? null,
+        showId: payload.showId ?? null,
+        budgetId: payload.budgetId ?? null,
+        visibilityScope,
+        createdById: userId,
+        approvedById: status === "approved" || status === "paid" ? userId : null,
+        approvedAt: status === "approved" || status === "paid" ? new Date() : null,
+        attachments: payload.attachments?.length
+          ? {
+              create: payload.attachments.map((attachment) => ({
+                filename: attachment.filename.trim(),
+                url: attachment.url,
+                mimeType: attachment.mimeType,
+                size: attachment.size ?? null,
+              })),
+            }
+          : undefined,
+        logs: {
+          create: {
+            fromStatus: null,
+            toStatus: status,
+            changedBy: { connect: { id: userId } },
+          },
+        },
+      },
+      include: {
+        show: { select: { id: true, title: true, year: true } },
+        budget: { include: { show: { select: { id: true, title: true, year: true } } } },
+        createdBy: { select: { id: true, name: true, email: true } },
+        approvedBy: { select: { id: true, name: true, email: true } },
+        memberPaidBy: { select: { id: true, name: true, email: true } },
+        attachments: true,
+        logs: {
+          include: { changedBy: { select: { id: true, name: true, email: true } } },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    });
+
+    return NextResponse.json({ entry: mapFinanceEntry(entry as FinanceEntryWithRelations) }, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues[0]?.message ?? "Ungültige Eingabe" }, { status: 400 });
+    }
+    if (error instanceof Error) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    return NextResponse.json({ error: "Eintrag konnte nicht gespeichert werden" }, { status: 400 });
+  }
+}

--- a/src/app/api/finance/summary/route.ts
+++ b/src/app/api/finance/summary/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { createEmptyFinanceSummary, resolveAllowedVisibilityScopes } from "../utils";
+import type { FinanceEntryStatus } from "@prisma/client";
+
+const STATUS_FOR_TOTALS: FinanceEntryStatus[] = ["pending", "approved", "paid"];
+const STATUS_FOR_DONATIONS: FinanceEntryStatus[] = ["approved", "paid"];
+const PENDING_STATUSES: FinanceEntryStatus[] = ["pending", "approved"];
+
+export async function GET() {
+  const session = await requireAuth();
+  const [canView, canApprove] = await Promise.all([
+    hasPermission(session.user, "mitglieder.finanzen"),
+    hasPermission(session.user, "mitglieder.finanzen.approve"),
+  ]);
+
+  if (!canView) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
+
+  const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
+
+  const [totals, pending, donations] = await Promise.all([
+    prisma.financeEntry.groupBy({
+      by: ["type"],
+      where: { visibilityScope: { in: allowedScopes }, status: { in: STATUS_FOR_TOTALS } },
+      _sum: { amount: true },
+    }),
+    prisma.financeEntry.aggregate({
+      where: {
+        kind: "invoice",
+        status: { in: PENDING_STATUSES },
+        visibilityScope: { in: allowedScopes },
+      },
+      _sum: { amount: true },
+      _count: { _all: true },
+    }),
+    prisma.financeEntry.aggregate({
+      where: {
+        kind: "donation",
+        status: { in: STATUS_FOR_DONATIONS },
+        visibilityScope: { in: allowedScopes },
+      },
+      _sum: { amount: true },
+    }),
+  ]);
+
+  const summary = createEmptyFinanceSummary();
+
+  for (const entry of totals) {
+    const sum = entry._sum.amount ?? 0;
+    if (entry.type === "income") {
+      summary.totalIncome += sum;
+    } else if (entry.type === "expense") {
+      summary.totalExpense += sum;
+    }
+  }
+
+  summary.pendingInvoices = pending._count._all ?? 0;
+  summary.pendingAmount = pending._sum.amount ?? 0;
+  summary.donationTotal = donations._sum.amount ?? 0;
+
+  return NextResponse.json({ summary });
+}

--- a/src/app/api/finance/utils.ts
+++ b/src/app/api/finance/utils.ts
@@ -1,0 +1,231 @@
+import type {
+  FinanceAttachment,
+  FinanceBudget,
+  FinanceEntry,
+  FinanceLog,
+  FinanceType,
+  VisibilityScope,
+} from "@prisma/client";
+
+export type NamedUser = { id: string; name: string | null; email: string | null } | null;
+
+export type FinanceEntryWithRelations = FinanceEntry & {
+  show?: { id: string; title: string | null; year: number } | null;
+  budget?: (FinanceBudget & { show?: { id: string; title: string | null; year: number } | null }) | null;
+  createdBy?: NamedUser;
+  approvedBy?: NamedUser;
+  memberPaidBy?: NamedUser;
+  attachments: FinanceAttachment[];
+  logs: (FinanceLog & { changedBy?: NamedUser })[];
+};
+
+export type FinanceEntryDTO = {
+  id: string;
+  type: FinanceType;
+  kind: FinanceEntry["kind"];
+  status: FinanceEntry["status"];
+  title: string;
+  description: string | null;
+  amount: number;
+  currency: string;
+  category: string | null;
+  bookingDate: string;
+  dueDate: string | null;
+  paidAt: string | null;
+  invoiceNumber: string | null;
+  vendor: string | null;
+  memberPaidById: string | null;
+  donationSource: string | null;
+  donorContact: string | null;
+  tags: unknown;
+  show: { id: string; title: string | null; year: number } | null;
+  budget:
+    | {
+        id: string;
+        category: string;
+        plannedAmount: number;
+        currency: string;
+        show: { id: string | null; title: string | null; year: number | null };
+      }
+    | null;
+  visibilityScope: FinanceEntry["visibilityScope"];
+  createdBy: NamedUser;
+  approvedBy: NamedUser;
+  memberPaidBy: NamedUser;
+  approvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  attachments: {
+    id: string;
+    filename: string;
+    url: string | null;
+    mimeType: string | null;
+    size: number | null;
+    createdAt: string;
+  }[];
+  logs: {
+    id: string;
+    fromStatus: FinanceLog["fromStatus"];
+    toStatus: FinanceLog["toStatus"];
+    note: string | null;
+    createdAt: string;
+    changedBy: NamedUser;
+  }[];
+};
+
+export function mapFinanceEntry(entry: FinanceEntryWithRelations): FinanceEntryDTO {
+  return {
+    id: entry.id,
+    type: entry.type,
+    kind: entry.kind,
+    status: entry.status,
+    title: entry.title,
+    description: entry.description ?? null,
+    amount: entry.amount,
+    currency: entry.currency,
+    category: entry.category ?? null,
+    bookingDate: entry.bookingDate.toISOString(),
+    dueDate: entry.dueDate ? entry.dueDate.toISOString() : null,
+    paidAt: entry.paidAt ? entry.paidAt.toISOString() : null,
+    invoiceNumber: entry.invoiceNumber ?? null,
+    vendor: entry.vendor ?? null,
+    memberPaidById: entry.memberPaidById ?? null,
+    donationSource: entry.donationSource ?? null,
+    donorContact: entry.donorContact ?? null,
+    tags: entry.tags ?? null,
+    show: entry.show
+      ? {
+          id: entry.show.id,
+          title: entry.show.title,
+          year: entry.show.year,
+        }
+      : null,
+    budget: entry.budget
+      ? {
+          id: entry.budget.id,
+          category: entry.budget.category,
+          plannedAmount: entry.budget.plannedAmount,
+          currency: entry.budget.currency,
+          show: {
+            id: entry.budget.show?.id ?? null,
+            title: entry.budget.show?.title ?? null,
+            year: entry.budget.show?.year ?? null,
+          },
+        }
+      : null,
+    visibilityScope: entry.visibilityScope,
+    createdBy: entry.createdBy ?? null,
+    approvedBy: entry.approvedBy ?? null,
+    memberPaidBy: entry.memberPaidBy ?? null,
+    approvedAt: entry.approvedAt ? entry.approvedAt.toISOString() : null,
+    createdAt: entry.createdAt.toISOString(),
+    updatedAt: entry.updatedAt.toISOString(),
+    attachments: entry.attachments.map((attachment) => ({
+      id: attachment.id,
+      filename: attachment.filename,
+      url: attachment.url ?? null,
+      mimeType: attachment.mimeType ?? null,
+      size: attachment.size ?? null,
+      createdAt: attachment.createdAt.toISOString(),
+    })),
+    logs: entry.logs
+      .slice()
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      .map((log) => ({
+        id: log.id,
+        fromStatus: log.fromStatus ?? null,
+        toStatus: log.toStatus,
+        note: log.note ?? null,
+        createdAt: log.createdAt.toISOString(),
+        changedBy: log.changedBy ?? null,
+      })),
+  };
+}
+
+export type FinanceBudgetWithMeta = FinanceBudget & {
+  show?: { id: string; title: string | null; year: number } | null;
+  actualAmount?: number;
+  entryCount?: number;
+};
+
+export type FinanceBudgetDTO = {
+  id: string;
+  category: string;
+  plannedAmount: number;
+  currency: string;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  show: { id: string | null; title: string | null; year: number | null };
+  actualAmount: number;
+  entryCount: number;
+};
+
+export function mapFinanceBudget(budget: FinanceBudgetWithMeta): FinanceBudgetDTO {
+  return {
+    id: budget.id,
+    category: budget.category,
+    plannedAmount: budget.plannedAmount,
+    currency: budget.currency,
+    notes: budget.notes ?? null,
+    createdAt: budget.createdAt.toISOString(),
+    updatedAt: budget.updatedAt.toISOString(),
+    show: {
+      id: budget.show?.id ?? null,
+      title: budget.show?.title ?? null,
+      year: budget.show?.year ?? null,
+    },
+    actualAmount: budget.actualAmount ?? 0,
+    entryCount: budget.entryCount ?? 0,
+  };
+}
+
+export type FinanceSummaryDTO = {
+  totalIncome: number;
+  totalExpense: number;
+  pendingInvoices: number;
+  pendingAmount: number;
+  donationTotal: number;
+};
+
+export function createEmptyFinanceSummary(): FinanceSummaryDTO {
+  return {
+    totalIncome: 0,
+    totalExpense: 0,
+    pendingInvoices: 0,
+    pendingAmount: 0,
+    donationTotal: 0,
+  };
+}
+
+type RoleLike = { role?: string | null; roles?: string[] | null } | null | undefined;
+
+export function collectOwnedRoles(user: RoleLike): Set<string> {
+  const roles = new Set<string>();
+  if (!user) return roles;
+  if (typeof user.role === "string" && user.role) {
+    roles.add(user.role);
+  }
+  if (Array.isArray(user.roles)) {
+    for (const role of user.roles) {
+      if (typeof role === "string" && role) {
+        roles.add(role);
+      }
+    }
+  }
+  return roles;
+}
+
+export function resolveAllowedVisibilityScopes(
+  user: RoleLike,
+  canApprove: boolean,
+): VisibilityScope[] {
+  const owned = collectOwnedRoles(user);
+  const elevated =
+    canApprove ||
+    owned.has("board") ||
+    owned.has("admin") ||
+    owned.has("owner");
+
+  return elevated ? ["finance", "board"] : ["finance"];
+}

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -36,6 +36,7 @@ import {
   UsersRound,
   ShieldCheck,
   Hammer,
+  PiggyBank,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -155,6 +156,12 @@ const QUICK_ACTION_LINKS = [
     href: "/mitglieder/meine-gewerke",
     label: "Meine Gewerke",
     icon: Hammer,
+  },
+  {
+    href: "/mitglieder/finanzen",
+    label: "Finanzen",
+    icon: PiggyBank,
+    roles: ["finance", "board", "admin", "owner"],
   },
   {
     href: "/mitglieder/probenplanung",

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -39,16 +39,15 @@ const PRODUCTION_ITEMS: Item[] = [
 ];
 
 const MYSTERY_ITEMS: Item[] = [
-  {
-    href: "/mitglieder/mystery/timer",
-    label: "Mystery-Timer",
-    permissionKey: "mitglieder.mystery.timer",
-  },
-  {
-    href: "/mitglieder/mystery/tipps",
-    label: "Mystery-Tipps",
-    permissionKey: "mitglieder.mystery.tips",
-  },
+  { href: "/mitglieder/mystery/timer", label: "Mystery-Timer", permissionKey: "mitglieder.mystery.timer" },
+  { href: "/mitglieder/mystery/tipps", label: "Mystery-Tipps", permissionKey: "mitglieder.mystery.tips" },
+];
+
+const FINANCE_ITEMS: Item[] = [
+  { href: "/mitglieder/finanzen", label: "Finanz-Dashboard", permissionKey: "mitglieder.finanzen" },
+  { href: "/mitglieder/finanzen/buchungen", label: "Buchungen", permissionKey: "mitglieder.finanzen" },
+  { href: "/mitglieder/finanzen/budgets", label: "Budgets", permissionKey: "mitglieder.finanzen" },
+  { href: "/mitglieder/finanzen/export", label: "Exporte", permissionKey: "mitglieder.finanzen.export" },
 ];
 
 const ADMIN_ITEMS: Item[] = [
@@ -213,6 +212,43 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
           <path d="M4 20h7" />
         </svg>
       );
+    case "/mitglieder/finanzen":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="6" width="18" height="12" rx="2" />
+          <path d="M7 10h10" />
+          <path d="M7 14h6" />
+          <circle cx="9" cy="10" r="0.5" fill="currentColor" />
+          <circle cx="15" cy="14" r="0.5" fill="currentColor" />
+        </svg>
+      );
+    case "/mitglieder/finanzen/buchungen":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 6h16v4H4z" />
+          <path d="M7 10v8a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-8" />
+          <path d="M9 14h6" />
+          <path d="M9 18h4" />
+        </svg>
+      );
+    case "/mitglieder/finanzen/budgets":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 19h16" />
+          <path d="M7 19v-7" />
+          <path d="M12 19v-11" />
+          <path d="M17 19v-5" />
+          <path d="M5 8h14l-2-3H7z" />
+        </svg>
+      );
+    case "/mitglieder/finanzen/export":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 3v12" />
+          <path d="m8 11 4 4 4-4" />
+          <path d="M4 19h16" />
+        </svg>
+      );
     default:
       return (
         <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -244,6 +280,7 @@ export function MembersNav({
       { label: "Allgemein", items: GENERAL_ITEMS },
       { label: assignmentLabel, items: ASSIGNMENT_ITEMS },
       { label: "Produktion", items: PRODUCTION_ITEMS },
+      { label: "Finanzen", items: FINANCE_ITEMS },
       { label: "Das Geheimnis", items: MYSTERY_ITEMS },
       { label: "Verwaltung", items: ADMIN_ITEMS },
     ],

--- a/src/components/members/finance/finance-budget-form.tsx
+++ b/src/components/members/finance/finance-budget-form.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import type { FinanceBudgetDTO } from "@/app/api/finance/utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+
+const budgetSchema = z.object({
+  category: z.string().min(2, "Kategorie angeben").max(120),
+  plannedAmount: z
+    .string()
+    .min(1, "Planwert angeben")
+    .refine((value) => {
+      const normalized = value.replace(",", ".");
+      const parsed = Number(normalized);
+      return !Number.isNaN(parsed) && parsed >= 0;
+    }, "Planwert muss eine positive Zahl sein"),
+  currency: z.string().trim().min(1).max(10),
+  notes: z.string().max(400).optional().nullable(),
+  showId: z.string().optional().nullable(),
+});
+
+type FinanceBudgetFormValues = z.infer<typeof budgetSchema>;
+
+type FinanceBudgetFormProps = {
+  showOptions: { id: string; title: string | null; year: number }[];
+  onCreated?: (budget: FinanceBudgetDTO) => void;
+  onUpdated?: (budget: FinanceBudgetDTO) => void;
+  onCancelEdit?: () => void;
+  initialBudget?: FinanceBudgetDTO | null;
+};
+
+function formatShowOption(show: { id: string; title: string | null; year: number }) {
+  const parts = [];
+  if (show.year) parts.push(show.year.toString());
+  if (show.title) parts.push(show.title);
+  return parts.join(" • ") || "Unbenannte Produktion";
+}
+
+export function FinanceBudgetForm({
+  showOptions,
+  onCreated,
+  onUpdated,
+  onCancelEdit,
+  initialBudget,
+}: FinanceBudgetFormProps) {
+  const form = useForm<FinanceBudgetFormValues>({
+    resolver: zodResolver(budgetSchema),
+    defaultValues: {
+      category: "",
+      plannedAmount: "",
+      currency: "EUR",
+      notes: "",
+      showId: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!initialBudget) {
+      form.reset({ category: "", plannedAmount: "", currency: "EUR", notes: "", showId: "" });
+      return;
+    }
+    form.reset({
+      category: initialBudget.category,
+      plannedAmount: initialBudget.plannedAmount.toString(),
+      currency: initialBudget.currency,
+      notes: initialBudget.notes ?? "",
+      showId: initialBudget.show.id ?? "",
+    });
+  }, [initialBudget, form]);
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const payload = {
+      category: values.category.trim(),
+      plannedAmount: Number(values.plannedAmount.replace(",", ".")),
+      currency: values.currency.trim().toUpperCase(),
+      notes: values.notes?.trim() || undefined,
+      showId: values.showId || undefined,
+    };
+
+    const targetUrl = initialBudget ? `/api/finance/budgets/${initialBudget.id}` : "/api/finance/budgets";
+    const method = initialBudget ? "PATCH" : "POST";
+
+    try {
+      const response = await fetch(targetUrl, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Budget konnte nicht gespeichert werden");
+      }
+      const budget = data?.budget as FinanceBudgetDTO | undefined;
+      if (!budget) throw new Error("Unerwartete Antwort vom Server");
+      if (initialBudget) {
+        onUpdated?.(budget);
+        toast.success("Budget aktualisiert");
+        onCancelEdit?.();
+      } else {
+        onCreated?.(budget);
+        toast.success("Budget angelegt");
+        form.reset({ category: "", plannedAmount: "", currency: payload.currency, notes: "", showId: values.showId ?? "" });
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Budget konnte nicht gespeichert werden");
+    }
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="category"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Kategorie</FormLabel>
+                <FormControl>
+                  <Input placeholder="z. B. Kostüme" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="plannedAmount"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Geplanter Betrag</FormLabel>
+                <FormControl>
+                  <Input
+                    inputMode="decimal"
+                    placeholder="0,00"
+                    value={field.value ?? ""}
+                    onChange={(event) => field.onChange(event.target.value)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="currency"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Währung</FormLabel>
+                <FormControl>
+                  <Input placeholder="z. B. EUR" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="showId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Produktion</FormLabel>
+                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Produktion auswählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="">Keiner Produktion zugeordnet</SelectItem>
+                    {showOptions.map((show) => (
+                      <SelectItem key={show.id} value={show.id}>
+                        {formatShowOption(show)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <FormField
+          control={form.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Notizen</FormLabel>
+              <FormControl>
+                <Textarea placeholder="Zweck, Annahmen oder Hinweise" value={field.value ?? ""} onChange={field.onChange} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex items-center gap-2">
+          <Button type="submit">{initialBudget ? "Budget speichern" : "Budget anlegen"}</Button>
+          {initialBudget ? (
+            <Button type="button" variant="ghost" onClick={onCancelEdit}>
+              Abbrechen
+            </Button>
+          ) : null}
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/members/finance/finance-budget-table.tsx
+++ b/src/components/members/finance/finance-budget-table.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import type { FinanceBudgetDTO } from "@/app/api/finance/utils";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function formatCurrency(amount: number, currency: string) {
+  try {
+    return new Intl.NumberFormat("de-DE", { style: "currency", currency }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+type FinanceBudgetTableProps = {
+  budgets: FinanceBudgetDTO[];
+  onRequestEdit: (budget: FinanceBudgetDTO) => void;
+  onBudgetDeleted: (id: string) => void;
+  canManage: boolean;
+};
+
+export function FinanceBudgetTable({ budgets, onRequestEdit, onBudgetDeleted, canManage }: FinanceBudgetTableProps) {
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const totals = useMemo(() => {
+    return budgets.reduce(
+      (acc, budget) => {
+        acc.planned += budget.plannedAmount;
+        acc.actual += budget.actualAmount;
+        return acc;
+      },
+      { planned: 0, actual: 0 },
+    );
+  }, [budgets]);
+
+  async function handleDelete(budget: FinanceBudgetDTO) {
+    if (!canManage) return;
+    if (!window.confirm(`Budget "${budget.category}" löschen?`)) return;
+    try {
+      setDeletingId(budget.id);
+      const response = await fetch(`/api/finance/budgets/${budget.id}`, { method: "DELETE" });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Budget konnte nicht gelöscht werden");
+      }
+      onBudgetDeleted(budget.id);
+      toast.success("Budget gelöscht");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Budget konnte nicht gelöscht werden");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  if (!budgets.length) {
+    return <p className="text-sm text-muted-foreground">Noch keine Budgets angelegt.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[720px] border-collapse text-sm">
+        <thead>
+          <tr className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <th className="px-3 py-2 font-medium">Kategorie</th>
+            <th className="px-3 py-2 font-medium">Produktion</th>
+            <th className="px-3 py-2 font-medium">Plan</th>
+            <th className="px-3 py-2 font-medium">Ist</th>
+            <th className="px-3 py-2 font-medium">Differenz</th>
+            <th className="px-3 py-2 font-medium">Buchungen</th>
+            <th className="px-3 py-2 font-medium">Notizen</th>
+            {canManage ? <th className="px-3 py-2 font-medium text-right">Aktionen</th> : null}
+          </tr>
+        </thead>
+        <tbody>
+          {budgets.map((budget) => {
+            const plannedLabel = formatCurrency(budget.plannedAmount, budget.currency);
+            const actualLabel = formatCurrency(budget.actualAmount, budget.currency);
+            const difference = budget.plannedAmount - budget.actualAmount;
+            const diffLabel = formatCurrency(difference, budget.currency);
+            const diffClass = difference >= 0 ? "text-success" : "text-destructive";
+            return (
+              <tr key={budget.id} className="border-b last:border-none hover:bg-accent/10">
+                <td className="px-3 py-2 align-top">
+                  <div className="font-medium text-foreground">{budget.category}</div>
+                  <div className="text-xs text-muted-foreground">{budget.currency}</div>
+                </td>
+                <td className="px-3 py-2 align-top">
+                  {budget.show.title ? (
+                    <div>
+                      <div className="font-medium">{budget.show.title}</div>
+                      <div className="text-xs text-muted-foreground">{budget.show.year ?? ""}</div>
+                    </div>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 align-top text-muted-foreground">{plannedLabel}</td>
+                <td className="px-3 py-2 align-top text-muted-foreground">{actualLabel}</td>
+                <td className={cn("px-3 py-2 align-top font-medium", diffClass)}>{diffLabel}</td>
+                <td className="px-3 py-2 align-top text-muted-foreground">{budget.entryCount}</td>
+                <td className="px-3 py-2 align-top text-muted-foreground whitespace-pre-line">{budget.notes ?? "—"}</td>
+                {canManage ? (
+                  <td className="px-3 py-2 align-top text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button type="button" variant="ghost" size="sm" onClick={() => onRequestEdit(budget)}>
+                        Bearbeiten
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(budget)}
+                        disabled={deletingId === budget.id}
+                      >
+                        Löschen
+                      </Button>
+                    </div>
+                  </td>
+                ) : null}
+              </tr>
+            );
+          })}
+        </tbody>
+        <tfoot>
+          <tr className="border-t bg-muted/30 text-sm font-medium">
+            <td className="px-3 py-2">Summe</td>
+            <td className="px-3 py-2" />
+            <td className="px-3 py-2 text-muted-foreground">{formatCurrency(totals.planned, budgets[0]?.currency ?? "EUR")}</td>
+            <td className="px-3 py-2 text-muted-foreground">{formatCurrency(totals.actual, budgets[0]?.currency ?? "EUR")}</td>
+            <td className={cn("px-3 py-2", totals.planned - totals.actual >= 0 ? "text-success" : "text-destructive")}
+            >
+              {formatCurrency(totals.planned - totals.actual, budgets[0]?.currency ?? "EUR")}
+            </td>
+            <td className="px-3 py-2" />
+            <td className="px-3 py-2" />
+            {canManage ? <td className="px-3 py-2" /> : null}
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}

--- a/src/components/members/finance/finance-entry-form.tsx
+++ b/src/components/members/finance/finance-entry-form.tsx
@@ -1,0 +1,672 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import type { VisibilityScope } from "@prisma/client";
+import {
+  FINANCE_ENTRY_KIND_DESCRIPTIONS,
+  FINANCE_ENTRY_KIND_LABELS,
+  FINANCE_ENTRY_KIND_VALUES,
+  FINANCE_ENTRY_STATUS_LABELS,
+  FINANCE_ENTRY_STATUS_VALUES,
+  FINANCE_TYPE_LABELS,
+} from "@/lib/finance";
+import type { FinanceBudgetDTO, FinanceEntryDTO } from "@/app/api/finance/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+const attachmentSchema = z.object({
+  filename: z.string().min(1, "Dateiname angeben"),
+  url: z
+    .string()
+    .trim()
+    .optional()
+    .refine((value) => !value || /^https?:\/\//i.test(value), {
+      message: "Ungültige URL (https://...)",
+    }),
+});
+
+const financeEntryFormSchema = z
+  .object({
+    title: z.string().min(3, "Titel angeben").max(200),
+    type: z.enum(["income", "expense"] as const),
+    kind: z.enum(FINANCE_ENTRY_KIND_VALUES),
+    status: z.enum(FINANCE_ENTRY_STATUS_VALUES),
+    amount: z
+      .string()
+      .min(1, "Betrag angeben")
+      .refine((value) => {
+        const normalized = value.replace(",", ".");
+        const parsed = Number(normalized);
+        return !Number.isNaN(parsed) && parsed > 0;
+      }, "Betrag muss größer als 0 sein"),
+    currency: z.string().trim().min(1).max(10),
+    category: z.string().max(120).optional().nullable(),
+    bookingDate: z.string().min(1, "Buchungsdatum wählen"),
+    dueDate: z.string().optional().nullable(),
+    showId: z.string().optional().nullable(),
+    budgetId: z.string().optional().nullable(),
+    memberPaidById: z.string().optional().nullable(),
+    invoiceNumber: z.string().max(120).optional().nullable(),
+    vendor: z.string().max(160).optional().nullable(),
+    donationSource: z.string().max(160).optional().nullable(),
+    donorContact: z.string().max(200).optional().nullable(),
+    description: z.string().max(4000).optional().nullable(),
+    visibilityScope: z.enum(["finance", "board"] as const),
+    attachments: z.array(attachmentSchema).optional(),
+  })
+  .superRefine((values, ctx) => {
+    if (values.kind === "invoice" && !values.memberPaidById) {
+      ctx.addIssue({
+        path: ["memberPaidById"],
+        code: z.ZodIssueCode.custom,
+        message: "Für Rechnungen muss ein zahlendes Mitglied angegeben werden.",
+      });
+    }
+    if (values.kind === "donation" && !values.donationSource) {
+      ctx.addIssue({
+        path: ["donationSource"],
+        code: z.ZodIssueCode.custom,
+        message: "Spenden benötigen eine Quelle.",
+      });
+    }
+  });
+
+type FinanceEntryFormValues = z.infer<typeof financeEntryFormSchema>;
+
+type FinanceEntryFormProps = {
+  onCreated: (entry: FinanceEntryDTO) => void;
+  showOptions: { id: string; title: string | null; year: number }[];
+  memberOptions: { id: string; name: string | null; email: string | null }[];
+  budgetOptions: FinanceBudgetDTO[];
+  allowedScopes: VisibilityScope[];
+  canApprove: boolean;
+  onAfterSubmit?: () => void;
+};
+
+function formatShowLabel(show: { id: string; title: string | null; year: number }) {
+  const parts = [];
+  if (show.year) parts.push(show.year.toString());
+  if (show.title) parts.push(show.title);
+  return parts.join(" • ") || "Unbenannte Produktion";
+}
+
+function formatMemberLabel(member: { name: string | null; email: string | null }) {
+  if (member.name && member.email) return `${member.name} (${member.email})`;
+  return member.name ?? member.email ?? "Unbekannt";
+}
+
+export function FinanceEntryForm({
+  onCreated,
+  showOptions,
+  memberOptions,
+  budgetOptions,
+  allowedScopes,
+  canApprove,
+  onAfterSubmit,
+}: FinanceEntryFormProps) {
+  const defaultScope = allowedScopes.includes("finance") ? "finance" : allowedScopes[0] ?? "finance";
+  const form = useForm<FinanceEntryFormValues>({
+    resolver: zodResolver(financeEntryFormSchema),
+    defaultValues: {
+      title: "",
+      type: "expense",
+      kind: "general",
+      status: "draft",
+      amount: "",
+      currency: "EUR",
+      category: "",
+      bookingDate: new Date().toISOString().slice(0, 10),
+      dueDate: "",
+      showId: "",
+      budgetId: "",
+      memberPaidById: "",
+      invoiceNumber: "",
+      vendor: "",
+      donationSource: "",
+      donorContact: "",
+      description: "",
+      visibilityScope: defaultScope,
+      attachments: [],
+    },
+  });
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: "attachments" });
+  const [submitting, setSubmitting] = useState(false);
+
+  const watchKind = form.watch("kind");
+  const watchShowId = form.watch("showId");
+
+  const filteredBudgets = useMemo(() => {
+    if (!watchShowId) return budgetOptions;
+    return budgetOptions.filter((budget) => budget.show.id === watchShowId);
+  }, [budgetOptions, watchShowId]);
+
+  useEffect(() => {
+    const currentStatus = form.getValues("status");
+    if (watchKind === "invoice" && currentStatus === "draft") {
+      form.setValue("status", "pending");
+    } else if (watchKind === "donation" && (currentStatus === "draft" || currentStatus === "pending")) {
+      form.setValue("status", canApprove ? "approved" : "pending");
+    } else if (watchKind === "general" && currentStatus === "pending") {
+      form.setValue("status", "draft");
+    }
+  }, [form, watchKind, canApprove]);
+
+  const statusOptions = useMemo(() => {
+    return FINANCE_ENTRY_STATUS_VALUES.filter((status) => {
+      if (status === "approved" || status === "paid") {
+        return canApprove;
+      }
+      return true;
+    });
+  }, [canApprove]);
+
+  const visibilityOptions: VisibilityScope[] = allowedScopes.includes("board") ? ["finance", "board"] : ["finance"];
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    setSubmitting(true);
+    try {
+      const payload = {
+        title: values.title.trim(),
+        type: values.type,
+        kind: values.kind,
+        status: values.status,
+        amount: Number(values.amount.replace(",", ".")),
+        currency: values.currency.trim().toUpperCase(),
+        category: values.category?.trim() || undefined,
+        bookingDate: values.bookingDate,
+        dueDate: values.dueDate ? values.dueDate : undefined,
+        showId: values.showId || undefined,
+        budgetId: values.budgetId || undefined,
+        memberPaidById: values.memberPaidById || undefined,
+        invoiceNumber: values.invoiceNumber?.trim() || undefined,
+        vendor: values.vendor?.trim() || undefined,
+        donationSource: values.donationSource?.trim() || undefined,
+        donorContact: values.donorContact?.trim() || undefined,
+        description: values.description?.trim() || undefined,
+        visibilityScope: values.visibilityScope,
+        attachments: values.attachments?.map((attachment) => ({
+          filename: attachment.filename.trim(),
+          url: attachment.url && attachment.url.trim().length
+            ? attachment.url.trim()
+            : undefined,
+        })),
+      };
+
+      const response = await fetch("/api/finance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Buchung konnte nicht angelegt werden");
+      }
+      if (!data?.entry) {
+        throw new Error("Unerwartete Antwort vom Server");
+      }
+      onCreated(data.entry as FinanceEntryDTO);
+      toast.success("Finanzbuchung wurde gespeichert");
+      form.reset({
+        title: "",
+        type: values.type,
+        kind: values.kind,
+        status: values.kind === "invoice" ? "pending" : values.kind === "donation" && canApprove ? "approved" : "draft",
+        amount: "",
+        currency: values.currency,
+        category: "",
+        bookingDate: new Date().toISOString().slice(0, 10),
+        dueDate: "",
+        showId: values.showId ?? "",
+        budgetId: values.budgetId ?? "",
+        memberPaidById: values.kind === "invoice" ? values.memberPaidById ?? "" : "",
+        invoiceNumber: "",
+        vendor: "",
+        donationSource: "",
+        donorContact: "",
+        description: "",
+        visibilityScope: values.visibilityScope,
+        attachments: [],
+      });
+      onAfterSubmit?.();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Buchung konnte nicht angelegt werden";
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  });
+
+  const showMemberField = watchKind === "invoice";
+  const showDonationFields = watchKind === "donation";
+
+  return (
+    <Form {...form}>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="title"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Titel</FormLabel>
+                <FormControl>
+                  <Input placeholder="Kurzbeschreibung" autoComplete="off" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="amount"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Betrag</FormLabel>
+                <FormControl>
+                  <Input
+                    inputMode="decimal"
+                    placeholder="0,00"
+                    value={field.value ?? ""}
+                    onChange={(event) => field.onChange(event.target.value)}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="type"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Art</FormLabel>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Typ wählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {(["expense", "income"] as const).map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {FINANCE_TYPE_LABELS[option]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="kind"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Buchungstyp</FormLabel>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Typ wählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {FINANCE_ENTRY_KIND_VALUES.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        <div className="flex flex-col text-left">
+                          <span>{FINANCE_ENTRY_KIND_LABELS[option]}</span>
+                          <span className="text-[11px] text-muted-foreground">
+                            {FINANCE_ENTRY_KIND_DESCRIPTIONS[option]}
+                          </span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="status"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Status</FormLabel>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Status wählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {statusOptions.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {FINANCE_ENTRY_STATUS_LABELS[option]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription>
+                  {canApprove ? "Status kann beim Erfassen gesetzt werden." : "Freigabe und Zahlung nur durch Finanzfreigabe."}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="bookingDate"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Buchungsdatum</FormLabel>
+                <FormControl>
+                  <Input type="date" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="dueDate"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Fällig bis</FormLabel>
+                <FormControl>
+                  <Input type="date" value={field.value ?? ""} onChange={field.onChange} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="category"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Kategorie</FormLabel>
+                <FormControl>
+                  <Input placeholder="z. B. Kostüme" value={field.value ?? ""} onChange={field.onChange} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <FormField
+            control={form.control}
+            name="showId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Produktion</FormLabel>
+                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Produktion auswählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="">Keine Zuordnung</SelectItem>
+                    {showOptions.map((show) => (
+                      <SelectItem key={show.id} value={show.id}>
+                        {formatShowLabel(show)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="budgetId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Budget</FormLabel>
+                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Budget auswählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="">Kein Budget</SelectItem>
+                    {filteredBudgets.map((budget) => (
+                      <SelectItem key={budget.id} value={budget.id}>
+                        {budget.category} ({budget.currency})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription>Budgets werden automatisch nach Produktion gefiltert.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {showMemberField ? (
+          <FormField
+            control={form.control}
+            name="memberPaidById"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Zahlendes Mitglied</FormLabel>
+                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Mitglied wählen" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="">Mitglied wählen</SelectItem>
+                    {memberOptions.map((member) => (
+                      <SelectItem key={member.id} value={member.id}>
+                        {formatMemberLabel(member)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        ) : null}
+
+        {watchKind === "invoice" ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="invoiceNumber"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Rechnungsnummer</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Rechnung / Quittung" value={field.value ?? ""} onChange={field.onChange} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="vendor"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Lieferant / Händler</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Name des Händlers" value={field.value ?? ""} onChange={field.onChange} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        ) : null}
+
+        {showDonationFields ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField
+              control={form.control}
+              name="donationSource"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Spendenquelle</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Person, Organisation oder Kampagne" value={field.value ?? ""} onChange={field.onChange} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="donorContact"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Kontakt</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Kontaktinformation" value={field.value ?? ""} onChange={field.onChange} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        ) : null}
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Beschreibung</FormLabel>
+              <FormControl>
+                <Textarea placeholder="Detailbeschreibung, Verwendungszweck oder Hinweise" value={field.value ?? ""} onChange={field.onChange} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="visibilityScope"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Sichtbarkeit</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {visibilityOptions.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option === "finance" ? "Finanzteam" : "Nur Vorstand"}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium">Anhänge</h3>
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => append({ filename: "" })}
+            >
+              Anhang hinzufügen
+            </Button>
+          </div>
+          {fields.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Optional: Verweise auf abgelegte Belege (z. B. Cloud-Ordner) hinzufügen.
+            </p>
+          ) : null}
+          <div className="space-y-3">
+            {fields.map((field, index) => (
+              <div key={field.id} className="grid gap-3 rounded-md border border-border/60 p-3 md:grid-cols-[1fr_1fr_auto]">
+                <FormField
+                  control={form.control}
+                  name={`attachments.${index}.filename`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs">Bezeichnung</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Belegname" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name={`attachments.${index}.url`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs">Link</FormLabel>
+                      <FormControl>
+                        <Input placeholder="https://…" value={field.value ?? ""} onChange={field.onChange} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="flex items-end justify-end">
+                  <Button type="button" variant="ghost" size="sm" onClick={() => remove(index)}>
+                    Entfernen
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <Button type="submit" disabled={submitting} className={cn(submitting && "opacity-70")}> 
+          {submitting ? "Speichere..." : "Finanzbuchung anlegen"}
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/members/finance/finance-entry-table.tsx
+++ b/src/components/members/finance/finance-entry-table.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import type { FinanceEntryDTO } from "@/app/api/finance/utils";
+import {
+  FINANCE_ENTRY_KIND_LABELS,
+  FINANCE_ENTRY_STATUS_LABELS,
+  FINANCE_ENTRY_STATUS_TONES,
+  FINANCE_ENTRY_STATUS_VALUES,
+  FINANCE_TYPE_LABELS,
+} from "@/lib/finance";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+function formatCurrency(amount: number, currency: string) {
+  try {
+    return new Intl.NumberFormat("de-DE", { style: "currency", currency }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return "—";
+  return parsed.toLocaleDateString("de-DE");
+}
+
+function getMemberDisplay(entry: FinanceEntryDTO) {
+  return entry.memberPaidBy?.name ?? entry.memberPaidBy?.email ?? "—";
+}
+
+type FinanceEntryTableProps = {
+  entries: FinanceEntryDTO[];
+  onEntryUpdated: (entry: FinanceEntryDTO) => void;
+  onEntryDeleted: (id: string) => void;
+  onRefresh: () => Promise<void> | void;
+  refreshing?: boolean;
+  canManage: boolean;
+  canApprove: boolean;
+};
+
+export function FinanceEntryTable({
+  entries,
+  onEntryUpdated,
+  onEntryDeleted,
+  onRefresh,
+  refreshing = false,
+  canManage,
+  canApprove,
+}: FinanceEntryTableProps) {
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [kindFilter, setKindFilter] = useState<string>("all");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [search, setSearch] = useState("");
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const filteredEntries = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return entries.filter((entry) => {
+      if (statusFilter !== "all" && entry.status !== statusFilter) return false;
+      if (kindFilter !== "all" && entry.kind !== kindFilter) return false;
+      if (typeFilter !== "all" && entry.type !== typeFilter) return false;
+      if (!normalizedSearch) return true;
+      const haystack = [
+        entry.title,
+        entry.description ?? "",
+        entry.invoiceNumber ?? "",
+        entry.vendor ?? "",
+        entry.donationSource ?? "",
+        entry.memberPaidBy?.name ?? "",
+        entry.memberPaidBy?.email ?? "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(normalizedSearch);
+    });
+  }, [entries, statusFilter, kindFilter, typeFilter, search]);
+
+  async function handleStatusChange(entry: FinanceEntryDTO, nextStatus: FinanceEntryDTO["status"]) {
+    if (entry.status === nextStatus) return;
+    try {
+      setUpdatingId(entry.id);
+      const response = await fetch(`/api/finance/${entry.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: nextStatus }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Status konnte nicht aktualisiert werden");
+      }
+      onEntryUpdated(data.entry as FinanceEntryDTO);
+      toast.success("Status aktualisiert");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Status konnte nicht aktualisiert werden");
+    } finally {
+      setUpdatingId(null);
+    }
+  }
+
+  async function handleDelete(entry: FinanceEntryDTO) {
+    if (!canManage) return;
+    if (!window.confirm(`Soll die Buchung "${entry.title}" wirklich gelöscht werden?`)) {
+      return;
+    }
+    try {
+      setDeletingId(entry.id);
+      const response = await fetch(`/api/finance/${entry.id}`, { method: "DELETE" });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error ?? "Buchung konnte nicht gelöscht werden");
+      }
+      onEntryDeleted(entry.id);
+      toast.success("Buchung gelöscht");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Buchung konnte nicht gelöscht werden");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  const totalExpenses = useMemo(
+    () => filteredEntries.filter((entry) => entry.type === "expense").reduce((acc, entry) => acc + entry.amount, 0),
+    [filteredEntries],
+  );
+  const totalIncome = useMemo(
+    () => filteredEntries.filter((entry) => entry.type === "income").reduce((acc, entry) => acc + entry.amount, 0),
+    [filteredEntries],
+  );
+  const dominantCurrency = filteredEntries[0]?.currency ?? "EUR";
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <Select value={statusFilter} onValueChange={setStatusFilter}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Alle Status</SelectItem>
+              {FINANCE_ENTRY_STATUS_VALUES.map((status) => (
+                <SelectItem key={status} value={status}>
+                  {FINANCE_ENTRY_STATUS_LABELS[status]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={kindFilter} onValueChange={setKindFilter}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Typ" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Alle Typen</SelectItem>
+              {Object.entries(FINANCE_ENTRY_KIND_LABELS).map(([key, label]) => (
+                <SelectItem key={key} value={key}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={typeFilter} onValueChange={setTypeFilter}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Art" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Einnahmen & Ausgaben</SelectItem>
+              {(["expense", "income"] as const).map((option) => (
+                <SelectItem key={option} value={option}>
+                  {FINANCE_TYPE_LABELS[option]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder="Suche nach Titel, Lieferant oder Spender"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            className="w-full min-w-[220px] md:w-64"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="text-xs text-muted-foreground">
+            {filteredEntries.length} von {entries.length} Buchungen · Ausgaben {formatCurrency(totalExpenses, dominantCurrency)} · Einnahmen {formatCurrency(totalIncome, dominantCurrency)}
+          </div>
+          <Button type="button" variant="secondary" size="sm" onClick={onRefresh} disabled={refreshing}>
+            {refreshing ? "Aktualisiere…" : "Aktualisieren"}
+          </Button>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[960px] border-collapse text-sm">
+          <thead>
+            <tr className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="px-3 py-2 font-medium">Titel</th>
+              <th className="px-3 py-2 font-medium">Betrag</th>
+              <th className="px-3 py-2 font-medium">Status</th>
+              <th className="px-3 py-2 font-medium">Produktion</th>
+              <th className="px-3 py-2 font-medium">Budget</th>
+              <th className="px-3 py-2 font-medium">Buchungsdatum</th>
+              <th className="px-3 py-2 font-medium">Fälligkeit</th>
+              <th className="px-3 py-2 font-medium">Mitglied</th>
+              <th className="px-3 py-2 font-medium">Anhänge</th>
+              {canManage ? <th className="px-3 py-2 font-medium text-right">Aktionen</th> : null}
+            </tr>
+          </thead>
+          <tbody>
+            {filteredEntries.map((entry) => {
+              const amountLabel = formatCurrency(entry.amount, entry.currency);
+              const attachments = entry.attachments;
+              return (
+                <tr key={entry.id} className="border-b last:border-none hover:bg-accent/10">
+                  <td className="max-w-[240px] px-3 py-2 align-top">
+                    <div className="font-medium text-foreground">{entry.title}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {FINANCE_ENTRY_KIND_LABELS[entry.kind]} · {FINANCE_TYPE_LABELS[entry.type]}
+                    </div>
+                    {entry.description ? (
+                      <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">{entry.description}</div>
+                    ) : null}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <div className={cn("font-semibold", entry.type === "expense" ? "text-destructive" : "text-success")}>{amountLabel}</div>
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    <Badge variant={FINANCE_ENTRY_STATUS_TONES[entry.status]} className="text-xs">
+                      {FINANCE_ENTRY_STATUS_LABELS[entry.status]}
+                    </Badge>
+                    {canManage ? (
+                      <div className="mt-1">
+                        <Select
+                          value={entry.status}
+                          onValueChange={(value) => handleStatusChange(entry, value as FinanceEntryDTO["status"])}
+                          disabled={updatingId === entry.id || (!canApprove && (entry.status === "approved" || entry.status === "paid"))}
+                        >
+                          <SelectTrigger className="h-8 w-full text-xs">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {FINANCE_ENTRY_STATUS_VALUES.map((status) => (
+                              <SelectItem key={status} value={status} disabled={!canApprove && (status === "approved" || status === "paid")}> 
+                                {FINANCE_ENTRY_STATUS_LABELS[status]}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    {entry.show ? (
+                      <div>
+                        <div className="font-medium">{entry.show.title ?? "—"}</div>
+                        <div className="text-xs text-muted-foreground">{entry.show.year ?? ""}</div>
+                      </div>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top">
+                    {entry.budget ? (
+                      <div>
+                        <div className="font-medium">{entry.budget.category}</div>
+                        {entry.budget.show.title ? (
+                          <div className="text-xs text-muted-foreground">{entry.budget.show.title}</div>
+                        ) : null}
+                      </div>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 align-top text-muted-foreground">{formatDate(entry.bookingDate)}</td>
+                  <td className="px-3 py-2 align-top text-muted-foreground">{formatDate(entry.dueDate)}</td>
+                  <td className="px-3 py-2 align-top">{getMemberDisplay(entry)}</td>
+                  <td className="px-3 py-2 align-top">
+                    {attachments.length ? (
+                      <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+                        {attachments.map((attachment) => (
+                          <span key={attachment.id} className="truncate">
+                            {attachment.url ? (
+                              <a
+                                href={attachment.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-primary underline-offset-2 hover:underline"
+                              >
+                                {attachment.filename}
+                              </a>
+                            ) : (
+                              attachment.filename
+                            )}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  {canManage ? (
+                    <td className="px-3 py-2 align-top text-right">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleDelete(entry)}
+                        disabled={deletingId === entry.id}
+                      >
+                        Löschen
+                      </Button>
+                    </td>
+                  ) : null}
+                </tr>
+              );
+            })}
+            {filteredEntries.length === 0 ? (
+              <tr>
+                <td className="px-3 py-6 text-center text-sm text-muted-foreground" colSpan={canManage ? 10 : 9}>
+                  Keine Buchungen gefunden.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/members/finance/finance-export-section.tsx
+++ b/src/components/members/finance/finance-export-section.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  FINANCE_EXPORT_FILENAME,
+  FINANCE_ENTRY_KIND_LABELS,
+  FINANCE_ENTRY_KIND_VALUES,
+  FINANCE_ENTRY_STATUS_LABELS,
+  FINANCE_ENTRY_STATUS_VALUES,
+  FINANCE_TYPE_LABELS,
+} from "@/lib/finance";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "sonner";
+
+export function FinanceExportSection() {
+  const [status, setStatus] = useState<string>("all");
+  const [kind, setKind] = useState<string>("all");
+  const [type, setType] = useState<string>("all");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [downloading, setDownloading] = useState(false);
+
+  const query = useMemo(() => {
+    const params = new URLSearchParams();
+    if (status !== "all") params.set("status", status);
+    if (kind !== "all") params.set("kind", kind);
+    if (type !== "all") params.set("type", type);
+    if (from) params.set("from", from);
+    if (to) params.set("to", to);
+    return params.toString();
+  }, [status, kind, type, from, to]);
+
+  const downloadUrl = query ? `/api/finance/export?${query}` : "/api/finance/export";
+
+  async function handleDownload() {
+    setDownloading(true);
+    try {
+      const response = await fetch(downloadUrl, { method: "GET" });
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error ?? "Export fehlgeschlagen");
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = FINANCE_EXPORT_FILENAME;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error(error);
+      toast.error(error instanceof Error ? error.message : "Export fehlgeschlagen");
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <Select value={status} onValueChange={setStatus}>
+          <SelectTrigger>
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Alle Status</SelectItem>
+            {FINANCE_ENTRY_STATUS_VALUES.map((value) => (
+              <SelectItem key={value} value={value}>
+                {FINANCE_ENTRY_STATUS_LABELS[value]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={kind} onValueChange={setKind}>
+          <SelectTrigger>
+            <SelectValue placeholder="Typ" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Alle Buchungstypen</SelectItem>
+            {FINANCE_ENTRY_KIND_VALUES.map((value) => (
+              <SelectItem key={value} value={value}>
+                {FINANCE_ENTRY_KIND_LABELS[value]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={type} onValueChange={setType}>
+          <SelectTrigger>
+            <SelectValue placeholder="Art" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Einnahmen & Ausgaben</SelectItem>
+            {(["expense", "income"] as const).map((value) => (
+              <SelectItem key={value} value={value}>
+                {FINANCE_TYPE_LABELS[value]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input type="date" value={from} onChange={(event) => setFrom(event.target.value)} placeholder="Von" />
+        <Input type="date" value={to} onChange={(event) => setTo(event.target.value)} placeholder="Bis" />
+      </div>
+      <div>
+        <Button type="button" onClick={handleDownload} disabled={downloading}>
+          {downloading ? "Export wird erstellt…" : "CSV-Export herunterladen"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/members/finance/finance-overview.tsx
+++ b/src/components/members/finance/finance-overview.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import type { VisibilityScope } from "@prisma/client";
+import type { FinanceBudgetDTO, FinanceEntryDTO, FinanceSummaryDTO } from "@/app/api/finance/utils";
+import { PageHeader } from "@/components/members/page-header";
+import { KeyMetricCard, KeyMetricGrid } from "@/design-system/patterns";
+import { FinanceEntryForm } from "./finance-entry-form";
+import { FinanceEntryTable } from "./finance-entry-table";
+import { FinanceBudgetForm } from "./finance-budget-form";
+import { FinanceBudgetTable } from "./finance-budget-table";
+import { FinanceExportSection } from "./finance-export-section";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  FINANCE_ENTRY_STATUS_LABELS,
+  FINANCE_ENTRY_STATUS_TONES,
+} from "@/lib/finance";
+import { cn } from "@/lib/utils";
+
+function formatCurrency(amount: number, currency = "EUR") {
+  try {
+    return new Intl.NumberFormat("de-DE", { style: "currency", currency }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}
+
+function sortBudgets(list: FinanceBudgetDTO[]) {
+  return [...list].sort((a, b) => {
+    const yearA = a.show.year ?? 0;
+    const yearB = b.show.year ?? 0;
+    if (yearA !== yearB) return yearB - yearA;
+    return a.category.localeCompare(b.category, "de");
+  });
+}
+
+type FinanceOverviewProps = {
+  initialEntries: FinanceEntryDTO[];
+  initialSummary: FinanceSummaryDTO;
+  initialBudgets: FinanceBudgetDTO[];
+  showOptions: { id: string; title: string | null; year: number }[];
+  memberOptions: { id: string; name: string | null; email: string | null }[];
+  canManage: boolean;
+  canApprove: boolean;
+  canExport: boolean;
+  allowedScopes: VisibilityScope[];
+  activeSection: "dashboard" | "buchungen" | "budgets" | "export";
+};
+
+export function FinanceOverview({
+  initialEntries,
+  initialSummary,
+  initialBudgets,
+  showOptions,
+  memberOptions,
+  canManage,
+  canApprove,
+  canExport,
+  allowedScopes,
+  activeSection,
+}: FinanceOverviewProps) {
+  const [entries, setEntries] = useState<FinanceEntryDTO[]>(initialEntries);
+  const [summary, setSummary] = useState<FinanceSummaryDTO>(initialSummary);
+  const [budgets, setBudgets] = useState<FinanceBudgetDTO[]>(sortBudgets(initialBudgets));
+  const [showEntryForm, setShowEntryForm] = useState(activeSection === "buchungen");
+  const [editingBudget, setEditingBudget] = useState<FinanceBudgetDTO | null>(null);
+  const [loadingEntries, setLoadingEntries] = useState(false);
+  const [loadingSummary, setLoadingSummary] = useState(false);
+
+  useEffect(() => {
+    setEntries(initialEntries);
+  }, [initialEntries]);
+
+  useEffect(() => {
+    setSummary(initialSummary);
+  }, [initialSummary]);
+
+  useEffect(() => {
+    setBudgets(sortBudgets(initialBudgets));
+  }, [initialBudgets]);
+
+  useEffect(() => {
+    setShowEntryForm(activeSection === "buchungen");
+  }, [activeSection]);
+
+  const refreshSummary = useCallback(async () => {
+    setLoadingSummary(true);
+    try {
+      const response = await fetch("/api/finance/summary");
+      const data = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(data?.error ?? "Übersicht konnte nicht geladen werden");
+      if (data?.summary) {
+        setSummary(data.summary as FinanceSummaryDTO);
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Übersicht konnte nicht geladen werden");
+    } finally {
+      setLoadingSummary(false);
+    }
+  }, []);
+
+  const refreshBudgets = useCallback(async () => {
+    try {
+      const response = await fetch("/api/finance/budgets");
+      const data = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(data?.error ?? "Budgets konnten nicht geladen werden");
+      if (data?.budgets) {
+        setBudgets(sortBudgets(data.budgets as FinanceBudgetDTO[]));
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Budgets konnten nicht geladen werden");
+    }
+  }, []);
+
+  const refreshEntries = useCallback(async () => {
+    setLoadingEntries(true);
+    try {
+      const response = await fetch("/api/finance");
+      const data = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(data?.error ?? "Buchungen konnten nicht geladen werden");
+      if (data?.entries) {
+        setEntries(data.entries as FinanceEntryDTO[]);
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Buchungen konnten nicht geladen werden");
+    } finally {
+      setLoadingEntries(false);
+    }
+  }, []);
+
+  const handleEntryCreated = useCallback(
+    (entry: FinanceEntryDTO) => {
+      setEntries((prev) => [entry, ...prev.filter((existing) => existing.id !== entry.id)]);
+      refreshSummary();
+      refreshBudgets();
+    },
+    [refreshSummary, refreshBudgets],
+  );
+
+  const handleEntryUpdated = useCallback(
+    (entry: FinanceEntryDTO) => {
+      setEntries((prev) => prev.map((existing) => (existing.id === entry.id ? entry : existing)));
+      refreshSummary();
+      refreshBudgets();
+    },
+    [refreshSummary, refreshBudgets],
+  );
+
+  const handleEntryDeleted = useCallback(
+    (id: string) => {
+      setEntries((prev) => prev.filter((entry) => entry.id !== id));
+      refreshSummary();
+      refreshBudgets();
+    },
+    [refreshSummary, refreshBudgets],
+  );
+
+  const handleBudgetCreated = useCallback((budget: FinanceBudgetDTO) => {
+    setBudgets((prev) => sortBudgets([...prev, budget]));
+  }, []);
+
+  const handleBudgetUpdated = useCallback((budget: FinanceBudgetDTO) => {
+    setBudgets((prev) => sortBudgets(prev.map((existing) => (existing.id === budget.id ? budget : existing))));
+  }, []);
+
+  const handleBudgetDeleted = useCallback((id: string) => {
+    setBudgets((prev) => prev.filter((budget) => budget.id !== id));
+  }, []);
+
+  const recentEntries = useMemo(() => entries.slice(0, 5), [entries]);
+  const net = summary.totalIncome - summary.totalExpense;
+  const budgetOptions = budgets;
+
+  function renderDashboard() {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title="Finanzen"
+          description="Einnahmen, Ausgaben und offene Rechnungen auf einen Blick."
+          actions={
+            <div className="flex gap-2">
+              {canManage ? (
+                <Button asChild variant="secondary">
+                  <Link href="/mitglieder/finanzen/buchungen">Neue Buchung</Link>
+                </Button>
+              ) : null}
+              {canManage ? (
+                <Button asChild variant="secondary">
+                  <Link href="/mitglieder/finanzen/budgets">Budgets verwalten</Link>
+                </Button>
+              ) : null}
+            </div>
+          }
+        />
+
+        <KeyMetricGrid>
+          <KeyMetricCard label="Einnahmen" value={formatCurrency(summary.totalIncome)} tone="positive" hint={loadingSummary ? "Aktualisiere…" : undefined} />
+          <KeyMetricCard label="Ausgaben" value={formatCurrency(summary.totalExpense)} tone="destructive" />
+          <KeyMetricCard
+            label="Saldo"
+            value={formatCurrency(net)}
+            tone={net >= 0 ? "positive" : "destructive"}
+            hint={loadingSummary ? "Aktualisiere…" : undefined}
+          />
+          <KeyMetricCard
+            label="Offene Rechnungen"
+            value={summary.pendingInvoices}
+            tone={summary.pendingInvoices > 0 ? "warning" : "default"}
+            hint={`Volumen ${formatCurrency(summary.pendingAmount)}`}
+          />
+          <KeyMetricCard label="Spenden" value={formatCurrency(summary.donationTotal)} tone="info" />
+        </KeyMetricGrid>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Neueste Buchungen</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {recentEntries.length === 0 ? (
+                <p className="text-sm text-muted-foreground">Noch keine Buchungen vorhanden.</p>
+              ) : (
+                recentEntries.map((entry) => (
+                  <div key={entry.id} className="flex items-start justify-between gap-3 border-b border-border/40 pb-2 last:border-none last:pb-0">
+                    <div className="flex-1">
+                      <div className="font-medium text-foreground">{entry.title}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {entry.show?.title ?? "Allgemein"} · {new Date(entry.bookingDate).toLocaleDateString("de-DE")}
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div className={cn("text-sm font-semibold", entry.type === "expense" ? "text-destructive" : "text-success")}>{formatCurrency(entry.amount, entry.currency)}</div>
+                      <Badge
+                        variant={FINANCE_ENTRY_STATUS_TONES[entry.status]}
+                        className="mt-1 text-xs"
+                      >
+                        {FINANCE_ENTRY_STATUS_LABELS[entry.status]}
+                      </Badge>
+                    </div>
+                  </div>
+                ))
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  function renderEntries() {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title="Finanzbuchungen"
+          description="Erfasse Rechnungen, Spenden und sonstige Buchungen."
+          actions={
+            canManage ? (
+              <Button type="button" onClick={() => setShowEntryForm((prev) => !prev)}>
+                {showEntryForm ? "Formular ausblenden" : "Neue Buchung"}
+              </Button>
+            ) : undefined
+          }
+        />
+
+        {canManage ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Neue Buchung</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {showEntryForm ? (
+                <FinanceEntryForm
+                  onCreated={handleEntryCreated}
+                  showOptions={showOptions}
+                  memberOptions={memberOptions}
+                  budgetOptions={budgetOptions}
+                  allowedScopes={allowedScopes}
+                  canApprove={canApprove}
+                  onAfterSubmit={() => setShowEntryForm(false)}
+                />
+              ) : (
+                <p className="text-sm text-muted-foreground">Nutze den Button oben, um das Formular zu öffnen.</p>
+              )}
+            </CardContent>
+          </Card>
+        ) : (
+          <p className="text-sm text-muted-foreground">Du kannst Buchungen einsehen, aber nicht bearbeiten.</p>
+        )}
+
+        <FinanceEntryTable
+          entries={entries}
+          onEntryUpdated={handleEntryUpdated}
+          onEntryDeleted={handleEntryDeleted}
+          onRefresh={refreshEntries}
+          refreshing={loadingEntries}
+          canManage={canManage}
+          canApprove={canApprove}
+        />
+      </div>
+    );
+  }
+
+  function renderBudgets() {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title="Budgets"
+          description="Plane Budgetrahmen pro Produktion und vergleiche sie mit den Ist-Ausgaben."
+        />
+
+        {canManage ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>{editingBudget ? `Budget "${editingBudget.category}" bearbeiten` : "Neues Budget anlegen"}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <FinanceBudgetForm
+                showOptions={showOptions}
+                initialBudget={editingBudget}
+                onCreated={handleBudgetCreated}
+                onUpdated={handleBudgetUpdated}
+                onCancelEdit={() => setEditingBudget(null)}
+              />
+            </CardContent>
+          </Card>
+        ) : (
+          <p className="text-sm text-muted-foreground">Du kannst Budgets einsehen, aber nicht bearbeiten.</p>
+        )}
+
+        <FinanceBudgetTable
+          budgets={budgets}
+          onRequestEdit={(budget) => setEditingBudget(budget)}
+          onBudgetDeleted={(id) => {
+            handleBudgetDeleted(id);
+            refreshSummary();
+          }}
+          canManage={canManage}
+        />
+      </div>
+    );
+  }
+
+  function renderExport() {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title="Exporte"
+          description="Erzeuge CSV-Dateien für Buchungslisten oder weiterführende Auswertungen."
+        />
+        {canExport ? <FinanceExportSection /> : <p className="text-sm text-muted-foreground">Für Exporte fehlen die Berechtigungen.</p>}
+      </div>
+    );
+  }
+
+  switch (activeSection) {
+    case "buchungen":
+      return renderEntries();
+    case "budgets":
+      return renderBudgets();
+    case "export":
+      return renderExport();
+    case "dashboard":
+    default:
+      return renderDashboard();
+  }
+}

--- a/src/lib/finance.ts
+++ b/src/lib/finance.ts
@@ -1,0 +1,72 @@
+import type {
+  FinanceEntryKind,
+  FinanceEntryStatus,
+  FinanceType,
+  VisibilityScope,
+} from "@prisma/client";
+
+export const FINANCE_ENTRY_STATUS_VALUES: FinanceEntryStatus[] = [
+  "draft",
+  "pending",
+  "approved",
+  "paid",
+  "cancelled",
+];
+
+export const FINANCE_ENTRY_STATUS_LABELS: Record<FinanceEntryStatus, string> = {
+  draft: "Entwurf",
+  pending: "Wartet auf Freigabe",
+  approved: "Freigegeben",
+  paid: "Bezahlt",
+  cancelled: "Storniert",
+};
+
+export const FINANCE_ENTRY_STATUS_TONES: Record<FinanceEntryStatus, "default" | "info" | "warning" | "success" | "destructive"> = {
+  draft: "default",
+  pending: "warning",
+  approved: "success",
+  paid: "info",
+  cancelled: "destructive",
+};
+
+export const FINANCE_ENTRY_KIND_VALUES: FinanceEntryKind[] = ["general", "invoice", "donation"];
+
+export const FINANCE_ENTRY_KIND_LABELS: Record<FinanceEntryKind, string> = {
+  general: "Allgemein",
+  invoice: "Rechnung / Auslage",
+  donation: "Spende",
+};
+
+export const FINANCE_ENTRY_KIND_DESCRIPTIONS: Record<FinanceEntryKind, string> = {
+  general: "Sonstige Finanzbuchungen oder interne Umbuchungen.",
+  invoice: "Rechnungen, Auslagen oder Erstattungen von Mitgliedern.",
+  donation: "Spenden- und Förderungseingänge inklusive Kontaktangaben.",
+};
+
+export const FINANCE_TYPE_LABELS: Record<FinanceType, string> = {
+  income: "Einnahme",
+  expense: "Ausgabe",
+};
+
+export const FINANCE_VISIBILITY_LABELS: Record<VisibilityScope, string> = {
+  board: "Nur Vorstand",
+  finance: "Finanzteam",
+};
+
+export function isFinanceEntryStatus(value: unknown): value is FinanceEntryStatus {
+  return typeof value === "string" && FINANCE_ENTRY_STATUS_VALUES.includes(value as FinanceEntryStatus);
+}
+
+export function isFinanceEntryKind(value: unknown): value is FinanceEntryKind {
+  return typeof value === "string" && FINANCE_ENTRY_KIND_VALUES.includes(value as FinanceEntryKind);
+}
+
+export function isFinanceType(value: unknown): value is FinanceType {
+  return value === "income" || value === "expense";
+}
+
+export function isVisibilityScope(value: unknown): value is VisibilityScope {
+  return value === "board" || value === "finance";
+}
+
+export const FINANCE_EXPORT_FILENAME = "mitglieder-finanzen.csv";


### PR DESCRIPTION
## Summary
- extend the Prisma schema with finance enums/models, add the finance migration, and seed demo budgets, entries, and permissions
- expose finance APIs for entries, budgets, summary, and CSV export together with shared finance helpers
- add finance UI components and navigation, including the members finance overview, forms, and tables wired to the new routes

## Testing
- pnpm prisma generate
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d05924a1dc832dad927f260558b32c