### PR TITLE
Limit costume measurement overview to cast members

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/utils.ts
+++ b/src/app/(members)/mitglieder/meine-gewerke/utils.ts
@@ -141,6 +141,10 @@ export type DepartmentMembershipWithDepartment = Prisma.DepartmentMembershipGetP
                 id: true;
                 name: true;
                 email: true;
+                firstName: true;
+                lastName: true;
+                role: true;
+                roles: { select: { role: true } };
               };
             };
           };
@@ -161,4 +165,16 @@ export type DepartmentMembershipWithDepartment = Prisma.DepartmentMembershipGetP
       };
     };
   };
-}>;
+}>; 
+
+export type DepartmentMemberUser = DepartmentMembershipWithDepartment["department"]["memberships"][number]["user"];
+
+export function isCastDepartmentUser(user: DepartmentMemberUser | null | undefined) {
+  if (!user) {
+    return false;
+  }
+  if (user.role === "cast") {
+    return true;
+  }
+  return user.roles?.some((entry) => entry.role === "cast") ?? false;
+}


### PR DESCRIPTION
## Summary
- restrict the costume department measurement overview to members with the ensemble/cast role
- load cast role information in department queries and reuse it via a shared helper

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d16e081c14832d808545c20e992a22