### PR TITLE
Add server logs tab to analytics

### DIFF
--- a/src/data/server-analytics-static.json
+++ b/src/data/server-analytics-static.json
@@ -304,5 +304,77 @@
       "impact": "Mittel",
       "metric": "Suche im Issue-Board 420 ms (Ziel < 250 ms)"
     }
+  ],
+  "serverLogs": [
+    {
+      "id": "log-db-connection",
+      "severity": "error",
+      "service": "Next.js API · /api/rehearsals",
+      "message": "Datenbank-Timeout bei der Probenplanung",
+      "description": "Der Connection-Pool erreichte das Limit und Prisma brach die Anfrage nach 5 s ab.",
+      "occurrences": 7,
+      "firstSeen": "2025-01-22T06:14:00.000Z",
+      "lastSeen": "2025-01-24T05:45:00.000Z",
+      "status": "open",
+      "recommendedAction": "Poolgröße auf 20 erhöhen und Slow-Query-Log für /api/rehearsals analysieren.",
+      "affectedUsers": 12,
+      "tags": ["Datenbank", "API"]
+    },
+    {
+      "id": "log-cache-stale",
+      "severity": "warning",
+      "service": "Edge Cache",
+      "message": "Stale-While-Revalidate dauerte länger als erwartet",
+      "description": "Mehrere Kacheln der Startseite liefen gleichzeitig aus und verursachten 1,8 s Revalidierungszeit.",
+      "occurrences": 42,
+      "firstSeen": "2025-01-23T08:05:00.000Z",
+      "lastSeen": "2025-01-24T06:58:00.000Z",
+      "status": "monitoring",
+      "recommendedAction": "Cache-Warmup in der Nacht aktivieren und TTL von Hero-Content erhöhen.",
+      "affectedUsers": 86,
+      "tags": ["Performance", "Frontend"]
+    },
+    {
+      "id": "log-realtime-handshake",
+      "severity": "error",
+      "service": "Realtime-Server",
+      "message": "Abgelehnte Socket-Handshakes",
+      "description": "18 Verbindungsversuche wurden mit 'Invalid token signature' verworfen.",
+      "occurrences": 18,
+      "firstSeen": "2025-01-23T05:42:00.000Z",
+      "lastSeen": "2025-01-24T05:12:00.000Z",
+      "status": "monitoring",
+      "recommendedAction": "Handshake-Token erneuern und Mitglieder über erneuten Login informieren.",
+      "affectedUsers": 5,
+      "tags": ["Realtime", "Authentifizierung"]
+    },
+    {
+      "id": "log-cron-backlog",
+      "severity": "warning",
+      "service": "Cronjob · /api/cron/rehearsal-reminders",
+      "message": "Versand der Probenerinnerungen verzögert",
+      "description": "Die Queue-Auslastung lag bei 82 % und die Ausführung verschob sich um 14 Minuten.",
+      "occurrences": 9,
+      "firstSeen": "2025-01-22T04:00:00.000Z",
+      "lastSeen": "2025-01-24T04:00:00.000Z",
+      "status": "open",
+      "recommendedAction": "Cronjob auf zwei Worker verteilen und Batch-Größe auf 35 reduzieren.",
+      "affectedUsers": 64,
+      "tags": ["Automatisierung", "Mitglieder"]
+    },
+    {
+      "id": "log-storage-permissions",
+      "severity": "error",
+      "service": "Dateispeicher",
+      "message": "Upload fehlgeschlagen – fehlende Schreibrechte",
+      "description": "Ein Deploy überschieb die IAM-Rolle, wodurch fünf Uploads auf S3 abgewiesen wurden.",
+      "occurrences": 5,
+      "firstSeen": "2025-01-21T16:22:00.000Z",
+      "lastSeen": "2025-01-23T11:10:00.000Z",
+      "status": "resolved",
+      "recommendedAction": "Rollback-Regel im CI aktivieren und Policy-Drift-Check ins Deployment aufnehmen.",
+      "affectedUsers": 3,
+      "tags": ["Storage", "Deployment"]
+    }
   ]
 }

--- a/src/lib/server-analytics.ts
+++ b/src/lib/server-analytics.ts
@@ -7,6 +7,24 @@ import staticAnalyticsData from "@/data/server-analytics-static.json";
 export type OptimizationImpact = "Hoch" | "Mittel" | "Niedrig";
 export type OptimizationArea = "Frontend" | "Mitgliederbereich" | "Infrastruktur";
 
+export type ServerLogSeverity = "info" | "warning" | "error";
+export type ServerLogStatus = "open" | "monitoring" | "resolved";
+
+export type ServerLogEvent = {
+  id: string;
+  severity: ServerLogSeverity;
+  service: string;
+  message: string;
+  description: string;
+  occurrences: number;
+  firstSeen: string;
+  lastSeen: string;
+  status: ServerLogStatus;
+  recommendedAction?: string;
+  affectedUsers?: number;
+  tags?: string[];
+};
+
 export type ServerSummary = {
   uptimePercentage: number;
   requestsLast24h: number;
@@ -110,6 +128,7 @@ export type ServerAnalytics = {
   deviceBreakdown: DeviceStat[];
   sessionInsights: SessionInsight[];
   optimizationInsights: OptimizationInsight[];
+  serverLogs: ServerLogEvent[];
 };
 
 type StaticAnalyticsData = Omit<ServerAnalytics, "generatedAt">;


### PR DESCRIPTION
## Summary
- extend the server analytics model with structured server log events and seed static data with representative warnings/errors
- add a dedicated "Serverlogs" tab to the members analytics view including summary cards and detailed log event cards filtered to warnings and errors
- surface the latest log timestamp beside the tab controls to highlight recent incidents and improve log visibility

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d13207e3bc832db76a2102dbbcc300