### PR TITLE
Fix onboarding acting preference defaults

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -261,8 +261,8 @@ type OnboardingWizardProps = {
 const initialActingPreferences: PreferenceEntry[] = actingOptions.map((option) => ({
   ...option,
   domain: "acting",
-  enabled: option.code === "acting_medium",
-  weight: option.code === "acting_medium" ? 60 : 40,
+  enabled: false,
+  weight: 50,
 }));
 
 const initialCrewPreferences: PreferenceEntry[] = crewOptions.map((option) => ({


### PR DESCRIPTION
## Summary
- remove the default "Mittlere Rolle" selection so no acting preference is pre-selected in the onboarding wizard

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1462c17bc832da81ec0ae324a3d74