### PR TITLE
Copy shared analytics utilities into production image

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -53,6 +53,7 @@ COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/realtime-server ./realtime-server
 COPY --from=builder /app/src/data ./src/data
+COPY --from=builder /app/src/lib ./src/lib
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary
- copy the shared `src/lib` directory into the production runner image so the realtime server can import analytics helpers during startup

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d16309e734832db5cc71bf7eee5d9e