### PR TITLE
Add recipe planner with shopping list for meal planning

### DIFF
--- a/src/app/(members)/mitglieder/essenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/essenplanung/page.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, ChefHat, CheckCircle2, Sparkles } from "lucide-react";
 import type { AllergyLevel } from "@prisma/client";
 
 import { PageHeader } from "@/components/members/page-header";
+import { MealPlanRecipeWorkbench } from "@/components/members/meal-plan-recipe-workbench";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { prisma } from "@/lib/prisma";
@@ -66,7 +67,14 @@ const SEVERITY_RANK: Record<AllergyLevel, number> = {
   LETHAL: 3,
 };
 
-const MEAL_SLOTS = ["Mittag", "Abend"] as const;
+const MEAL_SLOTS = ["Frühstück", "Mittag", "Abendbrot"] as const;
+
+type RecipeIngredient = {
+  name: string;
+  amount: number;
+  unit: string;
+  category?: string;
+};
 
 function normalizeAllergen(value: string) {
   return value.trim().toLocaleLowerCase("de-DE");
@@ -116,6 +124,10 @@ type DishConcept = {
   highlights: string[];
   avoids: string[];
   caution?: string[];
+  servings: number;
+  ingredients: RecipeIngredient[];
+  instructions: string[];
+  idealSlots?: (typeof MEAL_SLOTS)[number][];
 };
 
 type MealPlanEntry = {
@@ -149,6 +161,29 @@ const DISH_LIBRARY: DishConcept[] = [
     highlights: ["proteinreich", "glutenfrei", "Meal-Prep"],
     avoids: ["Milch", "Ei"],
     caution: ["Sesam"],
+    servings: 6,
+    idealSlots: ["Mittag", "Abendbrot"],
+    ingredients: [
+      { name: "Quinoa", amount: 450, unit: "g", category: "Basis" },
+      { name: "Süßkartoffeln", amount: 3, unit: "Stk", category: "Gemüse" },
+      { name: "Kichererbsen (gekocht)", amount: 800, unit: "g", category: "Hülsenfrüchte" },
+      { name: "Rote Bete", amount: 2, unit: "Knollen", category: "Gemüse" },
+      { name: "Rote Paprika", amount: 3, unit: "Stk", category: "Gemüse" },
+      { name: "Babyspinat", amount: 200, unit: "g", category: "Gemüse" },
+      { name: "Tahini", amount: 160, unit: "g", category: "Vorrat" },
+      { name: "Zitronensaft", amount: 80, unit: "ml", category: "Vorrat" },
+      { name: "Olivenöl", amount: 90, unit: "ml", category: "Vorrat" },
+      { name: "Knoblauchzehen", amount: 3, unit: "Stk", category: "Vorrat" },
+      { name: "Salz", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Schwarzer Pfeffer", amount: 1, unit: "TL", category: "Gewürze" },
+      { name: "Granatapfelkerne", amount: 120, unit: "g", category: "Topping" },
+    ],
+    instructions: [
+      "Quinoa gründlich waschen und nach Packungsanleitung in Salzwasser garen.",
+      "Süßkartoffeln, Rote Bete und Paprika würfeln, mit der Hälfte des Olivenöls sowie Salz und Pfeffer mischen und im Ofen bei 200 °C etwa 25 Minuten rösten.",
+      "Kichererbsen abspülen und gemeinsam mit dem Babyspinat kurz in einer Pfanne mit etwas Olivenöl erwärmen.",
+      "Tahini, übriges Olivenöl, Zitronensaft, Knoblauch und etwas Wasser cremig rühren. Bowls mit Quinoa, Ofengemüse und Kichererbsen anrichten, mit Tahini-Dressing und Granatapfelkernen toppen.",
+    ],
   },
   {
     id: "lunar-lentil-stew",
@@ -157,6 +192,31 @@ const DISH_LIBRARY: DishConcept[] = [
     suitableFor: ["vegan", "vegetarian", "halal", "custom"],
     highlights: ["wärmend", "eisenreich"],
     avoids: ["Milch", "Ei"],
+    servings: 8,
+    idealSlots: ["Mittag", "Abendbrot"],
+    ingredients: [
+      { name: "Belugalinsen", amount: 600, unit: "g", category: "Hülsenfrüchte" },
+      { name: "Karotten", amount: 4, unit: "Stk", category: "Gemüse" },
+      { name: "Staudensellerie", amount: 3, unit: "Stangen", category: "Gemüse" },
+      { name: "Rote Zwiebeln", amount: 2, unit: "Stk", category: "Gemüse" },
+      { name: "Knoblauchzehen", amount: 3, unit: "Stk", category: "Vorrat" },
+      { name: "Tomaten aus der Dose", amount: 800, unit: "g", category: "Vorrat" },
+      { name: "Gemüsefond", amount: 1.5, unit: "l", category: "Vorrat" },
+      { name: "Chiliflocken", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Kreuzkümmel", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Lorbeerblätter", amount: 2, unit: "Stk", category: "Gewürze" },
+      { name: "Olivenöl", amount: 60, unit: "ml", category: "Vorrat" },
+      { name: "Salz", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Pfeffer", amount: 1, unit: "TL", category: "Gewürze" },
+      { name: "Lupinenchips", amount: 120, unit: "g", category: "Topping" },
+      { name: "Frischer Koriander", amount: 1, unit: "Bund", category: "Kräuter" },
+    ],
+    instructions: [
+      "Linsen abspülen. Karotten, Sellerie und Zwiebeln fein würfeln, Knoblauch hacken.",
+      "Olivenöl in einem großen Topf erhitzen und das Gemüse darin 5 Minuten anschwitzen. Chiliflocken und Kreuzkümmel hinzufügen und kurz mitrösten.",
+      "Linsen, Tomaten, Lorbeer und Gemüsefond zugeben. Aufkochen, dann bei mittlerer Hitze 25–30 Minuten köcheln lassen, bis die Linsen weich sind.",
+      "Mit Salz und Pfeffer abschmecken. Vor dem Servieren mit gehacktem Koriander und Lupinenchips bestreuen.",
+    ],
   },
   {
     id: "stellar-salmon",
@@ -166,6 +226,30 @@ const DISH_LIBRARY: DishConcept[] = [
     highlights: ["Omega-3", "leicht"],
     avoids: ["Rind", "Schwein"],
     caution: ["Fisch", "Sesam"],
+    servings: 6,
+    idealSlots: ["Mittag", "Abendbrot"],
+    ingredients: [
+      { name: "Lachsfilets", amount: 6, unit: "Stk", category: "Protein" },
+      { name: "Wildreis", amount: 400, unit: "g", category: "Basis" },
+      { name: "Yuzu-Saft", amount: 60, unit: "ml", category: "Vorrat" },
+      { name: "Sojasauce", amount: 40, unit: "ml", category: "Vorrat" },
+      { name: "Honig", amount: 30, unit: "g", category: "Vorrat" },
+      { name: "Gurken", amount: 2, unit: "Stk", category: "Gemüse" },
+      { name: "Fenchelknollen", amount: 2, unit: "Stk", category: "Gemüse" },
+      { name: "Reisessig", amount: 30, unit: "ml", category: "Vorrat" },
+      { name: "Shiso-Blätter", amount: 12, unit: "Stk", category: "Kräuter" },
+      { name: "Mayonnaise", amount: 120, unit: "g", category: "Vorrat" },
+      { name: "Limettensaft", amount: 40, unit: "ml", category: "Vorrat" },
+      { name: "Sesamöl", amount: 20, unit: "ml", category: "Vorrat" },
+      { name: "Salz", amount: 1, unit: "TL", category: "Gewürze" },
+      { name: "Schwarzer Pfeffer", amount: 0.5, unit: "TL", category: "Gewürze" },
+    ],
+    instructions: [
+      "Wildreis in reichlich Salzwasser garen.",
+      "Yuzu-Saft, Sojasauce und Honig verrühren, Lachsfilets darin 10 Minuten marinieren. Anschließend in einer Pfanne oder im Ofen garen, bis der Fisch glasig ist.",
+      "Gurken und Fenchel fein hobeln und mit Reisessig, Sesamöl, Salz und Pfeffer marinieren.",
+      "Mayonnaise mit Limettensaft und gehackten Shiso-Blättern mischen. Reis auf Teller geben, Lachs daraufsetzen, mit Salat und Shiso-Mayo servieren.",
+    ],
   },
   {
     id: "cosmic-kufteh",
@@ -175,6 +259,29 @@ const DISH_LIBRARY: DishConcept[] = [
     highlights: ["Batch Cooking", "würzig"],
     avoids: ["Schwein"],
     caution: ["Gluten", "Milch"],
+    servings: 6,
+    idealSlots: ["Mittag", "Abendbrot"],
+    ingredients: [
+      { name: "Bulgur", amount: 400, unit: "g", category: "Basis" },
+      { name: "Rote Linsen", amount: 250, unit: "g", category: "Hülsenfrüchte" },
+      { name: "Zwiebeln", amount: 2, unit: "Stk", category: "Gemüse" },
+      { name: "Karotten", amount: 2, unit: "Stk", category: "Gemüse" },
+      { name: "Petersilie", amount: 1, unit: "Bund", category: "Kräuter" },
+      { name: "Minze", amount: 0.5, unit: "Bund", category: "Kräuter" },
+      { name: "Safranfäden", amount: 0.5, unit: "g", category: "Gewürze" },
+      { name: "Griechischer Joghurt", amount: 300, unit: "g", category: "Milchprodukte" },
+      { name: "Granatapfelkerne", amount: 120, unit: "g", category: "Topping" },
+      { name: "Olivenöl", amount: 70, unit: "ml", category: "Vorrat" },
+      { name: "Salz", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Korianderpulver", amount: 1, unit: "TL", category: "Gewürze" },
+      { name: "Paprikapulver", amount: 1, unit: "TL", category: "Gewürze" },
+    ],
+    instructions: [
+      "Bulgur mit Safran und heißem Wasser übergießen und quellen lassen.",
+      "Rote Linsen in Salzwasser weich kochen, abgießen und mit fein gehackten Zwiebeln, Karotten und Petersilie mischen.",
+      "Die Masse mit Salz, Koriander- und Paprikapulver würzen, Kugeln formen und in Olivenöl knusprig ausbacken.",
+      "Minze fein hacken und unter den Joghurt rühren. Bowls mit Bulgur, Linsenbällchen, Joghurt und Granatapfel anrichten.",
+    ],
   },
   {
     id: "orbit-citrus-chicken",
@@ -183,6 +290,26 @@ const DISH_LIBRARY: DishConcept[] = [
     suitableFor: ["omnivore", "flexitarian", "halal", "none"],
     highlights: ["Comfort", "laktosefrei"],
     avoids: ["Schwein"],
+    servings: 8,
+    idealSlots: ["Mittag", "Abendbrot"],
+    ingredients: [
+      { name: "Hähnchenschenkel", amount: 8, unit: "Stk", category: "Protein" },
+      { name: "Süßkartoffeln", amount: 4, unit: "Stk", category: "Gemüse" },
+      { name: "Brokkolini", amount: 600, unit: "g", category: "Gemüse" },
+      { name: "Zitronen", amount: 2, unit: "Stk", category: "Obst" },
+      { name: "Thymian", amount: 1, unit: "Bund", category: "Kräuter" },
+      { name: "Knoblauchzehen", amount: 4, unit: "Stk", category: "Vorrat" },
+      { name: "Olivenöl", amount: 90, unit: "ml", category: "Vorrat" },
+      { name: "Ahornsirup", amount: 30, unit: "ml", category: "Vorrat" },
+      { name: "Salz", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Pfeffer", amount: 1, unit: "TL", category: "Gewürze" },
+    ],
+    instructions: [
+      "Hähnchen mit Zitronensaft, Thymian, gehacktem Knoblauch, Ahornsirup, Salz und Pfeffer marinieren.",
+      "Süßkartoffeln würfeln, mit etwas Olivenöl und Salz mischen und auf ein Blech geben. Hähnchen darauf verteilen und bei 200 °C 35 Minuten rösten.",
+      "Brokkolini blanchieren, danach in Olivenöl schwenken und mit Salz abschmecken.",
+      "Alles zusammen auf Platten anrichten und mit Zitronenscheiben sowie frischem Thymian servieren.",
+    ],
   },
   {
     id: "nebula-ratatouille",
@@ -192,6 +319,29 @@ const DISH_LIBRARY: DishConcept[] = [
     highlights: ["Ofengericht", "sättigend"],
     avoids: ["Milch", "Ei"],
     caution: ["Nüsse"],
+    servings: 8,
+    idealSlots: ["Mittag", "Abendbrot"],
+    ingredients: [
+      { name: "Zucchini", amount: 4, unit: "Stk", category: "Gemüse" },
+      { name: "Auberginen", amount: 2, unit: "Stk", category: "Gemüse" },
+      { name: "Paprika", amount: 4, unit: "Stk", category: "Gemüse" },
+      { name: "Kirschtomaten", amount: 500, unit: "g", category: "Gemüse" },
+      { name: "Polenta", amount: 400, unit: "g", category: "Basis" },
+      { name: "Gemüsefond", amount: 1.2, unit: "l", category: "Vorrat" },
+      { name: "Basilikum", amount: 2, unit: "Bund", category: "Kräuter" },
+      { name: "Olivenöl", amount: 100, unit: "ml", category: "Vorrat" },
+      { name: "Pinienkerne", amount: 60, unit: "g", category: "Topping" },
+      { name: "Knoblauchzehen", amount: 3, unit: "Stk", category: "Vorrat" },
+      { name: "Zitronenschale", amount: 1, unit: "Stk", category: "Gewürze" },
+      { name: "Salz", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Pfeffer", amount: 1, unit: "TL", category: "Gewürze" },
+    ],
+    instructions: [
+      "Gemüse in Scheiben schneiden, mit Olivenöl, Salz, Pfeffer und Zitronenschale mischen und auf Blechen verteilen. Bei 190 °C 30 Minuten rösten.",
+      "Polenta mit Gemüsefond aufkochen, unter Rühren ausquellen lassen und auf ein Blech streichen. Nach dem Auskühlen in Würfel schneiden und in Olivenöl knusprig braten.",
+      "Basilikum, Pinienkerne, Knoblauch und Olivenöl zu einem Pistou mixen.",
+      "Ratatouille-Gemüse mit Polenta-Cubes anrichten und mit Pistou beträufeln.",
+    ],
   },
   {
     id: "galaxy-shakshuka",
@@ -201,6 +351,28 @@ const DISH_LIBRARY: DishConcept[] = [
     highlights: ["Brunch-tauglich", "energiegeladen"],
     avoids: [],
     caution: ["Ei", "Milch"],
+    servings: 6,
+    idealSlots: ["Frühstück", "Mittag"],
+    ingredients: [
+      { name: "Rote Paprika", amount: 3, unit: "Stk", category: "Gemüse" },
+      { name: "Zwiebeln", amount: 2, unit: "Stk", category: "Gemüse" },
+      { name: "Knoblauchzehen", amount: 3, unit: "Stk", category: "Vorrat" },
+      { name: "Tomaten aus der Dose", amount: 800, unit: "g", category: "Vorrat" },
+      { name: "Eier", amount: 12, unit: "Stk", category: "Protein" },
+      { name: "Feta", amount: 200, unit: "g", category: "Milchprodukte" },
+      { name: "Harissa", amount: 2, unit: "EL", category: "Gewürze" },
+      { name: "Kreuzkümmel", amount: 1, unit: "TL", category: "Gewürze" },
+      { name: "Olivenöl", amount: 50, unit: "ml", category: "Vorrat" },
+      { name: "Frische Petersilie", amount: 1, unit: "Bund", category: "Kräuter" },
+      { name: "Fladenbrot", amount: 3, unit: "Stk", category: "Beilage" },
+      { name: "Salz", amount: 1.5, unit: "TL", category: "Gewürze" },
+    ],
+    instructions: [
+      "Zwiebeln, Paprika und Knoblauch würfeln und in Olivenöl anschwitzen.",
+      "Harissa und Kreuzkümmel zugeben, dann Tomaten einrühren und 10 Minuten einkochen lassen.",
+      "Mit einem Löffel Mulden formen, Eier hineinschlagen und bei mittlerer Hitze stocken lassen.",
+      "Mit zerbröckeltem Feta und gehackter Petersilie bestreuen und mit warmem Fladenbrot servieren.",
+    ],
   },
   {
     id: "zen-noodle-box",
@@ -210,23 +382,150 @@ const DISH_LIBRARY: DishConcept[] = [
     highlights: ["kalt servierbar", "schnell"],
     avoids: ["Milch", "Ei"],
     caution: ["Soja", "Sesam", "Gluten"],
+    servings: 6,
+    idealSlots: ["Mittag", "Abendbrot"],
+    ingredients: [
+      { name: "Soba-Nudeln", amount: 500, unit: "g", category: "Basis" },
+      { name: "Fester Tofu", amount: 400, unit: "g", category: "Protein" },
+      { name: "Edamame", amount: 300, unit: "g", category: "Hülsenfrüchte" },
+      { name: "Karotten", amount: 3, unit: "Stk", category: "Gemüse" },
+      { name: "Rotkohl", amount: 0.5, unit: "Kopf", category: "Gemüse" },
+      { name: "Frühlingszwiebeln", amount: 1, unit: "Bund", category: "Gemüse" },
+      { name: "Ponzu-Sauce", amount: 120, unit: "ml", category: "Vorrat" },
+      { name: "Sesamöl", amount: 30, unit: "ml", category: "Vorrat" },
+      { name: "Reisessig", amount: 40, unit: "ml", category: "Vorrat" },
+      { name: "Gerösteter Sesam", amount: 30, unit: "g", category: "Topping" },
+      { name: "Salz", amount: 1, unit: "TL", category: "Gewürze" },
+      { name: "Pfeffer", amount: 0.5, unit: "TL", category: "Gewürze" },
+    ],
+    instructions: [
+      "Soba nach Packungsanleitung kochen, kalt abschrecken und abtropfen lassen.",
+      "Tofu würfeln und in Sesamöl knusprig braten. Mit Salz und Pfeffer würzen.",
+      "Karotten in feine Streifen schneiden, Rotkohl hobeln, Frühlingszwiebeln in Ringe schneiden.",
+      "Ponzu, Reisessig und Sesamöl verrühren. Nudeln mit Gemüse, Edamame und Tofu mischen, Dressing zugeben und mit Sesam toppen.",
+    ],
+  },
+  {
+    id: "starlight-overnight-oats",
+    title: "Starlight Overnight Oats",
+    description: "Haferflocken, Chiasamen und Pflanzenmilch mit Sternenstaub-Toppings für den frühen Energieschub.",
+    suitableFor: ["vegan", "vegetarian", "flexitarian", "pescetarian"],
+    highlights: ["Meal-Prep", "ballaststoffreich"],
+    avoids: ["Milch", "Ei"],
+    servings: 6,
+    idealSlots: ["Frühstück"],
+    ingredients: [
+      { name: "Feine Haferflocken", amount: 360, unit: "g", category: "Basis" },
+      { name: "Chiasamen", amount: 60, unit: "g", category: "Vorrat" },
+      { name: "Pflanzendrink", amount: 1.2, unit: "l", category: "Vorrat" },
+      { name: "Ahornsirup", amount: 60, unit: "ml", category: "Vorrat" },
+      { name: "Vanilleextrakt", amount: 2, unit: "TL", category: "Gewürze" },
+      { name: "Heidelbeeren", amount: 300, unit: "g", category: "Obst" },
+      { name: "Mango", amount: 2, unit: "Stk", category: "Obst" },
+      { name: "Kokoschips", amount: 80, unit: "g", category: "Topping" },
+      { name: "Limettenschale", amount: 1, unit: "Stk", category: "Gewürze" },
+    ],
+    instructions: [
+      "Haferflocken, Chiasamen, Pflanzendrink, Ahornsirup und Vanille in einer großen Schüssel verrühren.",
+      "Mischung in verschließbare Behälter füllen und über Nacht kalt stellen.",
+      "Mango würfeln, Heidelbeeren waschen.",
+      "Vor dem Servieren Oats mit Mango, Heidelbeeren, Kokoschips und etwas Limettenschale toppen.",
+    ],
+  },
+  {
+    id: "meteor-morning-parfait",
+    title: "Meteor Morning Parfait",
+    description: "Schichtdessert aus Skyr, Gewürz-Granola, Kompott und Kakaonibs für den süßen Start.",
+    suitableFor: ["vegetarian", "flexitarian", "none"],
+    highlights: ["vorbereitbar", "proteinreich"],
+    avoids: ["Schwein"],
+    caution: ["Milch", "Gluten", "Nüsse"],
+    servings: 6,
+    idealSlots: ["Frühstück"],
+    ingredients: [
+      { name: "Skyr", amount: 900, unit: "g", category: "Milchprodukte" },
+      { name: "Honig", amount: 50, unit: "g", category: "Vorrat" },
+      { name: "Zimtgranola", amount: 240, unit: "g", category: "Topping" },
+      { name: "Erdbeeren", amount: 400, unit: "g", category: "Obst" },
+      { name: "Rhabarber", amount: 250, unit: "g", category: "Obst" },
+      { name: "Orangensaft", amount: 120, unit: "ml", category: "Vorrat" },
+      { name: "Kakaonibs", amount: 60, unit: "g", category: "Topping" },
+      { name: "Frische Minze", amount: 1, unit: "Bund", category: "Kräuter" },
+    ],
+    instructions: [
+      "Rhabarber schälen, mit halbierten Erdbeeren und Orangensaft kurz aufkochen und zu einem Kompott einkochen.",
+      "Skyr mit Honig glatt rühren.",
+      "Gläser schichten: Skyr, Kompott, Granola. Wiederholen, bis die Zutaten aufgebraucht sind.",
+      "Mit Kakaonibs und gehackter Minze bestreuen und bis zum Servieren kalt stellen.",
+    ],
+  },
+  {
+    id: "orbit-breakfast-wraps",
+    title: "Orbit Breakfast Wraps",
+    description: "Weiche Tortillas mit Rührei, Bohnen, Avocado und Kräuter-Salsa – perfekt zum Mitnehmen.",
+    suitableFor: ["omnivore", "flexitarian", "custom"],
+    highlights: ["to-go", "sättigend"],
+    avoids: ["Schwein"],
+    caution: ["Ei", "Gluten"],
+    servings: 6,
+    idealSlots: ["Frühstück"],
+    ingredients: [
+      { name: "Weizentortillas", amount: 6, unit: "Stk", category: "Basis" },
+      { name: "Eier", amount: 10, unit: "Stk", category: "Protein" },
+      { name: "Schwarze Bohnen", amount: 400, unit: "g", category: "Hülsenfrüchte" },
+      { name: "Cheddar", amount: 150, unit: "g", category: "Milchprodukte" },
+      { name: "Avocado", amount: 2, unit: "Stk", category: "Obst" },
+      { name: "Kirschtomaten", amount: 250, unit: "g", category: "Obst" },
+      { name: "Koriander", amount: 1, unit: "Bund", category: "Kräuter" },
+      { name: "Limetten", amount: 2, unit: "Stk", category: "Obst" },
+      { name: "Olivenöl", amount: 30, unit: "ml", category: "Vorrat" },
+      { name: "Salz", amount: 1, unit: "TL", category: "Gewürze" },
+      { name: "Pfeffer", amount: 0.5, unit: "TL", category: "Gewürze" },
+      { name: "Rauchpaprika", amount: 1, unit: "TL", category: "Gewürze" },
+    ],
+    instructions: [
+      "Eier verquirlen und in Olivenöl zu einem cremigen Rührei stocken lassen.",
+      "Bohnen abspülen, mit Rauchpaprika und etwas Salz in einer Pfanne erwärmen.",
+      "Avocado und Tomaten würfeln, mit Limettensaft, Salz und gehacktem Koriander zu einer Salsa vermischen.",
+      "Tortillas erwärmen, mit Bohnen, Rührei, geriebenem Cheddar und Salsa füllen und eng einrollen.",
+    ],
   },
 ];
 
 function pickDishForStyle(
   style: DietaryStyleOption,
+  slot: (typeof MEAL_SLOTS)[number],
   dishes: DishConcept[],
   used: Set<string>,
 ): DishConcept {
-  const candidates = dishes.filter((dish) => dish.suitableFor.includes(style));
-  const available = candidates.find((dish) => !used.has(dish.id));
-  if (available) {
-    used.add(available.id);
-    return available;
+  const slotCandidates = dishes.filter((dish) => {
+    if (!dish.suitableFor.includes(style)) {
+      return false;
+    }
+    if (!dish.idealSlots || dish.idealSlots.length === 0) {
+      return true;
+    }
+    return dish.idealSlots.includes(slot);
+  });
+  const availableSlotCandidate = slotCandidates.find((dish) => !used.has(dish.id));
+  if (availableSlotCandidate) {
+    used.add(availableSlotCandidate.id);
+    return availableSlotCandidate;
   }
 
-  if (candidates.length) {
-    return candidates[0];
+  if (slotCandidates.length) {
+    return slotCandidates[0];
+  }
+
+  const styleCandidates = dishes.filter((dish) => dish.suitableFor.includes(style));
+  const availableStyleCandidate = styleCandidates.find((dish) => !used.has(dish.id));
+  if (availableStyleCandidate) {
+    used.add(availableStyleCandidate.id);
+    return availableStyleCandidate;
+  }
+
+  if (styleCandidates.length) {
+    return styleCandidates[0];
   }
 
   const fallback = dishes.find((dish) => !used.has(dish.id));
@@ -264,7 +563,7 @@ function buildMealPlan({ startDate, styleSummaries, criticalAllergens, dishes }:
     const label = date ? formatter.format(date) : `Tag ${dayIndex + 1}`;
     const entries = MEAL_SLOTS.map((slot, slotIndex) => {
       const focus = focusList[(dayIndex + slotIndex) % focusList.length];
-      const dish = pickDishForStyle(focus.style, dishes, used);
+      const dish = pickDishForStyle(focus.style, slot, dishes, used);
       const cautionMatches = (dish.caution ?? []).filter((entry) => criticalAllergens.has(normalizeAllergen(entry)));
       return {
         slot,
@@ -534,6 +833,7 @@ export default async function EssensplanungPage() {
 
   const finalWeekStart = show?.finalRehearsalWeekStart ?? null;
   const numberFormatter = new Intl.NumberFormat("de-DE");
+  const dayDateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
   const finalWeekStartLabel = finalWeekStart
     ? new Intl.DateTimeFormat("de-DE", { dateStyle: "long" }).format(finalWeekStart)
     : null;
@@ -569,6 +869,19 @@ export default async function EssensplanungPage() {
       hint: finalWeekCountdown !== null ? "Tage bis Start" : "Bitte Termin definieren",
     },
   ];
+
+  const plannerDays = mealPlan.map((day) => ({
+    key: day.key,
+    label: day.label,
+    dateLabel: day.date ? dayDateFormatter.format(day.date) : null,
+    slots: day.entries.map((entry) => ({
+      slot: entry.slot,
+      focusLabel: entry.focusLabel,
+      focusStyle: entry.focusStyle,
+      dishId: entry.dish.id,
+    })),
+  }));
+  const defaultParticipantCount = totalParticipants > 0 ? totalParticipants : 12;
 
   return (
     <div className="space-y-6">
@@ -648,7 +961,7 @@ export default async function EssensplanungPage() {
                           <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{day.label}</div>
                           {day.date ? (
                             <div className="text-xs text-muted-foreground/80">
-                              {new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(day.date)}
+                              {dayDateFormatter.format(day.date)}
                             </div>
                           ) : null}
                         </div>
@@ -718,6 +1031,14 @@ export default async function EssensplanungPage() {
               )}
             </CardContent>
           </Card>
+
+          <MealPlanRecipeWorkbench
+            library={DISH_LIBRARY}
+            days={plannerDays}
+            defaultParticipants={defaultParticipantCount}
+            mealSlots={MEAL_SLOTS}
+            styleBadgeVariants={STYLE_BADGE_VARIANTS}
+          />
         </div>
 
         <div className="space-y-4">

--- a/src/components/members/meal-plan-recipe-workbench.tsx
+++ b/src/components/members/meal-plan-recipe-workbench.tsx
@@ -1,0 +1,694 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ListChecks, Plus, Trash2 } from "lucide-react";
+
+import type { DietaryStyleOption } from "@/data/dietary-preferences";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+export type PlannerIngredient = {
+  name: string;
+  amount: number;
+  unit: string;
+  category?: string;
+};
+
+export type PlannerRecipe = {
+  id: string;
+  title: string;
+  description: string;
+  suitableFor: DietaryStyleOption[];
+  highlights: string[];
+  avoids: string[];
+  caution?: string[];
+  servings: number;
+  ingredients: PlannerIngredient[];
+  instructions: string[];
+  idealSlots?: readonly string[];
+};
+
+export type PlannerSlot = {
+  slot: string;
+  focusLabel: string;
+  focusStyle: DietaryStyleOption;
+  dishId?: string | null;
+};
+
+export type PlannerDay = {
+  key: string;
+  label: string;
+  dateLabel: string | null;
+  slots: PlannerSlot[];
+};
+
+type MealPlanRecipeWorkbenchProps = {
+  library: PlannerRecipe[];
+  days: PlannerDay[];
+  defaultParticipants: number;
+  mealSlots: readonly string[];
+  styleBadgeVariants: Record<DietaryStyleOption, string>;
+};
+
+type IngredientDraft = {
+  name: string;
+  amount: string;
+  unit: string;
+};
+
+type RecipeDraft = {
+  title: string;
+  description: string;
+  servings: string;
+  slot: string;
+  ingredients: IngredientDraft[];
+  instructions: string[];
+};
+
+export function MealPlanRecipeWorkbench({
+  library,
+  days,
+  defaultParticipants,
+  mealSlots,
+  styleBadgeVariants,
+}: MealPlanRecipeWorkbenchProps) {
+  const [recipes, setRecipes] = useState<PlannerRecipe[]>(library);
+  const [participantInput, setParticipantInput] = useState<string>(() =>
+    String(Math.max(defaultParticipants, 1)),
+  );
+  const participantCount = useMemo(() => {
+    const parsed = Number.parseInt(participantInput, 10);
+    if (Number.isNaN(parsed) || parsed <= 0) {
+      return 1;
+    }
+    return parsed;
+  }, [participantInput]);
+  const [selectedRecipes, setSelectedRecipes] = useState<Record<string, Record<string, string>>>(() => {
+    const mapping: Record<string, Record<string, string>> = {};
+    for (const day of days) {
+      const slotMap: Record<string, string> = {};
+      for (const slot of day.slots) {
+        if (slot.dishId) {
+          slotMap[slot.slot] = slot.dishId;
+        }
+      }
+      mapping[day.key] = slotMap;
+    }
+    return mapping;
+  });
+  const [showCustomForm, setShowCustomForm] = useState(false);
+  const [newRecipe, setNewRecipe] = useState<RecipeDraft>(() => ({
+    title: "",
+    description: "",
+    servings: "6",
+    slot: mealSlots[0] ?? "Frühstück",
+    ingredients: [{ name: "", amount: "", unit: "" }],
+    instructions: [""],
+  }));
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const recipeMap = useMemo(() => {
+    return new Map(recipes.map((recipe) => [recipe.id, recipe]));
+  }, [recipes]);
+
+  const numberFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat("de-DE", {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 0,
+      }),
+    [],
+  );
+
+  const shoppingList = useMemo(() => {
+    const totals = new Map<
+      string,
+      { name: string; unit: string; amount: number; category?: string }
+    >();
+    for (const day of days) {
+      const daySelection = selectedRecipes[day.key] ?? {};
+      for (const slot of day.slots) {
+        const recipeId = daySelection[slot.slot];
+        if (!recipeId) {
+          continue;
+        }
+        const recipe = recipeMap.get(recipeId);
+        if (!recipe) {
+          continue;
+        }
+        const servings = recipe.servings > 0 ? recipe.servings : 1;
+        const scaleFactor = participantCount / servings;
+        for (const ingredient of recipe.ingredients) {
+          const key = `${ingredient.name.toLowerCase()}__${ingredient.unit.toLowerCase()}`;
+          const existing = totals.get(key);
+          const scaledAmount = ingredient.amount * scaleFactor;
+          if (existing) {
+            existing.amount += scaledAmount;
+          } else {
+            totals.set(key, {
+              name: ingredient.name,
+              unit: ingredient.unit,
+              amount: scaledAmount,
+              category: ingredient.category,
+            });
+          }
+        }
+      }
+    }
+    return Array.from(totals.values()).sort((a, b) => a.name.localeCompare(b.name, "de-DE"));
+  }, [days, participantCount, recipeMap, selectedRecipes]);
+
+  const handleParticipantChange = (value: string) => {
+    const sanitized = value.replace(/[^0-9]/g, "");
+    setParticipantInput(sanitized);
+  };
+
+  const ensureParticipantMinimum = () => {
+    if (!participantInput || participantInput === "0") {
+      setParticipantInput("1");
+    }
+  };
+
+  const handleRecipeSelect = (dayKey: string, slotLabel: string, recipeId: string) => {
+    setSelectedRecipes((prev) => {
+      const next: Record<string, Record<string, string>> = {};
+      for (const day of days) {
+        next[day.key] = { ...(prev[day.key] ?? {}) };
+      }
+      next[dayKey][slotLabel] = recipeId;
+      return next;
+    });
+  };
+
+  const addIngredientRow = () => {
+    setNewRecipe((prev) => ({
+      ...prev,
+      ingredients: [...prev.ingredients, { name: "", amount: "", unit: "" }],
+    }));
+  };
+
+  const updateIngredientRow = (index: number, field: keyof IngredientDraft, value: string) => {
+    setNewRecipe((prev) => ({
+      ...prev,
+      ingredients: prev.ingredients.map((ingredient, current) =>
+        current === index ? { ...ingredient, [field]: value } : ingredient,
+      ),
+    }));
+  };
+
+  const removeIngredientRow = (index: number) => {
+    setNewRecipe((prev) => {
+      if (prev.ingredients.length <= 1) {
+        return prev;
+      }
+      return {
+        ...prev,
+        ingredients: prev.ingredients.filter((_, current) => current !== index),
+      };
+    });
+  };
+
+  const addInstructionRow = () => {
+    setNewRecipe((prev) => ({
+      ...prev,
+      instructions: [...prev.instructions, ""],
+    }));
+  };
+
+  const updateInstructionRow = (index: number, value: string) => {
+    setNewRecipe((prev) => ({
+      ...prev,
+      instructions: prev.instructions.map((instruction, current) =>
+        current === index ? value : instruction,
+      ),
+    }));
+  };
+
+  const removeInstructionRow = (index: number) => {
+    setNewRecipe((prev) => {
+      if (prev.instructions.length <= 1) {
+        return prev;
+      }
+      return {
+        ...prev,
+        instructions: prev.instructions.filter((_, current) => current !== index),
+      };
+    });
+  };
+
+  const handleAddCustomRecipe = () => {
+    const title = newRecipe.title.trim();
+    if (!title) {
+      setFormError("Bitte gib dem Rezept einen Titel.");
+      return;
+    }
+
+    const servingsValue = Number.parseInt(newRecipe.servings, 10);
+    const normalizedServings = Number.isNaN(servingsValue) || servingsValue <= 0 ? 1 : servingsValue;
+
+    const parsedIngredients = newRecipe.ingredients
+      .map((ingredient) => ({
+        name: ingredient.name.trim(),
+        amount: Number.parseFloat(ingredient.amount.replace(",", ".")),
+        unit: ingredient.unit.trim() || "Stk",
+      }))
+      .filter((ingredient) => ingredient.name && !Number.isNaN(ingredient.amount) && ingredient.amount > 0);
+
+    if (parsedIngredients.length === 0) {
+      setFormError("Mindestens eine gültige Zutat angeben.");
+      return;
+    }
+
+    const parsedInstructions = newRecipe.instructions
+      .map((instruction) => instruction.trim())
+      .filter((instruction) => instruction.length > 0);
+
+    if (parsedInstructions.length === 0) {
+      setFormError("Mindestens einen Zubereitungsschritt angeben.");
+      return;
+    }
+
+    const recipeId = `custom-${Date.now()}`;
+
+    const recipe: PlannerRecipe = {
+      id: recipeId,
+      title,
+      description: newRecipe.description.trim() || "Eigenes Rezept",
+      suitableFor: ["custom"],
+      highlights: ["individuell"],
+      avoids: [],
+      caution: [],
+      servings: normalizedServings,
+      ingredients: parsedIngredients,
+      instructions: parsedInstructions,
+      idealSlots: [newRecipe.slot],
+    };
+
+    setRecipes((prev) => [...prev, recipe]);
+    setSelectedRecipes((prev) => {
+      const next: Record<string, Record<string, string>> = {};
+      for (const day of days) {
+        next[day.key] = { ...(prev[day.key] ?? {}) };
+      }
+      const targetSlot = recipe.idealSlots?.[0];
+      if (targetSlot) {
+        for (const day of days) {
+          if (day.slots.some((entry) => entry.slot === targetSlot)) {
+            next[day.key][targetSlot] = recipe.id;
+            break;
+          }
+        }
+      }
+      return next;
+    });
+
+    setNewRecipe({
+      title: "",
+      description: "",
+      servings: newRecipe.servings,
+      slot: newRecipe.slot,
+      ingredients: [{ name: "", amount: "", unit: "" }],
+      instructions: [""],
+    });
+    setFormError(null);
+    setShowCustomForm(false);
+  };
+
+  return (
+    <Card className="border border-border/60 bg-background/70">
+      <CardHeader className="space-y-2">
+        <CardTitle className="text-lg font-semibold">
+          Rezept- & Einkaufsgenerator
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Wähle oder ergänze Rezepte pro Mahlzeit, skaliere die Zutatenmengen und exportiere eine gebündelte Einkaufsliste.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div className="max-w-xs space-y-1">
+            <Label htmlFor="planner-participants">Personenanzahl</Label>
+            <Input
+              id="planner-participants"
+              inputMode="numeric"
+              min={1}
+              value={participantInput}
+              onChange={(event) => handleParticipantChange(event.target.value)}
+              onBlur={ensureParticipantMinimum}
+              placeholder="z. B. 24"
+            />
+            <p className="text-xs text-muted-foreground">
+              Zutatenmengen werden auf diese Gruppengröße hochgerechnet.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => setShowCustomForm((prev) => !prev)}>
+              {showCustomForm ? "Formular schließen" : "Eigenes Rezept hinzufügen"}
+            </Button>
+          </div>
+        </div>
+
+        {showCustomForm ? (
+          <div className="rounded-2xl border border-dashed border-border/70 bg-background/80 p-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-1">
+                <Label htmlFor="custom-title">Rezeptname</Label>
+                <Input
+                  id="custom-title"
+                  value={newRecipe.title}
+                  onChange={(event) => setNewRecipe((prev) => ({ ...prev, title: event.target.value }))}
+                  placeholder="z. B. Sonnendeck-Porridge"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="custom-servings">Standardportionen</Label>
+                <Input
+                  id="custom-servings"
+                  inputMode="numeric"
+                  min={1}
+                  value={newRecipe.servings}
+                  onChange={(event) =>
+                    setNewRecipe((prev) => ({
+                      ...prev,
+                      servings: event.target.value.replace(/[^0-9]/g, ""),
+                    }))
+                  }
+                  placeholder="6"
+                />
+              </div>
+            </div>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <div className="space-y-1">
+                <Label htmlFor="custom-description">Kurzbeschreibung</Label>
+                <Textarea
+                  id="custom-description"
+                  value={newRecipe.description}
+                  onChange={(event) =>
+                    setNewRecipe((prev) => ({ ...prev, description: event.target.value }))
+                  }
+                  placeholder="Was macht das Rezept besonders?"
+                  rows={3}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="custom-slot">Bevorzugter Slot</Label>
+                <Select
+                  value={newRecipe.slot}
+                  onValueChange={(value) => setNewRecipe((prev) => ({ ...prev, slot: value }))}
+                >
+                  <SelectTrigger id="custom-slot">
+                    <SelectValue placeholder="Slot auswählen" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {mealSlots.map((slot) => (
+                      <SelectItem key={slot} value={slot}>
+                        {slot}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <Label>Zutaten</Label>
+                <Button variant="ghost" size="sm" onClick={addIngredientRow}>
+                  <Plus className="mr-2 h-4 w-4" /> Neue Zutat
+                </Button>
+              </div>
+              <div className="space-y-2">
+                {newRecipe.ingredients.map((ingredient, index) => (
+                  <div
+                    key={index}
+                    className="grid gap-2 rounded-lg border border-border/60 bg-background/70 p-3 md:grid-cols-[minmax(0,0.8fr)_minmax(0,0.6fr)_minmax(0,1fr)_auto]"
+                  >
+                    <Input
+                      placeholder="Menge"
+                      inputMode="decimal"
+                      value={ingredient.amount}
+                      onChange={(event) =>
+                        updateIngredientRow(index, "amount", event.target.value.replace(/[^0-9.,]/g, ""))
+                      }
+                    />
+                    <Input
+                      placeholder="Einheit"
+                      value={ingredient.unit}
+                      onChange={(event) => updateIngredientRow(index, "unit", event.target.value)}
+                    />
+                    <Input
+                      placeholder="Zutat"
+                      value={ingredient.name}
+                      onChange={(event) => updateIngredientRow(index, "name", event.target.value)}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground"
+                      onClick={() => removeIngredientRow(index)}
+                      disabled={newRecipe.ingredients.length <= 1}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <Label>Zubereitungsschritte</Label>
+                <Button variant="ghost" size="sm" onClick={addInstructionRow}>
+                  <Plus className="mr-2 h-4 w-4" /> Neuer Schritt
+                </Button>
+              </div>
+              <div className="space-y-2">
+                {newRecipe.instructions.map((instruction, index) => (
+                  <div key={index} className="flex items-start gap-2">
+                    <Textarea
+                      value={instruction}
+                      onChange={(event) => updateInstructionRow(index, event.target.value)}
+                      placeholder={`Schritt ${index + 1}`}
+                      rows={2}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="mt-1 text-muted-foreground"
+                      onClick={() => removeInstructionRow(index)}
+                      disabled={newRecipe.instructions.length <= 1}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {formError ? (
+              <p className="mt-4 text-sm text-destructive">{formError}</p>
+            ) : null}
+
+            <div className="mt-4 flex justify-end gap-2">
+              <Button variant="ghost" onClick={() => setShowCustomForm(false)}>
+                Abbrechen
+              </Button>
+              <Button onClick={handleAddCustomRecipe}>Rezept speichern</Button>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 xl:grid-cols-2">
+          {days.map((day) => (
+            <div
+              key={day.key}
+              className="flex h-full flex-col gap-3 rounded-2xl border border-border/60 bg-background/80 p-4 shadow-sm"
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <div>
+                  <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{day.label}</div>
+                  {day.dateLabel ? (
+                    <div className="text-xs text-muted-foreground/80">{day.dateLabel}</div>
+                  ) : null}
+                </div>
+              </div>
+              <div className="space-y-3">
+                {day.slots.map((slot) => {
+                  const selectedId = selectedRecipes[day.key]?.[slot.slot];
+                  const matchingRecipes = recipes.filter(
+                    (recipe) => !recipe.idealSlots || recipe.idealSlots.includes(slot.slot),
+                  );
+                  const fallbackRecipes = recipes.filter(
+                    (recipe) => recipe.idealSlots && !recipe.idealSlots.includes(slot.slot),
+                  );
+                  const recipeOptions = [...matchingRecipes, ...fallbackRecipes];
+                  const recipe = selectedId ? recipeMap.get(selectedId) : null;
+                  const scaleFactor = recipe ? participantCount / (recipe.servings > 0 ? recipe.servings : 1) : 1;
+                  return (
+                    <div
+                      key={`${day.key}-${slot.slot}`}
+                      className="space-y-3 rounded-xl border border-border/60 bg-background/90 p-3 shadow-sm"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{slot.slot}</div>
+                          <div className="text-sm font-semibold text-foreground">
+                            {recipe ? recipe.title : "Rezept auswählen"}
+                          </div>
+                          {recipe ? (
+                            <p className="text-xs text-muted-foreground">{recipe.description}</p>
+                          ) : (
+                            <p className="text-xs text-muted-foreground">
+                              Wähle ein Rezept, um Details und Mengen zu sehen.
+                            </p>
+                          )}
+                        </div>
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "self-start border-transparent text-[11px]",
+                            styleBadgeVariants[slot.focusStyle] ?? "border-border/60 bg-muted/40 text-muted-foreground",
+                          )}
+                        >
+                          {slot.focusLabel}
+                        </Badge>
+                      </div>
+                      <Select
+                        value={selectedId ?? undefined}
+                        onValueChange={(value) => handleRecipeSelect(day.key, slot.slot, value)}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Rezept auswählen" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {recipeOptions.map((option) => (
+                            <SelectItem key={option.id} value={option.id}>
+                              {option.title}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {recipe ? (
+                        <div className="space-y-3">
+                          <div className="flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+                            {recipe.highlights.map((highlight) => (
+                              <span
+                                key={`${recipe.id}-highlight-${highlight}`}
+                                className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-primary"
+                              >
+                                {highlight}
+                              </span>
+                            ))}
+                            {recipe.avoids.map((avoid) => (
+                              <span
+                                key={`${recipe.id}-avoid-${avoid}`}
+                                className="rounded-full border border-emerald-300/40 bg-emerald-500/10 px-2 py-0.5 text-emerald-500"
+                              >
+                                ohne {avoid}
+                              </span>
+                            ))}
+                          </div>
+                          {recipe.caution && recipe.caution.length ? (
+                            <div className="flex flex-wrap gap-1.5 text-[11px] text-destructive">
+                              {recipe.caution.map((entry) => (
+                                <span
+                                  key={`${recipe.id}-caution-${entry}`}
+                                  className="rounded-full border border-destructive/50 bg-destructive/10 px-2 py-0.5"
+                                >
+                                  Achtung: {entry}
+                                </span>
+                              ))}
+                            </div>
+                          ) : null}
+                          <div className="rounded-xl border border-border/50 bg-muted/20 p-3">
+                            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                              Skalierte Zutaten
+                            </div>
+                            <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+                              {recipe.ingredients.map((ingredient) => {
+                                const scaledAmount = ingredient.amount * scaleFactor;
+                                const rounded = Math.round(scaledAmount * 100) / 100;
+                                return (
+                                  <li key={`${recipe.id}-${ingredient.name}-${ingredient.unit}`}>
+                                    <span className="font-medium text-foreground">
+                                      {numberFormatter.format(rounded)} {ingredient.unit}
+                                    </span>{" "}
+                                    {ingredient.name}
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          </div>
+                          <div className="rounded-xl border border-border/50 bg-muted/10 p-3">
+                            <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                              Zubereitung
+                            </div>
+                            <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs text-muted-foreground">
+                              {recipe.instructions.map((instruction, index) => (
+                                <li key={`${recipe.id}-instruction-${index}`}>{instruction}</li>
+                              ))}
+                            </ol>
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="rounded-2xl border border-border/60 bg-background/80 p-4 shadow-sm">
+          <div className="flex items-center gap-2">
+            <ListChecks className="h-5 w-5 text-primary" />
+            <p className="text-sm font-semibold text-foreground">Einkaufsliste</p>
+          </div>
+          {shoppingList.length === 0 ? (
+            <p className="mt-2 text-sm text-muted-foreground">
+              Bitte wähle mindestens ein Rezept, um automatisch eine Einkaufsliste zu erstellen.
+            </p>
+          ) : (
+            <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+              {shoppingList.map((entry) => {
+                const rounded = Math.round(entry.amount * 100) / 100;
+                return (
+                  <li
+                    key={`${entry.name}-${entry.unit}`}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-border/50 bg-background/90 px-3 py-2"
+                  >
+                    <span>
+                      <span className="font-semibold text-foreground">
+                        {numberFormatter.format(rounded)} {entry.unit}
+                      </span>{" "}
+                      {entry.name}
+                    </span>
+                    {entry.category ? (
+                      <Badge variant="outline" className="border-border/60 bg-background/70 text-[11px]">
+                        {entry.category}
+                      </Badge>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- extend the meal planning data model with breakfast coverage, recipe metadata, and slot-aware suggestions
- embed a new MealPlanRecipeWorkbench that surfaces scaled ingredient lists, shopping list aggregation, and custom recipe capture

## Testing
- pnpm lint
- pnpm test
- TERM=dumb CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1677b6478832db636faf3aabd01d9