### PR TITLE
Improve Sperrliste responsiveness on mobile

### DIFF
--- a/docs/sperrliste-responsiveness-study.md
+++ b/docs/sperrliste-responsiveness-study.md
@@ -1,0 +1,49 @@
+# Studie: Responsiveness und Mobilfreundlichkeit des Sperrlistenbereichs
+
+## Zielsetzung
+Die Studie bewertet den Sperrlistenbereich der Mitgliederoberfläche hinsichtlich Layout-Anpassungen über verschiedene Viewport-Breiten, Touch-Bedienbarkeit sowie Informationsdichte für mobile Nutzerinnen und Nutzer.
+
+## Methodik
+- Codeanalyse der relevanten Komponenten (`SperrlisteTabs`, `BlockCalendar`, `BlockOverview`, `MonthCalendar`) inklusive Tailwind-Klassen, konditionaler Renderings und ARIA-Attributen.
+- Ableitung der erwarteten Darstellung auf vier Breakpoint-Gruppen (unter 640 px, 640–767 px, 768–1023 px, ab 1024 px) auf Basis der eingesetzten `sm`-, `lg`- und `hidden`/`block`-Utility-Klassen.
+- Bewertung der Interaktionsmuster (z. B. horizontale Scrollcontainer, Mehrfachauswahl, Dialoge) im Hinblick auf Touch-Geräte.
+
+## Bereichsüberblick
+### Tab-Navigation
+Der Einstieg in die Sperrliste erfolgt über zwei Registerkarten, die dank `overflow-x-auto` auf kleinen Displays horizontal scrollbar sind und durch kompakte, aber großflächige Trigger (`px-5`, `py-2`) bedient werden können.【F:src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx†L37-L59】
+
+### Meine Sperrtermine (BlockCalendar)
+- Der Monatskalender kapselt seine Rasterdarstellung in einem `overflow-x-auto`-Container und erzwingt mindestens die Breite des Viewports (`min-w-full`), während ab `sm`-Breakpoint auf eine größere Mindestbreite gewechselt wird; Steuerleiste und zusätzliche Aktionen sind in einer flexibel umbrechenden Kopfzeile untergebracht.【F:src/components/calendar/month-calendar.tsx†L105-L360】
+- Tageszellen sind vollflächige Buttons mit mindestens 68 px Höhe (96 px ab `sm`) und enthalten zusätzliche Ferien-Tags sowie Statusindikatoren, wobei Interaktionen per Klick, Pointer-Drag oder Tastatur möglich sind.【F:src/components/calendar/month-calendar.tsx†L338-L360】【F:src/app/(members)/mitglieder/sperrliste/block-calendar.tsx†L362-L445】
+- Das Mehrfachauswahl-Panel wechselt zwischen vertikaler Stapelung und nebeneinanderliegenden Controls je nach Breakpoint, wobei Eingabefelder und Aktionsbuttons auf mobilen Ansichten automatisch die volle Breite einnehmen.【F:src/app/(members)/mitglieder/sperrliste/block-calendar.tsx†L533-L627】
+- Die Ferienübersicht nutzt kompakte Typografie (`text-xs`, `sm:text-sm`) und flexible Zeilenumbrüche, um auch auf engen Bildschirmen lesbar zu bleiben.【F:src/app/(members)/mitglieder/sperrliste/block-calendar.tsx†L630-L670】
+- Dialogaktionen für einzelne Sperrtermine stapeln sich auf kleinen Screens und teilen sich ab `sm`-Breakpoint den verfügbaren Raum, wodurch sowohl Touch-Bedienung als auch Desktop-Layout abgedeckt werden.【F:src/app/(members)/mitglieder/sperrliste/block-calendar.tsx†L802-L867】
+
+### Übersicht (BlockOverview)
+- Der Kopfbereich kombiniert heroische Typografie, Navigationsbuttons und Kennzahlen in einem flexiblen Layout, das von Spalten- auf Zeilenanordnung umschaltet und so die Breite kleiner Bildschirme schont.【F:src/app/(members)/mitglieder/sperrliste/block-overview.tsx†L212-L304】
+- Ab `sm`-Breakpoint steht eine tabellarische Zeitachse mit Sticky-Spalte und horizontalem Scrollen zur Verfügung; Zellen reagieren visuell auf Ferientage, Wochenenden und heutiges Datum.【F:src/app/(members)/mitglieder/sperrliste/block-overview.tsx†L307-L455】
+- Für schmalere Displays blendet der Bereich stattdessen kartenbasierte Mitglieder-Module mit horizontal scrollbarer Tagesliste ein, inklusive Snap-Scrolling und farbcodierter Legendenübertragung, um die Informationsdichte mobil zugänglich zu halten.【F:src/app/(members)/mitglieder/sperrliste/block-overview.tsx†L459-L533】
+
+## Breakpoint-Bewertung
+| Komponente | <640 px | 640–767 px | 768–1023 px | ≥1024 px |
+| --- | --- | --- | --- | --- |
+| Tabs | Horizontal scrollbarer Pillen-Header, Vollbreite-Buttons | Gleiche Struktur mit erhöhtem Schriftgrad | Identisch, eingebettet in großzügigere Seite | Identisch |
+| Monatlicher Kalender | Raster in voller Breite, Kopfzeile wrappt, Buttons 68 px hoch | Raster erhält Mindestbreite 640 px, größere Zellhöhen | Mehr Platz für Holiday-Badges und Mehrfachauswahl-Panels | Zusätzliche Weißräume, Panels bleiben rechts unter dem Grid |
+| Mehrfachauswahl/Holidays | Vertikales Stacken, Vollbreite-Controls | Erste horizontale Gruppierungen durch `sm:flex-row` | Stabil, wirkt luftiger | Stabil |
+| Übersicht (Hero + Kennzahlen) | Karten stapeln vertikal | Dreispaltiges Grid ab `sm` | Mehr Platz, Legende bleibt rechts | Gleichbleibend |
+| Team-Ansicht | Karten mit horizontaler Timeline, Snap-Scroll | Desktop-Tabelle wird eingeblendet, Karten verschwinden | Tabelle mit viel horizontalem Raum | Tabelle mit Sticky-Spalte nutzt breite Layouts |
+
+## Stärken
+- Konsistente Nutzung von Tailwind-Breakpoints sorgt für klare mobile/desktop Umschaltungen ohne Layoutsprünge.【F:src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx†L37-L59】【F:src/app/(members)/mitglieder/sperrliste/block-overview.tsx†L307-L533】
+- Touch-Zielgrößen (Kalenderzellen ≥ 68 px, Vollbreite-Buttons) erfüllen mobile Usability-Anforderungen.【F:src/components/calendar/month-calendar.tsx†L338-L360】【F:src/app/(members)/mitglieder/sperrliste/block-calendar.tsx†L533-L867】
+- Mobile Alternativen zur Desktop-Tabelle bewahren Informationsvielfalt durch Scroll-Snap-Listen und kompakte Typografie.【F:src/app/(members)/mitglieder/sperrliste/block-overview.tsx†L459-L533】
+
+## Verbesserungspotenzial
+- Auf sehr schmalen Displays können sieben Spalten à `min-w-full` zu gedrungenen Tageszellen führen; optionaler Breakpoint für horizontales Scrollen (z. B. `min-w-[540px]`) würde Luft schaffen, ohne Desktop-Erlebnis zu stören.【F:src/components/calendar/month-calendar.tsx†L105-L360】
+- Ferien-Tags und Mehrfachauswahl-Texte verwenden `text-[10px]` bzw. `text-xs`; größere Typografie oder Zeilenhöhe könnte die Lesbarkeit in heller Umgebung verbessern.【F:src/app/(members)/mitglieder/sperrliste/block-calendar.tsx†L394-L445】【F:src/app/(members)/mitglieder/sperrliste/block-calendar.tsx†L533-L670】
+- Die mobile Timeline verlangt horizontales Scrollen ohne visuelle Hinweise; zusätzliche Gradienten oder Hinweistext (z. B. "Wische für weitere Tage") könnten die Entdeckung erleichtern.【F:src/app/(members)/mitglieder/sperrliste/block-overview.tsx†L486-L527】
+
+## Empfehlungen
+1. Prüfen, ob für sehr schmale Geräte (<360 px) ein alternativer Kalender-Modus mit horizontalem Scrollen oder Wochenansicht sinnvoll ist.
+2. Typografische Hierarchie mobiler Zusatztexte leicht vergrößern (11–12 px) und Zeilenhöhe erhöhen, um Barrierefreiheit zu stärken.
+3. Scroll-Indikatoren (Gradient, Icon) an mobilen horizontalen Listen ergänzen, damit Nutzer das Wischen intuitiv erkennen.

