### PR TITLE
refactor: improve Dockerfile caching

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,43 +1,39 @@
+# syntax=docker/dockerfile:1.4
+
 # Production Dockerfile bundling the Next.js app and realtime server
 ARG GIT_COMMIT_SHA
 
-FROM node:20-alpine AS deps
+FROM node:20-alpine AS base
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NEXT_TELEMETRY_DISABLED=1
 RUN apk add --no-cache openssl \
     && corepack enable
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
-RUN SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --frozen-lockfile
 
-FROM node:20-alpine AS builder
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3 \
+    SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --frozen-lockfile
+
+FROM base AS builder
 ARG GIT_COMMIT_SHA
-ENV PNPM_HOME=/root/.local/share/pnpm \
-    PATH=/root/.local/share/pnpm:$PATH \
-    NODE_ENV=production \
-    NEXT_TELEMETRY_DISABLED=1 \
+ENV NODE_ENV=production \
     VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
     NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
     REALTIME_BASE_PATH=/realtime \
     NEXT_PUBLIC_REALTIME_URL=/realtime \
     NEXT_PUBLIC_REALTIME_PATH=/realtime/socket.io \
     REALTIME_SERVER_EVENT_PATH=/realtime/events
-RUN apk add --no-cache openssl \
-    && corepack enable
-WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN pnpm prisma:generate
 RUN pnpm build
 RUN pnpm prune --prod
 
-FROM node:20-alpine AS runner
+FROM base AS runner
 ARG GIT_COMMIT_SHA
-ENV PNPM_HOME=/root/.local/share/pnpm \
-    PATH=/root/.local/share/pnpm:$PATH \
-    NODE_ENV=production \
-    NEXT_TELEMETRY_DISABLED=1 \
+ENV NODE_ENV=production \
     VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
     NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA=${GIT_COMMIT_SHA} \
     PORT=3000 \
@@ -48,9 +44,6 @@ ENV PNPM_HOME=/root/.local/share/pnpm \
     REALTIME_SERVER_EVENT_PATH=/realtime/events \
     REALTIME_INTERNAL_ORIGIN=http://127.0.0.1:3001 \
     REALTIME_SERVER_URL=http://127.0.0.1:3001/realtime
-RUN apk add --no-cache openssl \
-    && corepack enable
-WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- introduce a shared base stage so dependency, build and runtime layers can be reused across image builds
- enable a BuildKit cache mount for pnpm installs to avoid re-downloading the store on incremental builds
- keep the production build flow intact while reducing duplicate setup steps in later stages

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1327f9f78832dbaa0658af085629f