### PR TITLE
Show department task lists to all members

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -62,7 +62,17 @@ export default async function GewerkDetailPage({ params }: PageProps) {
             },
           },
           tasks: {
-            where: { assigneeId: userId },
+            include: {
+              assignee: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  firstName: true,
+                  lastName: true,
+                },
+              },
+            },
             orderBy: { createdAt: "asc" },
           },
         },
@@ -135,13 +145,15 @@ export default async function GewerkDetailPage({ params }: PageProps) {
   const planningWindowLabel = format(planningEnd, "d. MMMM yyyy", { locale: de });
   const now = new Date();
 
-  const activeTasksCount = membership.department.tasks.filter((task) => task.status !== "done").length;
-  const completedTasksCount = membership.department.tasks.filter((task) => task.status === "done").length;
+  const isEnsembleDepartment = membership.department.slug?.toLowerCase() === "ensemble";
+  const tasksForStats = isEnsembleDepartment ? [] : membership.department.tasks;
+  const activeTasksCount = tasksForStats.filter((task) => task.status !== "done").length;
+  const completedTasksCount = tasksForStats.filter((task) => task.status === "done").length;
 
   const summaryStats: SummaryStat[] = [
     { label: "Teammitglieder", value: membership.department.memberships.length, hint: "Aktive Personen", icon: Users },
-    { label: "Aktive Aufgaben", value: activeTasksCount, hint: "Status offen & in Arbeit", icon: ListTodo },
-    { label: "Abgeschlossen", value: completedTasksCount, hint: "Eigene erledigte Aufgaben", icon: CheckCircle2 },
+    { label: "Aktive Aufgaben", value: activeTasksCount, hint: "Offen & in Arbeit im Gewerk", icon: ListTodo },
+    { label: "Abgeschlossen", value: completedTasksCount, hint: "Erledigte Gewerke-Aufgaben", icon: CheckCircle2 },
   ];
 
   const headerActions = (

--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -59,7 +59,17 @@ export default async function MeineGewerkePage() {
             },
           },
           tasks: {
-            where: { assigneeId: userId },
+            include: {
+              assignee: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  firstName: true,
+                  lastName: true,
+                },
+              },
+            },
             orderBy: { createdAt: "asc" },
           },
         },
@@ -140,6 +150,10 @@ export default async function MeineGewerkePage() {
 
   const taskTotals: Record<"todo" | "doing" | "done", number> = { todo: 0, doing: 0, done: 0 };
   for (const membership of memberships) {
+    const isEnsembleDepartment = membership.department.slug?.toLowerCase() === "ensemble";
+    if (isEnsembleDepartment) {
+      continue;
+    }
     for (const task of membership.department.tasks) {
       taskTotals[task.status] += 1;
     }
@@ -152,8 +166,8 @@ export default async function MeineGewerkePage() {
 
   const summaryStats: SummaryStat[] = [
     { label: "Gewerke", value: memberships.length, hint: "Aktive Zuordnungen", icon: Users },
-    { label: "Aktive Aufgaben", value: openTaskCount, hint: "Status offen & in Arbeit", icon: ListTodo },
-    { label: "Abgeschlossen", value: taskTotals.done, hint: "Eigene erledigte Aufgaben", icon: CheckCircle2 },
+    { label: "Aktive Aufgaben", value: openTaskCount, hint: "Offen & in Arbeit in deinen Gewerken", icon: ListTodo },
+    { label: "Abgeschlossen", value: taskTotals.done, hint: "Erledigte Gewerke-Aufgaben", icon: CheckCircle2 },
   ];
 
   const headerActions = (

--- a/src/app/(members)/mitglieder/meine-gewerke/utils.ts
+++ b/src/app/(members)/mitglieder/meine-gewerke/utils.ts
@@ -145,7 +145,19 @@ export type DepartmentMembershipWithDepartment = Prisma.DepartmentMembershipGetP
             };
           };
         };
-        tasks: true;
+        tasks: {
+          include: {
+            assignee: {
+              select: {
+                id: true;
+                name: true;
+                email: true;
+                firstName: true;
+                lastName: true;
+              };
+            };
+          };
+        };
       };
     };
   };


### PR DESCRIPTION
## Summary
- load full department task lists for every gewerk membership, including assignee data and excluding the ensemble from global totals
- render gewerk cards with shared to-do lists, assignee hints, and hide the list when the gewerk is the ensemble
- keep gewerk detail statistics aligned with the shared task lists and updated copy

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d15a599718832daa2844529b93938e