### PR TITLE
Show digital signature previews inline

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -62,6 +62,7 @@ export default async function ProfilePage() {
         },
         photoConsent: {
           select: {
+            id: true,
             status: true,
             createdAt: true,
             updatedAt: true,
@@ -69,6 +70,7 @@ export default async function ProfilePage() {
             rejectionReason: true,
             documentUploadedAt: true,
             documentName: true,
+            documentMime: true,
             approvedBy: { select: { name: true } },
           },
         },
@@ -136,6 +138,7 @@ export default async function ProfilePage() {
     dateOfBirth: user.dateOfBirth,
     photoConsent: user.photoConsent
       ? {
+          id: user.photoConsent.id,
           status: user.photoConsent.status,
           createdAt: user.photoConsent.createdAt ?? undefined,
           updatedAt: user.photoConsent.updatedAt ?? undefined,
@@ -143,6 +146,7 @@ export default async function ProfilePage() {
           rejectionReason: user.photoConsent.rejectionReason ?? null,
           documentUploadedAt: user.photoConsent.documentUploadedAt ?? null,
           documentName: user.photoConsent.documentName ?? null,
+          documentMime: user.photoConsent.documentMime ?? null,
           approvedByName: user.photoConsent.approvedBy?.name ?? null,
         }
       : null,

--- a/src/app/api/photo-consents/[id]/document/route.ts
+++ b/src/app/api/photo-consents/[id]/document/route.ts
@@ -9,7 +9,7 @@ function sanitizeForHeader(value: string): string {
 }
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   context: { params: Promise<{ id: string }> },
 ) {
   const session = await requireAuth();
@@ -43,11 +43,14 @@ export async function GET(
   const safeFileName = sanitizeForHeader(fileName);
   const encodedFileName = encodeURIComponent(fileName);
 
+  const mode = request.nextUrl.searchParams.get("mode");
+  const disposition = mode === "inline" ? "inline" : "attachment";
+
   const response = new NextResponse(buffer, {
     headers: {
       "Content-Type": mime,
       "Content-Length": consent.documentSize ? String(consent.documentSize) : String(buffer.byteLength),
-      "Content-Disposition": `attachment; filename="${safeFileName}"; filename*=UTF-8''${encodedFileName}`,
+      "Content-Disposition": `${disposition}; filename="${safeFileName}"; filename*=UTF-8''${encodedFileName}`,
       "Cache-Control": "no-store",
     },
   });

--- a/src/app/api/photo-consents/admin/route.ts
+++ b/src/app/api/photo-consents/admin/route.ts
@@ -19,6 +19,7 @@ type ConsentWithUser = {
   rejectionReason: string | null;
   documentUploadedAt: Date | null;
   documentName: string | null;
+  documentMime: string | null;
   userId: string;
   user: {
     id: string;
@@ -59,6 +60,10 @@ function mapConsent(consent: ConsentWithUser): PhotoConsentAdminEntry {
     ? combineNameParts(consent.approvedBy.firstName, consent.approvedBy.lastName) ??
       (consent.approvedBy.name ?? null)
     : null;
+  const documentPreviewUrl =
+    consent.documentUploadedAt && consent.documentMime?.toLowerCase().startsWith("image/")
+      ? `/api/photo-consents/${consent.id}/document?mode=inline`
+      : null;
   return {
     id: consent.id,
     userId: consent.userId,
@@ -78,6 +83,8 @@ function mapConsent(consent: ConsentWithUser): PhotoConsentAdminEntry {
     documentName: consent.documentName ?? null,
     documentUrl: consent.documentUploadedAt ? `/api/photo-consents/${consent.id}/document` : null,
     documentUploadedAt: consent.documentUploadedAt ? consent.documentUploadedAt.toISOString() : null,
+    documentMime: consent.documentMime ?? null,
+    documentPreviewUrl,
   };
 }
 

--- a/src/app/api/photo-consents/route.ts
+++ b/src/app/api/photo-consents/route.ts
@@ -26,6 +26,7 @@ type ConsentRecord = {
   rejectionReason: string | null;
   documentUploadedAt: Date | null;
   documentName: string | null;
+  documentMime: string | null;
   approvedBy: { name: string | null } | null;
 };
 
@@ -72,6 +73,12 @@ function buildSummary(user: UserRecord): PhotoConsentSummary {
 
   const status: PhotoConsentSummary["status"] = consent?.status ?? "none";
 
+  const documentMime = consent?.documentMime ?? null;
+  const documentPreviewUrl =
+    consent?.documentUploadedAt && documentMime?.toLowerCase().startsWith("image/")
+      ? `/api/photo-consents/${consent.id}/document?mode=inline`
+      : null;
+
   return {
     status,
     requiresDocument,
@@ -86,6 +93,8 @@ function buildSummary(user: UserRecord): PhotoConsentSummary {
     dateOfBirth: dateOfBirth ? dateOfBirth.toISOString() : null,
     documentName: consent?.documentName ?? null,
     documentUploadedAt: consent?.documentUploadedAt ? consent.documentUploadedAt.toISOString() : null,
+    documentMime,
+    documentPreviewUrl,
   };
 }
 
@@ -131,6 +140,7 @@ export async function GET() {
           rejectionReason: true,
           documentUploadedAt: true,
           documentName: true,
+          documentMime: true,
           approvedBy: { select: { name: true } },
         },
       },
@@ -304,6 +314,7 @@ export async function POST(request: NextRequest) {
         rejectionReason: true,
         documentUploadedAt: true,
         documentName: true,
+        documentMime: true,
         approvedBy: { select: { name: true } },
       },
     });

--- a/src/components/members/photo-consent-admin-panel.tsx
+++ b/src/components/members/photo-consent-admin-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Image from "next/image";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -61,6 +62,32 @@ function formatDate(value: string | null | undefined) {
 
 function formatDateTime(value: string | null | undefined) {
   return formatWithFormatter(value, dateTimeFormatter);
+}
+
+type DocumentPreviewProps = {
+  previewUrl: string | null;
+  documentName: string | null;
+};
+
+function DocumentPreview({ previewUrl, documentName }: DocumentPreviewProps) {
+  if (!previewUrl) {
+    return null;
+  }
+  return (
+    <div className="mt-3 space-y-2">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Dokumentvorschau</p>
+      <div className="relative h-60 w-full overflow-hidden rounded-lg border border-border/60 bg-background shadow-sm">
+        <Image
+          src={previewUrl}
+          alt={documentName ? `Dokumentvorschau: ${documentName}` : "Digitale Unterschrift"}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 60vw, 420px"
+          className="object-contain bg-white"
+          unoptimized
+        />
+      </div>
+    </div>
+  );
 }
 
 function isPendingEntry(entry: PhotoConsentAdminEntry): entry is PendingEntry {
@@ -340,6 +367,7 @@ function PendingEntryCard({ entry, onAction, processing }: PendingEntryCardProps
               )}
             </div>
           )}
+          <DocumentPreview previewUrl={entry.documentPreviewUrl} documentName={entry.documentName} />
         </div>
         <div className="space-y-2">
           {allRequirementsMet ? (
@@ -463,25 +491,26 @@ function ProcessedEntryCard({ entry, onAction, processing }: ProcessedEntryCardP
           )}
         </div>
 
-        <div className="space-y-1 text-xs text-foreground/70">
-          <div>Aktualisiert: {updatedAt}</div>
-          {approvedAt && <div>Freigegeben am {approvedAt}</div>}
-          {entry.approvedByName && <div>Bearbeitet durch {entry.approvedByName}</div>}
-          {entry.rejectionReason && <div className="text-destructive">Grund: {entry.rejectionReason}</div>}
-          {entry.documentName && (
-            <div>
-              Dokument: {entry.documentName}
-              {entry.documentUrl && (
-                <>
-                  {" "}
-                  <a className="underline" href={entry.documentUrl} target="_blank" rel="noreferrer">
-                    öffnen
-                  </a>
-                </>
-              )}
-            </div>
-          )}
-        </div>
+      <div className="space-y-1 text-xs text-foreground/70">
+        <div>Aktualisiert: {updatedAt}</div>
+        {approvedAt && <div>Freigegeben am {approvedAt}</div>}
+        {entry.approvedByName && <div>Bearbeitet durch {entry.approvedByName}</div>}
+        {entry.rejectionReason && <div className="text-destructive">Grund: {entry.rejectionReason}</div>}
+        {entry.documentName && (
+          <div>
+            Dokument: {entry.documentName}
+            {entry.documentUrl && (
+              <>
+                {" "}
+                <a className="underline" href={entry.documentUrl} target="_blank" rel="noreferrer">
+                  öffnen
+                </a>
+              </>
+            )}
+          </div>
+        )}
+        <DocumentPreview previewUrl={entry.documentPreviewUrl} documentName={entry.documentName} />
+      </div>
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2">

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import type { ChangeEvent, FormEvent } from "react";
 import { toast } from "sonner";
@@ -57,6 +58,8 @@ const EMPTY_SUMMARY: PhotoConsentSummary = {
   dateOfBirth: null,
   documentName: null,
   documentUploadedAt: null,
+  documentMime: null,
+  documentPreviewUrl: null,
 };
 
 function formatDate(value: string | null | undefined) {
@@ -64,6 +67,33 @@ function formatDate(value: string | null | undefined) {
   const date = new Date(value);
   if (Number.isNaN(date.valueOf())) return null;
   return dateFormatter.format(date);
+}
+
+type ConsentDocumentPreviewProps = {
+  previewUrl: string | null;
+  documentName: string | null;
+};
+
+function ConsentDocumentPreview({ previewUrl, documentName }: ConsentDocumentPreviewProps) {
+  if (!previewUrl) {
+    return null;
+  }
+  return (
+    <div className="space-y-3 rounded-xl border border-primary/25 bg-background/80 p-4 shadow-inner shadow-primary/5 backdrop-blur">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Digitale Unterschrift</p>
+      <div className="relative h-60 w-full overflow-hidden rounded-lg border border-border/50 bg-background">
+        <Image
+          src={previewUrl}
+          alt={documentName ? `Digitale Unterschrift: ${documentName}` : "Digitale Unterschrift"}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 60vw, 420px"
+          className="object-contain bg-white"
+          unoptimized
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">Die Unterschrift ist nur für freigeschaltete Mitglieder sichtbar.</p>
+    </div>
+  );
 }
 
 interface PhotoConsentCardProps {
@@ -406,6 +436,13 @@ export function PhotoConsentCard({
                   )}
                 </div>
               </form>
+            )}
+
+            {summary?.documentPreviewUrl && (
+              <ConsentDocumentPreview
+                previewUrl={summary.documentPreviewUrl}
+                documentName={summary.documentName}
+              />
             )}
           </>
         )}

--- a/src/lib/photo-consent-summary.ts
+++ b/src/lib/photo-consent-summary.ts
@@ -1,6 +1,7 @@
 import type { PhotoConsentSummary } from "@/types/photo-consent";
 
 type ConsentRecord = {
+  id?: string;
   status: "pending" | "approved" | "rejected" | "none";
   createdAt?: Date | null;
   updatedAt?: Date | null;
@@ -8,6 +9,7 @@ type ConsentRecord = {
   rejectionReason?: string | null;
   documentUploadedAt?: Date | null;
   documentName?: string | null;
+  documentMime?: string | null;
   approvedByName?: string | null;
 };
 
@@ -39,6 +41,11 @@ export function buildPhotoConsentSummary(
   const requiresDateOfBirth = !dateOfBirth;
 
   const status = consent?.status ?? "none";
+  const documentMime = consent?.documentMime ?? null;
+  const documentPreviewUrl =
+    consent?.documentUploadedAt && consent?.id && documentMime?.toLowerCase().startsWith("image/")
+      ? `/api/photo-consents/${consent.id}/document?mode=inline`
+      : null;
 
   return {
     status,
@@ -56,5 +63,7 @@ export function buildPhotoConsentSummary(
     documentUploadedAt: consent?.documentUploadedAt
       ? consent.documentUploadedAt.toISOString()
       : null,
+    documentMime,
+    documentPreviewUrl,
   };
 }

--- a/src/types/photo-consent.ts
+++ b/src/types/photo-consent.ts
@@ -14,6 +14,8 @@ export type PhotoConsentSummary = {
   dateOfBirth: string | null;
   documentName: string | null;
   documentUploadedAt: string | null;
+  documentMime: string | null;
+  documentPreviewUrl: string | null;
 };
 
 export type PhotoConsentAdminEntry = {
@@ -35,4 +37,6 @@ export type PhotoConsentAdminEntry = {
   documentName: string | null;
   documentUrl: string | null;
   documentUploadedAt: string | null;
+  documentMime: string | null;
+  documentPreviewUrl: string | null;
 };


### PR DESCRIPTION
## Summary
- show photo consent signature images directly in the admin dashboard and member profile cards
- expose preview URLs and mime metadata from the photo consent APIs and shared types
- allow the document download endpoint to return the signature inline for previewing

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d158f5c330832d934708132aa82292