### PR TITLE
Adjust rehearsal calendar highlight behavior

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -523,10 +523,10 @@ export function BlockCalendar({
             "border-emerald-400/60 bg-emerald-500/10 dark:border-emerald-500/40 dark:bg-emerald-500/10",
           !entry && isHoliday &&
             "border-sky-400/60 bg-sky-50/80 dark:border-sky-500/40 dark:bg-sky-500/10",
-          !entry && !isHoliday && isPreferredDay &&
-            "border-primary/40 bg-primary/5 text-primary dark:border-primary/60 dark:bg-primary/10 dark:text-primary-foreground",
-          !entry && !isHoliday && isExceptionDay &&
-            "border-amber-300/60 bg-amber-100/60 text-amber-900 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-100",
+          !entry &&
+            !isHoliday &&
+            (isPreferredDay || isExceptionDay) &&
+            "border-primary/30 bg-[linear-gradient(135deg,_rgba(129,140,248,0.12),_rgba(129,140,248,0))] dark:border-primary/40 dark:bg-[linear-gradient(135deg,_rgba(99,102,241,0.18),_rgba(129,140,248,0.06))]",
           day.isToday && !isSelected && "ring-2 ring-primary/80",
           isSelected && "border-primary ring-2 ring-primary/60",
           "hover:shadow-sm hover:-translate-y-[1px]",

--- a/src/components/calendar/month-calendar.tsx
+++ b/src/components/calendar/month-calendar.tsx
@@ -371,21 +371,7 @@ export function MonthCalendar({
         @keyframes calendarRemovedFlash { 0% { background-color: rgba(239,68,68,.15); } 100% { background-color: transparent; } }
         @keyframes calendarMonthInRight { 0% { opacity: 0; transform: translateX(24px);} 100% { opacity: 1; transform: translateX(0);} }
         @keyframes calendarMonthInLeft { 0% { opacity: 0; transform: translateX(-24px);} 100% { opacity: 1; transform: translateX(0);} }
-        .calendar-weekday[data-weekend="true"] {
-          background: linear-gradient(120deg, rgba(129,140,248,.14), rgba(129,140,248,.04));
-          color: rgba(67,56,202,.9);
-        }
-        .dark .calendar-weekday[data-weekend="true"] {
-          background: linear-gradient(120deg, rgba(129,140,248,.22), rgba(99,102,241,.08));
-          color: rgba(224,231,255,.92);
-        }
         .calendar-cell { position: relative; transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease; }
-        .calendar-cell[data-weekend="true"] {
-          background-image: linear-gradient(135deg, rgba(129,140,248,.12), rgba(129,140,248,0));
-        }
-        .dark .calendar-cell[data-weekend="true"] {
-          background-image: linear-gradient(135deg, rgba(99,102,241,.18), rgba(129,140,248,.06));
-        }
         .calendar-cell:hover { border-color: rgba(99,102,241,.55); transform: translateY(-2px) scale(1.01); box-shadow: 0 16px 28px -18px rgba(79,70,229,.65); }
         .dark .calendar-cell:hover { border-color: rgba(165,180,252,.75); box-shadow: 0 16px 32px -16px rgba(30,64,175,.65); }
         .calendar-month-enter { will-change: transform, opacity; }


### PR DESCRIPTION
## Summary
- remove the hardcoded weekend gradient from the shared MonthCalendar so only dynamic states style cells
- restyle the block calendar's preferred/exception weekday highlight to reuse the subtle weekend-inspired gradient

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d13bf288f4832da12595dd18c6c129