### PR TITLE
Sync admin theme preview color mode

### DIFF
--- a/prisma/migrations/20270308120000_website_theme_settings/migration.sql
+++ b/prisma/migrations/20270308120000_website_theme_settings/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "public"."WebsiteTheme" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "tokens" JSONB NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "WebsiteTheme_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."WebsiteSettings" (
+    "id" TEXT NOT NULL,
+    "siteTitle" TEXT NOT NULL DEFAULT 'Sommertheater im Schlosspark',
+    "colorMode" TEXT NOT NULL DEFAULT 'dark',
+    "themeId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "WebsiteSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebsiteSettings_themeId_idx"
+  ON "public"."WebsiteSettings"("themeId");
+
+-- AddForeignKey
+ALTER TABLE "public"."WebsiteSettings"
+  ADD CONSTRAINT "WebsiteSettings_themeId_fkey"
+  FOREIGN KEY ("themeId")
+  REFERENCES "public"."WebsiteTheme"("id")
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -521,6 +521,29 @@ model MysterySettings {
   updatedAt          DateTime @updatedAt
 }
 
+model WebsiteTheme {
+  id          String            @id @default(cuid())
+  name        String
+  description String?
+  tokens      Json
+  isDefault   Boolean           @default(false)
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
+  settings    WebsiteSettings[]
+}
+
+model WebsiteSettings {
+  id        String   @id @default("public")
+  siteTitle String   @default("Sommertheater im Schlosspark")
+  colorMode String   @default("dark")
+  themeId   String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  theme     WebsiteTheme? @relation(fields: [themeId], references: [id], onDelete: SetNull)
+
+  @@index([themeId])
+}
+
 model SperrlisteSettings {
   id                     String   @id @default("default")
   holidaySourceMode      String   @default("default")

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -6,6 +6,7 @@ import {
 } from "@prisma/client";
 import bcrypt from "bcryptjs";
 import chronikAltrossthal from "../src/data/chronik-altrossthal.json" assert { type: "json" };
+import designTokens from "../src/design-system/tokens.json" assert { type: "json" };
 const prisma = new PrismaClient();
 
 function splitFullName(value) {
@@ -41,6 +42,41 @@ function combineName(firstName, lastName) {
 }
 
 async function main() {
+  const defaultThemeId = "default-website-theme";
+  const themeTokens = JSON.parse(JSON.stringify(designTokens));
+
+  await prisma.websiteTheme.upsert({
+    where: { id: defaultThemeId },
+    update: {
+      name: "Sommertheater Standard",
+      description: "Dynamisches Theme basierend auf dem aktuellen Designsystem.",
+      tokens: themeTokens,
+      isDefault: true,
+    },
+    create: {
+      id: defaultThemeId,
+      name: "Sommertheater Standard",
+      description: "Dynamisches Theme basierend auf dem aktuellen Designsystem.",
+      tokens: themeTokens,
+      isDefault: true,
+    },
+  });
+
+  await prisma.websiteSettings.upsert({
+    where: { id: "public" },
+    update: {
+      siteTitle: "Sommertheater im Schlosspark",
+      colorMode: "dark",
+      theme: { connect: { id: defaultThemeId } },
+    },
+    create: {
+      id: "public",
+      siteTitle: "Sommertheater im Schlosspark",
+      colorMode: "dark",
+      theme: { connect: { id: defaultThemeId } },
+    },
+  });
+
   // --- Chronik: use ONLY the provided Altroßthal data below ---
 
   // Altroßthal data provided (curated demo -> replace with real assets later)

--- a/src/app/(members)/mitglieder/website/page.tsx
+++ b/src/app/(members)/mitglieder/website/page.tsx
@@ -1,0 +1,51 @@
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import {
+  ensureWebsiteSettingsRecord,
+  resolveWebsiteSettings,
+  toClientWebsiteSettings,
+} from "@/lib/website-settings";
+
+import { WebsiteThemeSettingsManager } from "./theme-settings-manager";
+
+export default async function WebsiteSettingsPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.website.settings");
+
+  if (!allowed) {
+    return <div className="text-sm text-muted-foreground">Kein Zugriff auf die Website-Einstellungen.</div>;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        Die Datenbank ist nicht konfiguriert. Website-Einstellungen können nicht geladen werden.
+      </div>
+    );
+  }
+
+  try {
+    const record = await ensureWebsiteSettingsRecord();
+    const resolved = resolveWebsiteSettings(record);
+    const clientSettings = toClientWebsiteSettings(resolved);
+
+    return (
+      <div className="space-y-8">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Website & Theme</h1>
+          <p className="text-sm text-muted-foreground">
+            Passe Farben, Branding und Darstellung der öffentlichen Website an. Änderungen werden sofort im aktuellen Fenster sichtbar.
+          </p>
+        </div>
+        <WebsiteThemeSettingsManager initialSettings={clientSettings} />
+      </div>
+    );
+  } catch (error) {
+    console.error("Failed to load website settings", error);
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        Website-Einstellungen konnten nicht geladen werden.
+      </div>
+    );
+  }
+}

