### PR TITLE
Add Gravatar signup link

### DIFF
--- a/src/components/members/profile-form.tsx
+++ b/src/components/members/profile-form.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import type { ChangeEvent, FormEvent } from "react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
@@ -431,6 +432,19 @@ export function ProfileForm({
                 <span>Eigenes Bild</span>
               </label>
             </div>
+
+            <p className="text-xs text-muted-foreground">
+              Du nutzt Gravatar noch nicht?{" "}
+              <Link
+                href="https://gravatar.com"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="font-medium text-foreground underline underline-offset-4"
+              >
+                Lege dir kostenlos ein Profil an
+              </Link>
+              , um dein Bild über deine E-Mail-Adresse zu steuern.
+            </p>
 
             {avatarSource === "UPLOAD" && (
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- add an external link in the profile avatar section so members can create a Gravatar account directly
- import Next.js Link to support the new call-to-action copy

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d08758a2b0832d9d39543ed9628e83