### PR TITLE
Add onboarding notes field

### DIFF
--- a/prisma/migrations/20260604120000_onboarding_profile_notes/migration.sql
+++ b/prisma/migrations/20260604120000_onboarding_profile_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."MemberOnboardingProfile" ADD COLUMN "notes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1025,6 +1025,7 @@ model MemberOnboardingProfile {
   redemptionId String?         @unique
   focus        OnboardingFocus
   background   String?
+  notes        String?
   gender       String?
   memberSinceYear Int?
   dietaryPreference String?

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -136,6 +136,7 @@ export default async function MemberProfileAdminPage({ params }: PageProps) {
           memberSinceYear: true,
           focus: true,
           background: true,
+          notes: true,
         },
       },
       interests: {
@@ -200,6 +201,7 @@ export default async function MemberProfileAdminPage({ params }: PageProps) {
   const onboardingFocusLabel = onboardingFocus ? ONBOARDING_FOCUS_LABELS[onboardingFocus] : "Kein Schwerpunkt hinterlegt";
 
   const onboardingBackground = member.onboardingProfile?.background?.trim() ?? null;
+  const onboardingNotes = member.onboardingProfile?.notes?.trim() ?? null;
 
   const email = member.email?.trim() ?? null;
   const dateOfBirthLabel = formatDate(member.dateOfBirth);
@@ -312,6 +314,9 @@ export default async function MemberProfileAdminPage({ params }: PageProps) {
                 <p className="mt-2 text-sm text-muted-foreground">{onboardingFocusLabel}</p>
                 {onboardingBackground ? (
                   <p className="mt-2 text-xs text-muted-foreground">{onboardingBackground}</p>
+                ) : null}
+                {onboardingNotes ? (
+                  <p className="mt-2 whitespace-pre-wrap text-xs text-muted-foreground">{onboardingNotes}</p>
                 ) : null}
               </div>
 

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -110,7 +110,7 @@ export async function GET() {
       }),
       prisma.memberOnboardingProfile.findUnique({
         where: { userId },
-        select: { focus: true, background: true, createdAt: true, updatedAt: true },
+        select: { focus: true, background: true, notes: true, createdAt: true, updatedAt: true },
       }),
       prisma.memberRolePreference.findMany({
         where: { userId },
@@ -183,6 +183,7 @@ export async function GET() {
       completedAt: onboardingProfile?.createdAt?.toISOString() ?? null,
       focus: onboardingProfile?.focus ?? null,
       background: onboardingProfile?.background ?? null,
+      notes: onboardingProfile?.notes ?? null,
       stats: {
         acting: { count: actingPreferences.length, averageWeight: averageWeight(actingPreferences) },
         crew: { count: crewPreferences.length, averageWeight: averageWeight(crewPreferences) },

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -108,6 +108,7 @@ const payloadSchema = z.object({
   email: z.string().email(),
   password: z.string().min(6).max(128),
   background: z.string().min(2),
+  notes: z.string().max(1000).optional().nullable(),
   dateOfBirth: z.string().optional().nullable(),
   gender: genderSchema,
   memberSinceYear: z.number().int().min(1900).max(CURRENT_YEAR).optional().nullable(),
@@ -180,6 +181,7 @@ export async function POST(request: NextRequest) {
   const lastName = payload.lastName.trim();
   const fullName = combineNameParts(firstName, lastName) ?? null;
   const background = payload.background.trim();
+  const notes = normalizeString(payload.notes);
   const focus = payload.focus;
   const password = payload.password;
   const preferences = payload.preferences.filter((pref) => pref.weight > 0);
@@ -301,6 +303,7 @@ export async function POST(request: NextRequest) {
     email,
     focus,
     background,
+    notes,
     dateOfBirth: dateOfBirth ? dateOfBirth.toISOString() : null,
     gender: {
       option: genderOption,
@@ -369,6 +372,7 @@ export async function POST(request: NextRequest) {
           redemptionId: redemption.id,
           focus,
           background,
+          notes: notes ?? undefined,
           gender: genderDisplay,
           memberSinceYear: memberSinceYear ?? undefined,
           dietaryPreference: dietaryStyleDisplay,

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -67,6 +67,7 @@ interface OnboardingOverview {
   completedAt: Date | null;
   focus: "acting" | "tech" | "both" | null;
   background: string | null;
+  notes: string | null;
   stats: {
     acting: OnboardingDomainStats;
     crew: OnboardingDomainStats;
@@ -281,6 +282,7 @@ function parseOnboardingOverview(value: unknown): OnboardingOverview | null {
   const focusRaw = value.focus;
   const focus = isFocusValue(focusRaw) ? focusRaw : null;
   const background = typeof value.background === "string" && value.background.trim() ? value.background : null;
+  const notes = typeof value.notes === "string" && value.notes.trim() ? value.notes : null;
   const completedAt = parseIsoDate(value.completedAt);
 
   const statsRecord = isRecord(value.stats) ? value.stats : {};
@@ -332,6 +334,7 @@ function parseOnboardingOverview(value: unknown): OnboardingOverview | null {
     completedAt,
     focus,
     background,
+    notes,
     stats: {
       acting: actingStats,
       crew: crewStats,
@@ -679,6 +682,9 @@ export function MembersDashboard() {
                   {onboarding.background}
                 </Badge>
               </div>
+            )}
+            {onboarding.notes && (
+              <p className="text-xs text-muted-foreground whitespace-pre-wrap">{onboarding.notes}</p>
             )}
           </div>
 

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -315,6 +315,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
     password: "",
     passwordConfirm: "",
     background: "",
+    notes: "",
     dateOfBirth: "",
     genderOption: "no_answer" as GenderOption,
     genderCustom: "",
@@ -812,6 +813,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
       const trimmedYear = form.memberSinceYear.trim();
       const parsedYear = trimmedYear ? Number.parseInt(trimmedYear, 10) : Number.NaN;
       const memberSinceYear = Number.isFinite(parsedYear) ? parsedYear : null;
+      const notes = form.notes.trim();
       const payload = {
         sessionToken,
         firstName: form.firstName.trim(),
@@ -819,6 +821,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
         email: form.email.trim(),
         password: form.password,
         background: form.background.trim(),
+        notes: notes || null,
         dateOfBirth: form.dateOfBirth ? form.dateOfBirth : null,
         gender: {
           option: form.genderOption,
@@ -1042,6 +1045,19 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                 />
               </label>
             </div>
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Gibt es noch etwas, das wir wissen sollten?</span>
+              <Textarea
+                value={form.notes}
+                onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+                placeholder="Optional: Besondere Erfahrungen, Wünsche oder Hinweise für das Team"
+                className="min-h-[120px]"
+                maxLength={1000}
+              />
+              <span className="text-xs text-muted-foreground">
+                Dieser Freitext hilft uns, dich besser kennenzulernen. Du kannst ihn später jederzeit anpassen.
+              </span>
+            </label>
             <div className="grid gap-4 md:grid-cols-2">
               <label className="space-y-1 text-sm">
                 <span className="font-medium">Passwort</span>
@@ -1765,6 +1781,16 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                     </Badge>
                   ) : (
                     <span className="text-xs text-muted-foreground">Keine Angaben</span>
+                  )}
+                </div>
+                <div className="mt-4 space-y-2">
+                  <span className="text-xs uppercase tracking-wide text-muted-foreground">Freitext</span>
+                  {form.notes ? (
+                    <p className="rounded-lg border border-border/60 bg-background/80 p-3 text-sm leading-relaxed text-foreground/80">
+                      {form.notes}
+                    </p>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Keine zusätzlichen Hinweise</span>
                   )}
                 </div>
               </section>

--- a/src/lib/onboarding-analytics.ts
+++ b/src/lib/onboarding-analytics.ts
@@ -9,6 +9,7 @@ export type OnboardingTalentProfile = {
   email: string | null;
   focus: OnboardingFocus;
   background: string | null;
+  notes: string | null;
   gender: string | null;
   memberSinceYear: number | null;
   inviteLabel: string | null;
@@ -223,6 +224,7 @@ export async function collectOnboardingAnalytics(now: Date = new Date()): Promis
         email: user?.email?.trim() || null,
         focus: profile.focus,
         background: profile.background?.trim() || null,
+        notes: profile.notes?.trim() || null,
         gender: profile.gender?.trim() || null,
         memberSinceYear: profile.memberSinceYear ?? null,
         inviteLabel: profile.invite?.label?.trim() || null,


### PR DESCRIPTION
## Summary
- add an optional notes textarea to the onboarding wizard and show it in the summary
- persist the new notes field via the onboarding API, Prisma schema and migration
- surface onboarding notes in the members dashboard, admin profile view and analytics exports

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d08737e0d8832db454d56540da25e0