--- a/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
+++ b/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { createThemeCss } from "@/lib/theme-css";
+import type {
+  ClientWebsiteSettings,
+  ThemeColorMode,
+  ThemeModeKey,
+  ThemeTokenKey,
+  ThemeTokens,
+} from "@/lib/website-settings";
+
+const LIGHT_MODE: ThemeModeKey = "light";
+const DARK_MODE: ThemeModeKey = "dark";
+
+const COLOR_MODE_OPTIONS: { value: ThemeColorMode; label: string }[] = [
+  { value: "dark", label: "Dunkelmodus" },
+  { value: "light", label: "Hellmodus" },
+];
+
+const UPDATED_AT_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+type ModeValuesState = Record<ThemeModeKey, Record<ThemeTokenKey, string>>;
+
+type WebsiteThemeSettingsManagerProps = {
+  initialSettings: ClientWebsiteSettings;
+};
+
+function buildModeValues(modes: ThemeTokens["modes"]): ModeValuesState {
+  const result = {} as ModeValuesState;
+  for (const mode of Object.keys(modes) as ThemeModeKey[]) {
+    result[mode] = { ...(modes[mode] as Record<ThemeTokenKey, string>) };
+  }
+  return result;
+}
+
+function formatTokenLabel(token: string) {
+  return token
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSettingsManagerProps) {
+  const [snapshot, setSnapshot] = useState<ClientWebsiteSettings>(initialSettings);
+  const [siteTitle, setSiteTitle] = useState(initialSettings.siteTitle);
+  const [colorMode, setColorMode] = useState<ThemeColorMode>(initialSettings.colorMode);
+  const [themeName, setThemeName] = useState(initialSettings.theme.name);
+  const [themeDescription, setThemeDescription] = useState(initialSettings.theme.description ?? "");
+  const [radius, setRadius] = useState(initialSettings.theme.tokens.radius.base);
+  const [modeValues, setModeValues] = useState<ModeValuesState>(() =>
+    buildModeValues(initialSettings.theme.tokens.modes),
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  const tokenKeys = useMemo(
+    () => Object.keys(snapshot.theme.tokens.modes[LIGHT_MODE]) as ThemeTokenKey[],
+    [snapshot],
+  );
+
+  const previewTokens = useMemo(() => {
+    const modes = {} as ThemeTokens["modes"];
+    for (const mode of Object.keys(modeValues) as ThemeModeKey[]) {
+      modes[mode] = { ...modeValues[mode] } as ThemeTokens["modes"][ThemeModeKey];
+    }
+    return {
+      radius: { base: radius },
+      modes,
+    } satisfies ThemeTokens;
+  }, [radius, modeValues]);
+
+  const lastSavedIso = snapshot.theme.updatedAt ?? snapshot.updatedAt;
+  const lastSavedLabel = lastSavedIso
+    ? UPDATED_AT_FORMATTER.format(new Date(lastSavedIso))
+    : "Noch nie gespeichert";
+
+  const isDirty = useMemo(() => {
+    const normalizedSiteTitle = siteTitle.trim();
+    if (normalizedSiteTitle !== snapshot.siteTitle.trim()) {
+      return true;
+    }
+    if (colorMode !== snapshot.colorMode) {
+      return true;
+    }
+    if (themeName.trim() !== snapshot.theme.name.trim()) {
+      return true;
+    }
+    if ((themeDescription ?? "").trim() !== (snapshot.theme.description ?? "").trim()) {
+      return true;
+    }
+    if (radius.trim() !== snapshot.theme.tokens.radius.base.trim()) {
+      return true;
+    }
+    for (const mode of Object.keys(snapshot.theme.tokens.modes) as ThemeModeKey[]) {
+      const snapshotTokens = snapshot.theme.tokens.modes[mode];
+      const currentTokens = modeValues[mode];
+      for (const token of Object.keys(snapshotTokens) as ThemeTokenKey[]) {
+        if (currentTokens[token] !== snapshotTokens[token]) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }, [siteTitle, colorMode, themeName, themeDescription, radius, modeValues, snapshot]);
+
+  useEffect(() => {
+    const styleElement = document.getElementById("website-theme-style") as HTMLStyleElement | null;
+    if (!styleElement) {
+      return;
+    }
+    styleElement.textContent = createThemeCss(previewTokens);
+  }, [previewTokens]);
+
+  useEffect(() => {
+    const savedCss = createThemeCss(snapshot.theme.tokens);
+    return () => {
+      const styleElement = document.getElementById("website-theme-style") as HTMLStyleElement | null;
+      if (!styleElement) {
+        return;
+      }
+      styleElement.textContent = savedCss;
+    };
+  }, [snapshot]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (colorMode === "dark") {
+      root.classList.add("dark");
+      root.style.colorScheme = "dark";
+    } else {
+      root.classList.remove("dark");
+      root.style.colorScheme = "light";
+    }
+  }, [colorMode]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    return () => {
+      if (snapshot.colorMode === "dark") {
+        root.classList.add("dark");
+        root.style.colorScheme = "dark";
+      } else {
+        root.classList.remove("dark");
+        root.style.colorScheme = "light";
+      }
+    };
+  }, [snapshot.colorMode]);
+
+  function applySettings(next: ClientWebsiteSettings, updateSnapshot = false) {
+    setSiteTitle(next.siteTitle);
+    setColorMode(next.colorMode);
+    setThemeName(next.theme.name);
+    setThemeDescription(next.theme.description ?? "");
+    setRadius(next.theme.tokens.radius.base);
+    setModeValues(buildModeValues(next.theme.tokens.modes));
+    if (updateSnapshot) {
+      setSnapshot(next);
+    }
+  }
+
+  function handleTokenChange(mode: ThemeModeKey, token: ThemeTokenKey, value: string) {
+    setModeValues((prev) => ({
+      ...prev,
+      [mode]: {
+        ...prev[mode],
+        [token]: value,
+      },
+    }));
+  }
+
+  async function handleSave() {
+    setIsSaving(true);
+    try {
+      const response = await fetch("/api/website/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          settings: {
+            siteTitle,
+            colorMode,
+          },
+          theme: {
+            id: snapshot.theme.id,
+            name: themeName,
+            description: themeDescription.length > 0 ? themeDescription : null,
+            tokens: previewTokens,
+          },
+        }),
+      });
+
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        const message = data?.error ?? "Die Einstellungen konnten nicht gespeichert werden.";
+        throw new Error(message);
+      }
+
+      if (!data?.settings) {
+        throw new Error("Die Einstellungen konnten nicht gespeichert werden.");
+      }
+
+      applySettings(data.settings as ClientWebsiteSettings, true);
+      toast.success("Website-Theme gespeichert.");
+    } catch (error) {
+      console.error(error);
+      toast.error(error instanceof Error ? error.message : "Fehler beim Speichern.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle>Allgemeine Einstellungen</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Lege den sichtbaren Seitentitel und den bevorzugten Standardmodus fest.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="site-title">Website-Titel</Label>
+              <Input
+                id="site-title"
+                value={siteTitle}
+                maxLength={160}
+                onChange={(event) => setSiteTitle(event.target.value)}
+                placeholder="Sommertheater im Schlosspark"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="color-mode">Standardmodus</Label>
+              <Select value={colorMode} onValueChange={(value) => setColorMode(value as ThemeColorMode)}>
+                <SelectTrigger id="color-mode">
+                  <SelectValue placeholder="Modus wählen" />
+                </SelectTrigger>
+                <SelectContent>
+                  {COLOR_MODE_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle>Theme-Farben</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Passe die Farbwerte für Light- und Dark-Mode an. Änderungen werden live angewendet.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="theme-name">Theme-Name</Label>
+              <Input
+                id="theme-name"
+                value={themeName}
+                maxLength={120}
+                onChange={(event) => setThemeName(event.target.value)}
+                placeholder="z. B. Sommertheater Standard"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="theme-radius">Grund-Radius</Label>
+              <Input
+                id="theme-radius"
+                value={radius}
+                maxLength={60}
+                onChange={(event) => setRadius(event.target.value)}
+                placeholder="0.625rem"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="theme-description">Beschreibung</Label>
+            <Textarea
+              id="theme-description"
+              value={themeDescription}
+              onChange={(event) => setThemeDescription(event.target.value)}
+              rows={3}
+              maxLength={500}
+              placeholder="Optionaler Hinweis zum Theme"
+            />
+          </div>
+          <Tabs defaultValue={LIGHT_MODE}>
+            <TabsList>
+              <TabsTrigger value={LIGHT_MODE}>Light</TabsTrigger>
+              <TabsTrigger value={DARK_MODE}>Dark</TabsTrigger>
+            </TabsList>
+            <TabsContent value={LIGHT_MODE} className="space-y-4 pt-4">
+              {tokenKeys.map((token) => (
+                <div key={`light-${token}`} className="grid gap-3 sm:grid-cols-[180px_minmax(0,1fr)]">
+                  <Label className="flex items-center gap-3 text-sm font-medium">
+                    <span
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border/60"
+                      style={{ backgroundColor: modeValues[LIGHT_MODE][token] }}
+                    />
+                    {formatTokenLabel(token)}
+                  </Label>
+                  <Input
+                    value={modeValues[LIGHT_MODE][token]}
+                    onChange={(event) => handleTokenChange(LIGHT_MODE, token, event.target.value)}
+                  />
+                </div>
+              ))}
+            </TabsContent>
+            <TabsContent value={DARK_MODE} className="space-y-4 pt-4">
+              {tokenKeys.map((token) => (
+                <div key={`dark-${token}`} className="grid gap-3 sm:grid-cols-[180px_minmax(0,1fr)]">
+                  <Label className="flex items-center gap-3 text-sm font-medium">
+                    <span
+                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border/60"
+                      style={{ backgroundColor: modeValues[DARK_MODE][token] }}
+                    />
+                    {formatTokenLabel(token)}
+                  </Label>
+                  <Input
+                    value={modeValues[DARK_MODE][token]}
+                    onChange={(event) => handleTokenChange(DARK_MODE, token, event.target.value)}
+                  />
+                </div>
+              ))}
+            </TabsContent>
+          </Tabs>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Zuletzt gespeichert: <span className="font-medium text-foreground">{lastSavedLabel}</span>
+        </p>
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => applySettings(snapshot)}
+            disabled={isSaving || !isDirty}
+          >
+            Änderungen verwerfen
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving || !isDirty}
+            data-state={isSaving ? "loading" : undefined}
+          >
+            {isSaving ? "Speichern…" : "Theme speichern"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/website/settings/route.ts
+++ b/src/app/api/website/settings/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import {
+  DEFAULT_THEME_ID,
+  THEME_TOKEN_KEYS,
+  ensureWebsiteSettingsRecord,
+  readWebsiteSettings,
+  resolveWebsiteSettings,
+  saveWebsiteSettings,
+  saveWebsiteTheme,
+  toClientWebsiteSettings,
+} from "@/lib/website-settings";
+
+const colorModeSchema = z.enum(["light", "dark"]);
+
+function createModeSchema() {
+  return z.object(
+    Object.fromEntries(
+      THEME_TOKEN_KEYS.map((token) => [token, z.string().trim().min(1).max(200)]),
+    ) as Record<string, z.ZodString>,
+  );
+}
+
+const themeTokensSchema = z.object({
+  radius: z.object({ base: z.string().trim().min(1).max(120) }),
+  modes: z.object({
+    light: createModeSchema(),
+    dark: createModeSchema(),
+  }),
+});
+
+const updateSchema = z.object({
+  settings: z
+    .object({
+      siteTitle: z.string().trim().min(1).max(160).optional(),
+      colorMode: colorModeSchema.optional(),
+    })
+    .optional(),
+  theme: z
+    .object({
+      id: z.string().trim().min(1),
+      name: z.string().trim().min(2).max(120).optional(),
+      description: z.string().trim().max(500).optional().nullable(),
+      tokens: themeTokensSchema,
+    })
+    .optional(),
+});
+
+async function ensurePermission() {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.website.settings"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET() {
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  try {
+    const record = await ensureWebsiteSettingsRecord();
+    const resolved = resolveWebsiteSettings(record);
+    return NextResponse.json({ settings: toClientWebsiteSettings(resolved) });
+  } catch (error) {
+    console.error("Failed to load website settings", error);
+    return NextResponse.json({ error: "Einstellungen konnten nicht geladen werden." }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const parsed = updateSchema.safeParse(payload);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json({ error: issue?.message ?? "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const themePayload = parsed.data.theme;
+  const settingsPayload = parsed.data.settings;
+
+  if (!themePayload && !settingsPayload) {
+    return NextResponse.json({ error: "Keine Änderungen übermittelt." }, { status: 400 });
+  }
+
+  try {
+    const record = await ensureWebsiteSettingsRecord();
+    const targetThemeId = themePayload?.id ?? record.theme?.id ?? DEFAULT_THEME_ID;
+
+    if (themePayload) {
+      await saveWebsiteTheme(targetThemeId, {
+        name: themePayload.name ?? undefined,
+        description: themePayload.description ?? undefined,
+        tokens: themePayload.tokens,
+      });
+    }
+
+    if (settingsPayload || themePayload) {
+      await saveWebsiteSettings({
+        siteTitle: settingsPayload?.siteTitle ?? undefined,
+        colorMode: settingsPayload?.colorMode ?? undefined,
+        themeId: targetThemeId,
+      });
+    }
+
+    const refreshed = await readWebsiteSettings();
+    const resolved = resolveWebsiteSettings(refreshed);
+
+    return NextResponse.json({ settings: toClientWebsiteSettings(resolved) });
+  } catch (error) {
+    console.error("Failed to save website settings", error);
+    return NextResponse.json({ error: "Die Einstellungen konnten nicht gespeichert werden." }, { status: 500 });
+  }
+}

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -67,6 +67,7 @@ const ADMIN_ITEMS: Item[] = [
   { href: "/mitglieder/server-analytics", label: "Server-Statistiken", permissionKey: "mitglieder.server.analytics" },
   { href: "/mitglieder/rechte", label: "Rechteverwaltung", permissionKey: "mitglieder.rechte" },
   { href: "/mitglieder/fotoerlaubnisse", label: "Fotoerlaubnisse", permissionKey: "mitglieder.fotoerlaubnisse" },
+  { href: "/mitglieder/website", label: "Website & Theme", permissionKey: "mitglieder.website.settings" },
 ];
 
 function resolveAssignmentLabel(focus: AssignmentFocus, permissions: readonly string[] | Set<string>) {
@@ -248,6 +249,16 @@ function NavIcon({ name, className }: { name: string; className?: string }) {
         <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M21 19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h3l2-3h4l2 3h3a2 2 0 0 1 2 2Z" />
           <circle cx="12" cy="14" r="3" />
+        </svg>
+      );
+    case "/mitglieder/website":
+      return (
+        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 22c4.97 0 9-3.6 9-8a7 7 0 0 0-7-7 4 4 0 0 1-4-4 9 9 0 0 0-9 9c0 4.4 4.03 8 9 8Z" />
+          <circle cx="6.5" cy="11.5" r="1.5" />
+          <circle cx="9.5" cy="7.5" r="1.5" />
+          <circle cx="14.5" cy="7.5" r="1.5" />
+          <circle cx="17.5" cy="11.5" r="1.5" />
         </svg>
       );
     case "/mitglieder/server-analytics":

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -21,9 +21,10 @@ type BuildInfo = {
 type SiteFooterProps = {
   buildInfo: BuildInfo;
   isDevBuild: boolean;
+  siteTitle: string;
 };
 
-export function SiteFooter({ buildInfo, isDevBuild }: SiteFooterProps) {
+export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps) {
   const currentYear = new Date().getFullYear();
 
   return (
@@ -33,7 +34,7 @@ export function SiteFooter({ buildInfo, isDevBuild }: SiteFooterProps) {
           <div className="space-y-6">
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.18em] text-primary/80">
-                Sommertheater im Schlosspark
+                {siteTitle}
               </p>
               <p className="mt-3 max-w-xl text-balance text-lg text-muted-foreground">
                 Open-Air-Aufführungen zwischen alten Baumkronen und modernen Inszenierungen.
@@ -105,7 +106,9 @@ export function SiteFooter({ buildInfo, isDevBuild }: SiteFooterProps) {
         </div>
 
         <div className="mt-12 flex flex-col gap-4 border-t border-border/50 pt-6 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
-          <p>© {currentYear} Schultheater „Sommertheater im Schlosspark“</p>
+          <p>
+            © {currentYear} Schultheater „{siteTitle}“
+          </p>
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
             <Link className="transition-colors hover:text-primary" href="/impressum">
               Impressum

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -8,7 +8,7 @@ import { NotificationBell } from "@/components/notification-bell";
 import { UserNav } from "@/components/user-nav";
 import { ctaNavigation, primaryNavigation } from "@/config/navigation";
 
-export function SiteHeader() {
+export function SiteHeader({ siteTitle }: { siteTitle: string }) {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const pathname = usePathname();
@@ -76,7 +76,7 @@ export function SiteHeader() {
           }`}
           href="/"
         >
-          Sommertheater
+          {siteTitle}
         </Link>
 
         <div className="hidden items-center gap-6 md:flex">

--- a/src/components/theme/theme-style-registry.tsx
+++ b/src/components/theme/theme-style-registry.tsx
@@ -1,0 +1,13 @@
+import { createThemeCss } from "@/lib/theme-css";
+import type { ThemeTokens } from "@/lib/website-settings";
+
+export function ThemeStyleRegistry({ tokens }: { tokens: ThemeTokens }) {
+  const css = createThemeCss(tokens);
+  return (
+    <style
+      id="website-theme-style"
+      data-theme-style="website"
+      dangerouslySetInnerHTML={{ __html: css }}
+    />
+  );
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -165,6 +165,13 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     category: "membership",
   },
   {
+    key: "mitglieder.website.settings",
+    label: "Website-Einstellungen verwalten",
+    description:
+      "Theme-Farben, Branding und öffentliche Website-Parameter anpassen.",
+    category: "membership",
+  },
+  {
     key: "mitglieder.fotoerlaubnisse",
     label: "Fotoerlaubnisse verwalten",
     description: "Bereich zum Prüfen und Freigeben von Fotoeinverständniserklärungen.",

--- a/src/lib/theme-css.ts
+++ b/src/lib/theme-css.ts
@@ -1,0 +1,39 @@
+import type { ThemeModeKey, ThemeTokenKey, ThemeTokens } from "@/lib/website-settings";
+
+function toVariableLines(record: Record<ThemeTokenKey, string>, tokenKeys: ThemeTokenKey[]) {
+  return tokenKeys.map((token) => `  --${token}: ${record[token]};`).join("\n");
+}
+
+export function createThemeCss(tokens: ThemeTokens) {
+  const modeKeys = Object.keys(tokens.modes) as ThemeModeKey[];
+  const baseMode: ThemeModeKey = modeKeys.includes("light" as ThemeModeKey)
+    ? ("light" as ThemeModeKey)
+    : modeKeys[0];
+  const darkMode: ThemeModeKey | null = modeKeys.includes("dark" as ThemeModeKey)
+    ? ("dark" as ThemeModeKey)
+    : modeKeys.find((key) => key !== baseMode) ?? null;
+
+  const tokenKeys = Object.keys(tokens.modes[baseMode]) as ThemeTokenKey[];
+  const lines: string[] = [];
+
+  lines.push("/* dynamically generated website theme */");
+  lines.push(":root {");
+  if (tokens.radius?.base) {
+    lines.push(`  --radius: ${tokens.radius.base};`);
+  }
+  lines.push(toVariableLines(tokens.modes[baseMode] as Record<ThemeTokenKey, string>, tokenKeys));
+  lines.push("}");
+
+  if (darkMode) {
+    lines.push("");
+    lines.push(".dark {");
+    const darkTokens = tokens.modes[darkMode] as Record<ThemeTokenKey, string>;
+    for (const token of tokenKeys) {
+      const value = darkTokens[token] ?? tokens.modes[baseMode][token];
+      lines.push(`  --${token}: ${value};`);
+    }
+    lines.push("}");
+  }
+
+  return lines.join("\n");
+}

--- a/src/lib/website-settings.ts
+++ b/src/lib/website-settings.ts
@@ -1,0 +1,359 @@
+import { designTokens } from "@/design-system";
+import { prisma } from "@/lib/prisma";
+import type { Prisma, WebsiteSettings, WebsiteTheme } from "@prisma/client";
+
+export const DEFAULT_THEME_ID = "default-website-theme" as const;
+export const DEFAULT_WEBSITE_SETTINGS_ID = "public" as const;
+export const DEFAULT_SITE_TITLE = "Sommertheater im Schlosspark" as const;
+export const DEFAULT_COLOR_MODE = "dark" as const;
+
+export const THEME_COLOR_MODES = ["light", "dark"] as const;
+export type ThemeColorMode = (typeof THEME_COLOR_MODES)[number];
+
+export type ThemeTokens = typeof designTokens;
+export type ThemeModeKey = keyof ThemeTokens["modes"];
+export type ThemeTokenKey = keyof ThemeTokens["modes"]["light"];
+
+const INTERNAL_MODE_KEYS = Object.keys(designTokens.modes) as ThemeModeKey[];
+const INTERNAL_TOKEN_KEYS = Object.keys(designTokens.modes.light) as ThemeTokenKey[];
+
+export const THEME_MODE_KEYS: ThemeModeKey[] = [...INTERNAL_MODE_KEYS];
+export const THEME_TOKEN_KEYS: ThemeTokenKey[] = [...INTERNAL_TOKEN_KEYS];
+
+function cloneThemeTokens(tokens: ThemeTokens): ThemeTokens {
+  const modes = {} as ThemeTokens["modes"];
+  for (const mode of Object.keys(tokens.modes) as ThemeModeKey[]) {
+    modes[mode] = { ...tokens.modes[mode] };
+  }
+  return {
+    radius: { base: tokens.radius.base },
+    modes,
+  };
+}
+
+function cloneDefaultTokens(): ThemeTokens {
+  return cloneThemeTokens(designTokens);
+}
+
+function sanitiseCssValue(value: unknown, fallback: string): string {
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function sanitiseThemeDescription(value: unknown, fallback: string | null): string | null {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.slice(0, 500);
+}
+
+export function sanitiseThemeTokens(value: unknown): ThemeTokens {
+  const base = cloneDefaultTokens();
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return base;
+  }
+
+  const record = value as Record<string, unknown>;
+  const radiusCandidate = record.radius;
+  if (radiusCandidate && typeof radiusCandidate === "object" && !Array.isArray(radiusCandidate)) {
+    const radiusRecord = radiusCandidate as Record<string, unknown>;
+    base.radius.base = sanitiseCssValue(radiusRecord.base, base.radius.base);
+  }
+
+  const modesCandidate = record.modes;
+  if (!modesCandidate || typeof modesCandidate !== "object" || Array.isArray(modesCandidate)) {
+    return base;
+  }
+
+  const modesRecord = modesCandidate as Record<string, unknown>;
+  for (const modeKey of INTERNAL_MODE_KEYS) {
+    const defaultModeTokens = designTokens.modes[modeKey];
+    const targetModeTokens = base.modes[modeKey];
+    const candidate = modesRecord[modeKey];
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+      for (const tokenKey of INTERNAL_TOKEN_KEYS) {
+        targetModeTokens[tokenKey] = defaultModeTokens[tokenKey];
+      }
+      continue;
+    }
+
+    const candidateRecord = candidate as Record<string, unknown>;
+    for (const tokenKey of INTERNAL_TOKEN_KEYS) {
+      targetModeTokens[tokenKey] = sanitiseCssValue(
+        candidateRecord[tokenKey],
+        defaultModeTokens[tokenKey],
+      );
+    }
+  }
+
+  return base;
+}
+
+function tokensToJson(tokens: ThemeTokens): Prisma.JsonObject {
+  return JSON.parse(JSON.stringify(tokens)) as Prisma.JsonObject;
+}
+
+function sanitiseSiteTitle(value: unknown): string {
+  if (typeof value !== "string") {
+    return DEFAULT_SITE_TITLE;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_SITE_TITLE;
+  }
+  return trimmed.slice(0, 160);
+}
+
+function sanitiseColorMode(value: unknown): ThemeColorMode {
+  if (typeof value !== "string") {
+    return DEFAULT_COLOR_MODE;
+  }
+  const normalised = value.trim().toLowerCase();
+  return THEME_COLOR_MODES.includes(normalised as ThemeColorMode)
+    ? (normalised as ThemeColorMode)
+    : DEFAULT_COLOR_MODE;
+}
+
+export type WebsiteSettingsRecord = (WebsiteSettings & { theme: WebsiteTheme | null }) | null;
+
+export type ResolvedWebsiteTheme = {
+  id: string;
+  name: string;
+  description: string | null;
+  tokens: ThemeTokens;
+  isDefault: boolean;
+  updatedAt: Date | null;
+};
+
+export type ResolvedWebsiteSettings = {
+  id: string;
+  siteTitle: string;
+  colorMode: ThemeColorMode;
+  updatedAt: Date | null;
+  theme: ResolvedWebsiteTheme;
+};
+
+const FALLBACK_THEME: ResolvedWebsiteTheme = {
+  id: "__design-system__",
+  name: "Designsystem",
+  description: "Standardfarben aus dem Designsystem.",
+  tokens: cloneDefaultTokens(),
+  isDefault: true,
+  updatedAt: null,
+};
+
+export function resolveWebsiteTheme(record: WebsiteTheme | null | undefined): ResolvedWebsiteTheme {
+  if (!record) {
+    return FALLBACK_THEME;
+  }
+
+  return {
+    id: record.id,
+    name: record.name,
+    description: record.description ?? null,
+    tokens: sanitiseThemeTokens(record.tokens ?? designTokens),
+    isDefault: record.isDefault ?? false,
+    updatedAt: record.updatedAt ?? null,
+  };
+}
+
+export function resolveWebsiteSettings(record: WebsiteSettingsRecord): ResolvedWebsiteSettings {
+  const theme = resolveWebsiteTheme(record?.theme ?? null);
+  return {
+    id: record?.id ?? DEFAULT_WEBSITE_SETTINGS_ID,
+    siteTitle: record ? sanitiseSiteTitle(record.siteTitle) : DEFAULT_SITE_TITLE,
+    colorMode: record ? sanitiseColorMode(record.colorMode) : DEFAULT_COLOR_MODE,
+    updatedAt: record?.updatedAt ?? null,
+    theme,
+  };
+}
+
+export type ClientWebsiteTheme = {
+  id: string;
+  name: string;
+  description: string | null;
+  tokens: ThemeTokens;
+  updatedAt: string | null;
+};
+
+export type ClientWebsiteSettings = {
+  id: string;
+  siteTitle: string;
+  colorMode: ThemeColorMode;
+  updatedAt: string | null;
+  theme: ClientWebsiteTheme;
+};
+
+export function toClientWebsiteSettings(resolved: ResolvedWebsiteSettings): ClientWebsiteSettings {
+  return {
+    id: resolved.id,
+    siteTitle: resolved.siteTitle,
+    colorMode: resolved.colorMode,
+    updatedAt: resolved.updatedAt ? resolved.updatedAt.toISOString() : null,
+    theme: {
+      id: resolved.theme.id,
+      name: resolved.theme.name,
+      description: resolved.theme.description,
+      tokens: cloneThemeTokens(resolved.theme.tokens),
+      updatedAt: resolved.theme.updatedAt ? resolved.theme.updatedAt.toISOString() : null,
+    },
+  };
+}
+
+export async function readWebsiteSettings() {
+  return prisma.websiteSettings.findUnique({
+    where: { id: DEFAULT_WEBSITE_SETTINGS_ID },
+    include: { theme: true },
+  });
+}
+
+export async function ensureWebsiteTheme(preferredId?: string | null) {
+  if (preferredId) {
+    const existing = await prisma.websiteTheme.findUnique({ where: { id: preferredId } });
+    if (existing) {
+      return existing;
+    }
+  }
+
+  const defaultTheme = await prisma.websiteTheme.findFirst({ where: { isDefault: true } });
+  if (defaultTheme) {
+    return defaultTheme;
+  }
+
+  return prisma.websiteTheme.upsert({
+    where: { id: DEFAULT_THEME_ID },
+    update: {},
+    create: {
+      id: DEFAULT_THEME_ID,
+      name: "Sommertheater Standard",
+      description: "Standard-Theme basierend auf dem aktuellen Designsystem.",
+      isDefault: true,
+      tokens: tokensToJson(cloneDefaultTokens()),
+    },
+  });
+}
+
+export async function ensureWebsiteSettingsRecord() {
+  const existing = await prisma.websiteSettings.findUnique({
+    where: { id: DEFAULT_WEBSITE_SETTINGS_ID },
+    include: { theme: true },
+  });
+
+  if (existing) {
+    if (existing.themeId && existing.theme) {
+      return existing;
+    }
+    const theme = await ensureWebsiteTheme(existing.themeId);
+    return prisma.websiteSettings.update({
+      where: { id: existing.id },
+      data: { theme: { connect: { id: theme.id } } },
+      include: { theme: true },
+    });
+  }
+
+  const theme = await ensureWebsiteTheme();
+  return prisma.websiteSettings.create({
+    data: {
+      id: DEFAULT_WEBSITE_SETTINGS_ID,
+      siteTitle: DEFAULT_SITE_TITLE,
+      colorMode: DEFAULT_COLOR_MODE,
+      theme: { connect: { id: theme.id } },
+    },
+    include: { theme: true },
+  });
+}
+
+export type WebsiteSettingsInput = {
+  siteTitle?: string | null;
+  colorMode?: ThemeColorMode | null;
+  themeId?: string | null;
+};
+
+export async function saveWebsiteSettings(input: WebsiteSettingsInput) {
+  const update: Prisma.WebsiteSettingsUpdateInput = {};
+  const create: Prisma.WebsiteSettingsCreateInput = {
+    id: DEFAULT_WEBSITE_SETTINGS_ID,
+    siteTitle: DEFAULT_SITE_TITLE,
+    colorMode: DEFAULT_COLOR_MODE,
+  };
+
+  if (input.siteTitle !== undefined) {
+    const title = sanitiseSiteTitle(input.siteTitle);
+    update.siteTitle = title;
+    create.siteTitle = title;
+  }
+
+  if (input.colorMode !== undefined) {
+    const mode = sanitiseColorMode(input.colorMode);
+    update.colorMode = mode;
+    create.colorMode = mode;
+  }
+
+  if (input.themeId !== undefined) {
+    if (input.themeId) {
+      update.theme = { connect: { id: input.themeId } };
+      create.theme = { connect: { id: input.themeId } };
+    } else {
+      update.theme = { disconnect: true };
+    }
+  }
+
+  return prisma.websiteSettings.upsert({
+    where: { id: DEFAULT_WEBSITE_SETTINGS_ID },
+    update,
+    create,
+    include: { theme: true },
+  });
+}
+
+export type WebsiteThemeInput = {
+  name?: string | null;
+  description?: string | null;
+  tokens?: unknown;
+};
+
+export async function saveWebsiteTheme(id: string, input: WebsiteThemeInput) {
+  const existing = await prisma.websiteTheme.findUnique({ where: { id } });
+
+  const baseName = existing?.name ?? "Unbenanntes Theme";
+  const resolvedName = sanitiseCssValue(input.name ?? baseName, baseName);
+  const resolvedDescription = sanitiseThemeDescription(input.description, existing?.description ?? null);
+  const resolvedTokens = input.tokens !== undefined
+    ? tokensToJson(sanitiseThemeTokens(input.tokens))
+    : tokensToJson(sanitiseThemeTokens(existing?.tokens ?? cloneDefaultTokens()));
+
+  if (existing) {
+    return prisma.websiteTheme.update({
+      where: { id },
+      data: {
+        name: resolvedName,
+        description: resolvedDescription,
+        tokens: resolvedTokens,
+      },
+    });
+  }
+
+  return prisma.websiteTheme.create({
+    data: {
+      id,
+      name: resolvedName,
+      description: resolvedDescription,
+      tokens: resolvedTokens,
+      isDefault: id === DEFAULT_THEME_ID,
+    },
+  });
+}


### PR DESCRIPTION
### Summary
* `WebsiteTheme` and `WebsiteSettings` Prisma models were added with a matching migration, and the seed script now creates a default theme plus settings so the app has initial data.
* Introduced theme/website settings infrastructure: utility module, CSS generator, API route, and server layout changes that inject dynamic theme styles and pass the configurable site title through header/footer.
* Built the admin UI for managing website theme colors, including navigation entry, permissions update, and the client-side manager that previews and saves changes.
* The admin theme manager now toggles the document color scheme while editing so the preview reflects the selected default mode immediately.

### Outstanding
* Verify end-to-end saving of website settings in a live environment. Pending tasks: run through API `/api/website/settings` with real credentials and confirm DB persistence plus SSR updates.
* Add integration tests around `WebsiteThemeSettingsManager` to cover fetch/save flows; current coverage is unit-level only.

### Testing gaps
* Need comprehensive tests for theme save edge cases (invalid tokens, missing themeId) to ensure API rejects bad payloads gracefully.

### Known quirks / setup notes
* No additional setup steps beyond running Prisma migrations. Ensure the database is reachable so the new models and seeds execute correctly during deployment.

------
https://chatgpt.com/codex/tasks/task_e_68d1949f94fc832dbd667950b34184b5