### PR TITLE
Add default Körpermaße permission assignment to system roles

### DIFF
--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -232,6 +232,34 @@ async function main() {
     });
   }
 
+  const measurementPermission = await prisma.permission.upsert({
+    where: { key: "mitglieder.koerpermasse" },
+    update: {
+      label: "Körpermaße pflegen",
+      description:
+        "Ermöglicht das Pflegen eigener Maße für Anproben und blendet den Menüpunkt \"Körpermaße\" in Proben & Gewerken ein, damit das Kostüm-Team die Angaben sieht.",
+    },
+    create: {
+      key: "mitglieder.koerpermasse",
+      label: "Körpermaße pflegen",
+      description:
+        "Ermöglicht das Pflegen eigener Maße für Anproben und blendet den Menüpunkt \"Körpermaße\" in Proben & Gewerken ein, damit das Kostüm-Team die Angaben sieht.",
+    },
+  });
+
+  const measurementRoleNames = ["member", "cast", "tech", "board", "finance"];
+  const measurementRoles = await prisma.appRole.findMany({
+    where: { name: { in: measurementRoleNames } },
+  });
+
+  for (const role of measurementRoles) {
+    await prisma.appRolePermission.upsert({
+      where: { roleId_permissionId: { roleId: role.id, permissionId: measurementPermission.id } },
+      update: {},
+      create: { roleId: role.id, permissionId: measurementPermission.id },
+    });
+  }
+
   const financePermissionKeys = financePermissionSeeds.map((perm) => perm.key);
   const boardPermissionKeys = ["mitglieder.finanzen", "mitglieder.finanzen.export"];
 

--- a/src/app/(members)/mitglieder/koerpermasse/page.tsx
+++ b/src/app/(members)/mitglieder/koerpermasse/page.tsx
@@ -1,0 +1,50 @@
+import { notFound } from "next/navigation";
+
+import { MemberMeasurementsManager } from "@/components/members/measurements/member-measurements-manager";
+import { PageHeader } from "@/components/members/page-header";
+import { prisma } from "@/lib/prisma";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import type { MeasurementType, MeasurementUnit } from "@/data/measurements";
+
+export default async function MemberMeasurementsPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.koerpermasse");
+
+  if (!allowed) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-red-600">
+        Kein Zugriff auf den Bereich für Körpermaße.
+      </div>
+    );
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    notFound();
+  }
+
+  const measurements = await prisma.memberMeasurement.findMany({
+    where: { userId },
+    orderBy: { type: "asc" },
+  });
+
+  const initialMeasurements = measurements.map((measurement) => ({
+    id: measurement.id,
+    type: measurement.type as MeasurementType,
+    value: measurement.value,
+    unit: measurement.unit as MeasurementUnit,
+    note: measurement.note,
+    updatedAt: measurement.updatedAt.toISOString(),
+  }));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Körpermaße"
+        description="Pflege deine Maße für das Kostüm-Team und bevorstehende Anproben."
+      />
+      <MemberMeasurementsManager initialMeasurements={initialMeasurements} />
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -3,13 +3,14 @@ import { notFound } from "next/navigation";
 import { addDays, format, startOfToday } from "date-fns";
 import { de } from "date-fns/locale/de";
 import type { LucideIcon } from "lucide-react";
