### PR TITLE
Refactor member profile with completion workflow

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -1,243 +1,187 @@
 import { notFound } from "next/navigation";
-import { PageHeader } from "@/components/members/page-header";
-import { PhotoConsentCard } from "@/components/members/photo-consent-card";
-import { ProfileForm } from "@/components/members/profile-form";
-import { ProfileInterestsCard } from "@/components/members/profile-interests-card";
-import { ProfileSummaryCard } from "@/components/members/profile-summary-card";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import type {
+  AllergyLevel,
+  MeasurementType,
+  MeasurementUnit,
+  Role,
+} from "@prisma/client";
+
+import { ProfilePageClient } from "@/components/members/profile-page-client";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
+import { sortRoles } from "@/lib/roles";
+import { buildPhotoConsentSummary } from "@/lib/photo-consent-summary";
+import { buildProfileChecklist } from "@/lib/profile-completion";
 import {
-  ROLE_BADGE_VARIANTS,
-  ROLE_DESCRIPTIONS,
-  ROLE_LABELS,
-  sortRoles,
-  type Role,
-} from "@/lib/roles";
-import { cn } from "@/lib/utils";
-import type { LucideIcon } from "lucide-react";
-import {
-  CheckCircle2,
-  Crown,
-  Gavel,
-  PiggyBank,
-  ShieldCheck,
-  UsersRound,
-  VenetianMask,
-  Wrench,
-} from "lucide-react";
-
-const ROLE_ICON_MAP: Record<Role, LucideIcon> = {
-  member: UsersRound,
-  cast: VenetianMask,
-  tech: Wrench,
-  board: Gavel,
-  finance: PiggyBank,
-  owner: Crown,
-  admin: ShieldCheck,
-};
-
-const ROLE_ICON_ACCENTS: Record<Role, string> = {
-  member: "border-emerald-400/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-200",
-  cast: "border-fuchsia-400/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-200",
-  tech: "border-sky-400/40 bg-sky-500/10 text-sky-600 dark:text-sky-200",
-  board: "border-teal-400/40 bg-teal-500/10 text-teal-600 dark:text-teal-200",
-  finance: "border-amber-400/40 bg-amber-500/10 text-amber-600 dark:text-amber-200",
-  owner: "border-purple-400/40 bg-purple-500/10 text-purple-600 dark:text-purple-200",
-  admin: "border-rose-400/40 bg-rose-500/10 text-rose-600 dark:text-rose-200",
-};
-
-const ROLE_STATUS_BADGE_CLASSES =
-  "border-emerald-400/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200";
+  DEFAULT_STRICTNESS_FOR_NONE,
+  parseDietaryStrictnessFromLabel,
+  parseDietaryStyleFromLabel,
+  type DietaryStrictnessOption,
+} from "@/data/dietary-preferences";
 
 export default async function ProfilePage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.profil");
+
   if (!allowed) {
     return <div className="text-sm text-destructive">Kein Zugriff auf den Profilbereich</div>;
   }
+
   const userId = session.user?.id;
 
   if (!userId) {
     notFound();
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: {
-      firstName: true,
-      lastName: true,
-      name: true,
-      email: true,
-      role: true,
-      roles: { select: { role: true } },
-      avatarSource: true,
-      avatarImageUpdatedAt: true,
-      dateOfBirth: true,
-    },
-  });
+  const canManageMeasurements = await hasPermission(
+    session.user,
+    "mitglieder.koerpermasse",
+  );
+
+  const [user, measurementRecords, allergyRecords] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        firstName: true,
+        lastName: true,
+        name: true,
+        email: true,
+        role: true,
+        roles: { select: { role: true } },
+        avatarSource: true,
+        avatarImageUpdatedAt: true,
+        dateOfBirth: true,
+        onboardingProfile: {
+          select: {
+            dietaryPreference: true,
+            dietaryPreferenceStrictness: true,
+          },
+        },
+        photoConsent: {
+          select: {
+            status: true,
+            createdAt: true,
+            updatedAt: true,
+            approvedAt: true,
+            rejectionReason: true,
+            documentUploadedAt: true,
+            documentName: true,
+            approvedBy: { select: { name: true } },
+          },
+        },
+      },
+    }),
+    canManageMeasurements
+      ? prisma.memberMeasurement.findMany({
+          where: { userId },
+          orderBy: { type: "asc" },
+        })
+      : Promise.resolve([]),
+    prisma.dietaryRestriction.findMany({
+      where: { userId, isActive: true },
+      orderBy: { allergen: "asc" },
+      select: {
+        allergen: true,
+        level: true,
+        symptoms: true,
+        treatment: true,
+        note: true,
+        updatedAt: true,
+      },
+    }),
+  ]);
 
   if (!user) {
     notFound();
   }
 
