### PR TITLE
Allow preferred days to bypass block freeze

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -853,7 +853,7 @@ export function BlockCalendar({ initialBlockedDays, holidays = [] }: BlockCalend
     setSubmitting(true);
     setError(null);
     try {
-      if (isWithinFreeze(selectedDateKey)) {
+      if (selectedKind === "BLOCKED" && isWithinFreeze(selectedDateKey)) {
         throw new Error(
           `Aus Planungsgründen können Sperrtermine erst ab ${format(freezeUntil, "EEEE, d. MMMM yyyy", { locale: de })} eingetragen werden.`
         );

--- a/src/app/api/block-days/route.ts
+++ b/src/app/api/block-days/route.ts
@@ -73,20 +73,22 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Ungültiges Datum" }, { status: 400 });
   }
 
-  // Planning window: no blocks within next 7 days including today
-  try {
-    const todayKey = new Date().toISOString().slice(0, 10);
-    const today = toDateOnly(todayKey);
-    const cutoff = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
-    if (blockDate.getTime() < cutoff.getTime()) {
-      return NextResponse.json(
-        { error: "Aus Planungsgründen können Sperrtermine erst ab einer Woche im Voraus eingetragen werden." },
-        { status: 400 }
-      );
-    }
-  } catch {}
-
   const kind = payload.kind ?? BlockedDayKind.BLOCKED;
+
+  // Planning window: no blocks within next 7 days including today
+  if (kind === BlockedDayKind.BLOCKED) {
+    try {
+      const todayKey = new Date().toISOString().slice(0, 10);
+      const today = toDateOnly(todayKey);
+      const cutoff = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+      if (blockDate.getTime() < cutoff.getTime()) {
+        return NextResponse.json(
+          { error: "Aus Planungsgründen können Sperrtermine erst ab einer Woche im Voraus eingetragen werden." },
+          { status: 400 }
+        );
+      }
+    } catch {}
+  }
 
   try {
     const entry = await prisma.blockedDay.create({


### PR DESCRIPTION
## Summary
- allow the block calendar to save preferred-day entries even when the 7-day freeze is active
- update the block-days single and bulk API routes so the planning window restriction only applies to blocked entries

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1191c43dc832dac391c704c50b27c