### PR TITLE
Clarify profile body measurement messaging

### DIFF
--- a/src/app/(members)/mitglieder/koerpermasse/page.tsx
+++ b/src/app/(members)/mitglieder/koerpermasse/page.tsx
@@ -42,7 +42,7 @@ export default async function MemberMeasurementsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Körpermaße"
-        description="Pflege deine Maße für das Kostüm-Team und bevorstehende Anproben."
+        description="Pflege deine Maße direkt in deinem Profil – das Kostüm-Team sieht sie in der Gewerke-Übersicht und behält alle Schauspieler:innen im Blick."
       />
       <MemberMeasurementsManager initialMeasurements={initialMeasurements} />
     </div>

--- a/src/app/(members)/mitglieder/meine-gewerke/department-card.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/department-card.tsx
@@ -258,6 +258,9 @@ export function DepartmentCard({
                 {membersWithMeasurements} {membersWithMeasurements === 1 ? "Person" : "Personen"} mit Angaben
               </Badge>
             </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Übersicht der in den Profilen hinterlegten Maße aller Schauspieler:innen dieses Gewerks.
+            </p>
             <ul className="mt-4 space-y-3">
               {sortedMembers.map((member) => {
                 const entries = measurementsForDepartment[member.userId]
@@ -270,7 +273,7 @@ export function DepartmentCard({
                         <p className="text-sm font-medium text-foreground">{formatUserName(member.user)}</p>
                         <span className="text-[11px] text-muted-foreground">Keine Angaben</span>
                       </div>
-                      <p className="mt-1 text-xs text-muted-foreground">Noch keine Maße hinterlegt.</p>
+                      <p className="mt-1 text-xs text-muted-foreground">Noch keine Maße im Profil hinterlegt.</p>
                     </li>
                   );
                 }

--- a/src/components/members/measurements/member-measurements-manager.tsx
+++ b/src/components/members/measurements/member-measurements-manager.tsx
@@ -158,8 +158,8 @@ export function MemberMeasurementsManager({
           </ul>
         ) : (
           <div className="rounded-2xl border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
-            Noch keine Maße hinterlegt. Erfasse deine Körpermaße, damit das Kostüm-Team dich
-            bei Anproben optimal unterstützen kann.
+            Noch keine Maße hinterlegt. Erfasse deine Körpermaße in deinem Profil, damit das Kostüm-Team dich{" "}
+            bei Anproben optimal unterstützen und in der Gewerke-Übersicht den Überblick behalten kann.
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- note on the profile measurements page that entries power the overview in the Gewerke section for costume teams
- expand the empty state copy to stress maintaining measurements in the profile and how the overview uses them
- add explanatory text to the costume department card clarifying it aggregates all actors’ profile measurements

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d12621a730832d97376f38dcb66a00