-import { CalendarDays, CheckCircle2, ListTodo, Sparkles, Users } from "lucide-react";
+import { CalendarDays, CheckCircle2, ListTodo, Ruler, Sparkles, Users } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
+import { sortMeasurements, type MeasurementType, type MeasurementUnit } from "@/data/measurements";
 
 import {
   DATE_KEY_FORMAT,
@@ -19,7 +20,7 @@ import {
   ROLE_LABELS,
   type DepartmentMembershipWithDepartment,
 } from "../utils";
-import { DepartmentCard } from "../department-card";
+import { DepartmentCard, type DepartmentMeasurementsByUser } from "../department-card";
 
 type SummaryStat = { label: string; value: number; hint?: string; icon: LucideIcon };
 
@@ -28,6 +29,7 @@ type PageProps = { params: { slug: string } };
 export default async function GewerkDetailPage({ params }: PageProps) {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.meine-gewerke");
+  const canManageMeasurements = await hasPermission(session.user, "mitglieder.koerpermasse");
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die persönliche Gewerkeübersicht.</div>;
   }
@@ -75,6 +77,32 @@ export default async function GewerkDetailPage({ params }: PageProps) {
 
   const memberIds = membership.department.memberships.map((entry) => entry.userId);
 
+  let departmentMeasurementsByUser: DepartmentMeasurementsByUser | undefined;
+  if (membership.department.slug === "kostuem" && memberIds.length) {
+    const measurementRecords = await prisma.memberMeasurement.findMany({
+      where: { userId: { in: memberIds } },
+      orderBy: { type: "asc" },
+    });
+
+    departmentMeasurementsByUser = {};
+    for (const record of measurementRecords) {
+      const existing = departmentMeasurementsByUser[record.userId] ?? [];
+      existing.push({
+        id: record.id,
+        type: record.type as MeasurementType,
+        value: record.value,
+        unit: record.unit as MeasurementUnit,
+        note: record.note,
+        updatedAt: record.updatedAt,
+      });
+      departmentMeasurementsByUser[record.userId] = existing;
+    }
+
+    for (const [userId, entries] of Object.entries(departmentMeasurementsByUser)) {
+      departmentMeasurementsByUser[userId] = sortMeasurements(entries);
+    }
+  }
+
   const blockedDays = memberIds.length
     ? await prisma.blockedDay.findMany({
         where: {
@@ -111,6 +139,19 @@ export default async function GewerkDetailPage({ params }: PageProps) {
 
   const headerActions = (
     <>
+      {canManageMeasurements ? (
+        <Button
+          asChild
+          size="sm"
+          variant="outline"
+          className="gap-2 rounded-full border-border/70 bg-background/80 px-4 backdrop-blur transition hover:border-primary/50 hover:bg-primary/10"
+        >
+          <Link href="/mitglieder/koerpermasse" title="Körpermaße verwalten">
+            <Ruler aria-hidden className="h-4 w-4" />
+            <span>Körpermaße</span>
+          </Link>
+        </Button>
+      ) : null}
       <Button
         asChild
         size="sm"
@@ -230,6 +271,7 @@ export default async function GewerkDetailPage({ params }: PageProps) {
         freezeUntilLabel={freezeUntilLabel}
         planningWindowLabel={planningWindowLabel}
         now={now}
+        measurementsByUser={departmentMeasurementsByUser}
       />
     </div>
   );

--- a/src/app/(members)/mitglieder/meine-proben/page.tsx
+++ b/src/app/(members)/mitglieder/meine-proben/page.tsx
@@ -5,6 +5,7 @@ import { de } from "date-fns/locale/de";
 import { PageHeader } from "@/components/members/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
@@ -76,6 +77,7 @@ type AttendanceHistoryEntry = {
 export default async function MeineProbenPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.meine-proben");
+  const canManageMeasurements = await hasPermission(session.user, "mitglieder.koerpermasse");
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die persönliche Probenübersicht.</div>;
   }
@@ -417,6 +419,22 @@ export default async function MeineProbenPage() {
         </div>
 
         <div className="space-y-6">
+          {canManageMeasurements ? (
+            <Card className="border-border/60">
+              <CardHeader>
+                <CardTitle>Körpermaße für Anproben</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Pflege deine Maße zentral, damit das Kostüm-Team dich bei Anproben optimal einplanen kann.
+                </p>
+              </CardHeader>
+              <CardContent>
+                <Button asChild size="sm">
+                  <Link href="/mitglieder/koerpermasse">Körpermaße verwalten</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ) : null}
+
           <Card>
             <CardHeader>
               <CardTitle>Rückmeldungsstatus</CardTitle>

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -20,6 +20,7 @@ const GENERAL_ITEMS: Item[] = [
 const ASSIGNMENT_ITEMS: Item[] = [
   { href: "/mitglieder/meine-proben", label: "Meine Proben", permissionKey: "mitglieder.meine-proben" },
   { href: "/mitglieder/meine-gewerke", label: "Meine Gewerke", permissionKey: "mitglieder.meine-gewerke" },
+  { href: "/mitglieder/koerpermasse", label: "Körpermaße", permissionKey: "mitglieder.koerpermasse" },
   { href: "/mitglieder/probenplanung", label: "Probenplanung", permissionKey: "mitglieder.probenplanung" },
 ];
 
@@ -120,6 +121,20 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
           <path d="M8 14h8" />
           <path d="M8 18h5" />
           <path d="m6 15 1.8 1.8L10 14" />
+        </svg>
+      );
+    case "/mitglieder/koerpermasse":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="6" width="18" height="12" rx="2" />
+          <path d="M6 10h.01" />
+          <path d="M9 10h.01" />
+          <path d="M12 10h.01" />
+          <path d="M15 10h.01" />
+          <path d="M18 10h.01" />
+          <path d="M6 14h6" />
+          <path d="M6 18v2" />
+          <path d="M18 18v2" />
         </svg>
       );
     case "/mitglieder/sperrliste":

--- a/src/components/members/measurements/member-measurements-manager.tsx
+++ b/src/components/members/measurements/member-measurements-manager.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { MeasurementForm } from "@/components/forms/measurement-form";
+import {
+  MEASUREMENT_TYPE_LABELS,
+  MEASUREMENT_UNIT_LABELS,
+  measurementSchema,
+  sortMeasurements,
+  type MeasurementFormData,
+  type MeasurementType,
+  type MeasurementUnit,
+} from "@/data/measurements";
+
+interface MeasurementEntry {
+  id: string;
+  type: MeasurementType;
+  value: number;
+  unit: MeasurementUnit;
+  note?: string | null;
+  updatedAt: string;
+}
+
+interface MemberMeasurementsManagerProps {
+  initialMeasurements: MeasurementEntry[];
+}
+
+type DialogState =
+  | { mode: "create"; initialType?: MeasurementType | null }
+  | { mode: "edit"; entry: MeasurementEntry };
+
+export function MemberMeasurementsManager({
+  initialMeasurements,
+}: MemberMeasurementsManagerProps) {
+  const [measurements, setMeasurements] = useState(() =>
+    sortMeasurements(initialMeasurements),
+  );
+  const [dialogState, setDialogState] = useState<DialogState | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const openCreateDialog = () => {
+    setDialogState({ mode: "create" });
+  };
+
+  const openEditDialog = (entry: MeasurementEntry) => {
+    setDialogState({ mode: "edit", entry });
+  };
+
+  const closeDialog = () => {
+    if (submitting) return;
+    setDialogState(null);
+  };
+
+  const handleSubmit = async (data: MeasurementFormData) => {
+    setSubmitting(true);
+    try {
+      const response = await fetch("/api/measurements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(
+          typeof error?.error === "string"
+            ? error.error
+            : "Speichern der Maße fehlgeschlagen.",
+        );
+      }
+
+      const payload = await response.json();
+      const parsed = measurementSchema.parse(payload);
+      const saved: MeasurementEntry = {
+        id:
+          typeof payload?.id === "string"
+            ? payload.id
+            : `${parsed.type}-${Date.now()}`,
+        type: parsed.type,
+        value: parsed.value,
+        unit: parsed.unit,
+        note: parsed.note,
+        updatedAt:
+          typeof payload?.updatedAt === "string"
+            ? payload.updatedAt
+            : new Date().toISOString(),
+      };
+      setMeasurements((prev) => {
+        const withoutType = prev.filter((entry) => entry.type !== saved.type);
+        return sortMeasurements([...withoutType, saved]);
+      });
+      setDialogState(null);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card className="border-border/60 bg-background/70">
+      <CardHeader className="space-y-2">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <CardTitle className="text-xl font-semibold">Körpermaße</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Hinterlege deine Maße für Anproben und Kostümabstimmungen. Änderungen
+              stehen deinem Kostüm-Team sofort zur Verfügung.
+            </p>
+          </div>
+          <Button size="sm" onClick={openCreateDialog}>
+            Neues Maß erfassen
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {measurements.length ? (
+          <ul className="divide-y divide-border/60 rounded-2xl border border-border/60 bg-background/60">
+            {measurements.map((entry) => (
+              <li
+                key={entry.type}
+                className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">
+                      {MEASUREMENT_TYPE_LABELS[entry.type]}
+                    </span>
+                    <Badge variant="outline" className="text-xs">
+                      {entry.unit in MEASUREMENT_UNIT_LABELS
+                        ? MEASUREMENT_UNIT_LABELS[entry.unit]
+                        : entry.unit}
+                    </Badge>
+                  </div>
+                  <p className="text-2xl font-semibold tracking-tight">
+                    {formatValue(entry.value)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Aktualisiert am {formatDate(entry.updatedAt)}
+                  </p>
+                  {entry.note ? (
+                    <p className="text-xs text-muted-foreground/90">
+                      Hinweis: {entry.note}
+                    </p>
+                  ) : null}
+                </div>
+                <Button variant="outline" size="sm" onClick={() => openEditDialog(entry)}>
+                  Bearbeiten
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="rounded-2xl border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+            Noch keine Maße hinterlegt. Erfasse deine Körpermaße, damit das Kostüm-Team dich
+            bei Anproben optimal unterstützen kann.
+          </div>
+        )}
+
+        <div className="rounded-xl border border-border/60 bg-muted/30 p-4 text-xs text-muted-foreground">
+          Datenschutz-Hinweis: Deine Maße sind ausschließlich für dich und Mitglieder des Kostüm-Teams sichtbar,
+          die für Anproben zuständig sind.
+        </div>
+      </CardContent>
+
+      <Dialog open={dialogState !== null} onOpenChange={closeDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {dialogState?.mode === "edit"
+                ? `${MEASUREMENT_TYPE_LABELS[dialogState.entry.type]} bearbeiten`
+                : "Neues Maß hinzufügen"}
+            </DialogTitle>
+          </DialogHeader>
+          {dialogState ? (
+            <MeasurementForm
+              initialData={
+                dialogState.mode === "edit"
+                  ? {
+                      type: dialogState.entry.type,
+                      value: dialogState.entry.value,
+                      unit: dialogState.entry.unit,
+                      note: dialogState.entry.note ?? "",
+                    }
+                  : dialogState.initialType
+                    ? { type: dialogState.initialType }
+                    : undefined
+              }
+              disableTypeSelection={dialogState.mode === "edit"}
+              onSubmit={handleSubmit}
+            />
+          ) : (
+            <div className="h-48 w-full animate-pulse rounded-xl border border-border/50 bg-muted/30" />
+          )}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
+
+function formatValue(value: number) {
+  return Number.isFinite(value) ? value.toLocaleString("de-DE", { minimumFractionDigits: 0, maximumFractionDigits: 1 }) : "-";
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "unbekannt";
+  return date.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}

--- a/src/data/measurements.ts
+++ b/src/data/measurements.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+export const measurementTypeEnum = z.enum([
+  "HEIGHT",
+  "CHEST",
+  "WAIST",
+  "HIPS",
+  "INSEAM",
+  "SHOULDER",
+  "SLEEVE",
+  "SHOE_SIZE",
+  "HEAD",
+] as const);
+
+export const measurementUnitEnum = z.enum([
+  "CM",
+  "INCH",
+  "EU",
+  "DE",
+] as const);
+
+export const measurementSchema = z.object({
+  type: measurementTypeEnum,
+  value: z.number().min(0, "Der Wert muss positiv sein."),
+  unit: measurementUnitEnum,
+  note: z.string().max(500, "Notizen dürfen höchstens 500 Zeichen haben.").optional(),
+});
+
+export type MeasurementType = z.infer<typeof measurementTypeEnum>;
+export type MeasurementUnit = z.infer<typeof measurementUnitEnum>;
+export type MeasurementFormData = z.infer<typeof measurementSchema>;
+
+export const MEASUREMENT_TYPE_LABELS: Record<MeasurementType, string> = {
+  HEIGHT: "Körpergröße",
+  CHEST: "Brustumfang",
+  WAIST: "Taillenumfang",
+  HIPS: "Hüftumfang",
+  INSEAM: "Innenbeinlänge",
+  SHOULDER: "Schulterbreite",
+  SLEEVE: "Armlänge",
+  SHOE_SIZE: "Schuhgröße",
+  HEAD: "Kopfumfang",
+};
+
+export const MEASUREMENT_UNIT_LABELS: Record<MeasurementUnit, string> = {
+  CM: "cm",
+  INCH: "Zoll",
+  EU: "EU",
+  DE: "DE",
+};
+
+export const MEASUREMENT_TYPE_ORDER = measurementTypeEnum.options.reduce<
+  Record<MeasurementType, number>
+>((acc, type, index) => {
+  acc[type] = index;
+  return acc;
+}, {} as Record<MeasurementType, number>);
+
+export function sortMeasurements<T extends { type: MeasurementType }>(
+  measurements: T[],
+) {
+  return [...measurements].sort((a, b) => {
+    const orderA = MEASUREMENT_TYPE_ORDER[a.type] ?? 0;
+    const orderB = MEASUREMENT_TYPE_ORDER[b.type] ?? 0;
+    if (orderA !== orderB) return orderA - orderB;
+    return 0;
+  });
+}


### PR DESCRIPTION
## Summary
- clarify the Körpermaße permission description and make sure the ensure-permissions routine grants it to all non-system member roles by default
- extend the Prisma seed to create the Körpermaße permission and preassign it to member, cast, tech, board and finance roles so every account can manage body measurements out of the box

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d068673c14832d882c0d88abc4c5da