-  const roles = sortRoles([user.role as Role, ...user.roles.map((r) => r.role as Role)]);
+  const roles = sortRoles([
+    user.role as Role,
+    ...user.roles.map((role) => role.role as Role),
+  ]);
+
+  const measurements = canManageMeasurements
+    ? measurementRecords.map((entry) => ({
+        id: entry.id,
+        type: entry.type as MeasurementType,
+        value: entry.value,
+        unit: entry.unit as MeasurementUnit,
+        note: entry.note,
+        updatedAt: entry.updatedAt.toISOString(),
+      }))
+    : [];
+
+  const allergies = allergyRecords.map((entry) => ({
+    allergen: entry.allergen,
+    level: entry.level as AllergyLevel,
+    symptoms: entry.symptoms,
+    treatment: entry.treatment,
+    note: entry.note,
+    updatedAt: entry.updatedAt.toISOString(),
+  }));
+
+  const styleInfo = parseDietaryStyleFromLabel(
+    user.onboardingProfile?.dietaryPreference ?? null,
+  );
+  const strictnessValue = parseDietaryStrictnessFromLabel(
+    user.onboardingProfile?.dietaryPreferenceStrictness ?? null,
+  );
+  const normalizedStrictness: DietaryStrictnessOption =
+    styleInfo.style === "none" ? DEFAULT_STRICTNESS_FOR_NONE : strictnessValue;
+
+  const photoSummary = buildPhotoConsentSummary({
+    dateOfBirth: user.dateOfBirth,
+    photoConsent: user.photoConsent
+      ? {
+          status: user.photoConsent.status,
+          createdAt: user.photoConsent.createdAt ?? undefined,
+          updatedAt: user.photoConsent.updatedAt ?? undefined,
+          approvedAt: user.photoConsent.approvedAt ?? undefined,
+          rejectionReason: user.photoConsent.rejectionReason ?? null,
+          documentUploadedAt: user.photoConsent.documentUploadedAt ?? null,
+          documentName: user.photoConsent.documentName ?? null,
+          approvedByName: user.photoConsent.approvedBy?.name ?? null,
+        }
+      : null,
+  });
+
+  const checklist = buildProfileChecklist({
+    hasBasicData: Boolean(user.firstName && user.lastName && user.email),
+    hasBirthdate: Boolean(user.dateOfBirth),
+    hasDietaryPreference: Boolean(
+      user.onboardingProfile?.dietaryPreference?.trim(),
+    ),
+    hasMeasurements: canManageMeasurements ? measurements.length > 0 : undefined,
+    photoConsent: {
+      consentGiven:
+        photoSummary.status === "pending" || photoSummary.status === "approved",
+    },
+  });
 
   return (
-    <div className="relative space-y-10 sm:space-y-12">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-64 bg-gradient-to-b from-primary/10 via-transparent to-transparent blur-3xl"
-      />
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute -bottom-40 left-1/2 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-secondary/15 blur-3xl dark:bg-secondary/20"
-      />
-      <section className="relative overflow-hidden rounded-3xl border border-border/50 bg-background/80 px-6 py-8 shadow-xl shadow-primary/10 backdrop-blur sm:px-8">
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -left-24 top-0 h-44 w-44 rounded-full bg-primary/15 opacity-60 blur-3xl dark:bg-primary/25"
-        />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -right-16 bottom-0 h-36 w-36 rounded-full bg-amber-200/30 opacity-70 blur-3xl dark:bg-amber-500/15"
-        />
-        <PageHeader
-          title="Mein Profil"
-          description="Halte deine Stammdaten aktuell und behalte im Blick, welche Rollen dir Zugriff auf die Module geben."
-        />
-        <div className="mt-6 flex flex-wrap items-center gap-2 text-xs sm:text-sm">
-          <Badge
-            variant="outline"
-            size="sm"
-            className="flex items-center gap-2 border-primary/30 bg-primary/10 text-primary/80"
-          >
-            <UsersRound className="h-3.5 w-3.5" aria-hidden />
-            {roles.length === 1 ? "1 aktive Rolle" : `${roles.length} aktive Rollen`}
-          </Badge>
-          <Badge
-            variant="outline"
-            size="sm"
-            className="flex items-center gap-2 border-muted-foreground/20 bg-muted/20 text-muted-foreground"
-          >
-            <ShieldCheck className="h-3.5 w-3.5" aria-hidden />
-            Datenpflege in Eigenregie
-          </Badge>
-        </div>
-      </section>
-
-      <div className="grid gap-6 lg:gap-8 xl:grid-cols-[minmax(0,380px)_minmax(0,1fr)] xl:items-start xl:gap-10 2xl:grid-cols-[minmax(0,420px)_minmax(0,1fr)] 2xl:gap-12">
-        <div className="space-y-6 xl:space-y-8">
-          <ProfileSummaryCard
-            userId={userId}
-            firstName={user.firstName}
-            lastName={user.lastName}
-            name={user.name}
-            email={user.email}
-            roles={roles}
-            avatarSource={user.avatarSource}
-            avatarUpdatedAt={user.avatarImageUpdatedAt?.toISOString() ?? null}
-          />
-
-          <PhotoConsentCard />
-
-          <Card className="rounded-2xl border border-border/60 bg-background/80 p-0 shadow-lg shadow-primary/10">
-            <CardHeader className="space-y-2 px-6 pb-4 pt-6 sm:px-7">
-              <CardTitle>Rollen &amp; Berechtigungen</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Deine Rollen steuern Sichtbarkeit und Handlungsrechte im Mitgliederportal. Wende dich bei fehlenden Rechten an die Administration.
-              </p>
-            </CardHeader>
-            <CardContent className="space-y-5 px-6 pb-6 sm:px-7">
-              {roles.length > 0 ? (
-                <>
-                  <div className="flex flex-wrap gap-2">
-                    {roles.map((role) => (
-                      <Badge
-                        key={role}
-                        className={cn(
-                          "px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide shadow-sm",
-                          ROLE_BADGE_VARIANTS[role],
-                        )}
-                      >
-                        {ROLE_LABELS[role] ?? role}
-                      </Badge>
-                    ))}
-                  </div>
-                  <ul className="space-y-3">
-                    {roles.map((role) => {
-                      const Icon = ROLE_ICON_MAP[role];
-                      const description = ROLE_DESCRIPTIONS[role] ?? "Diese Rolle ist aktuell aktiv.";
-                      return (
-                        <li
-                          key={role}
-                          className="flex gap-3 rounded-xl border border-border/60 bg-background/70 p-3 shadow-sm backdrop-blur"
-                        >
-                          <div
-                            className={cn(
-                              "flex h-10 w-10 items-center justify-center rounded-full border text-sm",
-                              ROLE_ICON_ACCENTS[role],
-                            )}
-                            aria-hidden
-                          >
-                            <Icon className="h-5 w-5" />
-                          </div>
-                          <div className="space-y-1.5">
-                            <div className="flex flex-wrap items-center gap-2">
-                              <span className="text-sm font-semibold text-foreground">{ROLE_LABELS[role] ?? role}</span>
-                              <Badge
-                                variant="outline"
-                                className={cn(
-                                  "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide",
-                                  ROLE_STATUS_BADGE_CLASSES,
-                                )}
-                              >
-                                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
-                                Aktiv
-                              </Badge>
-                            </div>
-                            <p className="text-xs text-muted-foreground">{description}</p>
-                          </div>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </>
-              ) : (
-                <div className="rounded-md border border-dashed border-border/60 bg-background/60 p-4 text-sm text-muted-foreground">
-                  Dir sind aktuell keine Rollen zugewiesen. Wende dich an die Produktionsleitung, wenn dir Inhalte fehlen.
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-        <div className="space-y-6 xl:space-y-8">
-          <Card className="rounded-2xl border border-border/60 bg-background/80 p-0 shadow-lg shadow-primary/10">
-            <CardHeader className="space-y-2 px-6 pb-4 pt-6 sm:px-7">
-              <CardTitle>Profildaten</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Name, Kontaktadresse und Passwort kannst du hier eigenständig anpassen. Änderungen werden sofort übernommen.
-              </p>
-            </CardHeader>
-            <CardContent className="space-y-0 px-6 pb-6 sm:px-7">
-              <ProfileForm
-                userId={userId}
-                initialFirstName={user.firstName}
-                initialLastName={user.lastName}
-                initialName={user.name}
-                initialEmail={user.email}
-                initialAvatarSource={user.avatarSource}
-                initialAvatarUpdatedAt={user.avatarImageUpdatedAt?.toISOString() ?? null}
-                initialDateOfBirth={user.dateOfBirth?.toISOString() ?? null}
-              />
-            </CardContent>
-          </Card>
-
-          <ProfileInterestsCard />
-        </div>
-      </div>
-    </div>
+    <ProfilePageClient
+      user={{
+        id: userId,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        name: user.name,
+        email: user.email ?? null,
+        roles,
+        avatarSource: user.avatarSource ?? null,
+        avatarUpdatedAt: user.avatarImageUpdatedAt?.toISOString() ?? null,
+        dateOfBirth: user.dateOfBirth?.toISOString() ?? null,
+      }}
+      checklist={checklist.items}
+      canManageMeasurements={canManageMeasurements}
+      measurements={measurements}
+      dietaryPreference={{
+        style: styleInfo.style,
+        customLabel: styleInfo.customLabel,
+        strictness: normalizedStrictness,
+      }}
+      allergies={allergies}
+      photoConsent={photoSummary}
+    />
   );
 }

--- a/src/app/api/profile/dietary/route.ts
+++ b/src/app/api/profile/dietary/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  DEFAULT_STRICTNESS_FOR_NONE,
+  dietaryPreferenceSchema,
+  resolveDietaryStrictnessLabel,
+  resolveDietaryStyleLabel,
+  type DietaryStrictnessOption,
+} from "@/data/dietary-preferences";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+
+function parseRequestBody(body: unknown) {
+  const result = dietaryPreferenceSchema.safeParse(body);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message ?? "Ungültige Eingaben.";
+    throw new Error(message);
+  }
+  return result.data;
+}
+
+export async function PUT(request: NextRequest) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const payload = await request.json().catch(() => null);
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  let parsed;
+  try {
+    parsed = parseRequestBody(payload);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Ungültige Eingaben.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const style = parsed.style;
+  const strictness: DietaryStrictnessOption =
+    style === "none" ? DEFAULT_STRICTNESS_FOR_NONE : parsed.strictness;
+  const customLabel = parsed.customLabel ?? null;
+
+  const { label: styleLabel, custom } = resolveDietaryStyleLabel(
+    style,
+    customLabel,
+  );
+  const strictnessLabel = resolveDietaryStrictnessLabel(style, strictness);
+
+  try {
+    const profile = await prisma.memberOnboardingProfile.upsert({
+      where: { userId },
+      update: {
+        dietaryPreference: styleLabel,
+        dietaryPreferenceStrictness: strictnessLabel,
+      },
+      create: {
+        userId,
+        focus: "acting",
+        dietaryPreference: styleLabel,
+        dietaryPreferenceStrictness: strictnessLabel,
+      },
+      select: {
+        dietaryPreference: true,
+        dietaryPreferenceStrictness: true,
+      },
+    });
+
+    return NextResponse.json({
+      preference: {
+        style,
+        strictness,
+        customLabel: custom,
+        label: profile.dietaryPreference,
+        strictnessLabel: profile.dietaryPreferenceStrictness,
+      },
+    });
+  } catch (error) {
+    console.error("[Profile][Dietary] update failed", error);
+    return NextResponse.json(
+      { error: "Speichern der Ernährungsangaben ist fehlgeschlagen." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/members/measurements/member-measurements-manager.tsx
+++ b/src/components/members/measurements/member-measurements-manager.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { MeasurementForm } from "@/components/forms/measurement-form";
+import { useProfileCompletion } from "@/components/members/profile-completion-context";
 import {
   MEASUREMENT_TYPE_LABELS,
   MEASUREMENT_UNIT_LABELS,
@@ -41,6 +42,7 @@ export function MemberMeasurementsManager({
   );
   const [dialogState, setDialogState] = useState<DialogState | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const { setItemComplete } = useProfileCompletion();
 
   const openCreateDialog = () => {
     setDialogState({ mode: "create" });
@@ -91,7 +93,9 @@ export function MemberMeasurementsManager({
       };
       setMeasurements((prev) => {
         const withoutType = prev.filter((entry) => entry.type !== saved.type);
-        return sortMeasurements([...withoutType, saved]);
+        const next = sortMeasurements([...withoutType, saved]);
+        setItemComplete("measurements", next.length > 0);
+        return next;
       });
       setDialogState(null);
     } finally {

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -66,7 +66,13 @@ function formatDate(value: string | null | undefined) {
   return dateFormatter.format(date);
 }
 
-export function PhotoConsentCard() {
+interface PhotoConsentCardProps {
+  onSummaryChange?: (summary: PhotoConsentSummary | null) => void;
+}
+
+export function PhotoConsentCard({
+  onSummaryChange,
+}: PhotoConsentCardProps = {}) {
   const [summary, setSummary] = useState<PhotoConsentSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -76,6 +82,10 @@ export function PhotoConsentCard() {
   const [documentError, setDocumentError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    onSummaryChange?.(summary);
+  }, [summary, onSummaryChange]);
 
   const load = useCallback(async () => {
     setLoading(true);

--- a/src/components/members/profile-checklist-card.tsx
+++ b/src/components/members/profile-checklist-card.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { CheckCircle2, Circle, Sparkles } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useProfileCompletion } from "@/components/members/profile-completion-context";
+import { cn } from "@/lib/utils";
+
+interface ProfileChecklistCardProps {
+  onNavigateToTab?: (tab: string) => void;
+}
+
+export function ProfileChecklistCard({
+  onNavigateToTab,
+}: ProfileChecklistCardProps) {
+  const { items, completed, total, isComplete } = useProfileCompletion();
+
+  const progress = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  return (
+    <Card className="relative overflow-hidden rounded-2xl border border-border/60 bg-gradient-to-br from-secondary/10 via-background/85 to-background/95 shadow-lg shadow-secondary/10">
+      <CardHeader className="space-y-4 px-6 pb-4 pt-6 sm:px-7">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-secondary">
+          <Sparkles className="h-4 w-4" />
+          Profil-Checkliste
+        </div>
+        <div className="flex flex-col gap-1">
+          <CardTitle className="text-xl">
+            {isComplete ? "Alles erledigt" : "Dein Profil wartet noch"}
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {isComplete
+              ? "Fantastisch! Alle Pflichtangaben sind auf dem neuesten Stand."
+              : `Du hast ${completed} von ${total} Aufgaben abgeschlossen.`}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5 px-6 pb-6 sm:px-7">
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted/30">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-secondary via-secondary/80 to-primary"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <ul className="space-y-3">
+          {items.map((item) => {
+            const Icon = item.complete ? CheckCircle2 : Circle;
+            return (
+              <li
+                key={item.id}
+                className="flex items-start justify-between gap-4 rounded-xl border border-border/50 bg-background/80 p-3 shadow-sm"
+              >
+                <div className="flex flex-1 gap-3">
+                  <div
+                    className={cn(
+                      "mt-0.5 flex h-6 w-6 items-center justify-center rounded-full border",
+                      item.complete
+                        ? "border-emerald-400/40 bg-emerald-500/15 text-emerald-500"
+                        : "border-border/60 bg-muted/30 text-muted-foreground",
+                    )}
+                  >
+                    <Icon className="h-3.5 w-3.5" aria-hidden />
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-foreground">
+                      {item.label}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {item.description}
+                    </p>
+                  </div>
+                </div>
+                {!item.complete && item.targetTab && onNavigateToTab ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="whitespace-nowrap"
+                    onClick={() => onNavigateToTab(item.targetTab!)}
+                  >
+                    Jetzt erledigen
+                  </Button>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/members/profile-completion-context.tsx
+++ b/src/components/members/profile-completion-context.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import type {
+  ProfileChecklistItem,
+  ProfileChecklistItemId,
+} from "@/lib/profile-completion";
+
+interface ProfileCompletionValue {
+  items: ProfileChecklistItem[];
+  completed: number;
+  total: number;
+  isComplete: boolean;
+  setItemComplete: (id: ProfileChecklistItemId, complete: boolean) => void;
+}
+
+const ProfileCompletionContext =
+  createContext<ProfileCompletionValue | null>(null);
+
+interface ProfileCompletionProviderProps {
+  initialItems: ProfileChecklistItem[];
+  children: React.ReactNode;
+}
+
+export function ProfileCompletionProvider({
+  initialItems,
+  children,
+}: ProfileCompletionProviderProps) {
+  const [items, setItems] = useState<ProfileChecklistItem[]>(initialItems);
+
+  const setItemComplete = useCallback(
+    (id: ProfileChecklistItemId, complete: boolean) => {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === id ? { ...item, complete } : item,
+        ),
+      );
+    },
+    [],
+  );
+
+  const completed = useMemo(
+    () => items.filter((item) => item.complete).length,
+    [items],
+  );
+  const total = items.length;
+  const isComplete = completed === total && total > 0;
+
+  const value = useMemo<ProfileCompletionValue>(
+    () => ({ items, completed, total, isComplete, setItemComplete }),
+    [items, completed, total, isComplete, setItemComplete],
+  );
+
+  return (
+    <ProfileCompletionContext.Provider value={value}>
+      {children}
+    </ProfileCompletionContext.Provider>
+  );
+}
+
+export function useProfileCompletion() {
+  const context = useContext(ProfileCompletionContext);
+  if (!context) {
+    throw new Error(
+      "useProfileCompletion muss innerhalb eines ProfileCompletionProvider verwendet werden.",
+    );
+  }
+  return context;
+}

--- a/src/components/members/profile-dietary-preferences.tsx
+++ b/src/components/members/profile-dietary-preferences.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AllergyLevel } from "@prisma/client";
+import { Loader2, Plus, Trash2, Pencil } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { AllergyForm } from "@/components/forms/allergy-form";
+import { useProfileCompletion } from "@/components/members/profile-completion-context";
+import {
+  DEFAULT_STRICTNESS_FOR_NONE,
+  DIETARY_STRICTNESS_OPTIONS,
+  DIETARY_STYLE_OPTIONS,
+  NONE_STRICTNESS_LABEL,
+  type DietaryStrictnessOption,
+  type DietaryStyleOption,
+  resolveDietaryStrictnessLabel,
+  resolveDietaryStyleLabel,
+} from "@/data/dietary-preferences";
+import { cn } from "@/lib/utils";
+
+const ALLERGY_LEVEL_STYLES: Record<AllergyLevel, string> = {
+  MILD: "border-emerald-400/40 bg-emerald-500/10 text-emerald-600",
+  MODERATE: "border-amber-400/40 bg-amber-500/10 text-amber-600",
+  SEVERE: "border-rose-400/40 bg-rose-500/10 text-rose-600",
+  LETHAL: "border-red-500/50 bg-red-500/10 text-red-600",
+};
+
+const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+
+type DietaryPreferenceState = {
+  style: DietaryStyleOption;
+  customLabel: string | null;
+  strictness: DietaryStrictnessOption;
+};
+
+type AllergyEntry = {
+  allergen: string;
+  level: AllergyLevel;
+  symptoms?: string | null;
+  treatment?: string | null;
+  note?: string | null;
+  updatedAt: string;
+};
+
+type DialogState =
+  | { mode: "create" }
+  | { mode: "edit"; entry: AllergyEntry };
+
+interface ProfileDietaryPreferencesProps {
+  initialPreference: DietaryPreferenceState;
+  initialAllergies: AllergyEntry[];
+}
+
+export function ProfileDietaryPreferences({
+  initialPreference,
+  initialAllergies,
+}: ProfileDietaryPreferencesProps) {
+  const { setItemComplete } = useProfileCompletion();
+  const [preference, setPreference] = useState<DietaryPreferenceState>(
+    initialPreference,
+  );
+  const [draftStyle, setDraftStyle] = useState<DietaryStyleOption>(
+    initialPreference.style,
+  );
+  const [draftStrictness, setDraftStrictness] =
+    useState<DietaryStrictnessOption>(initialPreference.strictness);
+  const [draftCustomStyle, setDraftCustomStyle] = useState(
+    initialPreference.customLabel ?? "",
+  );
+  const [savingPreference, setSavingPreference] = useState(false);
+  const [preferenceError, setPreferenceError] = useState<string | null>(null);
+
+  const [allergies, setAllergies] = useState<AllergyEntry[]>(() =>
+    sortAllergies(initialAllergies),
+  );
+  const [dialogState, setDialogState] = useState<DialogState | null>(null);
+  const [deletingAllergen, setDeletingAllergen] = useState<string | null>(null);
+
+  const styleRequiresCustom = draftStyle === "custom";
+  const strictnessDisabled = draftStyle === "none";
+
+  const hasPreferenceChanges = useMemo(() => {
+    const custom = draftCustomStyle.trim();
+    return (
+      draftStyle !== preference.style ||
+      draftStrictness !== preference.strictness ||
+      (styleRequiresCustom
+        ? custom !== (preference.customLabel ?? "")
+        : preference.customLabel !== null)
+    );
+  }, [draftStyle, draftStrictness, draftCustomStyle, preference, styleRequiresCustom]);
+
+  const preferenceLabel = useMemo(() => {
+    const { label } = resolveDietaryStyleLabel(
+      draftStyle,
+      draftCustomStyle,
+    );
+    return label;
+  }, [draftStyle, draftCustomStyle]);
+
+  const strictnessLabel = useMemo(() => {
+    return resolveDietaryStrictnessLabel(draftStyle, draftStrictness);
+  }, [draftStyle, draftStrictness]);
+
+  const handleSavePreference = async () => {
+    setPreferenceError(null);
+    if (styleRequiresCustom && !draftCustomStyle.trim()) {
+      setPreferenceError("Bitte beschreibe deinen Ernährungsstil.");
+      return;
+    }
+    setSavingPreference(true);
+    try {
+      const response = await fetch("/api/profile/dietary", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          style: draftStyle,
+          strictness: draftStrictness,
+          customLabel: styleRequiresCustom ? draftCustomStyle.trim() : null,
+        }),
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message =
+          typeof data?.error === "string"
+            ? data.error
+            : "Ernährungsstil konnte nicht gespeichert werden.";
+        throw new Error(message);
+      }
+      const payload = (data as { preference?: unknown })?.preference;
+      const nextPreference = normalizePreferencePayload(payload, {
+        style: draftStyle,
+        strictness: draftStrictness,
+        customLabel: styleRequiresCustom ? draftCustomStyle.trim() : null,
+      });
+      setPreference(nextPreference);
+      setDraftStyle(nextPreference.style);
+      setDraftStrictness(nextPreference.strictness);
+      setDraftCustomStyle(nextPreference.customLabel ?? "");
+      setItemComplete("dietary", true);
+      toast.success("Ernährungsinformationen aktualisiert.");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Ernährungsstil konnte nicht gespeichert werden.";
+      setPreferenceError(message);
+      toast.error(message);
+    } finally {
+      setSavingPreference(false);
+    }
+  };
+
+  const openCreateDialog = () => setDialogState({ mode: "create" });
+  const openEditDialog = (entry: AllergyEntry) =>
+    setDialogState({ mode: "edit", entry });
+  const closeDialog = () => setDialogState(null);
+
+  const handleAllergySubmit = async (data: {
+    allergen: string;
+    level: AllergyLevel;
+    symptoms?: string;
+    treatment?: string;
+    note?: string;
+  }) => {
+    const response = await fetch("/api/allergies", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      const payload = await response.json().catch(() => null);
+      const message =
+        typeof payload?.error === "string"
+          ? payload.error
+          : "Allergie konnte nicht gespeichert werden.";
+      throw new Error(message);
+    }
+    const saved = (await response.json().catch(() => null)) as
+      | (AllergyEntry & { id?: string })
+      | null;
+    const entry: AllergyEntry = {
+      allergen: saved?.allergen ?? data.allergen,
+      level: saved?.level ?? data.level,
+      symptoms: saved?.symptoms ?? data.symptoms,
+      treatment: saved?.treatment ?? data.treatment,
+      note: saved?.note ?? data.note,
+      updatedAt: saved?.updatedAt ?? new Date().toISOString(),
+    };
+    setAllergies((prev) =>
+      sortAllergies([
+        ...prev.filter(
+          (item) => item.allergen.toLowerCase() !== entry.allergen.toLowerCase(),
+        ),
+        entry,
+      ]),
+    );
+    setDialogState(null);
+  };
+
+  const handleDeleteAllergy = async (allergen: string) => {
+    setDeletingAllergen(allergen);
+    try {
+      const response = await fetch(
+        `/api/allergies?allergen=${encodeURIComponent(allergen)}`,
+        { method: "DELETE" },
+      );
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const message =
+          typeof payload?.error === "string"
+            ? payload.error
+            : "Allergie konnte nicht entfernt werden.";
+        throw new Error(message);
+      }
+      setAllergies((prev) =>
+        prev.filter(
+          (entry) => entry.allergen.toLowerCase() !== allergen.toLowerCase(),
+        ),
+      );
+      toast.success("Allergie entfernt.");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Allergie konnte nicht entfernt werden.";
+      toast.error(message);
+    } finally {
+      setDeletingAllergen(null);
+    }
+  };
+
+  return (
+    <Card className="rounded-2xl border border-border/60 bg-background/85 shadow-lg shadow-primary/5">
+      <CardHeader className="space-y-3 px-6 pb-4 pt-6 sm:px-7">
+        <div className="text-xs font-semibold uppercase tracking-wider text-primary">
+          Ernährung &amp; Verträglichkeiten
+        </div>
+        <CardTitle className="text-xl">Passe deinen Ernährungsstil an</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Teile uns mit, wie wir bei Verpflegung, Proben und Events auf dich achten
+          können und verwalte Allergien oder Unverträglichkeiten zentral.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6 px-6 pb-6 sm:px-7">
+        <section className="space-y-4 rounded-xl border border-border/60 bg-background/90 p-4 shadow-sm">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground/90">
+                Ernährungsstil
+              </label>
+              <Select value={draftStyle} onValueChange={(value) => {
+                const next = value as DietaryStyleOption;
+                setDraftStyle(next);
+                if (next === "none") {
+                  setDraftStrictness(DEFAULT_STRICTNESS_FOR_NONE);
+                }
+              }}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Wähle deinen Ernährungsstil" />
+                </SelectTrigger>
+                <SelectContent>
+                  {DIETARY_STYLE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground/90">
+                Strenge / Flexibilität
+              </label>
+              <Select
+                value={draftStrictness}
+                disabled={strictnessDisabled}
+                onValueChange={(value) =>
+                  setDraftStrictness(value as DietaryStrictnessOption)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Wie strikt ist deine Ernährung?" />
+                </SelectTrigger>
+                <SelectContent>
+                  {DIETARY_STRICTNESS_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {strictnessDisabled ? (
+                <p className="text-xs text-muted-foreground">
+                  {NONE_STRICTNESS_LABEL}
+                </p>
+              ) : null}
+            </div>
+            {styleRequiresCustom ? (
+              <div className="space-y-2 md:col-span-2">
+                <label className="text-sm font-medium text-foreground/90" htmlFor="profile-dietary-custom">
+                  Eigene Beschreibung
+                </label>
+                <Input
+                  id="profile-dietary-custom"
+                  value={draftCustomStyle}
+                  onChange={(event) => setDraftCustomStyle(event.target.value)}
+                  placeholder="z.B. Paleo, Clean Eating, Intervallfasten"
+                />
+              </div>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-border/50 bg-muted/20 p-3 text-xs text-muted-foreground">
+            <div>
+              <p className="font-medium text-foreground/80">Vorschau</p>
+              <p>{preferenceLabel}</p>
+              <p>{strictnessLabel}</p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSavePreference}
+              disabled={!hasPreferenceChanges || savingPreference}
+            >
+              {savingPreference ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Speichern …
+                </>
+              ) : (
+                "Einstellungen speichern"
+              )}
+            </Button>
+          </div>
+          {preferenceError ? (
+            <p className="text-xs text-destructive">{preferenceError}</p>
+          ) : null}
+        </section>
+
+        <section className="space-y-4 rounded-xl border border-border/60 bg-background/90 p-4 shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">
+                Allergien &amp; Unverträglichkeiten
+              </h3>
+              <p className="text-xs text-muted-foreground">
+                Hinterlege relevante Informationen für Notfälle und Planungen.
+              </p>
+            </div>
+            <Button type="button" size="sm" onClick={openCreateDialog}>
+              <Plus className="mr-2 h-4 w-4" /> Neu hinzufügen
+            </Button>
+          </div>
+          {allergies.length ? (
+            <ul className="space-y-3">
+              {allergies.map((entry) => (
+                <li
+                  key={entry.allergen}
+                  className="flex flex-col gap-3 rounded-lg border border-border/50 bg-background/80 p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-medium text-foreground">
+                        {entry.allergen}
+                      </p>
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          "text-[0.7rem]",
+                          ALLERGY_LEVEL_STYLES[entry.level],
+                        )}
+                      >
+                        {levelLabel(entry.level)}
+                      </Badge>
+                    </div>
+                    {entry.note ? (
+                      <p className="text-xs text-muted-foreground">
+                        Hinweis: {entry.note}
+                      </p>
+                    ) : null}
+                    {entry.symptoms ? (
+                      <p className="text-xs text-muted-foreground">
+                        Symptome: {entry.symptoms}
+                      </p>
+                    ) : null}
+                    {entry.treatment ? (
+                      <p className="text-xs text-muted-foreground">
+                        Behandlung: {entry.treatment}
+                      </p>
+                    ) : null}
+                    <p className="text-[11px] text-muted-foreground">
+                      Aktualisiert am {formatDate(entry.updatedAt)}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => openEditDialog(entry)}
+                    >
+                      <Pencil className="mr-2 h-3.5 w-3.5" /> Bearbeiten
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:bg-destructive/10"
+                      onClick={() => handleDeleteAllergy(entry.allergen)}
+                      disabled={deletingAllergen === entry.allergen}
+                    >
+                      {deletingAllergen === entry.allergen ? (
+                        <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Trash2 className="mr-2 h-3.5 w-3.5" />
+                      )}
+                      Entfernen
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+              Noch keine Allergien hinterlegt.
+            </div>
+          )}
+        </section>
+      </CardContent>
+
+      <Dialog open={dialogState !== null} onOpenChange={closeDialog}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {dialogState?.mode === "edit"
+                ? `${dialogState.entry.allergen} bearbeiten`
+                : "Neue Allergie hinzufügen"}
+            </DialogTitle>
+          </DialogHeader>
+          {dialogState ? (
+            <AllergyForm
+              initialData={
+                dialogState.mode === "edit"
+                  ? {
+                      allergen: dialogState.entry.allergen,
+                      level: dialogState.entry.level,
+                      symptoms: dialogState.entry.symptoms ?? "",
+                      treatment: dialogState.entry.treatment ?? "",
+                      note: dialogState.entry.note ?? "",
+                    }
+                  : undefined
+              }
+              onSubmit={async (data) => {
+                await handleAllergySubmit(data);
+              }}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}
+
+function normalizePreferencePayload(
+  payload: unknown,
+  fallback: DietaryPreferenceState,
+): DietaryPreferenceState {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "style" in payload &&
+    typeof (payload as { style?: unknown }).style === "string"
+  ) {
+    const styleRaw = (payload as { style: string }).style;
+    const style = isDietaryStyleOption(styleRaw) ? styleRaw : fallback.style;
+
+    const customRaw = (payload as { customLabel?: unknown }).customLabel;
+    const customLabel =
+      typeof customRaw === "string" ? customRaw.trim() || null : null;
+
+    const strictnessRaw = (payload as { strictness?: unknown }).strictness;
+    const strictness =
+      typeof strictnessRaw === "string" && isDietaryStrictnessOption(strictnessRaw)
+        ? (strictnessRaw as DietaryStrictnessOption)
+        : fallback.strictness;
+
+    return {
+      style,
+      customLabel,
+      strictness,
+    };
+  }
+  return fallback;
+}
+
+function sortAllergies(entries: AllergyEntry[]) {
+  return [...entries].sort((a, b) =>
+    a.allergen.localeCompare(b.allergen, "de-DE", {
+      sensitivity: "base",
+    }),
+  );
+}
+
+function levelLabel(level: AllergyLevel) {
+  switch (level) {
+    case "MILD":
+      return "Leicht";
+    case "MODERATE":
+      return "Mittel";
+    case "SEVERE":
+      return "Stark";
+    case "LETHAL":
+      return "Kritisch";
+    default:
+      return level;
+  }
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) {
+    return value;
+  }
+  return dateFormatter.format(date);
+}
+
+function isDietaryStyleOption(value: string): value is DietaryStyleOption {
+  return DIETARY_STYLE_OPTIONS.some((option) => option.value === value);
+}
+
+function isDietaryStrictnessOption(value: string): value is DietaryStrictnessOption {
+  return DIETARY_STRICTNESS_OPTIONS.some((option) => option.value === value);
+}

--- a/src/components/members/profile-form.tsx
+++ b/src/components/members/profile-form.tsx
@@ -11,6 +11,7 @@ import { UserAvatar } from "@/components/user-avatar";
 import type { AvatarSource } from "@/components/user-avatar";
 import { combineNameParts, splitFullName } from "@/lib/names";
 import { cn } from "@/lib/utils";
+import { useProfileCompletion } from "@/components/members/profile-completion-context";
 
 interface ProfileFormProps {
   initialFirstName?: string | null;
@@ -88,6 +89,7 @@ export function ProfileForm({
   const [removeAvatar, setRemoveAvatar] = useState(false);
   const [avatarError, setAvatarError] = useState<string | null>(null);
   const hasStoredAvatar = Boolean(avatarUpdatedAt);
+  const completion = useProfileCompletion();
 
   useEffect(() => {
     return () => {
@@ -268,6 +270,12 @@ export function ProfileForm({
       setRemoveAvatar(false);
       setSuccess("Profil wurde erfolgreich aktualisiert");
       toast.success("Profil wurde aktualisiert");
+
+      completion.setItemComplete(
+        "basics",
+        Boolean(updatedFirstName && updatedLastName && updatedEmail),
+      );
+      completion.setItemComplete("birthdate", Boolean(updatedDateOfBirthIso));
 
       // Aktualisiere die Session-Daten, damit Navigationskomponenten sofort aktualisiert werden.
       try {

--- a/src/components/members/profile-page-client.tsx
+++ b/src/components/members/profile-page-client.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { AllergyLevel, MeasurementType, MeasurementUnit, Role } from "@prisma/client";
+
+import { PageHeader } from "@/components/members/page-header";
+import { ProfileSummaryCard } from "@/components/members/profile-summary-card";
+import { ProfileForm } from "@/components/members/profile-form";
+import { ProfileInterestsCard } from "@/components/members/profile-interests-card";
+import { MemberMeasurementsManager } from "@/components/members/measurements/member-measurements-manager";
+import { ProfileCompletionProvider } from "@/components/members/profile-completion-context";
+import { ProfileChecklistCard } from "@/components/members/profile-checklist-card";
+import { ProfilePhotoConsentNotice } from "@/components/members/profile-photo-consent-notice";
+import { ProfileDietaryPreferences } from "@/components/members/profile-dietary-preferences";
+import { PhotoConsentCard } from "@/components/members/photo-consent-card";
+import type { ProfileChecklistItem } from "@/lib/profile-completion";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { AvatarSource } from "@/components/user-avatar";
+import type { PhotoConsentSummary } from "@/types/photo-consent";
+import type {
+  DietaryStrictnessOption,
+  DietaryStyleOption,
+} from "@/data/dietary-preferences";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  ROLE_BADGE_VARIANTS,
+  ROLE_DESCRIPTIONS,
+  ROLE_LABELS,
+} from "@/lib/roles";
+import {
+  CheckCircle2,
+  Crown,
+  Gavel,
+  PiggyBank,
+  ShieldCheck,
+  UsersRound,
+  VenetianMask,
+  Wrench,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+interface MeasurementEntry {
+  id: string;
+  type: MeasurementType;
+  value: number;
+  unit: MeasurementUnit;
+  note?: string | null;
+  updatedAt: string;
+}
+
+interface AllergyEntry {
+  allergen: string;
+  level: AllergyLevel;
+  symptoms?: string | null;
+  treatment?: string | null;
+  note?: string | null;
+  updatedAt: string;
+}
+
+interface ProfileUserSummary {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  name?: string | null;
+  email: string | null;
+  roles: Role[];
+  avatarSource: string | null;
+  avatarUpdatedAt: string | null;
+  dateOfBirth: string | null;
+}
+
+interface DietaryPreferenceState {
+  style: DietaryStyleOption;
+  customLabel: string | null;
+  strictness: DietaryStrictnessOption;
+}
+
+function toAvatarSource(value: string | null): AvatarSource | null {
+  if (!value) return null;
+  const normalized = value.toString().trim().toUpperCase();
+  return normalized === "GRAVATAR" || normalized === "UPLOAD" || normalized === "INITIALS"
+    ? (normalized as AvatarSource)
+    : null;
+}
+
+const ROLE_ICON_MAP: Record<Role, LucideIcon> = {
+  member: UsersRound,
+  cast: VenetianMask,
+  tech: Wrench,
+  board: Gavel,
+  finance: PiggyBank,
+  owner: Crown,
+  admin: ShieldCheck,
+};
+
+const ROLE_ICON_ACCENTS: Record<Role, string> = {
+  member: "border-emerald-400/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-200",
+  cast: "border-fuchsia-400/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-200",
+  tech: "border-sky-400/40 bg-sky-500/10 text-sky-600 dark:text-sky-200",
+  board: "border-teal-400/40 bg-teal-500/10 text-teal-600 dark:text-teal-200",
+  finance: "border-amber-400/40 bg-amber-500/10 text-amber-600 dark:text-amber-200",
+  owner: "border-purple-400/40 bg-purple-500/10 text-purple-600 dark:text-purple-200",
+  admin: "border-rose-400/40 bg-rose-500/10 text-rose-600 dark:text-rose-200",
+};
+
+const ROLE_STATUS_BADGE_CLASSES =
+  "border-emerald-400/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200";
+
+interface ProfilePageClientProps {
+  user: ProfileUserSummary;
+  checklist: ProfileChecklistItem[];
+  canManageMeasurements: boolean;
+  measurements: MeasurementEntry[];
+  dietaryPreference: DietaryPreferenceState;
+  allergies: AllergyEntry[];
+  photoConsent: PhotoConsentSummary | null;
+}
+
+function ProfileRolesCard({ roles }: { roles: Role[] }) {
+  if (!roles.length) {
+    return (
+      <Card className="rounded-2xl border border-border/60 bg-background/85 p-6 shadow-lg shadow-primary/10">
+        <CardHeader className="px-0 pt-0">
+          <CardTitle>Rollen &amp; Berechtigungen</CardTitle>
+        </CardHeader>
+        <CardContent className="px-0 pt-0">
+          <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+            Dir sind aktuell keine Rollen zugewiesen. Wende dich an die Produktionsleitung, wenn dir Inhalte fehlen.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="rounded-2xl border border-border/60 bg-background/85 p-0 shadow-lg shadow-primary/10">
+      <CardHeader className="space-y-2 px-6 pb-4 pt-6 sm:px-7">
+        <CardTitle>Rollen &amp; Berechtigungen</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Deine Rollen steuern Sichtbarkeit und Handlungsrechte im Mitgliederportal. Wende dich bei fehlenden Rechten an die Administration.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-5 px-6 pb-6 sm:px-7">
+        <div className="flex flex-wrap gap-2">
+          {roles.map((role) => (
+            <Badge
+              key={role}
+              className={cn(
+                "px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide shadow-sm",
+                ROLE_BADGE_VARIANTS[role],
+              )}
+            >
+              {ROLE_LABELS[role] ?? role}
+            </Badge>
+          ))}
+        </div>
+        <ul className="space-y-3">
+          {roles.map((role) => {
+            const Icon = ROLE_ICON_MAP[role];
+            const description =
+              ROLE_DESCRIPTIONS[role] ?? "Diese Rolle ist aktuell aktiv.";
+            return (
+              <li
+                key={role}
+                className="flex gap-3 rounded-xl border border-border/60 bg-background/70 p-3 shadow-sm backdrop-blur"
+              >
+                <div
+                  className={cn(
+                    "flex h-10 w-10 items-center justify-center rounded-full border text-sm",
+                    ROLE_ICON_ACCENTS[role],
+                  )}
+                  aria-hidden
+                >
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div className="space-y-1.5">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold text-foreground">
+                      {ROLE_LABELS[role] ?? role}
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide",
+                        ROLE_STATUS_BADGE_CLASSES,
+                      )}
+                    >
+                      <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+                      Aktiv
+                    </Badge>
+                  </div>
+                  <p className="text-xs text-muted-foreground">{description}</p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ProfilePageClient({
+  user,
+  checklist,
+  canManageMeasurements,
+  measurements,
+  dietaryPreference,
+  allergies,
+  photoConsent,
+}: ProfilePageClientProps) {
+  const [activeTab, setActiveTab] = useState("stammdaten");
+  const [photoSummary, setPhotoSummary] = useState<PhotoConsentSummary | null>(
+    photoConsent,
+  );
+
+  const handleNavigateToTab = useCallback((tab: string) => {
+    setActiveTab(tab);
+  }, []);
+
+  const handleManagePhoto = useCallback(() => {
+    setActiveTab("freigaben");
+  }, []);
+
+  const handlePhotoSummaryChange = useCallback(
+    (summary: PhotoConsentSummary | null) => {
+      setPhotoSummary(summary);
+    },
+    [],
+  );
+
+  return (
+    <ProfileCompletionProvider initialItems={checklist}>
+      <div className="relative space-y-10 sm:space-y-12">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-64 bg-gradient-to-b from-primary/10 via-transparent to-transparent blur-3xl"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -bottom-40 left-1/2 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-secondary/15 blur-3xl dark:bg-secondary/20"
+        />
+        <section className="rounded-3xl border border-border/60 bg-background/90 px-6 py-8 shadow-lg shadow-primary/10 sm:px-8">
+          <PageHeader
+            title="Mein Profil"
+            description="Halte deine Angaben aktuell, damit Teams und Kolleg:innen optimal planen können."
+          />
+          <div className="mt-6">
+            <ProfilePhotoConsentNotice
+              summary={photoSummary}
+              onManage={handleManagePhoto}
+            />
+          </div>
+        </section>
+
+        <div className="grid gap-6 lg:gap-8 xl:grid-cols-[minmax(0,380px)_minmax(0,1fr)] xl:items-start xl:gap-10 2xl:grid-cols-[minmax(0,420px)_minmax(0,1fr)] 2xl:gap-12">
+          <div className="space-y-6 xl:space-y-8">
+            <ProfileSummaryCard
+              userId={user.id}
+              firstName={user.firstName}
+              lastName={user.lastName}
+              name={user.name}
+              email={user.email}
+              roles={user.roles}
+              avatarSource={user.avatarSource}
+              avatarUpdatedAt={user.avatarUpdatedAt}
+            />
+
+            <ProfileRolesCard roles={user.roles} />
+
+            <ProfileChecklistCard onNavigateToTab={handleNavigateToTab} />
+          </div>
+
+          <div className="space-y-6 xl:space-y-8">
+            <div className="rounded-3xl border border-border/60 bg-background/90 p-6 shadow-lg shadow-primary/10 sm:p-7">
+              <Tabs value={activeTab} onValueChange={setActiveTab}>
+                <TabsList className="mb-6">
+                  <TabsTrigger value="stammdaten">Stammdaten</TabsTrigger>
+                  <TabsTrigger value="ernaehrung">Ernährung</TabsTrigger>
+                  {canManageMeasurements ? (
+                    <TabsTrigger value="masse">Maße</TabsTrigger>
+                  ) : null}
+                  <TabsTrigger value="interessen">Interessen</TabsTrigger>
+                  <TabsTrigger value="freigaben">Freigaben</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="stammdaten" className="space-y-4">
+                  <ProfileForm
+                    userId={user.id}
+                    initialFirstName={user.firstName}
+                    initialLastName={user.lastName}
+                    initialName={user.name}
+                    initialEmail={user.email}
+                    initialAvatarSource={toAvatarSource(user.avatarSource)}
+                    initialAvatarUpdatedAt={user.avatarUpdatedAt}
+                    initialDateOfBirth={user.dateOfBirth}
+                  />
+                </TabsContent>
+
+                <TabsContent value="ernaehrung">
+                  <ProfileDietaryPreferences
+                    initialPreference={dietaryPreference}
+                    initialAllergies={allergies}
+                  />
+                </TabsContent>
+
+                {canManageMeasurements ? (
+                  <TabsContent value="masse">
+                    <MemberMeasurementsManager initialMeasurements={measurements} />
+                  </TabsContent>
+                ) : null}
+
+                <TabsContent value="interessen">
+                  <ProfileInterestsCard />
+                </TabsContent>
+
+                <TabsContent value="freigaben">
+                  <PhotoConsentCard onSummaryChange={handlePhotoSummaryChange} />
+                </TabsContent>
+              </Tabs>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ProfileCompletionProvider>
+  );
+}

--- a/src/components/members/profile-photo-consent-notice.tsx
+++ b/src/components/members/profile-photo-consent-notice.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { AlertTriangle } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useProfileCompletion } from "@/components/members/profile-completion-context";
+import type { PhotoConsentSummary } from "@/types/photo-consent";
+
+interface ProfilePhotoConsentNoticeProps {
+  summary: PhotoConsentSummary | null;
+  onManage?: () => void;
+}
+
+function isConsentComplete(summary: PhotoConsentSummary | null): boolean {
+  if (!summary) return false;
+  if (summary.status === "none" || summary.status === "rejected") {
+    return false;
+  }
+  return true;
+}
+
+export function ProfilePhotoConsentNotice({
+  summary,
+  onManage,
+}: ProfilePhotoConsentNoticeProps) {
+  const { setItemComplete } = useProfileCompletion();
+
+  const consentComplete = isConsentComplete(summary);
+
+  // Synchronisiere den Completion-Status mit der Checkliste
+  useEffect(() => {
+    setItemComplete("photo-consent", consentComplete);
+  }, [consentComplete, setItemComplete]);
+
+  if (!summary) {
+    return null;
+  }
+
+  const needsBirthdate = summary.requiresDateOfBirth;
+  const needsDocument = summary.requiresDocument && !summary.hasDocument;
+  const statusIsPending = summary.status === "pending";
+
+  const shouldShowBanner =
+    !consentComplete || needsBirthdate || needsDocument;
+
+  if (!shouldShowBanner) {
+    return null;
+  }
+
+  let title = "Fotoeinverständnis ausstehend";
+  let description =
+    "Bitte bestätige dein Fotoeinverständnis, damit wir dich bei Produktionen und Marketing berücksichtigen können.";
+
+  if (summary.status === "rejected") {
+    title = "Fotoeinverständnis abgelehnt";
+    description =
+      "Die letzte Einreichung wurde abgelehnt. Bitte reiche die Erklärung erneut ein, damit wir dich berücksichtigen dürfen.";
+  } else if (needsBirthdate) {
+    description =
+      "Ergänze zuerst dein Geburtsdatum, um das Fotoeinverständnis abschließen zu können.";
+  } else if (needsDocument && !statusIsPending) {
+    description =
+      "Für Minderjährige benötigen wir zusätzlich das unterschriebene Dokument. Lade es hoch, um die Freigabe zu vervollständigen.";
+  }
+
+  return (
+    <div className="rounded-2xl border border-warning/45 bg-warning/10 p-4 text-sm text-warning shadow-[0_18px_48px_rgba(253,176,34,0.12)]">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="rounded-full border border-warning/40 bg-warning/15 p-2">
+            <AlertTriangle className="h-4 w-4" aria-hidden />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold">{title}</p>
+            <p className="text-xs text-warning/90">{description}</p>
+          </div>
+        </div>
+        {onManage ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="self-start border-warning/40 text-warning hover:bg-warning/10"
+            onClick={onManage}
+          >
+            Jetzt erledigen
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type ButtonHTMLAttributes,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+type TabsContextValue = {
+  value: string;
+  setValue: (value: string) => void;
+  idBase: string;
+};
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+function useTabsContext(component: string): TabsContextValue {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error(`${component} muss innerhalb von <Tabs> verwendet werden.`);
+  }
+  return context;
+}
+
+interface TabsProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function Tabs({
+  value: controlledValue,
+  defaultValue,
+  onValueChange,
+  className,
+  children,
+}: TabsProps) {
+  const [uncontrolledValue, setUncontrolledValue] = useState<string>(
+    defaultValue ?? "",
+  );
+  const value = controlledValue ?? uncontrolledValue;
+
+  useEffect(() => {
+    if (controlledValue === undefined && defaultValue !== undefined) {
+      setUncontrolledValue(defaultValue);
+    }
+  }, [controlledValue, defaultValue]);
+
+  const setValue = useCallback(
+    (next: string) => {
+      if (controlledValue === undefined) {
+        setUncontrolledValue(next);
+      }
+      onValueChange?.(next);
+    },
+    [controlledValue, onValueChange],
+  );
+
+  const idBase = useId();
+
+  const contextValue = useMemo<TabsContextValue>(
+    () => ({ value, setValue, idBase }),
+    [value, setValue, idBase],
+  );
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+interface TabsListProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function TabsList({ className, children }: TabsListProps) {
+  return (
+    <div
+      role="tablist"
+      aria-orientation="horizontal"
+      className={cn(
+        "inline-flex flex-wrap items-center gap-2 rounded-full bg-muted/40 p-1",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface TabsTriggerProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+
+export function TabsTrigger({
+  value,
+  className,
+  children,
+  ...props
+}: TabsTriggerProps) {
+  const { value: activeValue, setValue, idBase } = useTabsContext("TabsTrigger");
+  const isActive = activeValue === value;
+  const triggerId = `${idBase}-trigger-${value}`;
+  const panelId = `${idBase}-content-${value}`;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      id={triggerId}
+      aria-selected={isActive}
+      aria-controls={panelId}
+      tabIndex={isActive ? 0 : -1}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition",
+        isActive
+          ? "border-primary/60 bg-primary/15 text-primary shadow-sm"
+          : "border-transparent bg-transparent text-muted-foreground hover:border-primary/20 hover:bg-primary/10 hover:text-foreground",
+        className,
+      )}
+      onClick={(event) => {
+        props.onClick?.(event);
+        if (!event.defaultPrevented) {
+          setValue(value);
+        }
+      }}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface TabsContentProps {
+  value: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function TabsContent({ value, className, children }: TabsContentProps) {
+  const { value: activeValue, idBase } = useTabsContext("TabsContent");
+  const isActive = activeValue === value;
+  const panelId = `${idBase}-content-${value}`;
+  const triggerId = `${idBase}-trigger-${value}`;
+
+  return (
+    <div
+      role="tabpanel"
+      id={panelId}
+      aria-labelledby={triggerId}
+      hidden={!isActive}
+      className={cn("focus-visible:outline-none", !isActive && "hidden", className)}
+    >
+      {isActive ? children : null}
+    </div>
+  );
+}

--- a/src/data/dietary-preferences.ts
+++ b/src/data/dietary-preferences.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+
+export const DIETARY_STYLE_OPTIONS = [
+  { value: "none", label: "Keine besondere Ernährung" },
+  { value: "omnivore", label: "Allesesser:in" },
+  { value: "vegetarian", label: "Vegetarisch" },
+  { value: "vegan", label: "Vegan" },
+  { value: "pescetarian", label: "Pescetarisch" },
+  { value: "flexitarian", label: "Flexitarisch" },
+  { value: "halal", label: "Halal" },
+  { value: "kosher", label: "Koscher" },
+  { value: "custom", label: "Individueller Stil" },
+] as const;
+
+export type DietaryStyleOption = (typeof DIETARY_STYLE_OPTIONS)[number]["value"];
+
+export const DIETARY_STRICTNESS_OPTIONS = [
+  { value: "strict", label: "Strikt – keine Ausnahmen" },
+  { value: "flexible", label: "Flexibel – kleine Ausnahmen sind möglich" },
+  { value: "situational", label: "Situationsabhängig / nach Rücksprache" },
+] as const;
+
+export type DietaryStrictnessOption =
+  (typeof DIETARY_STRICTNESS_OPTIONS)[number]["value"];
+
+export const dietaryPreferenceSchema = z.object({
+  style: z.enum([
+    "none",
+    "omnivore",
+    "vegetarian",
+    "vegan",
+    "pescetarian",
+    "flexitarian",
+    "halal",
+    "kosher",
+    "custom",
+  ]),
+  customLabel: z
+    .string()
+    .max(120)
+    .optional()
+    .nullable()
+    .transform((value) => value?.trim() ?? null),
+  strictness: z.enum(["strict", "flexible", "situational"]),
+});
+
+export const DEFAULT_STRICTNESS_FOR_NONE: DietaryStrictnessOption = "flexible";
+export const NONE_STRICTNESS_LABEL = "Nicht relevant";
+
+export function resolveDietaryStyleLabel(
+  style: DietaryStyleOption,
+  customLabel?: string | null,
+): { label: string; custom: string | null } {
+  if (style === "custom") {
+    const normalized = customLabel?.trim() ?? "";
+    if (!normalized) {
+      return { label: DIETARY_STYLE_OPTIONS[0].label, custom: null };
+    }
+    return { label: normalized, custom: normalized };
+  }
+  const option = DIETARY_STYLE_OPTIONS.find((entry) => entry.value === style);
+  return {
+    label: option?.label ?? DIETARY_STYLE_OPTIONS[0].label,
+    custom: null,
+  };
+}
+
+export function resolveDietaryStrictnessLabel(
+  style: DietaryStyleOption,
+  strictness: DietaryStrictnessOption,
+): string {
+  if (style === "none") {
+    return NONE_STRICTNESS_LABEL;
+  }
+  const option = DIETARY_STRICTNESS_OPTIONS.find(
+    (entry) => entry.value === strictness,
+  );
+  return option?.label ?? DIETARY_STRICTNESS_OPTIONS[1].label;
+}
+
+export function parseDietaryStyleFromLabel(
+  label: string | null | undefined,
+): { style: DietaryStyleOption; customLabel: string | null } {
+  const trimmed = label?.trim();
+  if (!trimmed) {
+    return { style: "none", customLabel: null };
+  }
+  const match = DIETARY_STYLE_OPTIONS.find(
+    (option) => option.label.toLowerCase() === trimmed.toLowerCase(),
+  );
+  if (!match || match.value === "custom") {
+    return { style: "custom", customLabel: trimmed };
+  }
+  return { style: match.value, customLabel: null };
+}
+
+export function parseDietaryStrictnessFromLabel(
+  label: string | null | undefined,
+): DietaryStrictnessOption {
+  const trimmed = label?.trim();
+  if (!trimmed || trimmed === NONE_STRICTNESS_LABEL) {
+    return DEFAULT_STRICTNESS_FOR_NONE;
+  }
+  const match = DIETARY_STRICTNESS_OPTIONS.find(
+    (option) => option.label.toLowerCase() === trimmed.toLowerCase(),
+  );
+  return match?.value ?? DIETARY_STRICTNESS_OPTIONS[1].value;
+}

--- a/src/lib/photo-consent-summary.ts
+++ b/src/lib/photo-consent-summary.ts
@@ -1,0 +1,60 @@
+import type { PhotoConsentSummary } from "@/types/photo-consent";
+
+type ConsentRecord = {
+  status: "pending" | "approved" | "rejected" | "none";
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+  approvedAt?: Date | null;
+  rejectionReason?: string | null;
+  documentUploadedAt?: Date | null;
+  documentName?: string | null;
+  approvedByName?: string | null;
+};
+
+type PhotoConsentUserLike = {
+  dateOfBirth: Date | null;
+  photoConsent: ConsentRecord | null;
+};
+
+export function calculatePhotoConsentAge(
+  date: Date | null | undefined,
+): number | null {
+  if (!date) return null;
+  const now = new Date();
+  let age = now.getFullYear() - date.getFullYear();
+  const monthDiff = now.getMonth() - date.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < date.getDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+export function buildPhotoConsentSummary(
+  user: PhotoConsentUserLike,
+): PhotoConsentSummary {
+  const consent = user.photoConsent;
+  const dateOfBirth = user.dateOfBirth;
+  const age = calculatePhotoConsentAge(dateOfBirth);
+  const requiresDocument = age !== null && age < 18;
+  const requiresDateOfBirth = !dateOfBirth;
+
+  const status = consent?.status ?? "none";
+
+  return {
+    status,
+    requiresDocument,
+    requiresDateOfBirth,
+    hasDocument: Boolean(consent?.documentUploadedAt),
+    submittedAt: consent?.createdAt?.toISOString() ?? null,
+    updatedAt: consent?.updatedAt?.toISOString() ?? null,
+    approvedAt: consent?.approvedAt?.toISOString() ?? null,
+    approvedByName: consent?.approvedByName ?? null,
+    rejectionReason: consent?.rejectionReason ?? null,
+    age,
+    dateOfBirth: dateOfBirth ? dateOfBirth.toISOString() : null,
+    documentName: consent?.documentName ?? null,
+    documentUploadedAt: consent?.documentUploadedAt
+      ? consent.documentUploadedAt.toISOString()
+      : null,
+  };
+}

--- a/src/lib/profile-completion.ts
+++ b/src/lib/profile-completion.ts
@@ -1,0 +1,87 @@
+export type ProfileChecklistItemId =
+  | "basics"
+  | "birthdate"
+  | "dietary"
+  | "measurements"
+  | "photo-consent";
+
+export type ProfileChecklistItem = {
+  id: ProfileChecklistItemId;
+  label: string;
+  description: string;
+  complete: boolean;
+  targetTab?: string;
+};
+
+export type ProfileCompletionSummary = {
+  items: ProfileChecklistItem[];
+  completed: number;
+  total: number;
+  complete: boolean;
+};
+
+type ChecklistInput = {
+  hasBasicData: boolean;
+  hasBirthdate: boolean;
+  hasDietaryPreference: boolean;
+  hasMeasurements?: boolean;
+  photoConsent?: { consentGiven: boolean };
+};
+
+export function buildProfileChecklist(
+  input: ChecklistInput,
+): ProfileCompletionSummary {
+  const items: ProfileChecklistItem[] = [
+    {
+      id: "basics",
+      label: "Stammdaten aktualisiert",
+      description: "Vorname, Nachname und Kontaktadresse hinterlegt.",
+      complete: input.hasBasicData,
+      targetTab: "stammdaten",
+    },
+    {
+      id: "birthdate",
+      label: "Geburtsdatum eingetragen",
+      description: "Hilft bei der Verwaltung notwendiger Einverständnisse.",
+      complete: input.hasBirthdate,
+      targetTab: "stammdaten",
+    },
+    {
+      id: "dietary",
+      label: "Ernährungsstil gepflegt",
+      description: "Informationen für Verpflegung & Eventplanung.",
+      complete: input.hasDietaryPreference,
+      targetTab: "ernaehrung",
+    },
+  ];
+
+  if (input.hasMeasurements !== undefined) {
+    items.push({
+      id: "measurements",
+      label: "Körpermaße hinterlegt",
+      description: "Ermöglicht dem Kostüm-Team passgenaue Planung.",
+      complete: Boolean(input.hasMeasurements),
+      targetTab: "masse",
+    });
+  }
+
+  if (input.photoConsent) {
+    items.push({
+      id: "photo-consent",
+      label: "Fotoeinverständnis bestätigt",
+      description: "Notwendig für Medienarbeit und Außendarstellung.",
+      complete: Boolean(input.photoConsent.consentGiven),
+      targetTab: "freigaben",
+    });
+  }
+
+  const total = items.length;
+  const completed = items.filter((item) => item.complete).length;
+
+  return {
+    items,
+    completed,
+    total,
+    complete: completed === total,
+  };
+}


### PR DESCRIPTION
## Summary
- restructure the members profile page to load dietary preferences, measurements and checklist metadata
- add a client profile shell with completion context, tabs, dietary preferences UI and photo consent notice
- expose a dietary preference API and surface the incomplete profile banner on the dashboard

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d08de28910832d97972a7830fc75fa