### PR TITLE
Add migration for blocked day kind

### DIFF
--- a/prisma/migrations/20260604140000_blocked_day_kind/migration.sql
+++ b/prisma/migrations/20260604140000_blocked_day_kind/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "BlockedDayKind" AS ENUM ('BLOCKED', 'PREFERRED');
+
+-- AlterTable
+ALTER TABLE "BlockedDay"
+  ADD COLUMN "kind" "BlockedDayKind" NOT NULL DEFAULT 'BLOCKED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,6 +89,11 @@ enum AvailabilityKind {
   PARTIAL
 }
 
+enum BlockedDayKind {
+  BLOCKED
+  PREFERRED
+}
+
 // Einheiten für Maße
 enum MeasurementUnit {
   CM    // Zentimeter
@@ -751,6 +756,7 @@ model BlockedDay {
   userId    String
   date      DateTime
   reason    String?
+  kind      BlockedDayKind @default(BLOCKED)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -108,6 +108,7 @@ export default async function GewerkDetailPage({ params }: PageProps) {
         where: {
           userId: { in: memberIds },
           date: { gte: today, lte: planningEnd },
+          kind: "BLOCKED",
         },
         orderBy: { date: "asc" },
       })
@@ -115,6 +116,7 @@ export default async function GewerkDetailPage({ params }: PageProps) {
 
   const blockedByUser = new Map<string, Set<string>>();
   for (const entry of blockedDays) {
+    if (entry.kind !== "BLOCKED") continue;
     const key = format(entry.date, DATE_KEY_FORMAT);
     const existing = blockedByUser.get(entry.userId);
     if (existing) {

--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -115,6 +115,7 @@ export default async function MeineGewerkePage() {
         where: {
           userId: { in: Array.from(memberIds) },
           date: { gte: today, lte: planningEnd },
+          kind: "BLOCKED",
         },
         orderBy: { date: "asc" },
       })
@@ -122,6 +123,7 @@ export default async function MeineGewerkePage() {
 
   const blockedByUser = new Map<string, Set<string>>();
   for (const entry of blockedDays) {
+    if (entry.kind !== "BLOCKED") continue;
     const key = format(entry.date, DATE_KEY_FORMAT);
     const existing = blockedByUser.get(entry.userId);
     if (existing) {

--- a/src/app/(members)/mitglieder/probenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/page.tsx
@@ -52,6 +52,7 @@ export default async function ProbenplanungPage() {
       include: {
         user: { select: { id: true, firstName: true, lastName: true, name: true, email: true } },
       },
+      where: { kind: "BLOCKED" },
     }),
     prisma.user.count(),
     prisma.rehearsal.findMany({
@@ -74,6 +75,7 @@ export default async function ProbenplanungPage() {
       date: iso,
       dateKey: iso.slice(0, 10),
       reason: entry.reason,
+      kind: "BLOCKED",
       user: {
         id: entry.user.id,
         firstName: entry.user.firstName ?? null,

--- a/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
@@ -57,6 +57,7 @@ export default async function RehearsalEditorPage({ params }: { params: { rehear
         gte: dayStart,
         lt: dayEnd,
       },
+      kind: "BLOCKED",
     },
     select: { userId: true },
   });

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
@@ -61,6 +61,7 @@ export type CalendarBlockedDay = {
   date: string;
   dateKey: string;
   reason: string | null;
+  kind: "BLOCKED";
   user: {
     id: string;
     firstName: string | null;

--- a/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
@@ -102,6 +102,7 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
         where: {
           userId: { in: memberIds },
           date: { gte: today, lte: planningEnd },
+          kind: "BLOCKED",
         },
         orderBy: { date: "asc" },
       })
@@ -109,6 +110,7 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
 
   const blockedByUser = new Map<string, Set<string>>();
   for (const entry of blockedDays) {
+    if (entry.kind !== "BLOCKED") continue;
     const key = format(entry.date, DATE_KEY_FORMAT);
     const existing = blockedByUser.get(entry.userId);
     if (existing) {

--- a/src/app/(members)/mitglieder/sperrliste/page.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page.tsx
@@ -45,6 +45,7 @@ export default async function SperrlistePage() {
             id: true,
             date: true,
             reason: true,
+            kind: true,
           },
         },
       },
@@ -55,6 +56,7 @@ export default async function SperrlistePage() {
     id: entry.id,
     date: format(entry.date, "yyyy-MM-dd"),
     reason: entry.reason,
+    kind: entry.kind,
   }));
 
   const overviewMembers: OverviewMember[] = overviewUsers.map((user) => ({
@@ -71,6 +73,7 @@ export default async function SperrlistePage() {
       id: entry.id,
       date: format(entry.date, "yyyy-MM-dd"),
       reason: entry.reason,
+      kind: entry.kind,
     })),
   }));
 

--- a/src/app/api/block-days/route.ts
+++ b/src/app/api/block-days/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { Prisma } from "@prisma/client";
+import { Prisma, BlockedDayKind } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
@@ -17,6 +17,7 @@ type SessionUser = { id?: string } | null | undefined;
 const blockDaySchema = z.object({
   date: z.string().regex(isoDate),
   reason: reasonSchema,
+  kind: z.nativeEnum(BlockedDayKind).optional(),
 });
 
 type BlockDayPayload = z.infer<typeof blockDaySchema>;
@@ -85,12 +86,15 @@ export async function POST(request: Request) {
     }
   } catch {}
 
+  const kind = payload.kind ?? BlockedDayKind.BLOCKED;
+
   try {
     const entry = await prisma.blockedDay.create({
       data: {
         userId,
         date: blockDate,
         reason: normaliseReason(payload.reason),
+        kind,
       },
     });
 

--- a/src/app/api/block-days/utils.ts
+++ b/src/app/api/block-days/utils.ts
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import { z } from "zod";
+import { BlockedDayKind } from "@prisma/client";
 
 export const isoDate = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -13,6 +14,7 @@ export type BlockDayResponse = {
   id: string;
   date: string;
   reason: string | null;
+  kind: BlockedDayKind;
 };
 
 export function normaliseReason(input?: string | null) {
@@ -29,10 +31,16 @@ export function toDateOnly(date: string) {
   return parsed;
 }
 
-export function toResponse(entry: { id: string; date: Date; reason: string | null }): BlockDayResponse {
+export function toResponse(entry: {
+  id: string;
+  date: Date;
+  reason: string | null;
+  kind: BlockedDayKind;
+}): BlockDayResponse {
   return {
     id: entry.id,
     date: format(entry.date, "yyyy-MM-dd"),
     reason: entry.reason,
+    kind: entry.kind,
   };
 }

--- a/src/app/api/rehearsals/blocked/route.ts
+++ b/src/app/api/rehearsals/blocked/route.ts
@@ -37,6 +37,7 @@ export async function GET(request: NextRequest) {
         gte: dayStart,
         lt: dayEnd,
       },
+      kind: "BLOCKED",
     },
     select: { userId: true },
   });


### PR DESCRIPTION
## Summary
- add a Prisma migration that introduces the `BlockedDayKind` enum and the `kind` column on `BlockedDay`

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d10f994e98832d85a2898e29eab813