### PR TITLE
Update Saxony holiday ICS feed URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/theater?schema=public
 NEXT_PUBLIC_AUTH_DEV_NO_DB=0
 
 # Optional: ICS feed for sächsische Schulferien. Wird genutzt, um die Sperrliste zu annotieren.
-#SAXONY_HOLIDAYS_ICS_URL=https://www.schulferien.org/media/ical/deutschland/ferien_sachsen.ics
+#SAXONY_HOLIDAYS_ICS_URL=https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics
 # Optional: Deaktiviert ausgehende HTTP-Abfragen und aktiviert den statischen Ferien-Datensatz.
 #OUTBOUND_HTTP_DISABLED=0
 

--- a/src/lib/sperrliste-settings.ts
+++ b/src/lib/sperrliste-settings.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import type { Prisma, SperrlisteSettings } from "@prisma/client";
 
 export const DEFAULT_SAXONY_HOLIDAY_FEED =
-  "https://www.schulferien.org/media/ical/deutschland/ferien_sachsen.ics";
+  "https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics";
 
 export const DEFAULT_FREEZE_DAYS = 7;
 export const DEFAULT_PREFERRED_WEEKDAYS = [6, 0] as const;


### PR DESCRIPTION
## Summary
- switch the default Saxony school holiday ICS feed to the feiertage-deutschland download URL
- update the environment template to point at the new feed as well

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d17b7e470c832da52bcb16914e8d5d