### PR TITLE
Move gallery into Archiv und Bilder with moderation rights

### DIFF
--- a/src/app/(members)/mitglieder/archiv-und-bilder/page.tsx
+++ b/src/app/(members)/mitglieder/archiv-und-bilder/page.tsx
@@ -17,9 +17,9 @@ import {
 import { GalleryMediaType } from "@prisma/client";
 
 export const metadata: Metadata = {
-  title: "Mediengalerie",
+  title: "Archiv und Bilder",
   description:
-    "Verwalte Jahrgangsordner, lade neue Fotos oder Videos hoch und behalte den Überblick über das gemeinsame Medienarchiv.",
+    "Pflege Jahrgangsordner mit Fotos und Videos der vergangenen Spielzeiten und organisiere gemeinsam das Ensemble-Archiv.",
 };
 
 type FolderStats = {
@@ -41,23 +41,24 @@ function formatRelative(date: Date | null) {
   }).format(date);
 }
 
-export default async function GalleryOverviewPage() {
+export default async function ArchiveOverviewPage() {
   const session = await requireAuth();
-  const [canView, canUpload] = await Promise.all([
+  const [canView, canUpload, canModerate] = await Promise.all([
     hasPermission(session.user, "mitglieder.galerie"),
     hasPermission(session.user, "mitglieder.galerie.upload"),
+    hasPermission(session.user, "mitglieder.galerie.delete"),
   ]);
 
   if (!canView) {
     return (
       <div className="space-y-6">
         <PageHeader
-          title="Mediengalerie"
-          description="Du benötigst eine spezielle Berechtigung, um auf die Galerie zuzugreifen. Bitte wende dich an das Team für die Freischaltung."
+          title="Archiv und Bilder"
+          description="Du benötigst eine spezielle Berechtigung, um auf das Archiv zuzugreifen. Bitte wende dich an das Team für die Freischaltung."
         />
         <Card>
           <CardContent className="py-10 text-sm text-muted-foreground">
-            Ohne Freigabe ist die Galerie im Mitgliederbereich nicht sichtbar.
+            Ohne Freigabe ist das Archiv im Mitgliederbereich nicht sichtbar.
           </CardContent>
         </Card>
       </div>
@@ -130,18 +131,24 @@ export default async function GalleryOverviewPage() {
   return (
     <div className="space-y-8">
       <PageHeader
-        title="Mediengalerie"
-        description="Ordne Bilder und Videos den passenden Jahrgängen zu, sieh alle Uploads auf einen Blick und ergänze das Archiv gemeinsam mit dem Team."
+        title="Archiv und Bilder"
+        description="Ordne Bilder und Videos den passenden Jahrgängen zu, entdecke Erinnerungen vergangener Spielzeiten und ergänze das Archiv gemeinsam mit dem Team."
       />
 
       <Card>
         <CardContent className="space-y-2 py-6 text-sm text-muted-foreground">
           <p>
-            In jedem Ordner findest du alle hochgeladenen Medien eines Jahrgangs. Du kannst bestehende Dateien öffnen
+            In jedem Ordner findest du hochgeladene Fotos und Videos eines Jahrgangs. Du kannst bestehende Dateien öffnen
             und – sofern freigeschaltet – eigene Inhalte mit kurzer Beschreibung ergänzen.
           </p>
-          {canUpload ? (
-            <p className="text-success">Du darfst neue Medien hochladen und deine eigenen Beiträge entfernen.</p>
+          {canUpload || canModerate ? (
+            <p className="text-success">
+              {canUpload && canModerate
+                ? "Du kannst neue Medien ergänzen und das gesamte Archiv moderieren – inklusive Löschen fremder Beiträge."
+                : canUpload
+                  ? "Du darfst neue Medien hochladen und deine eigenen Beiträge entfernen."
+                  : "Du darfst Beiträge aus allen Jahrgängen entfernen."}
+            </p>
           ) : (
             <p>Zum Hochladen benötigst du eine zusätzliche Berechtigung. Frage bei Bedarf im Admin-Team nach.</p>
           )}
@@ -185,11 +192,11 @@ export default async function GalleryOverviewPage() {
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
                   <Button asChild>
-                    <Link href={`/mitglieder/galerie/${folder.year}`}>Ordner öffnen</Link>
+                    <Link href={`/mitglieder/archiv-und-bilder/${folder.year}`}>Ordner öffnen</Link>
                   </Button>
                   {canUpload ? (
                     <Button asChild variant="outline">
-                      <Link href={`/mitglieder/galerie/${folder.year}#upload`}>Direkt zum Upload</Link>
+                      <Link href={`/mitglieder/archiv-und-bilder/${folder.year}#upload`}>Direkt zum Upload</Link>
                     </Button>
                   ) : null}
                 </div>

--- a/src/app/api/gallery/folders/[year]/route.ts
+++ b/src/app/api/gallery/folders/[year]/route.ts
@@ -80,9 +80,10 @@ export async function POST(
     return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
   }
 
-  const [canView, canUpload] = await Promise.all([
+  const [canView, canUpload, canModerate] = await Promise.all([
     hasPermission(session.user, "mitglieder.galerie"),
     hasPermission(session.user, "mitglieder.galerie.upload"),
+    hasPermission(session.user, "mitglieder.galerie.delete"),
   ]);
 
   if (!canView || !canUpload) {
@@ -198,7 +199,7 @@ export async function POST(
         email: item.uploadedBy?.email ?? null,
       },
       downloadUrl: `/api/gallery/items/${item.id}/file`,
-      canDelete: item.uploadedById === userId,
+      canDelete: canModerate || item.uploadedById === userId,
     }));
 
     return NextResponse.json({ items });

--- a/src/app/api/gallery/items/[id]/route.ts
+++ b/src/app/api/gallery/items/[id]/route.ts
@@ -16,12 +16,13 @@ export async function DELETE(
     return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
   }
 
-  const [canView, canUpload] = await Promise.all([
+  const [canView, canUpload, canModerate] = await Promise.all([
     hasPermission(session.user, "mitglieder.galerie"),
     hasPermission(session.user, "mitglieder.galerie.upload"),
+    hasPermission(session.user, "mitglieder.galerie.delete"),
   ]);
 
-  if (!canView || !canUpload) {
+  if (!canView || (!canUpload && !canModerate)) {
     return NextResponse.json({ error: "Keine Berechtigung" }, { status: 403 });
   }
 
@@ -38,7 +39,7 @@ export async function DELETE(
     return NextResponse.json({ error: "Datei nicht gefunden" }, { status: 404 });
   }
 
-  if (item.uploadedById !== userId) {
+  if (item.uploadedById !== userId && !canModerate) {
     return NextResponse.json({ error: "Nur eigene Uploads können gelöscht werden." }, { status: 403 });
   }
 

--- a/src/app/galerie/page.tsx
+++ b/src/app/galerie/page.tsx
@@ -5,9 +5,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
 export const metadata: Metadata = {
-  title: "Galerie & Medienarchiv",
+  title: "Archiv und Bilder",
   description:
-    "Die Upload-Zentrale ist in den geschützten Mitgliederbereich umgezogen. Bitte melde dich an, um auf die Jahrgangsordner zuzugreifen.",
+    "Das Medienarchiv mit Upload-Funktion liegt im geschützten Mitgliederbereich. Melde dich an, um Fotos und Videos vergangener Jahre zu verwalten.",
 };
 
 export default function PublicGalleryPage() {
@@ -16,14 +16,14 @@ export default function PublicGalleryPage() {
       <Card className="max-w-2xl">
         <CardContent className="space-y-6 p-8 text-center">
           <div className="space-y-3">
-            <h1 className="text-3xl font-semibold">Galerie nur für Mitglieder</h1>
+            <h1 className="text-3xl font-semibold">Archiv und Bilder nur für Mitglieder</h1>
             <p className="text-sm text-muted-foreground">
-              Unsere Mediengalerie mit Upload-Bereich ist in den geschützten Mitgliederbereich umgezogen. Melde dich mit deinem
-              Konto an, um Bilder und Videos zu verwalten.
+              Unser Medienarchiv mit Jahrgangsordnern liegt im geschützten Mitgliederbereich. Dort kannst du Fotos und Videos aus
+              vergangenen Spielzeiten hochladen, beschreiben und ansehen.
             </p>
           </div>
           <Button asChild>
-            <Link href="/login?redirect=/mitglieder/galerie">Zum Login</Link>
+            <Link href="/login?redirect=/mitglieder/archiv-und-bilder">Zum Login</Link>
           </Button>
         </CardContent>
       </Card>

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -14,7 +14,7 @@ export type AssignmentFocus = "none" | "rehearsals" | "departments" | "both";
 const GENERAL_ITEMS: Item[] = [
   { href: "/mitglieder", label: "Dashboard", permissionKey: "mitglieder.dashboard" },
   { href: "/mitglieder/profil", label: "Profil", permissionKey: "mitglieder.profil" },
-  { href: "/mitglieder/galerie", label: "Galerie", permissionKey: "mitglieder.galerie" },
+  { href: "/mitglieder/archiv-und-bilder", label: "Archiv und Bilder", permissionKey: "mitglieder.galerie" },
   { href: "/mitglieder/sperrliste", label: "Sperrliste", permissionKey: "mitglieder.sperrliste" },
   { href: "/mitglieder/issues", label: "Feedback & Support", permissionKey: "mitglieder.issues" },
 ];
@@ -91,7 +91,7 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
           <path d="M6 20c0-3.314 2.686-6 6-6s6 2.686 6 6" />
         </svg>
       );
-    case "/mitglieder/galerie":
+    case "/mitglieder/archiv-und-bilder":
       return (
         <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M3 8a2 2 0 0 1 2-2h2l1.2-2h5.6L15 6h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />

--- a/src/components/members/gallery/member-gallery-manager.tsx
+++ b/src/components/members/gallery/member-gallery-manager.tsx
@@ -52,6 +52,7 @@ export type MemberGalleryItem = {
 type MemberGalleryManagerProps = {
   year: number;
   canUpload: boolean;
+  canModerate: boolean;
   initialItems: MemberGalleryItem[];
 };
 
@@ -107,7 +108,7 @@ function getUploaderLabel(uploadedBy: MemberGalleryItem["uploadedBy"]) {
   return uploadedBy.name?.trim() || uploadedBy.email?.trim() || "Unbekannt";
 }
 
-export function MemberGalleryManager({ year, canUpload, initialItems }: MemberGalleryManagerProps) {
+export function MemberGalleryManager({ year, canUpload, canModerate, initialItems }: MemberGalleryManagerProps) {
   const [items, setItems] = useState<MemberGalleryItem[]>(() => {
     return [...initialItems].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   });
@@ -344,6 +345,11 @@ export function MemberGalleryManager({ year, canUpload, initialItems }: MemberGa
           <span>
             {stats.latest ? `Letzter Upload: ${formatDateTime(stats.latest.toISOString())}` : "Noch keine Uploads"}
           </span>
+          {canModerate ? (
+            <span className="basis-full text-xs font-medium text-success">
+              Du darfst Uploads anderer Mitglieder entfernen.
+            </span>
+          ) : null}
         </CardContent>
       </Card>
 
@@ -536,7 +542,7 @@ export function MemberGalleryManager({ year, canUpload, initialItems }: MemberGa
                         Öffnen
                       </a>
                     </Button>
-                    {item.canDelete ? (
+                    {item.canDelete || canModerate ? (
                       <Button
                         type="button"
                         variant="destructive"

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -16,9 +16,9 @@ export const primaryNavigation: NavigationItem[] = [
     description: "Tauche in die Welt hinter dem mystischen Vorhang ein.",
   },
   {
-    label: "Galerie",
+    label: "Archiv und Bilder",
     href: "/galerie",
-    description: "Lade Bilder hoch und pflege das Archiv von 2009 bis heute.",
+    description: "Alle Infos zum geschützten Medienarchiv mit Fotos und Videos vergangener Jahre.",
   },
   {
     label: "Unsere Schulkatze",

--- a/src/data/server-analytics-static.json
+++ b/src/data/server-analytics-static.json
@@ -99,7 +99,7 @@
     },
     {
       "path": "/galerie",
-      "title": "Galerie",
+      "title": "Archiv und Bilder",
       "views": 1885,
       "uniqueVisitors": 1532,
       "avgTimeOnPageSeconds": 208,

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -53,16 +53,23 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { key: "mitglieder.profil", label: "Profilbereich aufrufen", category: "base" },
   {
     key: "mitglieder.galerie",
-    label: "Galerie öffnen",
+    label: "Archiv und Bilder öffnen",
     description:
-      "Zugang zum Medienarchiv mit Jahrgangsordnern und Upload-Bereich im Mitgliederportal.",
+      "Zugang zum Medienarchiv mit Jahrgangsordnern, Fotos und Videos im Mitgliederportal.",
     category: "self",
   },
   {
     key: "mitglieder.galerie.upload",
-    label: "Medien in der Galerie hochladen",
+    label: "Medien in Archiv und Bilder hochladen",
     description:
       "Eigene Fotos und Videos in Jahrgangsordnern ablegen sowie Beschreibungen ergänzen.",
+    category: "self",
+  },
+  {
+    key: "mitglieder.galerie.delete",
+    label: "Uploads im Archiv moderieren",
+    description:
+      "Fremde Beiträge löschen, Inhalte kuratieren und das Medienarchiv aufräumen.",
     category: "self",
   },
   {


### PR DESCRIPTION
## Summary
- rename the members gallery pages to the new Archiv und Bilder area and refresh the descriptions
- extend gallery permissions to include a moderator role that may delete uploads from any member
- update navigation, the public gallery info page, and analytics labels to reflect the new wording

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d17cb1087c832d82ea81c52eb45c32