### PR TITLE
Fix finance select placeholders

### DIFF
--- a/src/components/members/finance/finance-budget-form.tsx
+++ b/src/components/members/finance/finance-budget-form.tsx
@@ -51,6 +51,8 @@ function formatShowOption(show: { id: string; title: string | null; year: number
   return parts.join(" • ") || "Unbenannte Produktion";
 }
 
+const EMPTY_SELECT_VALUE = "__none__";
+
 export function FinanceBudgetForm({
   showOptions,
   onCreated,
@@ -178,14 +180,17 @@ export function FinanceBudgetForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Produktion</FormLabel>
-                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                <Select
+                  value={field.value ? field.value : EMPTY_SELECT_VALUE}
+                  onValueChange={(value) => field.onChange(value === EMPTY_SELECT_VALUE ? "" : value)}
+                >
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Produktion auswählen" />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="">Keiner Produktion zugeordnet</SelectItem>
+                    <SelectItem value={EMPTY_SELECT_VALUE}>Keiner Produktion zugeordnet</SelectItem>
                     {showOptions.map((show) => (
                       <SelectItem key={show.id} value={show.id}>
                         {formatShowOption(show)}

--- a/src/components/members/finance/finance-entry-form.tsx
+++ b/src/components/members/finance/finance-entry-form.tsx
@@ -111,6 +111,8 @@ function formatMemberLabel(member: { name: string | null; email: string | null }
   return member.name ?? member.email ?? "Unbekannt";
 }
 
+const EMPTY_SELECT_VALUE = "__none__";
+
 export function FinanceEntryForm({
   onCreated,
   showOptions,
@@ -430,14 +432,17 @@ export function FinanceEntryForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Produktion</FormLabel>
-                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                <Select
+                  value={field.value ? field.value : EMPTY_SELECT_VALUE}
+                  onValueChange={(value) => field.onChange(value === EMPTY_SELECT_VALUE ? "" : value)}
+                >
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Produktion auswählen" />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="">Keine Zuordnung</SelectItem>
+                    <SelectItem value={EMPTY_SELECT_VALUE}>Keine Zuordnung</SelectItem>
                     {showOptions.map((show) => (
                       <SelectItem key={show.id} value={show.id}>
                         {formatShowLabel(show)}
@@ -456,14 +461,17 @@ export function FinanceEntryForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Budget</FormLabel>
-                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                <Select
+                  value={field.value ? field.value : EMPTY_SELECT_VALUE}
+                  onValueChange={(value) => field.onChange(value === EMPTY_SELECT_VALUE ? "" : value)}
+                >
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Budget auswählen" />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="">Kein Budget</SelectItem>
+                    <SelectItem value={EMPTY_SELECT_VALUE}>Kein Budget</SelectItem>
                     {filteredBudgets.map((budget) => (
                       <SelectItem key={budget.id} value={budget.id}>
                         {budget.category} ({budget.currency})
@@ -485,14 +493,17 @@ export function FinanceEntryForm({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Zahlendes Mitglied</FormLabel>
-                <Select value={field.value ?? ""} onValueChange={field.onChange}>
+                <Select
+                  value={field.value ? field.value : EMPTY_SELECT_VALUE}
+                  onValueChange={(value) => field.onChange(value === EMPTY_SELECT_VALUE ? "" : value)}
+                >
                   <FormControl>
                     <SelectTrigger>
                       <SelectValue placeholder="Mitglied wählen" />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="">Mitglied wählen</SelectItem>
+                    <SelectItem value={EMPTY_SELECT_VALUE}>Mitglied wählen</SelectItem>
                     {memberOptions.map((member) => (
                       <SelectItem key={member.id} value={member.id}>
                         {formatMemberLabel(member)}


### PR DESCRIPTION
## Summary
- replace empty SelectItem values in the finance entry form with a sentinel that maps back to no selection
- apply the same sentinel handling for the finance budget form select to allow clearing the production

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d13de89f18832d8e5e63d3e1badcd6