### PR TITLE
Fix measurement form submission error

### DIFF
--- a/src/components/members/measurements/member-measurements-control-center.tsx
+++ b/src/components/members/measurements/member-measurements-control-center.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { z } from "zod";
 import { AlertTriangle, Clock3, Filter, Search, Sparkles } from "lucide-react";
 
 import { MeasurementForm } from "@/components/forms/measurement-form";
@@ -19,9 +18,8 @@ import { UserAvatar, type AvatarSource } from "@/components/user-avatar";
 import {
   MEASUREMENT_TYPE_LABELS,
   MEASUREMENT_UNIT_LABELS,
-  measurementSchema,
+  measurementResponseSchema,
   measurementTypeEnum,
-  measurementUnitEnum,
   sortMeasurements,
   type MeasurementFormData,
   type MeasurementType,
@@ -98,19 +96,6 @@ const RELATIVE_TIME_UNITS: { unit: Intl.RelativeTimeFormatUnit; seconds: number 
   { unit: "minute", seconds: 60 },
   { unit: "second", seconds: 1 },
 ];
-
-const measurementResponseSchema = measurementSchema
-  .extend({
-    id: z.string(),
-    userId: z.string(),
-    updatedAt: z.string(),
-    note: z.string().nullable().optional(),
-  })
-  .extend({
-    type: measurementTypeEnum,
-    unit: measurementUnitEnum,
-    value: z.number(),
-  });
 
 export function MemberMeasurementsControlCenter({
   members,

--- a/src/components/members/measurements/member-measurements-manager.tsx
+++ b/src/components/members/measurements/member-measurements-manager.tsx
@@ -10,7 +10,7 @@ import { useOptionalProfileCompletion } from "@/components/members/profile-compl
 import {
   MEASUREMENT_TYPE_LABELS,
   MEASUREMENT_UNIT_LABELS,
-  measurementSchema,
+  measurementResponseSchema,
   sortMeasurements,
   type MeasurementFormData,
   type MeasurementType,
@@ -76,19 +76,19 @@ export function MemberMeasurementsManager({
       }
 
       const payload = await response.json();
-      const parsed = measurementSchema.parse(payload);
+      const parsed = measurementResponseSchema.parse(payload);
       const saved: MeasurementEntry = {
         id:
-          typeof payload?.id === "string"
-            ? payload.id
+          typeof parsed?.id === "string"
+            ? parsed.id
             : `${parsed.type}-${Date.now()}`,
         type: parsed.type,
         value: parsed.value,
         unit: parsed.unit,
-        note: parsed.note,
+        note: parsed.note ?? null,
         updatedAt:
-          typeof payload?.updatedAt === "string"
-            ? payload.updatedAt
+          typeof parsed?.updatedAt === "string"
+            ? parsed.updatedAt
             : new Date().toISOString(),
       };
       setMeasurements((prev) => {

--- a/src/data/measurements.ts
+++ b/src/data/measurements.ts
@@ -19,11 +19,21 @@ export const measurementUnitEnum = z.enum([
   "DE",
 ] as const);
 
+const measurementNoteSchema = z.string().max(500, "Notizen dürfen höchstens 500 Zeichen haben.");
+
 export const measurementSchema = z.object({
   type: measurementTypeEnum,
   value: z.number().min(0, "Der Wert muss positiv sein."),
   unit: measurementUnitEnum,
-  note: z.string().max(500, "Notizen dürfen höchstens 500 Zeichen haben.").optional(),
+  note: measurementNoteSchema.optional(),
+});
+
+export const measurementResponseSchema = measurementSchema.extend({
+  id: z.string(),
+  userId: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  note: measurementNoteSchema.nullish(),
 });
 
 export type MeasurementType = z.infer<typeof measurementTypeEnum>;


### PR DESCRIPTION
## Summary
- add a reusable measurement response schema that accepts nullable notes from the API
- update the profile measurement manager to parse API responses with the new schema and keep the UI in sync after saving
- reuse the shared schema inside the measurement control center instead of maintaining a local copy

## Testing
- pnpm lint
- pnpm test
- CI=1 FORCE_COLOR=0 TERM=dumb pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d13cbf2f88832d82d2658ec6fcfdbd