### PR TITLE
Remove Docker build cache usage in CI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,5 +83,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ matrix.build_args }}
-          cache-from: type=registry,ref=${{ env.WEBSITE_IMAGE_NAME }}:${{ matrix.environment }}-buildcache
-          cache-to: type=registry,ref=${{ env.WEBSITE_IMAGE_NAME }}:${{ matrix.environment }}-buildcache,mode=max,oci-mediatypes=true


### PR DESCRIPTION
## Summary
- remove the Buildx cache configuration from the Docker image build step so CI no longer pushes or pulls the build cache

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d123333adc832da19b47c2f5974ecc