### PR TITLE
Align personal gewerk view with mission control

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { addDays, format, startOfToday } from "date-fns";
 import { de } from "date-fns/locale/de";
 import type { LucideIcon } from "lucide-react";
@@ -32,6 +32,10 @@ export default async function GewerkDetailPage({ params }: PageProps) {
   const hasMeasurementPermission = await hasPermission(
     session.user,
     "mitglieder.koerpermasse",
+  );
+  const canManageDepartments = await hasPermission(
+    session.user,
+    "mitglieder.produktionen",
   );
   const isEnsembleMember = hasRole(session.user, "cast");
   const canManageMeasurements = hasMeasurementPermission && isEnsembleMember;
@@ -85,6 +89,10 @@ export default async function GewerkDetailPage({ params }: PageProps) {
   }
 
   const membership = membershipRaw as DepartmentMembershipWithDepartment;
+
+  if (canManageDepartments) {
+    redirect(`/mitglieder/produktionen/gewerke/${membership.department.id}`);
+  }
 
   const today = startOfToday();
   const planningStart = addDays(today, PLANNING_FREEZE_DAYS);

--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -29,6 +29,10 @@ export default async function MeineGewerkePage() {
     session.user,
     "mitglieder.koerpermasse",
   );
+  const canManageDepartments = await hasPermission(
+    session.user,
+    "mitglieder.produktionen",
+  );
   const isEnsembleMember = hasRole(session.user, "cast");
   const canManageMeasurements = hasMeasurementPermission && isEnsembleMember;
   if (!allowed) {
@@ -329,9 +333,12 @@ export default async function MeineGewerkePage() {
 
       <div className="space-y-8">
         {memberships.map((membership) => {
-          const teamLinkHref = membership.department.slug
-            ? `/mitglieder/meine-gewerke/${encodeURIComponent(membership.department.slug)}`
-            : undefined;
+          const teamLinkHref = canManageDepartments
+            ? `/mitglieder/produktionen/gewerke/${membership.department.id}`
+            : membership.department.slug
+              ? `/mitglieder/meine-gewerke/${encodeURIComponent(membership.department.slug)}`
+              : undefined;
+          const teamLinkLabel = canManageDepartments ? "Gewerk-Hub öffnen" : "Team ansehen";
 
           return (
             <DepartmentCard
@@ -345,6 +352,7 @@ export default async function MeineGewerkePage() {
               planningWindowLabel={planningWindowLabel}
               now={now}
               teamLinkHref={teamLinkHref}
+              teamLinkLabel={teamLinkLabel}
               measurementsByUser={costumeMeasurementsByUser}
             />
           );


### PR DESCRIPTION
## Summary
- expose the mission control permission on the "Meine Gewerke" overview to build team links to the production hub when the user may manage departments
- redirect authorized users from the slug based gewerk detail page to the production mission control view to avoid the read-only duplicate

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d176fcb0ec832d95316d1977152a77