### PR TITLE
feat: allow managing Sperrliste settings in UI

### DIFF
--- a/prisma/migrations/20270215090000_sperrliste_settings/migration.sql
+++ b/prisma/migrations/20270215090000_sperrliste_settings/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "public"."SperrlisteSettings" (
+    "id" TEXT NOT NULL DEFAULT 'default',
+    "holidaySourceMode" TEXT NOT NULL DEFAULT 'default',
+    "holidaySourceUrl" TEXT,
+    "holidaySourceStatus" TEXT NOT NULL DEFAULT 'unknown',
+    "holidaySourceMessage" TEXT,
+    "holidaySourceCheckedAt" TIMESTAMP(3),
+    "freezeDays" INTEGER NOT NULL DEFAULT 7,
+    "preferredWeekdays" JSONB,
+    "exceptionWeekdays" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "SperrlisteSettings_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -490,6 +490,20 @@ model MysterySettings {
   updatedAt          DateTime @updatedAt
 }
 
+model SperrlisteSettings {
+  id                     String   @id @default("default")
+  holidaySourceMode      String   @default("default")
+  holidaySourceUrl       String?
+  holidaySourceStatus    String   @default("unknown")
+  holidaySourceMessage   String?
+  holidaySourceCheckedAt DateTime?
+  freezeDays             Int      @default(7)
+  preferredWeekdays      Json?
+  exceptionWeekdays      Json?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+}
+
 model MysteryTip {
   id             String   @id @default(cuid())
   text           String

--- a/src/app/(members)/mitglieder/sperrliste/page-client.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page-client.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+import type { ClientSperrlisteSettings } from "@/lib/sperrliste-settings";
+import type { HolidayRange } from "@/types/holidays";
+
+import type { BlockedDay } from "./block-calendar";
+import type { OverviewMember } from "./block-overview";
+import { SperrlisteSettingsManager } from "./settings-manager";
+import { SperrlisteTabs } from "./sperrliste-tabs";
+
+interface SperrlistePageClientProps {
+  initialBlockedDays: BlockedDay[];
+  initialHolidays: HolidayRange[];
+  overviewMembers: OverviewMember[];
+  initialSettings: ClientSperrlisteSettings;
+  canManageSettings: boolean;
+  defaultHolidaySourceUrl: string;
+}
+
+export function SperrlistePageClient({
+  initialBlockedDays,
+  initialHolidays,
+  overviewMembers,
+  initialSettings,
+  canManageSettings,
+  defaultHolidaySourceUrl,
+}: SperrlistePageClientProps) {
+  const [settings, setSettings] = useState<ClientSperrlisteSettings>(initialSettings);
+  const [holidays, setHolidays] = useState<HolidayRange[]>(initialHolidays);
+  const [defaultHolidayUrl, setDefaultHolidayUrl] = useState(defaultHolidaySourceUrl);
+
+  return (
+    <div className="space-y-6">
+      {canManageSettings ? (
+        <SperrlisteSettingsManager
+          settings={settings}
+          defaultHolidaySourceUrl={defaultHolidayUrl}
+          onSettingsChange={(payload) => {
+            setSettings(payload.settings);
+            if (payload.holidays) {
+              setHolidays(payload.holidays);
+            }
+            if (payload.defaults?.holidaySourceUrl) {
+              setDefaultHolidayUrl(payload.defaults.holidaySourceUrl);
+            }
+          }}
+        />
+      ) : null}
+
+      <SperrlisteTabs
+        initialBlockedDays={initialBlockedDays}
+        holidays={holidays}
+        overviewMembers={overviewMembers}
+        freezeDays={settings.freezeDays}
+        preferredWeekdays={settings.preferredWeekdays}
+        exceptionWeekdays={settings.exceptionWeekdays}
+      />
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
@@ -1,0 +1,428 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { AlertCircle, CheckCircle2, Loader2, PlugZap, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import type { ClientSperrlisteSettings, HolidaySourceStatus, HolidaySourceMode } from "@/lib/sperrliste-settings";
+import { formatWeekdayList, WEEKDAY_OPTIONS, WEEKDAY_ORDER } from "@/lib/weekdays";
+import type { HolidayRange } from "@/types/holidays";
+
+const CHECKED_AT_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+interface SperrlisteSettingsManagerProps {
+  settings: ClientSperrlisteSettings;
+  defaultHolidaySourceUrl: string;
+  onSettingsChange?: (
+    payload: {
+      settings: ClientSperrlisteSettings;
+      holidays?: HolidayRange[];
+      defaults?: { holidaySourceUrl: string };
+    },
+  ) => void;
+}
+
+type HolidayStatusMeta = {
+  label: string;
+  tone: "ok" | "warning" | "disabled" | "unknown";
+  description: string;
+};
+
+function getStatusMeta(status: HolidaySourceStatus): HolidayStatusMeta {
+  switch (status) {
+    case "ok":
+      return {
+        label: "Quelle aktiv",
+        tone: "ok",
+        description: "Der konfigurierte Feed lieferte nutzbare Termine.",
+      };
+    case "error":
+      return {
+        label: "Fehler bei der Quelle",
+        tone: "warning",
+        description: "Die zuletzt getestete Quelle konnte nicht geladen werden.",
+      };
+    case "disabled":
+      return {
+        label: "Quelle deaktiviert",
+        tone: "disabled",
+        description: "Es werden ausschließlich statische Ferientermine genutzt.",
+      };
+    default:
+      return {
+        label: "Status unbekannt",
+        tone: "unknown",
+        description: "Für die aktuelle Quelle liegt noch kein Prüfstatus vor.",
+      };
+  }
+}
+
+function sortArray(values: Iterable<number>) {
+  const set = new Set<number>();
+  for (const value of values) {
+    if (!Number.isInteger(value)) continue;
+    if (value < 0 || value > 6) continue;
+    set.add(value);
+  }
+  return WEEKDAY_ORDER.filter((weekday) => set.has(weekday));
+}
+
+export function SperrlisteSettingsManager({
+  settings,
+  defaultHolidaySourceUrl,
+  onSettingsChange,
+}: SperrlisteSettingsManagerProps) {
+  const [freezeDaysValue, setFreezeDaysValue] = useState(String(settings.freezeDays));
+  const [holidayMode, setHolidayMode] = useState<HolidaySourceMode>(settings.holidaySource.mode);
+  const [holidayUrl, setHolidayUrl] = useState(settings.holidaySource.url ?? "");
+  const [preferredDays, setPreferredDays] = useState(() => new Set(settings.preferredWeekdays));
+  const [exceptionDays, setExceptionDays] = useState(() => new Set(settings.exceptionWeekdays));
+  const [status, setStatus] = useState(settings.holidayStatus);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [defaults, setDefaults] = useState({ holidaySourceUrl: defaultHolidaySourceUrl });
+
+  useEffect(() => {
+    setFreezeDaysValue(String(settings.freezeDays));
+    setHolidayMode(settings.holidaySource.mode);
+    setHolidayUrl(settings.holidaySource.url ?? "");
+    setPreferredDays(new Set(settings.preferredWeekdays));
+    setExceptionDays(new Set(settings.exceptionWeekdays));
+    setStatus(settings.holidayStatus);
+  }, [settings]);
+
+  useEffect(() => {
+    setDefaults({ holidaySourceUrl: defaultHolidaySourceUrl });
+  }, [defaultHolidaySourceUrl]);
+
+  const preferredList = useMemo(
+    () => formatWeekdayList(preferredDays, { fallback: "keine bevorzugten Tage" }),
+    [preferredDays],
+  );
+  const exceptionList = useMemo(
+    () => formatWeekdayList(exceptionDays, { fallback: "keine Ausnahmen" }),
+    [exceptionDays],
+  );
+
+  const statusMeta = useMemo(() => getStatusMeta(status.status), [status.status]);
+  const formattedCheckedAt = useMemo(() => {
+    if (!status.checkedAt) return null;
+    const parsed = new Date(status.checkedAt);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return CHECKED_AT_FORMATTER.format(parsed);
+  }, [status.checkedAt]);
+
+  const togglePreferred = (weekday: number) => {
+    setPreferredDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(weekday)) {
+        next.delete(weekday);
+      } else {
+        next.add(weekday);
+      }
+      return next;
+    });
+    setExceptionDays((prev) => {
+      if (!prev.has(weekday)) return prev;
+      const next = new Set(prev);
+      next.delete(weekday);
+      return next;
+    });
+    setSuccess(null);
+    setError(null);
+  };
+
+  const toggleException = (weekday: number) => {
+    setExceptionDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(weekday)) {
+        next.delete(weekday);
+      } else {
+        next.add(weekday);
+      }
+      return next;
+    });
+    setPreferredDays((prev) => {
+      if (!prev.has(weekday)) return prev;
+      const next = new Set(prev);
+      next.delete(weekday);
+      return next;
+    });
+    setSuccess(null);
+    setError(null);
+  };
+
+  const handleResetToDefaultUrl = () => {
+    setHolidayUrl(defaults.holidaySourceUrl ?? "");
+    setSuccess(null);
+    setError(null);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const parsedFreezeDays = Number.parseInt(freezeDaysValue, 10);
+    if (!Number.isFinite(parsedFreezeDays) || parsedFreezeDays < 0) {
+      setError("Bitte gib eine gültige Anzahl an Vorlauftagen an.");
+      return;
+    }
+
+    const payload = {
+      freezeDays: parsedFreezeDays,
+      preferredWeekdays: sortArray(preferredDays),
+      exceptionWeekdays: sortArray(exceptionDays),
+      holidaySourceMode: holidayMode,
+      holidaySourceUrl: holidayMode === "custom" ? holidayUrl.trim() : null,
+    } as const;
+
+    if (holidayMode === "custom" && !payload.holidaySourceUrl) {
+      setError("Bitte hinterlege eine gültige URL für den individuellen Ferien-Feed.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await fetch("/api/sperrliste/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data = (await response.json().catch(() => ({}))) as {
+        settings?: ClientSperrlisteSettings;
+        holidays?: HolidayRange[];
+        defaults?: { holidaySourceUrl: string };
+        error?: string;
+      };
+
+      if (!response.ok || !data?.settings) {
+        throw new Error(data?.error || "Die Einstellungen konnten nicht gespeichert werden.");
+      }
+
+      setStatus(data.settings.holidayStatus);
+      setDefaults({ holidaySourceUrl: data.defaults?.holidaySourceUrl ?? defaultHolidaySourceUrl });
+      setSuccess("Die Sperrlisten-Einstellungen wurden aktualisiert.");
+      onSettingsChange?.({
+        settings: data.settings,
+        holidays: data.holidays,
+        defaults: data.defaults,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler beim Speichern.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const renderWeekdayToggle = (
+    type: "preferred" | "exception",
+    weekday: number,
+    label: string,
+    shortLabel: string,
+  ) => {
+    const isPreferred = preferredDays.has(weekday);
+    const isException = exceptionDays.has(weekday);
+    const isActive = type === "preferred" ? isPreferred : isException;
+    const onToggle = type === "preferred" ? togglePreferred : toggleException;
+
+    return (
+      <button
+        key={`${type}-${weekday}`}
+        type="button"
+        onClick={() => onToggle(weekday)}
+        aria-pressed={isActive}
+        className={cn(
+          "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary",
+          isActive && type === "preferred" && "border-primary bg-primary/10 text-primary",
+          isActive && type === "exception" &&
+            "border-amber-400 bg-amber-100 text-amber-900 dark:border-amber-500/70 dark:bg-amber-500/10 dark:text-amber-100",
+          !isActive && "border-border/60 bg-background/80 hover:border-primary/40",
+        )}
+      >
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+          {shortLabel}
+        </span>
+        <span className="hidden text-sm sm:inline">{label}</span>
+      </button>
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader className="space-y-3">
+        <CardTitle className="flex items-center gap-2 text-xl">
+          <Sparkles className="h-5 w-5 text-primary" aria-hidden />
+          Sperrlisten-Einstellungen
+        </CardTitle>
+        <Text variant="small" tone="muted">
+          Lege fest, welche Ferienquelle genutzt wird, wie groß der Planungsvorlauf ist und welche Wochentage als bevorzugte
+          oder Ausnahme-Proben gelten.
+        </Text>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-8">
+          <section className="space-y-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Ferienquelle</h3>
+                <p className="text-sm text-muted-foreground">
+                  Wähle, ob die Ferien automatisch geladen werden oder ob die Sperrliste ohne externe Quelle arbeitet.
+                </p>
+              </div>
+              <div
+                className={cn(
+                  "flex items-center gap-2 rounded-lg border px-3 py-2 text-sm",
+                  statusMeta.tone === "ok" && "border-emerald-400/60 bg-emerald-500/10 text-emerald-700 dark:text-emerald-100",
+                  statusMeta.tone === "warning" && "border-amber-400/60 bg-amber-100 text-amber-900 dark:border-amber-500/70 dark:bg-amber-500/10 dark:text-amber-100",
+                  statusMeta.tone === "disabled" && "border-border/60 bg-muted/50 text-muted-foreground",
+                  statusMeta.tone === "unknown" && "border-slate-400/50 bg-slate-100 text-slate-700 dark:border-slate-600/60 dark:bg-slate-800/40 dark:text-slate-100",
+                )}
+              >
+                {statusMeta.tone === "ok" ? (
+                  <CheckCircle2 className="h-4 w-4" aria-hidden />
+                ) : statusMeta.tone === "warning" ? (
+                  <AlertCircle className="h-4 w-4" aria-hidden />
+                ) : statusMeta.tone === "disabled" ? (
+                  <PlugZap className="h-4 w-4" aria-hidden />
+                ) : (
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                )}
+                <div className="flex flex-col">
+                  <span className="text-xs font-semibold uppercase tracking-wide">{statusMeta.label}</span>
+                  <span className="text-xs text-muted-foreground/80 dark:text-inherit">
+                    {status.message ?? statusMeta.description}
+                    {formattedCheckedAt ? ` — geprüft am ${formattedCheckedAt}` : ""}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="holiday-mode">Quelle auswählen</Label>
+                <Select value={holidayMode} onValueChange={(value) => setHolidayMode(value as HolidaySourceMode)}>
+                  <SelectTrigger id="holiday-mode">
+                    <SelectValue placeholder="Modus wählen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Standardfeed (Schulferien Sachsen)</SelectItem>
+                    <SelectItem value="custom">Eigener Feed (ICS oder JSON)</SelectItem>
+                    <SelectItem value="disabled">Keine externe Quelle verwenden</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="holiday-url">Feed-URL</Label>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Input
+                    id="holiday-url"
+                    type="url"
+                    value={holidayUrl}
+                    onChange={(event) => setHolidayUrl(event.target.value)}
+                    placeholder={defaults.holidaySourceUrl}
+                    disabled={holidayMode !== "custom" || saving}
+                    className="sm:flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleResetToDefaultUrl}
+                    disabled={holidayMode !== "custom" || saving}
+                  >
+                    Standard übernehmen
+                  </Button>
+                </div>
+                <Text variant="small" tone="muted">
+                  Für individuelle Quellen kannst du ICS-Kalender oder JSON-Endpunkte (z. B. ferien-api.de) hinterlegen.
+                </Text>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Bevorzugte Probentage
+              </h3>
+              <Text variant="small" tone="muted">
+                Diese Tage werden im Kalender hervorgehoben und in der Übersicht standardmäßig angezeigt.
+              </Text>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {WEEKDAY_OPTIONS.map((option) =>
+                  renderWeekdayToggle("preferred", option.value, option.label, option.short),
+                )}
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">Aktuell: {preferredList}</p>
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Ausnahmeproben
+              </h3>
+              <Text variant="small" tone="muted">
+                Tage, die nur in besonderen Fällen eingeplant werden. Sie erscheinen in der Übersicht in warmen Gelbtönen.
+              </Text>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {WEEKDAY_OPTIONS.map((option) =>
+                  renderWeekdayToggle("exception", option.value, option.label, option.short),
+                )}
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">Aktuell: {exceptionList}</p>
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="freeze-days">Vorlauf für Sperrtermine (Tage)</Label>
+              <Input
+                id="freeze-days"
+                type="number"
+                min={0}
+                max={365}
+                value={freezeDaysValue}
+                onChange={(event) => setFreezeDaysValue(event.target.value.replace(/[^0-9]/g, ""))}
+                disabled={saving}
+              />
+              <Text variant="small" tone="muted">
+                Innerhalb dieses Zeitraums können Mitglieder keine neuen Sperrtage hinzufügen. Bestehende Einträge lassen sich
+                weiterhin entfernen.
+              </Text>
+            </div>
+          </section>
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          {success ? <p className="text-sm text-emerald-600 dark:text-emerald-300">{success}</p> : null}
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <Text variant="small" tone="muted">
+              Änderungen beeinflussen sofort die Hinweise im Kalender und die Farbgebung der Sperrlisten-Übersicht.
+            </Text>
+            <Button type="submit" disabled={saving} className="sm:w-auto">
+              {saving ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  Speichern …
+                </span>
+              ) : (
+                "Änderungen speichern"
+              )}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { format, isValid, parseISO } from "date-fns";
+import { addDays, format } from "date-fns";
 import { de } from "date-fns/locale/de";
 
 import { CalendarCheck2, UsersRound } from "lucide-react";
@@ -15,23 +15,28 @@ interface SperrlisteTabsProps {
   initialBlockedDays: BlockedDay[];
   holidays?: HolidayRange[];
   overviewMembers: OverviewMember[];
-  freezeUntil?: string | null;
+  freezeDays?: number;
+  preferredWeekdays?: number[];
+  exceptionWeekdays?: number[];
 }
 
 export function SperrlisteTabs({
   initialBlockedDays,
   holidays = [],
   overviewMembers,
-  freezeUntil,
+  freezeDays = 0,
+  preferredWeekdays = [],
+  exceptionWeekdays = [],
 }: SperrlisteTabsProps) {
   const formattedFreeze = useMemo(() => {
-    if (!freezeUntil) return null;
-    const parsed = parseISO(freezeUntil);
-    if (!isValid(parsed)) {
-      return freezeUntil;
+    if (!freezeDays || freezeDays <= 0) {
+      return null;
     }
-    return format(parsed, "EEEE, d. MMMM yyyy", { locale: de });
-  }, [freezeUntil]);
+    const today = new Date();
+    const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const freezeUntil = addDays(startOfToday, freezeDays);
+    return format(freezeUntil, "EEEE, d. MMMM yyyy", { locale: de });
+  }, [freezeDays]);
 
   return (
     <Tabs defaultValue="personal" className="space-y-6">
@@ -52,11 +57,22 @@ export function SperrlisteTabs({
             Hinweis: Aus Planungsgründen können Sperrtermine erst ab {formattedFreeze} eingetragen werden.
           </div>
         ) : null}
-        <BlockCalendar initialBlockedDays={initialBlockedDays} holidays={holidays} />
+        <BlockCalendar
+          initialBlockedDays={initialBlockedDays}
+          holidays={holidays}
+          freezeDays={freezeDays}
+          preferredWeekdays={preferredWeekdays}
+          exceptionWeekdays={exceptionWeekdays}
+        />
       </TabsContent>
 
       <TabsContent value="overview">
-        <BlockOverview members={overviewMembers} holidays={holidays} />
+        <BlockOverview
+          members={overviewMembers}
+          holidays={holidays}
+          preferredWeekdays={preferredWeekdays}
+          exceptionWeekdays={exceptionWeekdays}
+        />
       </TabsContent>
     </Tabs>
   );

--- a/src/app/api/sperrliste/settings/route.ts
+++ b/src/app/api/sperrliste/settings/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  applyHolidaySourceStatus,
+  getDefaultHolidaySourceUrl,
+  readSperrlisteSettings,
+  resolveSperrlisteSettings,
+  saveSperrlisteSettings,
+  toClientSperrlisteSettings,
+} from "@/lib/sperrliste-settings";
+import { fetchHolidayRangesForSettings } from "@/lib/holidays";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { sortWeekdays } from "@/lib/weekdays";
+
+const updateSchema = z.object({
+  freezeDays: z.coerce.number().int().min(0).max(365),
+  preferredWeekdays: z
+    .array(z.coerce.number().int().min(0).max(6))
+    .optional()
+    .transform((value) => value ?? []),
+  exceptionWeekdays: z
+    .array(z.coerce.number().int().min(0).max(6))
+    .optional()
+    .transform((value) => value ?? []),
+  holidaySourceMode: z.enum(["default", "custom", "disabled"]),
+  holidaySourceUrl: z
+    .union([z.string().trim().url().max(500), z.literal(""), z.null()])
+    .transform((value) => {
+      if (value === null || value === "") {
+        return null;
+      }
+      return value;
+    }),
+});
+
+function sanitiseExceptionWeekdays(preferred: number[], exception: number[]) {
+  const preferredSet = new Set(preferred);
+  return exception.filter((weekday) => !preferredSet.has(weekday));
+}
+
+async function ensurePermission() {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.sperrliste.settings"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET() {
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  try {
+    const record = await readSperrlisteSettings();
+    const resolved = resolveSperrlisteSettings(record);
+    return NextResponse.json({
+      settings: toClientSperrlisteSettings(resolved),
+      defaults: {
+        holidaySourceUrl: getDefaultHolidaySourceUrl(),
+      },
+    });
+  } catch (error) {
+    console.error("Failed to load sperrliste settings", error);
+    return NextResponse.json({ error: "Einstellungen konnten nicht geladen werden." }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const parsed = updateSchema.safeParse(payload);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json({ error: issue?.message ?? "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const preferredWeekdays = sortWeekdays(parsed.data.preferredWeekdays);
+  const exceptionWeekdays = sanitiseExceptionWeekdays(
+    preferredWeekdays,
+    sortWeekdays(parsed.data.exceptionWeekdays),
+  );
+
+  const mode = parsed.data.holidaySourceMode;
+  const url = mode === "custom" ? parsed.data.holidaySourceUrl : null;
+
+  if (mode === "custom" && !url) {
+    return NextResponse.json(
+      { error: "Bitte gib eine gültige URL für die Ferienquelle an." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const existingRecord = await readSperrlisteSettings();
+    const resolvedBefore = resolveSperrlisteSettings(existingRecord);
+
+    const modeChanged = resolvedBefore.holidaySource.mode !== mode;
+    const urlChanged = (resolvedBefore.holidaySource.url ?? null) !== (url ?? null);
+
+    const savedRecord = await saveSperrlisteSettings(
+      {
+        freezeDays: parsed.data.freezeDays,
+        preferredWeekdays,
+        exceptionWeekdays,
+        holidaySourceMode: mode,
+        holidaySourceUrl: url,
+      },
+      { resetStatus: modeChanged || urlChanged },
+    );
+
+    const resolvedAfterSave = resolveSperrlisteSettings(savedRecord);
+    const result = await fetchHolidayRangesForSettings(resolvedAfterSave);
+    await applyHolidaySourceStatus(result.status);
+
+    const refreshedRecord = await readSperrlisteSettings();
+    const resolved = resolveSperrlisteSettings(refreshedRecord);
+
+    return NextResponse.json({
+      settings: toClientSperrlisteSettings(resolved),
+      holidays: result.ranges,
+      defaults: {
+        holidaySourceUrl: getDefaultHolidaySourceUrl(),
+      },
+    });
+  } catch (error) {
+    console.error("Failed to save sperrliste settings", error);
+    return NextResponse.json({ error: "Die Einstellungen konnten nicht gespeichert werden." }, { status: 500 });
+  }
+}

--- a/src/lib/__tests__/holidays.test.ts
+++ b/src/lib/__tests__/holidays.test.ts
@@ -5,6 +5,38 @@ vi.mock("next/cache", () => ({
   unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
 }));
 
+const resolvedSettings = {
+  id: "default",
+  freezeDays: 7,
+  preferredWeekdays: [6, 0],
+  exceptionWeekdays: [5],
+  holidaySource: {
+    mode: "default" as const,
+    url: null,
+    effectiveUrl: "https://example.com/ferien.ics",
+  },
+  holidayStatus: {
+    status: "unknown" as const,
+    message: null,
+    checkedAt: null,
+  },
+  updatedAt: null,
+  cacheKey: "default|https://example.com/ferien.ics",
+};
+
+vi.mock("@/lib/sperrliste-settings", () => ({
+  readSperrlisteSettings: vi.fn().mockResolvedValue(null),
+  resolveSperrlisteSettings: vi
+    .fn()
+    .mockImplementation(() => ({
+      ...resolvedSettings,
+      holidaySource: { ...resolvedSettings.holidaySource },
+      holidayStatus: { ...resolvedSettings.holidayStatus },
+    })),
+  applyHolidaySourceStatus: vi.fn().mockResolvedValue(undefined),
+  getDefaultHolidaySourceUrl: vi.fn(() => resolvedSettings.holidaySource.effectiveUrl),
+}));
+
 import { SAXONY_SCHOOL_HOLIDAYS } from "@/data/saxony-school-holidays";
 import { getSaxonySchoolHolidayRanges } from "@/lib/holidays";
 

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -97,6 +97,12 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { key: "mitglieder.rechte", label: "Rechteverwaltung öffnen", category: "membership" },
   { key: "mitglieder.sperrliste", label: "Sperrliste pflegen", category: "membership" },
   {
+    key: "mitglieder.sperrliste.settings",
+    label: "Sperrlisten-Einstellungen verwalten",
+    description: "Ferienquelle, Vorlaufzeit und bevorzugte Probentage anpassen.",
+    category: "membership",
+  },
+  {
     key: "mitglieder.fotoerlaubnisse",
     label: "Fotoerlaubnisse verwalten",
     description: "Bereich zum Prüfen und Freigeben von Fotoeinverständniserklärungen.",

--- a/src/lib/sperrliste-settings.ts
+++ b/src/lib/sperrliste-settings.ts
@@ -1,0 +1,294 @@
+import { prisma } from "@/lib/prisma";
+import type { Prisma, SperrlisteSettings } from "@prisma/client";
+
+export const DEFAULT_SAXONY_HOLIDAY_FEED =
+  "https://www.schulferien.org/media/ical/deutschland/ferien_sachsen.ics";
+
+export const DEFAULT_FREEZE_DAYS = 7;
+export const DEFAULT_PREFERRED_WEEKDAYS = [6, 0] as const;
+export const DEFAULT_EXCEPTION_WEEKDAYS = [5] as const;
+
+export const HOLIDAY_SOURCE_MODES = ["default", "custom", "disabled"] as const;
+export type HolidaySourceMode = (typeof HOLIDAY_SOURCE_MODES)[number];
+
+export const HOLIDAY_SOURCE_STATUSES = [
+  "unknown",
+  "ok",
+  "error",
+  "disabled",
+] as const;
+export type HolidaySourceStatus = (typeof HOLIDAY_SOURCE_STATUSES)[number];
+
+export type SperrlisteSettingsRecord = SperrlisteSettings | null;
+
+export type ResolvedSperrlisteSettings = {
+  id: string;
+  freezeDays: number;
+  preferredWeekdays: number[];
+  exceptionWeekdays: number[];
+  holidaySource: {
+    mode: HolidaySourceMode;
+    url: string | null;
+    effectiveUrl: string | null;
+  };
+  holidayStatus: {
+    status: HolidaySourceStatus;
+    message: string | null;
+    checkedAt: Date | null;
+  };
+  updatedAt: Date | null;
+  cacheKey: string;
+};
+
+export type ResolvedHolidaySourceStatus = ResolvedSperrlisteSettings["holidayStatus"];
+
+export type ClientSperrlisteSettings = {
+  freezeDays: number;
+  preferredWeekdays: number[];
+  exceptionWeekdays: number[];
+  holidaySource: {
+    mode: HolidaySourceMode;
+    url: string | null;
+    effectiveUrl: string | null;
+  };
+  holidayStatus: {
+    status: HolidaySourceStatus;
+    message: string | null;
+    checkedAt: string | null;
+  };
+  updatedAt: string | null;
+  cacheKey: string;
+};
+
+export type SperrlisteSettingsInput = {
+  freezeDays: number;
+  preferredWeekdays: number[];
+  exceptionWeekdays: number[];
+  holidaySourceMode: HolidaySourceMode;
+  holidaySourceUrl: string | null;
+};
+
+export type HolidayStatusUpdate = {
+  status: HolidaySourceStatus;
+  message: string | null;
+  checkedAt: Date;
+};
+
+const DEFAULT_RECORD_ID = "default" as const;
+
+function normaliseUrl(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function clampNumber(value: unknown, minimum: number, maximum: number, fallback: number) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const rounded = Math.round(value);
+  if (rounded < minimum) return minimum;
+  if (rounded > maximum) return maximum;
+  return rounded;
+}
+
+const WEEKDAY_ORDER: number[] = [1, 2, 3, 4, 5, 6, 0];
+
+function sanitiseWeekdayJson(value: Prisma.JsonValue | null | undefined, fallback: readonly number[]) {
+  if (!Array.isArray(value)) {
+    return [...fallback];
+  }
+
+  const set = new Set<number>();
+  for (const entry of value) {
+    if (typeof entry === "number" && Number.isInteger(entry) && entry >= 0 && entry <= 6) {
+      set.add(entry);
+      continue;
+    }
+    if (typeof entry === "string") {
+      const parsed = Number.parseInt(entry, 10);
+      if (Number.isInteger(parsed) && parsed >= 0 && parsed <= 6) {
+        set.add(parsed);
+      }
+    }
+  }
+
+  if (set.size === 0) {
+    return [];
+  }
+
+  return WEEKDAY_ORDER.filter((weekday) => set.has(weekday));
+}
+
+function resolveMode(value: unknown): HolidaySourceMode {
+  if (typeof value !== "string") {
+    return "default";
+  }
+  const normalised = value.trim().toLowerCase();
+  if (HOLIDAY_SOURCE_MODES.includes(normalised as HolidaySourceMode)) {
+    return normalised as HolidaySourceMode;
+  }
+  return "default";
+}
+
+function resolveStatus(value: unknown): HolidaySourceStatus {
+  if (typeof value !== "string") {
+    return "unknown";
+  }
+  const normalised = value.trim().toLowerCase();
+  if (HOLIDAY_SOURCE_STATUSES.includes(normalised as HolidaySourceStatus)) {
+    return normalised as HolidaySourceStatus;
+  }
+  return "unknown";
+}
+
+function resolveDefaultHolidayUrl() {
+  const envValue = normaliseUrl(process.env.SAXONY_HOLIDAYS_ICS_URL);
+  return envValue ?? DEFAULT_SAXONY_HOLIDAY_FEED;
+}
+
+export function getDefaultHolidaySourceUrl() {
+  return resolveDefaultHolidayUrl();
+}
+
+export function resolveSperrlisteSettings(record: SperrlisteSettingsRecord): ResolvedSperrlisteSettings {
+  const mode = resolveMode(record?.holidaySourceMode);
+  const url = normaliseUrl(record?.holidaySourceUrl);
+  const freezeDays = clampNumber(record?.freezeDays, 0, 365, DEFAULT_FREEZE_DAYS);
+  const preferredWeekdays = sanitiseWeekdayJson(record?.preferredWeekdays ?? null, DEFAULT_PREFERRED_WEEKDAYS);
+  const exceptionWeekdays = sanitiseWeekdayJson(record?.exceptionWeekdays ?? null, DEFAULT_EXCEPTION_WEEKDAYS);
+  const effectiveUrl = mode === "disabled" ? null : mode === "custom" ? url : resolveDefaultHolidayUrl();
+
+  const resolvedStatus = mode === "disabled" ? "disabled" : resolveStatus(record?.holidaySourceStatus);
+
+  const holidayStatus = {
+    status: resolvedStatus,
+    message: record?.holidaySourceMessage ?? null,
+    checkedAt: record?.holidaySourceCheckedAt ?? null,
+  } as const;
+
+  const cacheKey = `${mode}|${effectiveUrl ?? "none"}`;
+
+  return {
+    id: record?.id ?? DEFAULT_RECORD_ID,
+    freezeDays,
+    preferredWeekdays,
+    exceptionWeekdays,
+    holidaySource: {
+      mode,
+      url,
+      effectiveUrl,
+    },
+    holidayStatus,
+    updatedAt: record?.updatedAt ?? null,
+    cacheKey,
+  };
+}
+
+export function toClientSperrlisteSettings(
+  resolved: ResolvedSperrlisteSettings,
+): ClientSperrlisteSettings {
+  return {
+    freezeDays: resolved.freezeDays,
+    preferredWeekdays: [...resolved.preferredWeekdays],
+    exceptionWeekdays: [...resolved.exceptionWeekdays],
+    holidaySource: {
+      mode: resolved.holidaySource.mode,
+      url: resolved.holidaySource.url,
+      effectiveUrl: resolved.holidaySource.effectiveUrl,
+    },
+    holidayStatus: {
+      status: resolved.holidayStatus.status,
+      message: resolved.holidayStatus.message,
+      checkedAt: resolved.holidayStatus.checkedAt
+        ? resolved.holidayStatus.checkedAt.toISOString()
+        : null,
+    },
+    updatedAt: resolved.updatedAt ? resolved.updatedAt.toISOString() : null,
+    cacheKey: resolved.cacheKey,
+  };
+}
+
+export async function readSperrlisteSettings() {
+  return prisma.sperrlisteSettings.findUnique({ where: { id: DEFAULT_RECORD_ID } });
+}
+
+function toJsonArray(values: number[]) {
+  const set = new Set<number>();
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    const rounded = Math.trunc(value);
+    if (!Number.isInteger(rounded) || rounded < 0 || rounded > 6) continue;
+    set.add(rounded);
+  }
+
+  if (set.size === 0) {
+    return [] as number[];
+  }
+
+  return WEEKDAY_ORDER.filter((weekday) => set.has(weekday));
+}
+
+export async function saveSperrlisteSettings(
+  data: SperrlisteSettingsInput,
+  options: { resetStatus?: boolean } = {},
+) {
+  const id = DEFAULT_RECORD_ID;
+  const resetStatus = Boolean(options.resetStatus);
+  const preferredWeekdays = toJsonArray(data.preferredWeekdays);
+  const exceptionWeekdays = toJsonArray(data.exceptionWeekdays);
+
+  const update: Prisma.SperrlisteSettingsUpdateInput = {
+    freezeDays: clampNumber(data.freezeDays, 0, 365, DEFAULT_FREEZE_DAYS),
+    holidaySourceMode: data.holidaySourceMode,
+    holidaySourceUrl: normaliseUrl(data.holidaySourceUrl),
+    preferredWeekdays,
+    exceptionWeekdays,
+  };
+
+  if (resetStatus) {
+    update.holidaySourceStatus = "unknown";
+    update.holidaySourceMessage = null;
+    update.holidaySourceCheckedAt = null;
+  }
+
+  return prisma.sperrlisteSettings.upsert({
+    where: { id },
+    update,
+    create: {
+      id,
+      freezeDays: clampNumber(data.freezeDays, 0, 365, DEFAULT_FREEZE_DAYS),
+      holidaySourceMode: data.holidaySourceMode,
+      holidaySourceUrl: normaliseUrl(data.holidaySourceUrl),
+      preferredWeekdays,
+      exceptionWeekdays,
+    },
+  });
+}
+
+export async function applyHolidaySourceStatus(update: HolidayStatusUpdate) {
+  const id = DEFAULT_RECORD_ID;
+  const resolvedStatus = update.status === "disabled" ? "disabled" : update.status;
+  return prisma.sperrlisteSettings.upsert({
+    where: { id },
+    update: {
+      holidaySourceStatus: resolvedStatus,
+      holidaySourceMessage: update.message,
+      holidaySourceCheckedAt: update.checkedAt,
+    },
+    create: {
+      id,
+      holidaySourceMode: "default",
+      holidaySourceUrl: null,
+      holidaySourceStatus: resolvedStatus,
+      holidaySourceMessage: update.message,
+      holidaySourceCheckedAt: update.checkedAt,
+      freezeDays: DEFAULT_FREEZE_DAYS,
+      preferredWeekdays: [...DEFAULT_PREFERRED_WEEKDAYS],
+      exceptionWeekdays: [...DEFAULT_EXCEPTION_WEEKDAYS],
+    },
+  });
+}

--- a/src/lib/weekdays.ts
+++ b/src/lib/weekdays.ts
@@ -1,0 +1,78 @@
+const WEEKDAY_DEFINITIONS = [
+  { value: 1, short: "Mo", label: "Montag" },
+  { value: 2, short: "Di", label: "Dienstag" },
+  { value: 3, short: "Mi", label: "Mittwoch" },
+  { value: 4, short: "Do", label: "Donnerstag" },
+  { value: 5, short: "Fr", label: "Freitag" },
+  { value: 6, short: "Sa", label: "Samstag" },
+  { value: 0, short: "So", label: "Sonntag" },
+] as const;
+
+type WeekdayDefinition = (typeof WEEKDAY_DEFINITIONS)[number];
+
+export type WeekdayValue = WeekdayDefinition["value"];
+
+export const WEEKDAY_ORDER = WEEKDAY_DEFINITIONS.map((entry) => entry.value) as WeekdayValue[];
+
+const WEEKDAY_MAP = new Map<WeekdayValue, WeekdayDefinition>(
+  WEEKDAY_DEFINITIONS.map((entry) => [entry.value, entry]),
+);
+
+const LONG_LIST_FORMATTER = new Intl.ListFormat("de-DE", {
+  style: "long",
+  type: "conjunction",
+});
+
+const SHORT_LIST_FORMATTER = new Intl.ListFormat("de-DE", {
+  style: "short",
+  type: "conjunction",
+});
+
+export const WEEKDAY_OPTIONS = WEEKDAY_DEFINITIONS.map((entry) => ({
+  value: entry.value,
+  short: entry.short,
+  label: entry.label,
+}));
+
+export function sortWeekdays(values: Iterable<number>) {
+  const set = new Set<WeekdayValue>();
+  for (const value of values) {
+    if (!Number.isInteger(value)) continue;
+    if (value < 0 || value > 6) continue;
+    set.add(value as WeekdayValue);
+  }
+  return WEEKDAY_ORDER.filter((weekday) => set.has(weekday));
+}
+
+export function formatWeekdayList(
+  values: Iterable<number>,
+  options: { style?: "long" | "short"; fallback?: string } = {},
+) {
+  const sorted = sortWeekdays(values);
+  if (sorted.length === 0) {
+    return options.fallback ?? "";
+  }
+
+  const labels = sorted.map((weekday) => {
+    const entry = WEEKDAY_MAP.get(weekday);
+    if (!entry) {
+      return String(weekday);
+    }
+    return options.style === "short" ? entry.short : entry.label;
+  });
+
+  const formatter = options.style === "short" ? SHORT_LIST_FORMATTER : LONG_LIST_FORMATTER;
+  return formatter.format(labels);
+}
+
+export function getWeekdayLabel(value: number, style: "long" | "short" = "long") {
+  if (!Number.isInteger(value) || value < 0 || value > 6) {
+    return String(value);
+  }
+
+  const entry = WEEKDAY_MAP.get(value as WeekdayValue);
+  if (!entry) {
+    return String(value);
+  }
+  return style === "short" ? entry.short : entry.label;
+}


### PR DESCRIPTION
## Summary
- add Prisma model, migration, and API endpoint to persist Sperrliste settings and integrate the holiday fetcher with those values
- implement a client-side settings manager so privileged users can adjust freeze days, holiday sources, and preferred/exception weekdays
- update Sperrliste calendar/overview components plus supporting helpers and tests to honour the dynamic settings and refreshed holiday status

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d11d0f6afc832d908858df9b4e242d