### PR TITLE
Rework member profile page layout

### DIFF
--- a/src/components/members/profile-checklist-card.tsx
+++ b/src/components/members/profile-checklist-card.tsx
@@ -6,13 +6,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useProfileCompletion } from "@/components/members/profile-completion-context";
 import { cn } from "@/lib/utils";
+import type { ProfileChecklistTarget } from "@/lib/profile-completion";
 
 interface ProfileChecklistCardProps {
-  onNavigateToTab?: (tab: string) => void;
+  onNavigateToSection?: (section: ProfileChecklistTarget) => void;
 }
 
 export function ProfileChecklistCard({
-  onNavigateToTab,
+  onNavigateToSection,
 }: ProfileChecklistCardProps) {
   const { items, completed, total, isComplete } = useProfileCompletion();
 
@@ -71,15 +72,15 @@ export function ProfileChecklistCard({
                     </p>
                   </div>
                 </div>
-                {!item.complete && item.targetTab && onNavigateToTab ? (
+                {!item.complete && item.targetSection && onNavigateToSection ? (
                   <Button
                     type="button"
                     size="sm"
                     variant="outline"
                     className="whitespace-nowrap"
-                    onClick={() => onNavigateToTab(item.targetTab!)}
+                    onClick={() => onNavigateToSection(item.targetSection!)}
                   >
-                    Jetzt erledigen
+                    Bereich öffnen
                   </Button>
                 ) : null}
               </li>

--- a/src/lib/profile-completion.ts
+++ b/src/lib/profile-completion.ts
@@ -5,12 +5,19 @@ export type ProfileChecklistItemId =
   | "measurements"
   | "photo-consent";
 
+export type ProfileChecklistTarget =
+  | "stammdaten"
+  | "ernaehrung"
+  | "masse"
+  | "interessen"
+  | "freigaben";
+
 export type ProfileChecklistItem = {
   id: ProfileChecklistItemId;
   label: string;
   description: string;
   complete: boolean;
-  targetTab?: string;
+  targetSection?: ProfileChecklistTarget;
 };
 
 export type ProfileCompletionSummary = {
@@ -37,21 +44,21 @@ export function buildProfileChecklist(
       label: "Stammdaten aktualisiert",
       description: "Vorname, Nachname und Kontaktadresse hinterlegt.",
       complete: input.hasBasicData,
-      targetTab: "stammdaten",
+      targetSection: "stammdaten",
     },
     {
       id: "birthdate",
       label: "Geburtsdatum eingetragen",
       description: "Hilft bei der Verwaltung notwendiger Einverständnisse.",
       complete: input.hasBirthdate,
-      targetTab: "stammdaten",
+      targetSection: "stammdaten",
     },
     {
       id: "dietary",
       label: "Ernährungsstil gepflegt",
       description: "Informationen für Verpflegung & Eventplanung.",
       complete: input.hasDietaryPreference,
-      targetTab: "ernaehrung",
+      targetSection: "ernaehrung",
     },
   ];
 
@@ -61,7 +68,7 @@ export function buildProfileChecklist(
       label: "Körpermaße hinterlegt",
       description: "Ermöglicht dem Kostüm-Team passgenaue Planung.",
       complete: Boolean(input.hasMeasurements),
-      targetTab: "masse",
+      targetSection: "masse",
     });
   }
 
@@ -71,7 +78,7 @@ export function buildProfileChecklist(
       label: "Fotoeinverständnis bestätigt",
       description: "Notwendig für Medienarbeit und Außendarstellung.",
       complete: Boolean(input.photoConsent.consentGiven),
-      targetTab: "freigaben",
+      targetSection: "freigaben",
     });
   }
 


### PR DESCRIPTION
## Summary
- replace the profile tabs with expandable sections that expose key details up front and allow opening additional areas on demand
- add a reusable profile section component with headings, toggle controls and smooth scrolling for checklist navigation
- update the profile checklist target typing and button copy to match the new section-based layout

## Testing
- pnpm lint
- pnpm test
- CI=1 FORCE_COLOR=0 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d15b7dbbd8832d8e4100aa3a201b83