### PR TITLE
Allow 18-year-olds to confirm photo consent without guardian paperwork

### DIFF
--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -286,7 +286,7 @@ export async function POST(request: NextRequest) {
     documentSize = documentBuffer.length;
   }
 
-  if (age !== null && age <= 18 && !skipDocument && !documentBuffer) {
+  if (age !== null && age < 18 && !skipDocument && !documentBuffer) {
     return NextResponse.json({ error: "Bitte lade die unterschriebene Einverständniserklärung hoch oder überspringe den Upload" }, { status: 400 });
   }
 
@@ -474,7 +474,7 @@ export async function POST(request: NextRequest) {
         });
       }
 
-      const shouldCreateConsent = photoConsent.consent || documentBuffer || (age !== null && age <= 18);
+      const shouldCreateConsent = photoConsent.consent || documentBuffer || (age !== null && age < 18);
       if (shouldCreateConsent) {
         await tx.photoConsent.create({
           data: {

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -449,7 +449,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
   }, []);
 
   const age = useMemo(() => calculateAge(form.dateOfBirth || null), [form.dateOfBirth]);
-  const requiresDocument = age !== null && age <= 18;
+  const requiresDocument = age !== null && age < 18;
   const requiresBackgroundClass = useMemo(() => requiresBszClass(form.background), [form.background]);
   const backgroundClassLabel = useMemo(() => {
     const trimmed = form.backgroundClass.trim();
@@ -1609,7 +1609,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
 
             {requiresDocument && (
               <div className="rounded-lg border border-amber-200 bg-amber-50/70 p-4 text-sm text-amber-900">
-                <p className="font-medium">Du bist 18 Jahre oder jünger</p>
+                <p className="font-medium">Du bist unter 18 Jahre alt</p>
                 <p>
                   Wir benötigen eine unterschriebene Foto-Einverständniserklärung. Lade sie als Datei hoch oder unterschreibe
                   direkt hier digital. Wenn es gerade nicht passt, kannst du die Unterschrift auch später im Profil nachreichen.


### PR DESCRIPTION
## Summary
- treat members who are 18 or older as adults in the onboarding wizard so no guardian upload is required
- align the onboarding completion API with the same age check for document enforcement and consent creation

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d115e123ac832d85e7ef5b89e50b6d