### PR TITLE
Add static Saxony holiday fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ NEXT_PUBLIC_AUTH_DEV_NO_DB=0
 
 # Optional: ICS feed for sächsische Schulferien. Wird genutzt, um die Sperrliste zu annotieren.
 #SAXONY_HOLIDAYS_ICS_URL=https://www.schulferien.org/media/ical/deutschland/ferien_sachsen.ics
+# Optional: Deaktiviert ausgehende HTTP-Abfragen und aktiviert den statischen Ferien-Datensatz.
+#OUTBOUND_HTTP_DISABLED=0
 
 # Realtime service authentication
 REALTIME_AUTH_TOKEN=replace-with-realtime-token

--- a/src/data/saxony-school-holidays.ts
+++ b/src/data/saxony-school-holidays.ts
@@ -1,0 +1,244 @@
+import type { HolidayRange } from "@/types/holidays";
+
+/**
+ * Static backup for sächsische Schulferien used when remote feeds are unavailable.
+ *
+ * The dataset intentionally spans multiple years (past + future) so UI filtering can
+ * still limit the result set to the relevant window around "today".
+ */
+export const SAXONY_SCHOOL_HOLIDAYS: HolidayRange[] = [
+  {
+    id: "ferien-api:winterferien sachsen 2023-2023-SN",
+    title: "Winterferien Sachsen 2023",
+    startDate: "2023-02-13",
+    endDate: "2023-02-24",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2023-2023-SN",
+    title: "Osterferien Sachsen 2023",
+    startDate: "2023-04-07",
+    endDate: "2023-04-15",
+  },
+  {
+    id: "ferien-api:pfingstferien sachsen 2023 (beweglicher ferientag)-2023-SN",
+    title: "Pfingstferien Sachsen 2023 (Beweglicher Ferientag)",
+    startDate: "2023-05-19",
+    endDate: "2023-05-19",
+  },
+  {
+    id: "ferien-api:sommerferien sachsen 2023-2023-SN",
+    title: "Sommerferien Sachsen 2023",
+    startDate: "2023-07-10",
+    endDate: "2023-08-18",
+  },
+  {
+    id: "ferien-api:herbstferien sachsen 2023-2023-SN",
+    title: "Herbstferien Sachsen 2023",
+    startDate: "2023-10-02",
+    endDate: "2023-10-14",
+  },
+  {
+    id: "ferien-api:herbstferien sachsen 2023 (beweglicher ferientag)-2023-SN",
+    title: "Herbstferien Sachsen 2023 (Beweglicher Ferientag)",
+    startDate: "2023-10-30",
+    endDate: "2023-10-30",
+  },
+  {
+    id: "ferien-api:weihnachtsferien sachsen 2023-2023-SN",
+    title: "Weihnachtsferien Sachsen 2023",
+    startDate: "2023-12-23",
+    endDate: "2024-01-02",
+  },
+  {
+    id: "ferien-api:winterferien sachsen 2024-2024-SN",
+    title: "Winterferien Sachsen 2024",
+    startDate: "2024-02-12",
+    endDate: "2024-02-23",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2024-2024-SN",
+    title: "Osterferien Sachsen 2024",
+    startDate: "2024-03-28",
+    endDate: "2024-04-05",
+  },
+  {
+    id: "ferien-api:pfingstferien sachsen 2024 (beweglicher ferientag)-2024-SN",
+    title: "Pfingstferien Sachsen 2024 (Beweglicher Ferientag)",
+    startDate: "2024-05-10",
+    endDate: "2024-05-10",
+  },
+  {
+    id: "ferien-api:pfingstferien sachsen 2024-2024-SN",
+    title: "Pfingstferien Sachsen 2024",
+    startDate: "2024-05-18",
+    endDate: "2024-05-21",
+  },
+  {
+    id: "ferien-api:sommerferien sachsen 2024-2024-SN",
+    title: "Sommerferien Sachsen 2024",
+    startDate: "2024-06-20",
+    endDate: "2024-08-02",
+  },
+  {
+    id: "ferien-api:herbstferien sachsen 2024-2024-SN",
+    title: "Herbstferien Sachsen 2024",
+    startDate: "2024-10-07",
+    endDate: "2024-10-19",
+  },
+  {
+    id: "ferien-api:weihnachtsferien sachsen 2024-2024-SN",
+    title: "Weihnachtsferien Sachsen 2024",
+    startDate: "2024-12-23",
+    endDate: "2025-01-03",
+  },
+  {
+    id: "ferien-api:winterferien sachsen 2025-2025-SN",
+    title: "Winterferien Sachsen 2025",
+    startDate: "2025-02-17",
+    endDate: "2025-03-01",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2025-2025-SN",
+    title: "Osterferien Sachsen 2025",
+    startDate: "2025-04-18",
+    endDate: "2025-04-25",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2025 (beweglicher ferientag)-2025-SN",
+    title: "Osterferien Sachsen 2025 (Beweglicher Ferientag)",
+    startDate: "2025-05-30",
+    endDate: "2025-05-30",
+  },
+  {
+    id: "ferien-api:sommerferien sachsen 2025-2025-SN",
+    title: "Sommerferien Sachsen 2025",
+    startDate: "2025-06-28",
+    endDate: "2025-08-08",
+  },
+  {
+    id: "ferien-api:herbstferien sachsen 2025-2025-SN",
+    title: "Herbstferien Sachsen 2025",
+    startDate: "2025-10-06",
+    endDate: "2025-10-18",
+  },
+  {
+    id: "ferien-api:weihnachtsferien sachsen 2025-2025-SN",
+    title: "Weihnachtsferien Sachsen 2025",
+    startDate: "2025-12-22",
+    endDate: "2026-01-02",
+  },
+  {
+    id: "ferien-api:winterferien sachsen 2026-2026-SN",
+    title: "Winterferien Sachsen 2026",
+    startDate: "2026-02-09",
+    endDate: "2026-02-22",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2026-2026-SN",
+    title: "Osterferien Sachsen 2026",
+    startDate: "2026-04-03",
+    endDate: "2026-04-11",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2026 (beweglicher ferientag)-2026-SN",
+    title: "Osterferien Sachsen 2026 (Beweglicher Ferientag)",
+    startDate: "2026-05-15",
+    endDate: "2026-05-16",
+  },
+  {
+    id: "ferien-api:sommerferien sachsen 2026-2026-SN",
+    title: "Sommerferien Sachsen 2026",
+    startDate: "2026-07-04",
+    endDate: "2026-08-15",
+  },
+  {
+    id: "ferien-api:herbstferien sachsen 2026-2026-SN",
+    title: "Herbstferien Sachsen 2026",
+    startDate: "2026-10-12",
+    endDate: "2026-10-25",
+  },
+  {
+    id: "ferien-api:weihnachtsferien sachsen 2026-2026-SN",
+    title: "Weihnachtsferien Sachsen 2026",
+    startDate: "2026-12-23",
+    endDate: "2027-01-03",
+  },
+  {
+    id: "ferien-api:winterferien sachsen 2027-2027-SN",
+    title: "Winterferien Sachsen 2027",
+    startDate: "2027-02-08",
+    endDate: "2027-02-19",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2027-2027-SN",
+    title: "Osterferien Sachsen 2027",
+    startDate: "2027-03-26",
+    endDate: "2027-04-02",
+  },
+  {
+    id: "ferien-api:pfingsferien sachsen 2027 (beweglicher ferientag)-2027-SN",
+    title: "Pfingsferien Sachsen 2027 (Beweglicher Ferientag)",
+    startDate: "2027-05-07",
+    endDate: "2027-05-07",
+  },
+  {
+    id: "ferien-api:pfingsferien sachsen 2027-2027-SN",
+    title: "Pfingsferien Sachsen 2027",
+    startDate: "2027-05-15",
+    endDate: "2027-05-18",
+  },
+  {
+    id: "ferien-api:sommerferien sachsen 2027-2027-SN",
+    title: "Sommerferien Sachsen 2027",
+    startDate: "2027-07-10",
+    endDate: "2027-08-20",
+  },
+  {
+    id: "ferien-api:herbstferien sachsen 2027-2027-SN",
+    title: "Herbstferien Sachsen 2027",
+    startDate: "2027-10-11",
+    endDate: "2027-10-23",
+  },
+  {
+    id: "ferien-api:weihnachtsferien sachsen 2027-2027-SN",
+    title: "Weihnachtsferien Sachsen 2027",
+    startDate: "2027-12-23",
+    endDate: "2028-01-01",
+  },
+  {
+    id: "ferien-api:winterferien sachsen 2028-2028-SN",
+    title: "Winterferien Sachsen 2028",
+    startDate: "2028-02-14",
+    endDate: "2028-02-26",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2028-2028-SN",
+    title: "Osterferien Sachsen 2028",
+    startDate: "2028-04-14",
+    endDate: "2028-04-22",
+  },
+  {
+    id: "ferien-api:osterferien sachsen 2028 (beweglicher ferientag)-2028-SN",
+    title: "Osterferien Sachsen 2028 (Beweglicher Ferientag)",
+    startDate: "2028-05-26",
+    endDate: "2028-05-26",
+  },
+  {
+    id: "ferien-api:sommerferien sachsen 2028-2028-SN",
+    title: "Sommerferien Sachsen 2028",
+    startDate: "2028-07-22",
+    endDate: "2028-09-01",
+  },
+  {
+    id: "ferien-api:herbstferien sachsen 2028-2028-SN",
+    title: "Herbstferien Sachsen 2028",
+    startDate: "2028-10-23",
+    endDate: "2028-11-03",
+  },
+  {
+    id: "ferien-api:weihnachtsferien sachsen 2028-2028-SN",
+    title: "Weihnachtsferien Sachsen 2028",
+    startDate: "2028-12-23",
+    endDate: "2029-01-03",
+  },
+];

