### PR TITLE
Restrict body measurements to ensemble members

### DIFF
--- a/src/app/(members)/mitglieder/koerpermasse/page.tsx
+++ b/src/app/(members)/mitglieder/koerpermasse/page.tsx
@@ -19,6 +19,12 @@ export default async function MemberMeasurementsPage() {
   }
 
   const members = await prisma.user.findMany({
+    where: {
+      OR: [
+        { role: "cast" },
+        { roles: { some: { role: "cast" } } },
+      ],
+    },
     orderBy: [
       { lastName: "asc" },
       { firstName: "asc" },

--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { CalendarDays, CheckCircle2, ListTodo, Ruler, Sparkles, Users } from "lu
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/rbac";
+import { hasAssignedRole, requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { sortMeasurements, type MeasurementType, type MeasurementUnit } from "@/data/measurements";
 
@@ -29,7 +29,12 @@ type PageProps = { params: { slug: string } };
 export default async function GewerkDetailPage({ params }: PageProps) {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.meine-gewerke");
-  const canManageMeasurements = await hasPermission(session.user, "mitglieder.koerpermasse");
+  const hasMeasurementPermission = await hasPermission(
+    session.user,
+    "mitglieder.koerpermasse",
+  );
+  const isEnsembleMember = hasAssignedRole(session.user, "cast");
+  const canManageMeasurements = hasMeasurementPermission && isEnsembleMember;
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die persönliche Gewerkeübersicht.</div>;
   }

--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -7,7 +7,7 @@ import { CalendarDays, CheckCircle2, Clock, ListTodo, Ruler, Sparkles, Users } f
 
 import { Button } from "@/components/ui/button";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/rbac";
+import { hasAssignedRole, requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { sortMeasurements, type MeasurementType, type MeasurementUnit } from "@/data/measurements";
 
@@ -24,7 +24,12 @@ type SummaryStat = { label: string; value: number; hint?: string; icon: LucideIc
 export default async function MeineGewerkePage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.meine-gewerke");
-  const canManageMeasurements = await hasPermission(session.user, "mitglieder.koerpermasse");
+  const hasMeasurementPermission = await hasPermission(
+    session.user,
+    "mitglieder.koerpermasse",
+  );
+  const isEnsembleMember = hasAssignedRole(session.user, "cast");
+  const canManageMeasurements = hasMeasurementPermission && isEnsembleMember;
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die persönliche Gewerkeübersicht.</div>;
   }

--- a/src/app/(members)/mitglieder/meine-proben/page.tsx
+++ b/src/app/(members)/mitglieder/meine-proben/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { requireAuth } from "@/lib/rbac";
+import { hasAssignedRole, requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 
@@ -77,7 +77,12 @@ type AttendanceHistoryEntry = {
 export default async function MeineProbenPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.meine-proben");
-  const canManageMeasurements = await hasPermission(session.user, "mitglieder.koerpermasse");
+  const hasMeasurementPermission = await hasPermission(
+    session.user,
+    "mitglieder.koerpermasse",
+  );
+  const isEnsembleMember = hasAssignedRole(session.user, "cast");
+  const canManageMeasurements = hasMeasurementPermission && isEnsembleMember;
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die persönliche Probenübersicht.</div>;
   }

--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -8,7 +8,7 @@ import type {
 
 import { ProfilePageClient } from "@/components/members/profile-page-client";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/rbac";
+import { hasAssignedRole, requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { sortRoles } from "@/lib/roles";
 import { buildPhotoConsentSummary } from "@/lib/photo-consent-summary";
@@ -34,10 +34,12 @@ export default async function ProfilePage() {
     notFound();
   }
 
-  const canManageMeasurements = await hasPermission(
+  const hasMeasurementPermission = await hasPermission(
     session.user,
     "mitglieder.koerpermasse",
   );
+  const isEnsembleMember = hasAssignedRole(session.user, "cast");
+  const canManageMeasurements = hasMeasurementPermission && isEnsembleMember;
 
   const [user, measurementRecords, allergyRecords] = await Promise.all([
     prisma.user.findUnique({

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
-import { requireAuth } from "@/lib/rbac";
+import { hasAssignedRole, requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProductionId } from "@/lib/active-production";
@@ -21,10 +21,12 @@ export async function GET() {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const canManageMeasurements = await hasPermission(
+    const hasMeasurementPermission = await hasPermission(
       session.user,
       "mitglieder.koerpermasse",
     );
+    const isEnsembleMember = hasAssignedRole(session.user, "cast");
+    const canManageMeasurements = hasMeasurementPermission && isEnsembleMember;
 
     const now = new Date();
     const startOfCurrentWeek = startOfWeek(now, { weekStartsOn: 1 });


### PR DESCRIPTION
## Summary
- limit the measurement control center to members with ensemble roles
- block measurement API writes for users outside the ensemble
- show personal measurement tasks only to ensemble members across profile and dashboard views
- treat ensemble checks as strict role assignments so wildcard admin roles no longer trigger measurement prompts

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d154c30cc4832d97baf56df95b9677