### PR TITLE
Implement member deactivation and deletion flows

### DIFF
--- a/prisma/migrations/20250922103702_member_deactivation/migration.sql
+++ b/prisma/migrations/20250922103702_member_deactivation/migration.sql
@@ -1,0 +1,24 @@
+-- DropForeignKey
+ALTER TABLE "public"."AvailabilityDay" DROP CONSTRAINT "AvailabilityDay_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."AvailabilityTemplate" DROP CONSTRAINT "AvailabilityTemplate_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Issue" DROP CONSTRAINT "Issue_createdById_fkey";
+
+-- AlterTable
+ALTER TABLE "public"."User" ADD COLUMN     "deactivatedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "public"."Issue" ALTER COLUMN "createdById" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "public"."AvailabilityDay" ADD CONSTRAINT "AvailabilityDay_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AvailabilityTemplate" ADD CONSTRAINT "AvailabilityTemplate_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Issue" ADD CONSTRAINT "Issue_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -131,7 +131,7 @@ model AvailabilityDay {
   availableFromMin Int?
   availableToMin   Int?
   note             String?
-  user             User             @relation(fields: [userId], references: [id])
+  user             User             @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, date])
 }
@@ -145,7 +145,7 @@ model AvailabilityTemplate {
   availableToMin   Int?
   validFrom        DateTime?
   validTo          DateTime?
-  user             User             @relation(fields: [userId], references: [id])
+  user             User             @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 enum TaskStatus {
@@ -221,6 +221,7 @@ model User {
   passwordHash String?
   createdAt DateTime @default(now())
   dateOfBirth DateTime?
+  deactivatedAt DateTime?
   avatarSource        AvatarSource @default(GRAVATAR)
   avatarImage         Bytes?
   avatarImageMime     String?
@@ -917,9 +918,9 @@ model Issue {
   updatedAt      DateTime       @updatedAt
   lastActivityAt DateTime       @default(now())
   resolvedAt     DateTime?
-  createdById    String
+  createdById    String?
   updatedById    String?
-  createdBy      User           @relation("IssueCreatedBy", fields: [createdById], references: [id])
+  createdBy      User?          @relation("IssueCreatedBy", fields: [createdById], references: [id], onDelete: SetNull)
   updatedBy      User?          @relation("IssueUpdatedBy", fields: [updatedById], references: [id])
   comments       IssueComment[]
 

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/page.tsx
@@ -31,6 +31,7 @@ export default async function MitgliederVerwaltungPage() {
         appRoles: { select: { role: { select: { id: true, name: true } } } },
         avatarSource: true,
         avatarImageUpdatedAt: true,
+        deactivatedAt: true,
       },
     }),
     prisma.appRole.findMany({ where: { isSystem: false, systemRole: null }, orderBy: { name: "asc" } }),
@@ -51,6 +52,8 @@ export default async function MitgliederVerwaltungPage() {
       customRoles: user.appRoles.map((ar) => ar.role),
       avatarSource: user.avatarSource,
       avatarUpdatedAt: user.avatarImageUpdatedAt?.toISOString() ?? null,
+      isDeactivated: Boolean(user.deactivatedAt),
+      deactivatedAt: user.deactivatedAt?.toISOString() ?? null,
     };
   });
 