--- a/src/lib/__tests__/holidays.test.ts
+++ b/src/lib/__tests__/holidays.test.ts
@@ -1,0 +1,54 @@
+import { addDays, format } from "date-fns";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+}));
+
+import { SAXONY_SCHOOL_HOLIDAYS } from "@/data/saxony-school-holidays";
+import { getSaxonySchoolHolidayRanges } from "@/lib/holidays";
+
+describe("getSaxonySchoolHolidayRanges", () => {
+  let previousOutboundToggle: string | undefined;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    previousOutboundToggle = process.env.OUTBOUND_HTTP_DISABLED;
+    delete process.env.OUTBOUND_HTTP_DISABLED;
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-01T00:00:00Z"));
+
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new TypeError("fetch is disabled in tests"));
+
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (previousOutboundToggle === undefined) {
+      delete process.env.OUTBOUND_HTTP_DISABLED;
+    } else {
+      process.env.OUTBOUND_HTTP_DISABLED = previousOutboundToggle;
+    }
+
+    fetchSpy.mockRestore();
+    consoleSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("falls back to the static Saxony dataset when remote feeds fail", async () => {
+    const ranges = await getSaxonySchoolHolidayRanges();
+
+    const thresholdStart = format(addDays(new Date(), -365), "yyyy-MM-dd");
+    const thresholdEnd = format(addDays(new Date(), 365 * 3), "yyyy-MM-dd");
+    const expected = SAXONY_SCHOOL_HOLIDAYS.filter(
+      (range) => range.endDate >= thresholdStart && range.startDate <= thresholdEnd,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(ranges).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add a static Saxony school holiday dataset for 2023–2028
- fall back to the local data set when external feeds fail or outbound HTTP is disabled
- cover the offline fallback with a Vitest that blocks fetch and document the new toggle in .env.example

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d07072dac4832daa6d052061e835e7