### PR TITLE
feat(chronik): add detail pages for timeline entries

### DIFF
--- a/src/app/chronik/[showId]/page.tsx
+++ b/src/app/chronik/[showId]/page.tsx
@@ -1,0 +1,279 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { TextLink } from "@/components/ui/text-link";
+import { Heading, Text } from "@/components/ui/typography";
+
+import { PosterSlideshow } from "../poster-slideshow";
+import { getChronikItem } from "../data";
+import { formatChronikPlayerName } from "../formatters";
+import type { ChronikCastEntry, ChronikMeta } from "../types";
+
+type ChronikDetailPageProps = {
+  params: {
+    showId: string;
+  };
+};
+
+function buildPrimaryDetails(meta: ChronikMeta | null) {
+  if (!meta) {
+    return [] as { label: string; value: string }[];
+  }
+
+  const entries: { label: string; value: string }[] = [];
+
+  const append = (label: string, value: string | null | undefined) => {
+    if (value) {
+      entries.push({ label, value });
+    }
+  };
+
+  append("Autor", meta.author ?? null);
+  append("Regie", meta.director ?? null);
+  append("Ort", meta.venue ?? null);
+  append("Organisation", meta.organizer ?? null);
+  append("Tickets", meta.ticket_info ?? null);
+  append("Anreise", meta.transport ?? null);
+
+  return entries;
+}
+
+function sanitizeCast(meta: ChronikMeta | null) {
+  if (!meta || !Array.isArray(meta.cast)) {
+    return [] as ChronikCastEntry[];
+  }
+
+  return meta.cast;
+}
+
+export async function generateMetadata({ params }: ChronikDetailPageProps): Promise<Metadata> {
+  const item = await getChronikItem(params.showId);
+
+  if (!item) {
+    return {
+      title: "Chronik-Eintrag nicht gefunden",
+      description: "Der angeforderte Eintrag ist in unserer Chronik nicht verfügbar.",
+    };
+  }
+
+  const baseTitle = item.title ? `${item.title} (${item.year})` : `Saison ${item.year}`;
+
+  return {
+    title: `${baseTitle} – Chronik`,
+    description: item.synopsis ?? `Erfahre mehr über die Saison ${item.year} unserer Chronik.`,
+  };
+}
+
+export default async function ChronikDetailPage({ params }: ChronikDetailPageProps) {
+  const item = await getChronikItem(params.showId);
+
+  if (!item) {
+    notFound();
+  }
+
+  const heading = item.title ?? `Saison ${item.year}`;
+  const meta: ChronikMeta | null = item.meta ?? null;
+  const primaryDetails = buildPrimaryDetails(meta);
+  const castEntries = sanitizeCast(meta);
+  const sources = Array.isArray(meta?.sources) ? meta?.sources : [];
+  const quotes = Array.isArray(meta?.quotes) ? meta?.quotes : [];
+  const evidence = Array.isArray(meta?.evidence) ? meta?.evidence : [];
+  const gallery = Array.isArray(meta?.gallery) ? meta?.gallery : [];
+
+  return (
+    <div className="relative">
+      <div className="relative isolate overflow-hidden border-b border-border/60 bg-background">
+        <div className="relative h-[65vh] min-h-[420px] w-full">
+          {item.posterSources.length > 0 && (
+            <PosterSlideshow
+              sources={item.posterSources}
+              alt={heading}
+              priority
+            />
+          )}
+          <div className="absolute inset-0 bg-gradient-to-t from-[color:color-mix(in_oklab,var(--foreground)_75%,transparent)] via-[color:color-mix(in_oklab,var(--foreground)_35%,transparent)] to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-background/30 to-background/95" />
+          <div className="absolute inset-0 bg-[radial-gradient(ellipse_60rem_40rem_at_35%_70%,_color-mix(in_oklab,var(--primary)_12%,transparent),transparent_80%)]" />
+
+          <div className="absolute inset-0 flex items-end">
+            <div className="layout-container w-full py-12 sm:py-16">
+              <div className="mx-auto max-w-4xl space-y-6 rounded-3xl border border-border/60 bg-background/75 p-6 shadow-2xl backdrop-blur-sm sm:p-8">
+                <div className="flex flex-wrap items-center gap-3 text-sm font-medium text-muted-foreground">
+                  <TextLink asChild variant="ghost" weight="semibold">
+                    <Link href="/chronik" className="inline-flex items-center gap-2 text-foreground">
+                      <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.75 19.5L8.25 12l7.5-7.5" />
+                      </svg>
+                      Zur Chronik
+                    </Link>
+                  </TextLink>
+                  <Badge variant="default" className="bg-primary/20 text-primary">
+                    Saison {item.year}
+                  </Badge>
+                </div>
+
+                <Heading level="h1" className="text-balance text-3xl leading-tight sm:text-4xl md:text-5xl">
+                  {heading}
+                </Heading>
+
+                {item.synopsis ? (
+                  <Text className="max-w-3xl text-base leading-relaxed text-foreground/90 md:text-lg">
+                    {item.synopsis}
+                  </Text>
+                ) : (
+                  <Text className="max-w-3xl text-base leading-relaxed text-muted-foreground md:text-lg">
+                    Für diese Saison liegt uns aktuell keine Zusammenfassung vor. Wir ergänzen die Chronik, sobald neue Informationen verfügbar sind.
+                  </Text>
+                )}
+
+                {primaryDetails.length > 0 && (
+                  <dl className="grid gap-4 sm:grid-cols-2">
+                    {primaryDetails.map((detail) => (
+                      <div
+                        key={`${item.id}-${detail.label}`}
+                        className="rounded-2xl border border-border/60 bg-muted/40 p-4 text-foreground/90 shadow-inner"
+                      >
+                        <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+                          {detail.label}
+                        </dt>
+                        <dd className="mt-1 text-base font-semibold md:text-lg">
+                          {detail.value}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="layout-container space-y-16 py-16">
+        <section className="mx-auto max-w-3xl space-y-4">
+          <Heading level="h2">Über diese Saison</Heading>
+          {item.synopsis ? (
+            <Text className="text-base leading-relaxed text-foreground/90 md:text-lg">
+              {item.synopsis}
+            </Text>
+          ) : (
+            <Text className="text-base leading-relaxed text-muted-foreground md:text-lg">
+              Noch haben wir keine weiteren Hintergründe zu dieser Saison aufgezeichnet. Wenn du Informationen beitragen möchtest, freuen wir uns über eine Nachricht.
+            </Text>
+          )}
+        </section>
+
+        {castEntries.length > 0 && (
+          <section className="mx-auto max-w-5xl space-y-6">
+            <Heading level="h2">Ensemble &amp; Rollen</Heading>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {castEntries.map((entry, index) => (
+                <div
+                  key={`${item.id}-cast-${index}`}
+                  className="rounded-2xl border border-border/60 bg-background/80 p-4 shadow-sm backdrop-blur-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg"
+                >
+                  <Heading level="h3" asChild>
+                    <span className="text-lg font-semibold text-foreground">
+                      {entry.role}
+                    </span>
+                  </Heading>
+                  <Text className="mt-2 text-sm text-foreground/80 md:text-base">
+                    {entry.players
+                      .map((player) => formatChronikPlayerName(player))
+                      .filter(Boolean)
+                      .join(", ")}
+                  </Text>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {quotes.length > 0 && (
+          <section className="mx-auto max-w-4xl space-y-5">
+            <Heading level="h2">Pressestimmen</Heading>
+            <div className="space-y-4">
+              {quotes.map((quote, index) => (
+                <blockquote
+                  key={`${item.id}-quote-${index}`}
+                  className="rounded-3xl border border-border/60 bg-muted/40 p-6 text-lg italic text-foreground/90 shadow-inner"
+                >
+                  “{quote}”
+                </blockquote>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {evidence.length > 0 && (
+          <section className="mx-auto max-w-4xl space-y-4">
+            <Heading level="h2">Zeitzeugnisse</Heading>
+            <ul className="grid list-disc gap-3 pl-6 text-base text-foreground/80">
+              {evidence.map((snippet, index) => (
+                <li key={`${item.id}-evidence-${index}`}>{snippet}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {sources.length > 0 && (
+          <section className="mx-auto max-w-4xl space-y-5">
+            <Heading level="h2">Weiterführende Quellen</Heading>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {sources.map((src, index) => (
+                <a
+                  key={`${item.id}-source-${index}`}
+                  href={src}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group relative flex flex-col rounded-2xl border border-border/60 bg-background/80 p-4 text-sm text-foreground transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/50 hover:bg-background/90 hover:shadow-lg"
+                >
+                  <span className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
+                    <svg className="h-4 w-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                    </svg>
+                    Quelle {index + 1}
+                  </span>
+                  <span className="mt-2 break-words text-xs text-muted-foreground group-hover:text-foreground/80">
+                    {src}
+                  </span>
+                </a>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {gallery.length > 0 && (
+          <section className="mx-auto max-w-5xl space-y-5">
+            <Heading level="h2">Galerie</Heading>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {gallery.map((src, index) => (
+                <a
+                  key={`${item.id}-gallery-${index}`}
+                  href={src}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group relative block overflow-hidden rounded-2xl border border-border/60 bg-muted/40 shadow-sm transition-transform duration-300 hover:-translate-y-0.5 hover:shadow-lg"
+                >
+                  <div
+                    className="aspect-[4/3] w-full bg-cover bg-center transition-transform duration-500 group-hover:scale-105"
+                    style={{ backgroundImage: `url(${JSON.stringify(src)})` }}
+                  />
+                  <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/50 via-black/10 to-transparent" />
+                  <div className="pointer-events-none absolute bottom-3 left-3 flex items-center gap-2 text-sm font-semibold text-white drop-shadow-lg">
+                    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h18M3 19h18M5 5l1.5 14h11L19 5" />
+                    </svg>
+                    Bild {index + 1}
+                  </div>
+                </a>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/chronik/data.ts
+++ b/src/app/chronik/data.ts
@@ -1,0 +1,282 @@
+import { chronikFallbackShows } from "@/data/chronik-fallback";
+import { prisma } from "@/lib/prisma";
+import type { Prisma, Show } from "@prisma/client";
+
+import type { ChronikMeta, ChronikPreparedItem } from "./types";
+
+type ChronikShowRecord = Pick<Show, "id" | "year" | "title" | "synopsis" | "posterUrl" | "meta">;
+
+type PosterOverride =
+  | { strategy: "replace"; sources: string[] }
+  | { strategy: "append"; sources: string[] };
+
+const CHRONIK_POSTER_OVERRIDES: Record<string, PosterOverride> = {
+  "altrossthal-2024": {
+    strategy: "replace",
+    sources: ["/images/Bunbury_Flyer.jpg", "/images/Sequenz%2001.Standbild137.jpg"],
+  },
+  "altrossthal-2023": {
+    strategy: "replace",
+    sources: ["/images/Screenshot%202025-09-21%20234531.png"],
+  },
+  "altrossthal-2022": { strategy: "append", sources: ["/images/Aladin_Bühne.jpg"] },
+  "altrossthal-2018": {
+    strategy: "replace",
+    sources: ["/images/Screenshot%202025-09-21%20235339.png"],
+  },
+  "altrossthal-2017": {
+    strategy: "replace",
+    sources: ["/images/SNT_1.png", "/images/SNT_2.png"],
+  },
+  "altrossthal-2016": {
+    strategy: "replace",
+    sources: ["/images/Canterville.png"],
+  },
+  "altrossthal-2015": {
+    strategy: "replace",
+    sources: ["/images/RuJ_1.png", "/images/RuJ_2.png", "/images/RuJ_3.png", "/images/RuJ_4.png"],
+  },
+  "altrossthal-2014": {
+    strategy: "replace",
+    sources: ["/images/Faust_1.png", "/images/Faust_2.png"],
+  },
+};
+
+function sanitizePosterSources(sources: (string | null | undefined)[]) {
+  const unique = new Set<string>();
+  const sanitized: string[] = [];
+
+  for (const entry of sources) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+
+    const trimmed = entry.trim();
+    if (!trimmed || unique.has(trimmed)) {
+      continue;
+    }
+
+    unique.add(trimmed);
+    sanitized.push(trimmed);
+  }
+
+  return sanitized;
+}
+
+function getChronikPosterSources(show: ChronikShowRecord) {
+  const override = CHRONIK_POSTER_OVERRIDES[show.id];
+  const baseSources = sanitizePosterSources([show.posterUrl]);
+
+  if (!override) {
+    return baseSources;
+  }
+
+  const overrideSources = sanitizePosterSources(override.sources);
+
+  if (override.strategy === "replace") {
+    return overrideSources;
+  }
+
+  return sanitizePosterSources([...baseSources, ...overrideSources]);
+}
+
+function sanitizeStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const unique = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+
+    const trimmed = entry.trim();
+    if (!trimmed || unique.has(trimmed)) {
+      continue;
+    }
+
+    unique.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized.length > 0 ? normalized : null;
+}
+
+function parseShowMeta(meta: Prisma.JsonValue | null | undefined): ChronikMeta | null {
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+    return null;
+  }
+
+  const record = meta as Record<string, unknown>;
+  const stringOrNull = (value: unknown) => (typeof value === "string" ? value.trim() || null : null);
+  const stringArrayOrNull = (value: unknown) => sanitizeStringArray(value);
+  const castOrNull = (value: unknown): ChronikMeta["cast"] => {
+    if (!Array.isArray(value)) {
+      return null;
+    }
+
+    const castEntries = value
+      .map((entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return null;
+        }
+
+        const castRecord = entry as Record<string, unknown>;
+        const role = typeof castRecord.role === "string" ? castRecord.role.trim() : "";
+        const players = Array.isArray(castRecord.players)
+          ? castRecord.players
+              .filter((player): player is string => typeof player === "string" && player.trim().length > 0)
+              .map((player) => player.trim())
+          : [];
+
+        if (!role || players.length === 0) {
+          return null;
+        }
+
+        return { role, players };
+      })
+      .filter((entry): entry is NonNullable<ChronikMeta["cast"]>[number] => Boolean(entry));
+
+    return castEntries.length > 0 ? castEntries : null;
+  };
+
+  const metaRecord: ChronikMeta = {
+    author: stringOrNull(record.author),
+    director: stringOrNull(record.director),
+    venue: stringOrNull(record.venue ?? record.location),
+    ticket_info: stringOrNull(record.ticket_info),
+    organizer: stringOrNull(record.organizer),
+    transport: stringOrNull(record.transport),
+    sources: stringArrayOrNull(record.sources),
+    gallery: stringArrayOrNull(record.gallery ?? record.images),
+    evidence: stringArrayOrNull(record.evidence ?? record.evidence_snippets),
+    quotes: stringArrayOrNull(record.quotes ?? record.press_quotes),
+    cast: castOrNull(record.cast),
+  };
+
+  const hasValue = Object.values(metaRecord).some((value) => {
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+
+    return value != null;
+  });
+
+  return hasValue ? metaRecord : null;
+}
+
+const CHRONIK_SUPPLEMENTS: Record<string, Partial<ChronikMeta>> = {
+  "altrossthal-2024": {
+    cast: [
+      { role: "Jack Worthing", players: ["Luca Totzek"] },
+      { role: "Algernon Moncrieff", players: ["Yann Lindemann"] },
+      { role: "Lady Augusta Brachnell", players: ["Tobias Schneider"] },
+      { role: "Gwendolen Fairfax", players: ["Leonie Thea Tänzer", "Cosima Werner"] },
+      { role: "Cecily Dardew", players: ["Bashi Deutsch"] },
+      { role: "Miss Laetitia Prism", players: ["Helene Irmer"] },
+      { role: "Dr. Frederick Chasuble", players: ["Jonas Fehrmann"] },
+      { role: "Mary", players: ["Bianca Milke"] },
+      { role: "Lane", players: ["Nicklas Gretzel"] },
+      { role: "Diener", players: ["Bianca Milke", "Jonas Fehrmann"] },
+      {
+        role: "Amüsierdamen",
+        players: ["Sarah König", "Bashi Deutsch", "Mathilda Hoffmann", "Helene Irmer", "Mia Däbler"],
+      },
+      { role: "Gäste", players: ["Sebastian Seifert", "Lennart Neumeister", "Justus Schmeling"] },
+    ],
+  },
+};
+
+function applyChronikSupplements(id: string, meta: ChronikMeta | null): ChronikMeta | null {
+  const supplements = CHRONIK_SUPPLEMENTS[id];
+  if (!supplements) {
+    return meta;
+  }
+
+  const base: ChronikMeta = { ...(meta ?? {}) };
+  if ((!base.cast || base.cast.length === 0) && Array.isArray(supplements.cast)) {
+    const supplementedCast = supplements.cast
+      .map((entry) => ({
+        role: entry?.role ?? "",
+        players: Array.isArray(entry?.players) ? [...entry.players] : [],
+      }))
+      .filter((entry) => Boolean(entry.role) && entry.players.length > 0);
+
+    base.cast = supplementedCast.length > 0 ? supplementedCast : null;
+  }
+
+  return base;
+}
+
+async function fetchChronikRecords(): Promise<ChronikShowRecord[]> {
+  const now = new Date();
+
+  try {
+    const shows = await prisma.show.findMany({
+      where: { revealedAt: { not: null, lte: now } },
+      orderBy: [{ year: "desc" }],
+      select: {
+        id: true,
+        year: true,
+        title: true,
+        synopsis: true,
+        posterUrl: true,
+        meta: true,
+      },
+    });
+
+    if (shows.length > 0) {
+      return shows;
+    }
+  } catch {
+    // Prisma is optional in some environments; fall back to static data when unavailable.
+  }
+
+  return [...chronikFallbackShows];
+}
+
+function mapChronikRecord(record: ChronikShowRecord): ChronikPreparedItem {
+  return {
+    id: record.id,
+    year: record.year,
+    title: record.title ?? null,
+    synopsis: record.synopsis ?? null,
+    posterSources: getChronikPosterSources(record),
+    meta: applyChronikSupplements(record.id, parseShowMeta(record.meta)),
+  };
+}
+
+export async function getChronikItems(): Promise<ChronikPreparedItem[]> {
+  const records = await fetchChronikRecords();
+  return records.map((record) => mapChronikRecord(record));
+}
+
+export async function getChronikItem(id: string): Promise<ChronikPreparedItem | null> {
+  const now = new Date();
+
+  try {
+    const record = await prisma.show.findFirst({
+      where: { id, revealedAt: { not: null, lte: now } },
+      select: {
+        id: true,
+        year: true,
+        title: true,
+        synopsis: true,
+        posterUrl: true,
+        meta: true,
+      },
+    });
+
+    if (record) {
+      return mapChronikRecord(record);
+    }
+  } catch {
+    // ignore and fall back to static data
+  }
+
+  const fallback = chronikFallbackShows.find((entry) => entry.id === id);
+  return fallback ? mapChronikRecord(fallback) : null;
+}

--- a/src/app/chronik/formatters.ts
+++ b/src/app/chronik/formatters.ts
@@ -1,0 +1,20 @@
+export function formatChronikPlayerName(name: string) {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0];
+  }
+
+  const lastName = parts.pop() ?? "";
+  const lastInitial = lastName.charAt(0);
+  const firstNames = parts.join(" ");
+  if (!lastInitial) {
+    return trimmed;
+  }
+
+  return `${firstNames} ${lastInitial}.`;
+}

--- a/src/app/chronik/page.tsx
+++ b/src/app/chronik/page.tsx
@@ -1,224 +1,15 @@
 export const dynamic = "force-dynamic";
 
-import { chronikFallbackShows } from "@/data/chronik-fallback";
-import { prisma } from "@/lib/prisma";
-import type { Prisma, Show } from "@prisma/client";
 import { Heading, Text } from "@/components/ui/typography";
+
 import { ChronikStacked } from "./stacked";
 import { ChronikTimeline } from "./timeline";
-
-type ShowCastEntry = {
-  role: string;
-  players: string[];
-};
-
-type ChronikShowRecord = Pick<Show, "id" | "year" | "title" | "synopsis" | "posterUrl" | "meta">;
-
-type ShowMeta = {
-  author?: string | null;
-  director?: string | null;
-  venue?: string | null;
-  ticket_info?: string | null;
-  sources?: string[] | null;
-  gallery?: string[] | null;
-  cast?: ShowCastEntry[] | null;
-};
-
-type PosterOverride =
-  | { strategy: "replace"; sources: string[] }
-  | { strategy: "append"; sources: string[] };
-
-const CHRONIK_POSTER_OVERRIDES: Record<string, PosterOverride> = {
-  "altrossthal-2024": {
-    strategy: "replace",
-    sources: ["/images/Bunbury_Flyer.jpg", "/images/Sequenz%2001.Standbild137.jpg"],
-  },
-  "altrossthal-2023": {
-    strategy: "replace",
-    sources: ["/images/Screenshot%202025-09-21%20234531.png"],
-  },
-  "altrossthal-2022": { strategy: "append", sources: ["/images/Aladin_Bühne.jpg"] },
-  "altrossthal-2018": {
-    strategy: "replace",
-    sources: ["/images/Screenshot%202025-09-21%20235339.png"],
-  },
-  "altrossthal-2017": {
-    strategy: "replace",
-    sources: ["/images/SNT_1.png", "/images/SNT_2.png"],
-  },
-  "altrossthal-2016": {
-    strategy: "replace",
-    sources: ["/images/Canterville.png"],
-  },
-  "altrossthal-2015": {
-    strategy: "replace",
-    sources: ["/images/RuJ_1.png", "/images/RuJ_2.png", "/images/RuJ_3.png", "/images/RuJ_4.png"],
-  },
-  "altrossthal-2014": {
-    strategy: "replace",
-    sources: ["/images/Faust_1.png", "/images/Faust_2.png"],
-  },
-};
-
-function sanitizePosterSources(sources: (string | null | undefined)[]) {
-  const unique = new Set<string>();
-  const sanitized: string[] = [];
-
-  for (const entry of sources) {
-    if (typeof entry !== "string") {
-      continue;
-    }
-
-    const trimmed = entry.trim();
-    if (!trimmed || unique.has(trimmed)) {
-      continue;
-    }
-
-    unique.add(trimmed);
-    sanitized.push(trimmed);
-  }
-
-  return sanitized;
-}
-
-function getChronikPosterSources(show: ChronikShowRecord) {
-  const override = CHRONIK_POSTER_OVERRIDES[show.id];
-  const baseSources = sanitizePosterSources([show.posterUrl]);
-
-  if (!override) {
-    return baseSources;
-  }
-
-  const overrideSources = sanitizePosterSources(override.sources);
-
-  if (override.strategy === "replace") {
-    return overrideSources;
-  }
-
-  return sanitizePosterSources([...baseSources, ...overrideSources]);
-}
-
-function parseShowMeta(meta: Prisma.JsonValue | null | undefined): ShowMeta | null {
-  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
-    return null;
-  }
-
-  const record = meta as Record<string, unknown>;
-  const stringOrNull = (value: unknown) => (typeof value === "string" ? value : null);
-  const stringArrayOrNull = (value: unknown) =>
-    Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : null;
-  const castOrNull = (value: unknown): ShowCastEntry[] | null => {
-    if (!Array.isArray(value)) {
-      return null;
-    }
-
-    const castEntries = value
-      .map((entry) => {
-        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-          return null;
-        }
-
-        const castRecord = entry as Record<string, unknown>;
-        const role = typeof castRecord.role === "string" ? castRecord.role.trim() : "";
-        const players = Array.isArray(castRecord.players)
-          ? castRecord.players
-              .filter((player): player is string => typeof player === "string" && player.trim().length > 0)
-              .map((player) => player.trim())
-          : [];
-
-        if (!role || players.length === 0) {
-          return null;
-        }
-
-        return {
-          role,
-          players,
-        } satisfies ShowCastEntry;
-      })
-      .filter((entry): entry is ShowCastEntry => Boolean(entry));
-
-    return castEntries.length > 0 ? castEntries : null;
-  };
-
-  return {
-    author: stringOrNull(record.author),
-    director: stringOrNull(record.director),
-    venue: stringOrNull(record.venue),
-    ticket_info: stringOrNull(record.ticket_info),
-    sources: stringArrayOrNull(record.sources),
-    gallery: stringArrayOrNull(record.gallery),
-    cast: castOrNull(record.cast),
-  };
-}
-
-const CHRONIK_SUPPLEMENTS: Record<string, Partial<ShowMeta>> = {
-  "altrossthal-2024": {
-    cast: [
-      { role: "Jack Worthing", players: ["Luca Totzek"] },
-      { role: "Algernon Moncrieff", players: ["Yann Lindemann"] },
-      { role: "Lady Augusta Brachnell", players: ["Tobias Schneider"] },
-      { role: "Gwendolen Fairfax", players: ["Leonie Thea Tänzer", "Cosima Werner"] },
-      { role: "Cecily Dardew", players: ["Bashi Deutsch"] },
-      { role: "Miss Laetitia Prism", players: ["Helene Irmer"] },
-      { role: "Dr. Frederick Chasuble", players: ["Jonas Fehrmann"] },
-      { role: "Mary", players: ["Bianca Milke"] },
-      { role: "Lane", players: ["Nicklas Gretzel"] },
-      { role: "Diener", players: ["Bianca Milke", "Jonas Fehrmann"] },
-      {
-        role: "Amüsierdamen",
-        players: ["Sarah König", "Bashi Deutsch", "Mathilda Hoffmann", "Helene Irmer", "Mia Däbler"],
-      },
-      { role: "Gäste", players: ["Sebastian Seifert", "Lennart Neumeister", "Justus Schmeling"] },
-    ],
-  },
-};
-
-function applyChronikSupplements(id: string, meta: ShowMeta | null): ShowMeta | null {
-  const supplements = CHRONIK_SUPPLEMENTS[id];
-  if (!supplements) {
-    return meta;
-  }
-
-  const base: ShowMeta = { ...(meta ?? {}) };
-  if ((!base.cast || base.cast.length === 0) && Array.isArray(supplements.cast)) {
-    const supplementedCast = supplements.cast
-      .map((entry) => ({
-        role: entry.role ?? "",
-        players: Array.isArray(entry.players) ? [...entry.players] : [],
-      }))
-      .filter((entry): entry is ShowCastEntry => Boolean(entry.role) && entry.players.length > 0);
-
-    base.cast = supplementedCast.length > 0 ? supplementedCast : null;
-  }
-
-  return base;
-}
+import { getChronikItems } from "./data";
 
 export default async function ChronikPage() {
-  const now = new Date();
-  let shows: ChronikShowRecord[] = [];
-  try {
-    shows = await prisma.show.findMany({
-      where: { revealedAt: { not: null, lte: now } },
-      orderBy: [{ year: "desc" }],
-      select: {
-        id: true,
-        year: true,
-        title: true,
-        synopsis: true,
-        posterUrl: true,
-        meta: true,
-      },
-    });
-  } catch {
-    shows = [];
-  }
+  const items = await getChronikItems();
 
-  if (shows.length === 0) {
-    shows = [...chronikFallbackShows];
-  }
-
-  if (shows.length === 0) {
+  if (items.length === 0) {
     return (
       <div className="layout-container py-16">
         <div className="mx-auto max-w-2xl space-y-6 text-center">
@@ -238,24 +29,6 @@ export default async function ChronikPage() {
     );
   }
 
-  const items = shows.map((s) => ({
-    id: s.id,
-    year: s.year,
-    title: s.title,
-    synopsis: s.synopsis ?? null,
-    posterUrl: (() => {
-      const posterSources = getChronikPosterSources(s);
-      if (posterSources.length === 0) {
-        return null;
-      }
-      if (posterSources.length === 1) {
-        return posterSources[0];
-      }
-      return posterSources;
-    })(),
-    meta: applyChronikSupplements(s.id, parseShowMeta(s.meta)),
-  }));
-  
   return (
     <div className="relative">
       <div className="layout-container space-y-6 py-16 text-center">
@@ -268,7 +41,7 @@ export default async function ChronikPage() {
       </div>
 
       <ChronikStacked items={items} />
-      <ChronikTimeline items={items} />
+      <ChronikTimeline items={items.map((item) => ({ id: item.id, year: item.year, title: item.title }))} />
     </div>
   );
 }

--- a/src/app/chronik/types.ts
+++ b/src/app/chronik/types.ts
@@ -1,0 +1,27 @@
+export type ChronikCastEntry = {
+  role: string;
+  players: string[];
+};
+
+export type ChronikMeta = {
+  author?: string | null;
+  director?: string | null;
+  venue?: string | null;
+  ticket_info?: string | null;
+  organizer?: string | null;
+  transport?: string | null;
+  sources?: string[] | null;
+  gallery?: string[] | null;
+  evidence?: string[] | null;
+  quotes?: string[] | null;
+  cast?: ChronikCastEntry[] | null;
+};
+
+export type ChronikPreparedItem = {
+  id: string;
+  year: number;
+  title: string | null;
+  synopsis: string | null;
+  posterSources: string[];
+  meta: ChronikMeta | null;
+};


### PR DESCRIPTION
## Summary
- extract shared chronik data helpers to prepare poster sources and metadata for shows
- make chronik cards keyboard accessible, link to dedicated entries, and surface quick source links
- introduce a chronik detail view with hero layout, ensemble listing, sources, quotes, and gallery sections

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d092b3b850832d9e197cbbae970f25