### PR TITLE
Fix onboarding interest delimiters in onboarding wizard

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -504,7 +504,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
       .slice(0, 12);
   }, [availableInterests, form.interests]);
 
-  const addInterest = useCallback(
+  const addInterestToForm = useCallback(
     (interest: string) => {
       const value = interest.trim();
       if (!value) return;
@@ -514,9 +514,41 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
         }
         return { ...prev, interests: [...prev.interests, value] };
       });
-      setNewInterest("");
     },
     [setForm],
+  );
+
+  const addInterest = useCallback(
+    (interest: string) => {
+      addInterestToForm(interest);
+      setNewInterest("");
+    },
+    [addInterestToForm, setNewInterest],
+  );
+
+  const handleInterestInputChange = useCallback(
+    (value: string) => {
+      if (!value) {
+        setNewInterest("");
+        return;
+      }
+
+      if (!/[;,\n]/.test(value)) {
+        setNewInterest(value);
+        return;
+      }
+
+      const segments = value.split(/[,;\n]+/);
+      const remainder = segments.pop() ?? "";
+      segments.forEach((segment) => {
+        const clean = segment.trim();
+        if (clean) {
+          addInterestToForm(clean);
+        }
+      });
+      setNewInterest(remainder.replace(/^\s+/, ""));
+    },
+    [addInterestToForm, setNewInterest],
   );
 
   const removeInterest = useCallback((interest: string) => {
@@ -1547,7 +1579,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
               <Input
                 value={newInterest}
-                onChange={(event) => setNewInterest(event.target.value)}
+                onChange={(event) => handleInterestInputChange(event.target.value)}
                 placeholder="z.B. Impro, Tanz, Requisite, Social Media …"
                 onKeyDown={(event) => {
                   if (event.key === "Enter") {


### PR DESCRIPTION
## Summary
- split entered interest chips on commas, semicolons, or newlines instead of keeping them in a single tag
- reuse the existing add helper so pasted lists or multiple separators still deduplicate values and keep the remainder in the input field

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1468fd798832db58959f3d2c03abd