--- a/src/app/api/members/[id]/status/route.ts
+++ b/src/app/api/members/[id]/status/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.rollenverwaltung"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Ungültige Anfrage" }, { status: 400 });
+  }
+
+  const rawBody: unknown = await request.json().catch(() => null);
+  if (!rawBody || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const { deactivated } = rawBody as { deactivated?: unknown };
+  if (typeof deactivated !== "boolean") {
+    return NextResponse.json({ error: "Status muss als boolescher Wert übermittelt werden" }, { status: 400 });
+  }
+
+  const target = await prisma.user.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      role: true,
+      roles: { select: { role: true } },
+      deactivatedAt: true,
+    },
+  });
+
+  if (!target) {
+    return NextResponse.json({ error: "Benutzer nicht gefunden" }, { status: 404 });
+  }
+
+  if (deactivated) {
+    const alreadyDeactivated = target.deactivatedAt ?? null;
+    const isOwner =
+      target.role === "owner" || target.roles.some((entry) => entry.role === "owner");
+
+    if (isOwner) {
+      const remainingOwners = await prisma.user.count({
+        where: {
+          id: { not: target.id },
+          deactivatedAt: null,
+          OR: [{ role: "owner" }, { roles: { some: { role: "owner" } } }],
+        },
+      });
+
+      if (remainingOwners === 0) {
+        return NextResponse.json({ error: "Es muss immer mindestens einen Owner geben" }, { status: 400 });
+      }
+    }
+
+    if (alreadyDeactivated) {
+      return NextResponse.json({
+        ok: true,
+        user: { id: target.id, deactivatedAt: alreadyDeactivated.toISOString() },
+      });
+    }
+  }
+
+  try {
+    const updated = await prisma.$transaction(async (tx) => {
+      const result = await tx.user.update({
+        where: { id: target.id },
+        data: { deactivatedAt: deactivated ? new Date() : null },
+        select: { id: true, deactivatedAt: true },
+      });
+
+      if (deactivated) {
+        await tx.session.deleteMany({ where: { userId: target.id } });
+      }
+
+      return result;
+    });
+
+    return NextResponse.json({
+      ok: true,
+      user: { id: updated.id, deactivatedAt: updated.deactivatedAt?.toISOString() ?? null },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Aktualisierung fehlgeschlagen";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/members/[id]/usage/route.ts
+++ b/src/app/api/members/[id]/usage/route.ts
@@ -1,0 +1,263 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { combineNameParts } from "@/lib/names";
+
+type UsageItem = {
+  key: string;
+  label: string;
+  count: number;
+  href?: string | null;
+};
+
+type UsageSection = {
+  key: string;
+  title: string;
+  total: number;
+  items: UsageItem[];
+};
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.rollenverwaltung"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Ungültige Anfrage" }, { status: 400 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      email: true,
+      firstName: true,
+      lastName: true,
+      name: true,
+      deactivatedAt: true,
+    },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "Benutzer nicht gefunden" }, { status: 404 });
+  }
+
+  const [
+    departmentMemberships,
+    characterCastings,
+    breakdownAssignments,
+    generalTasks,
+    departmentTasksAssigned,
+    departmentTasksCreated,
+    rehearsalInvites,
+    rehearsalAttendance,
+    attendanceLogsAuthored,
+    attendanceLogsTarget,
+    blockedDays,
+    availabilityEntries,
+    availabilityDayEntries,
+    availabilityTemplateEntries,
+    financeEntriesCreated,
+    financeEntriesApproved,
+    financeEntriesPaid,
+    financeLogsAuthored,
+    issuesCreated,
+    issuesUpdated,
+    issueComments,
+    notifications,
+    measurements,
+    sizes,
+    dietaryRestrictions,
+    rolePreferences,
+    interests,
+    photoConsentCount,
+    approvedPhotoConsents,
+    onboardingProfileCount,
+    memberInvitesCreated,
+    inviteRedemptions,
+    sessions,
+    accounts,
+    guesses,
+    userAppRoles,
+    interestsAuthored,
+    rehearsalProposalsApproved,
+    rehearsalsCreated,
+  ] = await prisma.$transaction([
+    prisma.departmentMembership.count({ where: { userId: id } }),
+    prisma.characterCasting.count({ where: { userId: id } }),
+    prisma.sceneBreakdownItem.count({ where: { assignedToId: id } }),
+    prisma.task.count({ where: { assigneeId: id } }),
+    prisma.departmentTask.count({ where: { assigneeId: id } }),
+    prisma.departmentTask.count({ where: { createdById: id } }),
+    prisma.rehearsalInvitee.count({ where: { userId: id } }),
+    prisma.rehearsalAttendance.count({ where: { userId: id } }),
+    prisma.rehearsalAttendanceLog.count({ where: { changedById: id } }),
+    prisma.rehearsalAttendanceLog.count({ where: { userId: id } }),
+    prisma.blockedDay.count({ where: { userId: id } }),
+    prisma.availability.count({ where: { userId: id } }),
+    prisma.availabilityDay.count({ where: { userId: id } }),
+    prisma.availabilityTemplate.count({ where: { userId: id } }),
+    prisma.financeEntry.count({ where: { createdById: id } }),
+    prisma.financeEntry.count({ where: { approvedById: id } }),
+    prisma.financeEntry.count({ where: { memberPaidById: id } }),
+    prisma.financeLog.count({ where: { changedById: id } }),
+    prisma.issue.count({ where: { createdById: id } }),
+    prisma.issue.count({ where: { updatedById: id } }),
+    prisma.issueComment.count({ where: { authorId: id } }),
+    prisma.notificationRecipient.count({ where: { userId: id } }),
+    prisma.memberMeasurement.count({ where: { userId: id } }),
+    prisma.memberSize.count({ where: { userId: id } }),
+    prisma.dietaryRestriction.count({ where: { userId: id } }),
+    prisma.memberRolePreference.count({ where: { userId: id } }),
+    prisma.userInterest.count({ where: { userId: id } }),
+    prisma.photoConsent.count({ where: { userId: id } }),
+    prisma.photoConsent.count({ where: { approvedById: id } }),
+    prisma.memberOnboardingProfile.count({ where: { userId: id } }),
+    prisma.memberInvite.count({ where: { createdById: id } }),
+    prisma.memberInviteRedemption.count({ where: { userId: id } }),
+    prisma.session.count({ where: { userId: id } }),
+    prisma.account.count({ where: { userId: id } }),
+    prisma.guess.count({ where: { userId: id } }),
+    prisma.userAppRole.count({ where: { userId: id } }),
+    prisma.interest.count({ where: { createdById: id } }),
+    prisma.rehearsalProposal.count({ where: { approvedBy: id } }),
+    prisma.rehearsal.count({ where: { createdBy: id } }),
+  ]);
+
+  const sections: UsageSection[] = [];
+  let total = 0;
+
+  const addSection = (section: UsageSection) => {
+    if (!section.items.length) return;
+    sections.push(section);
+    total += section.total;
+  };
+
+  const productionItems: UsageItem[] = [
+    { key: "departmentMemberships", label: "Gewerkemitgliedschaften", count: departmentMemberships },
+    { key: "characterCastings", label: "Besetzungen in Produktionen", count: characterCastings },
+    { key: "breakdownAssignments", label: "Szenische Aufgaben", count: breakdownAssignments },
+    { key: "rehearsalsCreated", label: "Erstellte Proben", count: rehearsalsCreated },
+  ].filter((item) => item.count > 0);
+
+  addSection({
+    key: "productions",
+    title: "Produktionen & Rollen",
+    total: productionItems.reduce((sum, item) => sum + item.count, 0),
+    items: productionItems,
+  });
+
+  const rehearsalItems: UsageItem[] = [
+    { key: "rehearsalInvites", label: "Probeeinladungen", count: rehearsalInvites },
+    { key: "rehearsalAttendance", label: "Anwesenheitseinträge", count: rehearsalAttendance },
+    { key: "attendanceLogsAuthored", label: "Anwesenheitsprotokolle (Autor)", count: attendanceLogsAuthored },
+    { key: "attendanceLogsTarget", label: "Anwesenheitsprotokolle (Ziel)", count: attendanceLogsTarget },
+    { key: "blockedDays", label: "Gesperrte Tage", count: blockedDays },
+    { key: "availabilityEntries", label: "Verfügbarkeitszeiträume", count: availabilityEntries },
+    { key: "availabilityDays", label: "Tagesverfügbarkeiten", count: availabilityDayEntries },
+    { key: "availabilityTemplates", label: "Verfügbarkeitsvorlagen", count: availabilityTemplateEntries },
+    { key: "rehearsalProposalsApproved", label: "Freigegebene Probenvorschläge", count: rehearsalProposalsApproved },
+  ].filter((item) => item.count > 0);
+
+  addSection({
+    key: "rehearsals",
+    title: "Proben & Verfügbarkeit",
+    total: rehearsalItems.reduce((sum, item) => sum + item.count, 0),
+    items: rehearsalItems,
+  });
+
+  const taskItems: UsageItem[] = [
+    { key: "generalTasks", label: "Allgemeine Aufgaben", count: generalTasks },
+    { key: "departmentTasksAssigned", label: "Gewerkaufgaben (zugewiesen)", count: departmentTasksAssigned },
+    { key: "departmentTasksCreated", label: "Gewerkaufgaben (erstellt)", count: departmentTasksCreated },
+  ].filter((item) => item.count > 0);
+
+  addSection({
+    key: "tasks",
+    title: "Aufgaben & Zusammenarbeit",
+    total: taskItems.reduce((sum, item) => sum + item.count, 0),
+    items: taskItems,
+  });
+
+  const financeItems: UsageItem[] = [
+    { key: "financeEntriesCreated", label: "Finanzvorgänge angelegt", count: financeEntriesCreated },
+    { key: "financeEntriesApproved", label: "Finanzvorgänge freigegeben", count: financeEntriesApproved },
+    { key: "financeEntriesPaid", label: "Als zahlendes Mitglied hinterlegt", count: financeEntriesPaid },
+    { key: "financeLogsAuthored", label: "Finanzprotokolle", count: financeLogsAuthored },
+  ].filter((item) => item.count > 0);
+
+  addSection({
+    key: "finance",
+    title: "Finanzen",
+    total: financeItems.reduce((sum, item) => sum + item.count, 0),
+    items: financeItems,
+  });
+
+  const supportItems: UsageItem[] = [
+    { key: "issuesCreated", label: "Supportanfragen erstellt", count: issuesCreated },
+    { key: "issuesUpdated", label: "Supportanfragen aktualisiert", count: issuesUpdated },
+    { key: "issueComments", label: "Kommentare in Supportanfragen", count: issueComments },
+    { key: "notifications", label: "Benachrichtigungen erhalten", count: notifications },
+    { key: "interestsAuthored", label: "Interessen erstellt", count: interestsAuthored },
+  ].filter((item) => item.count > 0);
+
+  addSection({
+    key: "support",
+    title: "Support & Kommunikation",
+    total: supportItems.reduce((sum, item) => sum + item.count, 0),
+    items: supportItems,
+  });
+
+  const onboardingItems: UsageItem[] = [
+    { key: "memberInvitesCreated", label: "Einladungslinks erstellt", count: memberInvitesCreated },
+    { key: "inviteRedemptions", label: "Einladungen eingelöst", count: inviteRedemptions },
+    { key: "onboardingProfile", label: "Onboardingprofil", count: onboardingProfileCount },
+    { key: "photoConsent", label: "Fotoeinverständnisse", count: photoConsentCount },
+    { key: "approvedPhotoConsents", label: "Fotoeinverständnisse geprüft", count: approvedPhotoConsents },
+  ].filter((item) => item.count > 0);
+
+  addSection({
+    key: "onboarding",
+    title: "Onboarding & Freigaben",
+    total: onboardingItems.reduce((sum, item) => sum + item.count, 0),
+    items: onboardingItems,
+  });
+
+  const profileItems: UsageItem[] = [
+    { key: "sessions", label: "Aktive Sitzungen", count: sessions },
+    { key: "accounts", label: "Verknüpfte Konten", count: accounts },
+    { key: "measurements", label: "Hinterlegte Maße", count: measurements },
+    { key: "sizes", label: "Konfektionsgrößen", count: sizes },
+    { key: "dietaryRestrictions", label: "Ernährungshinweise", count: dietaryRestrictions },
+    { key: "rolePreferences", label: "Rollenpräferenzen", count: rolePreferences },
+    { key: "interests", label: "Interessensgebiete", count: interests },
+    { key: "userAppRoles", label: "Zusätzliche Rollen (Custom)", count: userAppRoles },
+    { key: "guesses", label: "Mystery-Gewinnspielteilnahmen", count: guesses },
+  ].filter((item) => item.count > 0);
+
+  addSection({
+    key: "profile",
+    title: "Profil & persönliche Daten",
+    total: profileItems.reduce((sum, item) => sum + item.count, 0),
+    items: profileItems,
+  });
+
+  const displayName =
+    combineNameParts(user.firstName, user.lastName) ?? user.name ?? user.email ?? user.id;
+
+  return NextResponse.json({
+    ok: true,
+    user: {
+      id: user.id,
+      email: user.email,
+      name: displayName,
+      deactivatedAt: user.deactivatedAt?.toISOString() ?? null,
+    },
+    total,
+    sections,
+  });
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -53,7 +53,13 @@ function LoginContent() {
   // Surface NextAuth error from ?error=...
   useEffect(() => {
     const err = sp?.get("error");
+    const reason = sp?.get("reason");
     if (err) {
+      if (err === "AccessDenied" && reason === "deactivated") {
+        toast.error("Dieses Konto wurde deaktiviert. Bitte kontaktiere die Administration.");
+        setShowMagicSuggestion(false);
+        return;
+      }
       const map: Record<string, string> = {
         OAuthAccountNotLinked: "Account nicht verknüpft",
         CredentialsSignin: "Ungültige Zugangsdaten",

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -28,6 +28,7 @@ export function hasRole(user: { role?: Role; roles?: Role[] } | null | undefined
 export async function requireAuth(roles?: Role[]) {
   const session = await getServerSession(authOptions);
   if (!session?.user) redirect("/login");
+  if (session.user.isDeactivated) redirect("/login?error=AccessDenied&reason=deactivated");
   if (roles && !hasRole(session.user, ...roles)) redirect("/");
   return session;
 }

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -14,6 +14,8 @@ declare module "next-auth" {
       avatarSource?: AvatarSource | null;
       avatarUpdatedAt?: string | null;
       dateOfBirth?: string | null;
+      isDeactivated?: boolean;
+      deactivatedAt?: string | null;
     };
   }
   interface User {
@@ -24,6 +26,8 @@ declare module "next-auth" {
     avatarSource?: AvatarSource | null;
     avatarUpdatedAt?: string | null;
     dateOfBirth?: string | null;
+    isDeactivated?: boolean;
+    deactivatedAt?: string | null;
   }
 }
 


### PR DESCRIPTION
## Summary
- add deactivation metadata to users and cascade-delete related availability
- surface deactivate/reactivate and delete actions in the members table with usage overview
- guard auth flow against deactivated accounts and expose supporting API routes

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d12460fc40832dac42b51af68a3b67