### PR TITLE
Handle invalid finance booking dates

### DIFF
--- a/src/components/members/finance/finance-overview.tsx
+++ b/src/components/members/finance/finance-overview.tsx
@@ -29,6 +29,13 @@ function formatCurrency(amount: number, currency = "EUR") {
   }
 }
 
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.valueOf())) return "—";
+  return parsed.toLocaleDateString("de-DE");
+}
+
 function sortBudgets(list: FinanceBudgetDTO[]) {
   return [...list].sort((a, b) => {
     const yearA = a.show.year ?? 0;
@@ -229,7 +236,7 @@ export function FinanceOverview({
                     <div className="flex-1">
                       <div className="font-medium text-foreground">{entry.title}</div>
                       <div className="text-xs text-muted-foreground">
-                        {entry.show?.title ?? "Allgemein"} · {new Date(entry.bookingDate).toLocaleDateString("de-DE")}
+                        {entry.show?.title ?? "Allgemein"} · {formatDate(entry.bookingDate)}
                       </div>
                     </div>
                     <div className="text-right">


### PR DESCRIPTION
## Summary
- guard the finance dashboard against invalid bookingDate strings by adding a dedicated formatter
- reuse the formatter when rendering the recent bookings list so malformed dates no longer crash the page

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d0922c631c832da6a8ba6704cc39fc