### PR TITLE
Set realtime analytics default interval to 2 seconds

### DIFF
--- a/realtime-server/src/createRealtimeServer.js
+++ b/realtime-server/src/createRealtimeServer.js
@@ -315,7 +315,7 @@ export function createRealtimeServer(options = {}) {
 
   const logError = typeof logger.error === 'function' ? (...args) => logger.error(...args) : (...args) => console.error(...args);
 
-  const defaultAnalyticsInterval = 15000;
+  const defaultAnalyticsInterval = 2000;
   const analyticsIntervalMsRaw = resolveNumber(
     explicitAnalyticsIntervalMs,
     resolveNumber(process.env.REALTIME_ANALYTICS_INTERVAL_MS, defaultAnalyticsInterval),


### PR DESCRIPTION
## Summary
- lower the realtime server analytics default interval to 2000 ms to refresh stats at the minimum supported cadence

## Testing
- not run (no automated checks provided for the realtime server)


------
https://chatgpt.com/codex/tasks/task_e_68d13e9e2d84832da0c2ca95001b5cc3