### PR TITLE
Add Canterville chronik background

### DIFF
--- a/src/app/chronik/page.tsx
+++ b/src/app/chronik/page.tsx
@@ -46,6 +46,10 @@ const CHRONIK_POSTER_OVERRIDES: Record<string, PosterOverride> = {
     strategy: "replace",
     sources: ["/images/SNT_1.png", "/images/SNT_2.png"],
   },
+  "altrossthal-2016": {
+    strategy: "replace",
+    sources: ["/images/Canterville.png"],
+  },
   "altrossthal-2015": {
     strategy: "replace",
     sources: ["/images/RuJ_1.png", "/images/RuJ_2.png", "/images/RuJ_3.png", "/images/RuJ_4.png"],


### PR DESCRIPTION
## Summary
- add a poster override so the 2016 "Das Gespenst von Canterville" chronik entry uses the Canterville background image

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d08b4d4f1c832dab48b93c09e11065