### PR TITLE
Hide measurement profile tab without permission

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -180,7 +180,7 @@ export default async function ProfilePage() {
       }}
       checklist={checklist.items}
       canManageMeasurements={canManageMeasurements}
-      measurements={measurements}
+      measurements={canManageMeasurements ? measurements : undefined}
       dietaryPreference={{
         style: styleInfo.style,
         customLabel: styleInfo.customLabel,

--- a/src/components/members/profile-page-client.tsx
+++ b/src/components/members/profile-page-client.tsx
@@ -177,7 +177,7 @@ interface ProfilePageClientProps {
   user: ProfileUserSummary;
   checklist: ProfileChecklistItem[];
   canManageMeasurements: boolean;
-  measurements: MeasurementEntry[];
+  measurements?: MeasurementEntry[];
   dietaryPreference: DietaryPreferenceState;
   allergies: AllergyEntry[];
   photoConsent: PhotoConsentSummary | null;
@@ -286,6 +286,7 @@ export function ProfilePageClient({
   const [photoSummary, setPhotoSummary] = useState<PhotoConsentSummary | null>(
     photoConsent,
   );
+  const measurementEntries = canManageMeasurements ? measurements ?? [] : null;
 
   const handleSectionOpenChange = useCallback(
     (section: ProfileSectionId, open: boolean) => {
@@ -428,7 +429,7 @@ export function ProfilePageClient({
                     open={openSections.masse}
                     onOpenChange={(open) => handleSectionOpenChange("masse", open)}
                   >
-                    <MemberMeasurementsManager initialMeasurements={measurements} />
+                    <MemberMeasurementsManager initialMeasurements={measurementEntries ?? []} />
                   </ProfileSection>
                 ) : null}
 


### PR DESCRIPTION
## Summary
- gate the profile measurement tab and manager on the permission flag in the client component
- avoid passing measurement data from the profile page when the user cannot manage measurements

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d15c6cdb14832da183b4d064c48a48