--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -392,7 +392,7 @@ export function BlockCalendar({ initialBlockedDays, holidays = [] }: BlockCalend
       }
 
       const holidayContent = isHoliday ? (
-        <div className="flex flex-wrap gap-1 text-[10px] font-medium sm:text-[11px]">
+        <div className="flex flex-wrap gap-1 text-[11px] leading-[1.1rem] font-medium sm:text-xs sm:leading-5">
           {holidayEntries.map((holiday) => (
             <span
               key={`${holiday.id}-${holiday.date}`}
@@ -438,7 +438,7 @@ export function BlockCalendar({ initialBlockedDays, holidays = [] }: BlockCalend
                 </span>
               </span>
             ) : (
-              <span className="mt-auto text-xs text-muted-foreground">Frei</span>
+              <span className="mt-auto text-xs leading-5 text-muted-foreground">Frei</span>
             )}
           </>
         ),
@@ -542,7 +542,7 @@ export function BlockCalendar({ initialBlockedDays, holidays = [] }: BlockCalend
                 } ausgewählt.`}
           </p>
           {selectedKeys.length > 0 && (
-            <p className="text-xs text-muted-foreground">
+            <p className="text-[13px] leading-5 text-muted-foreground sm:text-xs sm:leading-5">
               {[
                 selectedFreeCount > 0
                   ? `${selectedFreeCount} ${
@@ -581,7 +581,7 @@ export function BlockCalendar({ initialBlockedDays, holidays = [] }: BlockCalend
           <div className="sm:flex-1">
             <label
               htmlFor="bulk-reason"
-              className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground"
+              className="mb-1 block text-sm font-medium uppercase tracking-wide text-muted-foreground sm:text-xs sm:leading-5"
             >
               Grund (optional)
             </label>
@@ -628,7 +628,7 @@ export function BlockCalendar({ initialBlockedDays, holidays = [] }: BlockCalend
   ) : null;
 
   const holidayPanel = upcomingHolidays.length ? (
-    <div className="space-y-3 rounded-lg border border-sky-200 bg-sky-50 p-4 text-xs sm:text-sm dark:border-sky-500/40 dark:bg-sky-500/10">
+    <div className="space-y-3 rounded-lg border border-sky-200 bg-sky-50 p-4 text-[13px] leading-5 sm:text-sm sm:leading-6 dark:border-sky-500/40 dark:bg-sky-500/10">
       <div className="flex items-center gap-2 text-sky-800 dark:text-sky-100">
         <CalendarDays className="h-4 w-4" aria-hidden />
         <span className="font-semibold">Schulferien in Sachsen</span>
@@ -650,10 +650,10 @@ export function BlockCalendar({ initialBlockedDays, holidays = [] }: BlockCalend
               >
                 {holiday.title}
               </div>
-              <div className="flex flex-wrap items-center gap-2 text-[11px] sm:text-xs text-sky-900/80 dark:text-sky-100/80">
+              <div className="flex flex-wrap items-center gap-2 text-xs leading-5 sm:text-sm sm:leading-6 text-sky-900/80 dark:text-sky-100/80">
                 <span>{rangeLabel}</span>
                 {isActive ? (
-                  <span className="inline-flex items-center rounded-full bg-sky-200/90 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-900 dark:bg-sky-500/30 dark:text-sky-50">
+                  <span className="inline-flex items-center rounded-full bg-sky-200/90 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-sky-900 dark:bg-sky-500/30 dark:text-sky-50">
                     Aktuell
                   </span>
                 ) : null}

--- a/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
@@ -16,7 +16,7 @@ import {
   startOfWeek,
 } from "date-fns";
 import { de } from "date-fns/locale/de";
-import { ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
+import { ArrowRightLeft, ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { UserAvatar } from "@/components/user-avatar";
@@ -137,10 +137,10 @@ function LegendItem({
         )}
       />
       <div className="flex flex-col">
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-foreground/90">
+        <span className="text-xs font-semibold uppercase tracking-wide text-foreground/90">
           {label}
         </span>
-        <span className="text-[10px] text-muted-foreground/80">{description}</span>
+        <span className="text-[11px] leading-5 text-muted-foreground/80">{description}</span>
       </div>
     </div>
   );
@@ -380,7 +380,7 @@ export function BlockOverview({
                             {stats?.total ? `${stats.total} Sperrtermin${stats.total === 1 ? "" : "e"}` : "Keine Sperrtermine"}
                           </div>
                           {stats?.upcoming ? (
-                            <div className="text-[11px] text-primary">{stats.upcoming} bevorstehend</div>
+                            <div className="text-sm leading-5 text-primary">{stats.upcoming} bevorstehend</div>
                           ) : null}
                         </div>
                       </div>
@@ -415,7 +415,7 @@ export function BlockOverview({
                         >
                           <div
                             className={cn(
-                              "flex h-full min-h-[64px] flex-col items-center justify-center rounded-xl border border-transparent px-2 py-3 text-[11px] shadow-sm transition-all",
+                              "flex h-full min-h-[64px] flex-col items-center justify-center rounded-xl border border-transparent px-2 py-3 text-xs leading-5 shadow-sm transition-all",
                               entry &&
                                 "border-destructive/70 bg-gradient-to-br from-destructive/80 via-destructive/60 to-destructive/25 text-destructive-foreground shadow-[0_12px_30px_-20px_rgba(220,38,38,0.65)]",
                               !entry && isHoliday &&
@@ -430,19 +430,19 @@ export function BlockOverview({
                             {entry ? (
                               <>
                                 <span className="text-xs font-semibold uppercase tracking-wide">Gesperrt</span>
-                                <span className="mt-1 line-clamp-3 text-[11px]">
+                                <span className="mt-1 line-clamp-3 text-xs leading-5">
                                   {entry.reason ?? "Ohne Grund"}
                                 </span>
                               </>
                             ) : isHoliday ? (
                               <>
-                                <span className="text-[11px] font-semibold uppercase tracking-wide">Ferien</span>
-                                <span className="mt-1 line-clamp-3 text-[11px]">
+                                <span className="text-xs font-semibold uppercase tracking-wide">Ferien</span>
+                                <span className="mt-1 line-clamp-3 text-xs leading-5">
                                   {holidayEntries[0]?.title}
                                 </span>
                               </>
                             ) : (
-                              <span className="text-[11px] font-medium text-muted-foreground/80">Frei</span>
+                              <span className="text-xs font-medium leading-5 text-muted-foreground/80">Frei</span>
                             )}
                           </div>
                         </td>
@@ -479,53 +479,67 @@ export function BlockOverview({
                     {stats?.total ? `${stats.total} Sperrtermin${stats.total === 1 ? "" : "e"}` : "Keine Sperrtermine"}
                   </div>
                   {stats?.upcoming ? (
-                    <div className="text-[11px] text-primary">{stats.upcoming} bevorstehend</div>
+                    <div className="text-sm leading-5 text-primary">{stats.upcoming} bevorstehend</div>
                   ) : null}
                 </div>
               </div>
-              <div className="mt-3 flex gap-2 overflow-x-auto pb-1 [scrollbar-width:thin] snap-x snap-mandatory">
-                {daysInView.map((day, index) => {
-                  const key = dayKeys[index];
-                  const entry = member.blockedMap.get(key);
-                  const holidayEntries = holidayMap.get(key) ?? [];
-                  const isHoliday = holidayEntries.length > 0;
-                  const label = [
-                    format(day, "EEEE, d. MMMM yyyy", { locale: de }),
-                    entry ? entry.reason ?? "gesperrt" : "frei",
-                  ];
-                  if (isHoliday) {
-                    label.push(`Ferien: ${holidayEntries.map((h) => h.title).join(", ")}`);
-                  }
+              <div className="relative mt-3">
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-y-0 left-0 w-6 bg-gradient-to-r from-[hsl(var(--background))] via-[hsl(var(--background))] to-transparent"
+                />
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[hsl(var(--background))] via-[hsl(var(--background))] to-transparent"
+                />
+                <div className="flex gap-2 overflow-x-auto pb-1 pl-1 pr-4 [scrollbar-width:thin] snap-x snap-mandatory">
+                  {daysInView.map((day, index) => {
+                    const key = dayKeys[index];
+                    const entry = member.blockedMap.get(key);
+                    const holidayEntries = holidayMap.get(key) ?? [];
+                    const isHoliday = holidayEntries.length > 0;
+                    const label = [
+                      format(day, "EEEE, d. MMMM yyyy", { locale: de }),
+                      entry ? entry.reason ?? "gesperrt" : "frei",
+                    ];
+                    if (isHoliday) {
+                      label.push(`Ferien: ${holidayEntries.map((h) => h.title).join(", ")}`);
+                    }
 
-                  return (
-                    <div
-                      key={key}
-                      className={cn(
-                        "flex min-w-[60px] shrink-0 snap-center flex-col items-center rounded-2xl border border-border/50 px-2 py-2 text-center text-[10px] shadow-sm",
-                        entry && "border-destructive/60 bg-destructive/15 text-destructive",
-                        !entry && isHoliday && "border-sky-400/40 bg-sky-500/15 text-sky-800 dark:text-sky-100",
-                        !entry && !isHoliday && "bg-muted/30 text-muted-foreground",
-                        isToday(day) && "ring-2 ring-primary/70",
-                      )}
-                      aria-label={label.join(". ")}
-                      title={entry?.reason ?? (isHoliday ? holidayEntries[0]?.title ?? "Ferien" : "Frei")}
-                    >
-                      <span className="text-[10px] uppercase tracking-wide">
-                        {format(day, "EE", { locale: de })}
-                      </span>
-                      <span className="text-sm font-semibold">
-                        {format(day, "d", { locale: de })}
-                      </span>
-                      {entry ? (
-                        <span className="mt-1 line-clamp-2 text-[10px]">{entry.reason ?? "Gesperrt"}</span>
-                      ) : isHoliday ? (
-                        <span className="mt-1 line-clamp-2 text-[10px]">{holidayEntries[0]?.title}</span>
-                      ) : (
-                        <span className="mt-1 text-[10px] text-muted-foreground">frei</span>
-                      )}
-                    </div>
-                  );
-                })}
+                    return (
+                      <div
+                        key={key}
+                        className={cn(
+                          "flex min-w-[64px] shrink-0 snap-center flex-col items-center rounded-2xl border border-border/50 px-2 py-2 text-center text-xs leading-5 shadow-sm",
+                          entry && "border-destructive/60 bg-destructive/15 text-destructive",
+                          !entry && isHoliday && "border-sky-400/40 bg-sky-500/15 text-sky-800 dark:text-sky-100",
+                          !entry && !isHoliday && "bg-muted/30 text-muted-foreground",
+                          isToday(day) && "ring-2 ring-primary/70",
+                        )}
+                        aria-label={label.join(". ")}
+                        title={entry?.reason ?? (isHoliday ? holidayEntries[0]?.title ?? "Ferien" : "Frei")}
+                      >
+                        <span className="text-xs uppercase tracking-wide text-muted-foreground/90">
+                          {format(day, "EE", { locale: de })}
+                        </span>
+                        <span className="text-sm font-semibold">
+                          {format(day, "d", { locale: de })}
+                        </span>
+                        {entry ? (
+                          <span className="mt-1 line-clamp-2 text-xs leading-4">{entry.reason ?? "Gesperrt"}</span>
+                        ) : isHoliday ? (
+                          <span className="mt-1 line-clamp-2 text-xs leading-4">{holidayEntries[0]?.title}</span>
+                        ) : (
+                          <span className="mt-1 text-xs leading-4 text-muted-foreground">frei</span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="mt-2 flex items-center justify-center gap-2 text-xs leading-5 text-muted-foreground/90">
+                  <ArrowRightLeft className="h-4 w-4" aria-hidden />
+                  <span>Wische für weitere Tage</span>
+                </div>
               </div>
             </div>
           );

--- a/src/components/calendar/month-calendar.tsx
+++ b/src/components/calendar/month-calendar.tsx
@@ -102,7 +102,7 @@ export function MonthCalendar({
   showWeekNumbers = true,
   className,
   contentClassName,
-  minGridWidthClassName = "min-w-full sm:min-w-[640px]",
+  minGridWidthClassName = "min-w-[540px] sm:min-w-[640px]",
   dayClassName,
   additionalContent,
 }: MonthCalendarProps) {


### PR DESCRIPTION
## Summary
- widen the monthly calendar grid to allow horizontal scrolling on extra narrow screens
- enlarge Sperrliste calendar chips, bulk controls and holiday list typography for easier mobile reading
- refine the overview hero and mobile timeline with gradients, hints and increased text sizes for better touch usability

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d108ebcbc8832d8a2536257fe9832e