### PR TITLE
feat: align theme manager with parametric tokens

### DIFF
--- a/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
+++ b/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
@@ -8,43 +8,96 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { createThemeCss } from "@/lib/theme-css";
 import type {
   ClientWebsiteSettings,
   ThemeColorMode,
   ThemeModeKey,
-  ThemeTokenKey,
+  ThemeTokenAdjustment,
   ThemeTokens,
 } from "@/lib/website-settings";
 
-const LIGHT_MODE: ThemeModeKey = "light";
-const DARK_MODE: ThemeModeKey = "dark";
+const LIGHT_MODE = "light" as ThemeModeKey;
+const DARK_MODE = "dark" as ThemeModeKey;
 
 const COLOR_MODE_OPTIONS: { value: ThemeColorMode; label: string }[] = [
   { value: "dark", label: "Dunkelmodus" },
   { value: "light", label: "Hellmodus" },
 ];
 
+const MODE_LABELS: Record<string, string> = {
+  dark: "Dark",
+  light: "Light",
+};
+
+const FAMILY_INHERIT_VALUE = "__inherit__";
+
+const RESERVED_PARAMETER_KEYS = new Set(["family", "description", "notes", "tags"]);
+
 const UPDATED_AT_FORMATTER = new Intl.DateTimeFormat("de-DE", {
   dateStyle: "medium",
   timeStyle: "short",
 });
 
-type ModeValuesState = Record<ThemeModeKey, Record<ThemeTokenKey, string>>;
-
-type WebsiteThemeSettingsManagerProps = {
-  initialSettings: ClientWebsiteSettings;
+type FamilyFormFields = {
+  l: string;
+  c: string;
+  h: string;
+  alpha: string;
 };
 
-function buildModeValues(modes: ThemeTokens["modes"]): ModeValuesState {
-  const result = {} as ModeValuesState;
-  for (const mode of Object.keys(modes) as ThemeModeKey[]) {
-    result[mode] = { ...(modes[mode] as Record<ThemeTokenKey, string>) };
+type FamiliesState = Record<string, Record<ThemeModeKey, FamilyFormFields>>;
+
+type TokenModeFields = {
+  l: string;
+  deltaL: string;
+  scaleL: string;
+  c: string;
+  deltaC: string;
+  scaleC: string;
+  h: string;
+  deltaH: string;
+  alpha: string;
+  deltaAlpha: string;
+  scaleAlpha: string;
+  value: string;
+  family: string;
+};
+
+type TokenMetaState = {
+  description?: string;
+  notes?: string;
+  tags?: string[];
+};
+
+type TokenFormState = Record<
+  string,
+  {
+    family: string;
+    modes: Record<ThemeModeKey, TokenModeFields>;
+    meta: TokenMetaState;
   }
-  return result;
-}
+>;
+
+type NumericOklch = {
+  l: number;
+  c: number;
+  h: number;
+  alpha: number;
+};
+
+type TokenAdjustment = ThemeTokenAdjustment;
+
+type NormalisedToken = TokenMetaState &
+  Partial<Record<ThemeModeKey, TokenAdjustment>> & {
+    family: string;
+  };
+
+type NormalisedParameters = {
+  families: Record<string, Record<ThemeModeKey, NumericOklch>>;
+  tokens: Record<string, NormalisedToken>;
+};
 
 function formatTokenLabel(token: string) {
   return token
@@ -53,6 +106,567 @@ function formatTokenLabel(token: string) {
     .join(" ");
 }
 
+function formatFamilyLabel(name: string) {
+  if (!name.includes("-")) {
+    return name.charAt(0).toUpperCase() + name.slice(1);
+  }
+  return name
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatModeLabel(mode: string) {
+  return mode
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function getModeLabel(mode: ThemeModeKey) {
+  return MODE_LABELS[mode] ?? formatModeLabel(mode);
+}
+
+function toInputValue(value: number | undefined) {
+  if (value === undefined || Number.isNaN(value)) {
+    return "";
+  }
+  return `${value}`;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function toPrecision(value: number, precision: number) {
+  return Number.parseFloat(value.toFixed(precision));
+}
+
+function wrapHue(value: number) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  let result = value % 360;
+  if (result < 0) {
+    result += 360;
+  }
+  return result;
+}
+
+function formatOklchValue(value: NumericOklch) {
+  const l = toPrecision(clamp(value.l, 0, 1), 3);
+  const c = toPrecision(Math.max(value.c, 0), 3);
+  const h = toPrecision(wrapHue(value.h), 1);
+  const alpha = clamp(value.alpha, 0, 1);
+  const prefix = `oklch(${l} ${c} ${h}`;
+  return alpha >= 0 && alpha < 1 ? `${prefix} / ${toPrecision(alpha, 2)})` : `${prefix})`;
+}
+
+function sortModeKeys(keys: ThemeModeKey[]): ThemeModeKey[] {
+  const priority = (mode: ThemeModeKey) => {
+    if (mode === LIGHT_MODE) {
+      return 0;
+    }
+    if (mode === DARK_MODE) {
+      return 1;
+    }
+    return 2;
+  };
+  return [...keys].sort((a, b) => {
+    const order = priority(a) - priority(b);
+    if (order !== 0) {
+      return order;
+    }
+    return a.localeCompare(b);
+  });
+}
+
+function deriveModeKeysFromTokens(tokens: ThemeTokens): ThemeModeKey[] {
+  const modeSet = new Set<ThemeModeKey>(
+    Object.keys(tokens.modes).map((key) => key as ThemeModeKey),
+  );
+  modeSet.add(LIGHT_MODE);
+  modeSet.add(DARK_MODE);
+  const parameterTokens = tokens.parameters?.tokens ?? {};
+  for (const definition of Object.values(parameterTokens) as Record<string, unknown>[]) {
+    if (!definition || typeof definition !== "object") {
+      continue;
+    }
+    for (const key of Object.keys(definition)) {
+      if (!RESERVED_PARAMETER_KEYS.has(key)) {
+        modeSet.add(key as ThemeModeKey);
+      }
+    }
+  }
+  return sortModeKeys(Array.from(modeSet));
+}
+
+function createFamilyFormState(
+  parameters: ThemeTokens["parameters"] | undefined,
+  modeKeys: ThemeModeKey[],
+): FamiliesState {
+  const familiesRecord = (parameters?.families ?? {}) as Record<string, unknown>;
+  const names = Object.keys(familiesRecord).sort((a, b) => a.localeCompare(b));
+  const state: FamiliesState = {};
+  for (const familyName of names) {
+    const modes = familiesRecord[familyName] as Record<string, unknown> | undefined;
+    state[familyName] = {} as Record<ThemeModeKey, FamilyFormFields>;
+    for (const mode of modeKeys) {
+      const data = modes?.[mode] as { l?: number; c?: number; h?: number; alpha?: number } | undefined;
+      state[familyName][mode] = {
+        l: toInputValue(data?.l ?? 0.5),
+        c: toInputValue(data?.c ?? 0),
+        h: toInputValue(data?.h ?? 0),
+        alpha: toInputValue(data?.alpha ?? 1),
+      };
+    }
+  }
+  return state;
+}
+
+function createTokenFormState(
+  parameters: ThemeTokens["parameters"] | undefined,
+  modeKeys: ThemeModeKey[],
+): TokenFormState {
+  const tokensRecord = (parameters?.tokens ?? {}) as Record<string, unknown>;
+  const names = Object.keys(tokensRecord).sort((a, b) => a.localeCompare(b));
+  const state: TokenFormState = {};
+  for (const tokenName of names) {
+    const definition = tokensRecord[tokenName] ?? {};
+    const definitionRecord = definition as Record<string, unknown>;
+    const modes: Record<ThemeModeKey, TokenModeFields> = {} as Record<ThemeModeKey, TokenModeFields>;
+    for (const mode of modeKeys) {
+      const rawAdjustments = definitionRecord[mode];
+      if (typeof rawAdjustments === "string") {
+        modes[mode] = {
+          l: "",
+          deltaL: "",
+          scaleL: "",
+          c: "",
+          deltaC: "",
+          scaleC: "",
+          h: "",
+          deltaH: "",
+          alpha: "",
+          deltaAlpha: "",
+          scaleAlpha: "",
+          value: rawAdjustments,
+          family: "",
+        };
+        continue;
+      }
+
+      const adjustments =
+        rawAdjustments && typeof rawAdjustments === "object" && !Array.isArray(rawAdjustments)
+          ? (rawAdjustments as Record<string, unknown>)
+          : undefined;
+
+      modes[mode] = {
+        l: toInputValue(typeof adjustments?.l === "number" ? (adjustments.l as number) : undefined),
+        deltaL: toInputValue(typeof adjustments?.deltaL === "number" ? (adjustments.deltaL as number) : undefined),
+        scaleL: toInputValue(typeof adjustments?.scaleL === "number" ? (adjustments.scaleL as number) : undefined),
+        c: toInputValue(typeof adjustments?.c === "number" ? (adjustments.c as number) : undefined),
+        deltaC: toInputValue(typeof adjustments?.deltaC === "number" ? (adjustments.deltaC as number) : undefined),
+        scaleC: toInputValue(typeof adjustments?.scaleC === "number" ? (adjustments.scaleC as number) : undefined),
+        h: toInputValue(typeof adjustments?.h === "number" ? (adjustments.h as number) : undefined),
+        deltaH: toInputValue(typeof adjustments?.deltaH === "number" ? (adjustments.deltaH as number) : undefined),
+        alpha: toInputValue(typeof adjustments?.alpha === "number" ? (adjustments.alpha as number) : undefined),
+        deltaAlpha: toInputValue(
+          typeof adjustments?.deltaAlpha === "number" ? (adjustments.deltaAlpha as number) : undefined,
+        ),
+        scaleAlpha: toInputValue(
+          typeof adjustments?.scaleAlpha === "number" ? (adjustments.scaleAlpha as number) : undefined,
+        ),
+        value: typeof adjustments?.value === "string" ? (adjustments.value as string) : "",
+        family: typeof adjustments?.family === "string" ? (adjustments.family as string) : "",
+      };
+    }
+
+    const meta: TokenMetaState = {};
+    const descriptionValue = definitionRecord.description;
+    if (typeof descriptionValue === "string") {
+      meta.description = descriptionValue;
+    }
+    const notesValue = definitionRecord.notes;
+    if (typeof notesValue === "string") {
+      meta.notes = notesValue;
+    }
+    const tagsValue = definitionRecord.tags;
+    if (Array.isArray(tagsValue)) {
+      meta.tags = tagsValue
+        .map((tag) => (typeof tag === "string" ? tag.trim() : String(tag).trim()))
+        .filter((tag) => tag.length > 0);
+    }
+
+    const familyValue = definitionRecord.family;
+    state[tokenName] = {
+      family: typeof familyValue === "string" ? familyValue : "",
+      modes,
+      meta,
+    };
+  }
+  return state;
+}
+
+function parseNumberWithFallback(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+  const parsed = Number.parseFloat(trimmed);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseAdjustmentValue(value: string | undefined, fallback?: number): number | undefined {
+  if (value === undefined) {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number.parseFloat(trimmed);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return fallback;
+}
+
+function parseOverrideString(value: string | undefined, fallback?: string): string | undefined {
+  if (value === undefined) {
+    return fallback?.trim() ? fallback.trim() : undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function normaliseParameters(tokens: ThemeTokens, modeKeys: ThemeModeKey[]): NormalisedParameters {
+  const families: Record<string, Record<ThemeModeKey, NumericOklch>> = {};
+  const familiesSource = (tokens.parameters?.families ?? {}) as Record<string, unknown>;
+  const familyNames = Object.keys(familiesSource).sort((a, b) => a.localeCompare(b));
+  for (const familyName of familyNames) {
+    const modesRecord = familiesSource[familyName] as Record<string, unknown> | undefined;
+    families[familyName] = {} as Record<ThemeModeKey, NumericOklch>;
+    for (const mode of modeKeys) {
+      const data = modesRecord?.[mode] as { l?: number; c?: number; h?: number; alpha?: number } | undefined;
+      families[familyName][mode] = {
+        l: typeof data?.l === "number" ? data.l : 0.5,
+        c: typeof data?.c === "number" ? data.c : 0,
+        h: typeof data?.h === "number" ? data.h : 0,
+        alpha: typeof data?.alpha === "number" ? data.alpha : 1,
+      };
+    }
+  }
+
+  const tokensResult: Record<string, NormalisedToken> = {};
+  const parameterTokens = (tokens.parameters?.tokens ?? {}) as Record<string, unknown>;
+  const tokenNames = Object.keys(parameterTokens).sort((a, b) => a.localeCompare(b));
+  for (const tokenName of tokenNames) {
+    const definition = parameterTokens[tokenName] ?? {};
+    const definitionRecord = definition as Record<string, unknown>;
+
+    const entry: NormalisedToken = {
+      family:
+        typeof definitionRecord.family === "string" && definitionRecord.family.trim()
+          ? definitionRecord.family.trim()
+          : "neutral",
+    };
+
+    const descriptionValue = definitionRecord.description;
+    if (typeof descriptionValue === "string") {
+      entry.description = descriptionValue;
+    }
+    const notesValue = definitionRecord.notes;
+    if (typeof notesValue === "string") {
+      entry.notes = notesValue;
+    }
+    const tagsValue = definitionRecord.tags;
+    if (Array.isArray(tagsValue)) {
+      entry.tags = tagsValue
+        .map((tag) => (typeof tag === "string" ? tag.trim() : String(tag).trim()))
+        .filter((tag) => tag.length > 0);
+    }
+
+    for (const mode of modeKeys) {
+      const adjustments = definitionRecord[mode];
+      if (!adjustments) {
+        continue;
+      }
+      if (typeof adjustments === "string") {
+        entry[mode] = { value: adjustments };
+        continue;
+      }
+      if (typeof adjustments === "object" && !Array.isArray(adjustments)) {
+        const record = adjustments as Record<string, unknown>;
+        const normalised: TokenAdjustment = {};
+        if (typeof record.l === "number") {
+          normalised.l = record.l;
+        }
+        if (typeof record.deltaL === "number") {
+          normalised.deltaL = record.deltaL;
+        }
+        if (typeof record.scaleL === "number") {
+          normalised.scaleL = record.scaleL;
+        }
+        if (typeof record.c === "number") {
+          normalised.c = record.c;
+        }
+        if (typeof record.deltaC === "number") {
+          normalised.deltaC = record.deltaC;
+        }
+        if (typeof record.scaleC === "number") {
+          normalised.scaleC = record.scaleC;
+        }
+        if (typeof record.h === "number") {
+          normalised.h = record.h;
+        }
+        if (typeof record.deltaH === "number") {
+          normalised.deltaH = record.deltaH;
+        }
+        if (typeof record.alpha === "number") {
+          normalised.alpha = record.alpha;
+        }
+        if (typeof record.deltaAlpha === "number") {
+          normalised.deltaAlpha = record.deltaAlpha;
+        }
+        if (typeof record.scaleAlpha === "number") {
+          normalised.scaleAlpha = record.scaleAlpha;
+        }
+        if (typeof record.value === "string" && record.value.trim()) {
+          normalised.value = record.value.trim();
+        }
+        if (typeof record.family === "string" && record.family.trim()) {
+          normalised.family = record.family.trim();
+        }
+        if (Object.keys(normalised).length > 0) {
+          entry[mode] = normalised;
+        }
+      }
+    }
+
+    tokensResult[tokenName] = entry;
+  }
+
+  return { families, tokens: tokensResult };
+}
+
+function buildNormalisedParameters(
+  familiesState: FamiliesState,
+  tokensState: TokenFormState,
+  modeKeys: ThemeModeKey[],
+  fallback: NormalisedParameters,
+): NormalisedParameters {
+  const families: Record<string, Record<ThemeModeKey, NumericOklch>> = {};
+  const familyNames = Array.from(
+    new Set([...Object.keys(fallback.families), ...Object.keys(familiesState)]),
+  ).sort((a, b) => a.localeCompare(b));
+
+  for (const familyName of familyNames) {
+    const fallbackModes = fallback.families[familyName];
+    const formModes = familiesState[familyName];
+    families[familyName] = {} as Record<ThemeModeKey, NumericOklch>;
+    for (const mode of modeKeys) {
+      const fallbackValue = fallbackModes?.[mode] ?? { l: 0.5, c: 0, h: 0, alpha: 1 };
+      const formValue = formModes?.[mode];
+      families[familyName][mode] = {
+        l: parseNumberWithFallback(formValue?.l, fallbackValue.l),
+        c: parseNumberWithFallback(formValue?.c, fallbackValue.c),
+        h: parseNumberWithFallback(formValue?.h, fallbackValue.h),
+        alpha: parseNumberWithFallback(formValue?.alpha, fallbackValue.alpha),
+      };
+    }
+  }
+
+  const tokens: Record<string, NormalisedToken> = {};
+  const tokenNames = Array.from(
+    new Set([...Object.keys(fallback.tokens), ...Object.keys(tokensState)]),
+  ).sort((a, b) => a.localeCompare(b));
+
+  for (const tokenName of tokenNames) {
+    const formToken = tokensState[tokenName];
+    const fallbackToken = fallback.tokens[tokenName];
+    const entry: NormalisedToken = {
+      family: formToken?.family.trim().length
+        ? formToken.family.trim()
+        : fallbackToken?.family ?? "neutral",
+    };
+
+    const descriptionValue = formToken?.meta.description ?? fallbackToken?.description;
+    if (descriptionValue !== undefined) {
+      entry.description = descriptionValue;
+    }
+    const notesValue = formToken?.meta.notes ?? fallbackToken?.notes;
+    if (notesValue !== undefined) {
+      entry.notes = notesValue;
+    }
+    const tagsValue = formToken?.meta.tags ?? fallbackToken?.tags;
+    if (tagsValue && tagsValue.length > 0) {
+      entry.tags = [...tagsValue];
+    }
+
+    for (const mode of modeKeys) {
+      const formMode = formToken?.modes?.[mode];
+      const fallbackMode = fallbackToken?.[mode];
+      const adjustments: TokenAdjustment = {};
+      const deltaL = parseAdjustmentValue(formMode?.deltaL, fallbackMode?.deltaL);
+      if (deltaL !== undefined) {
+        adjustments.deltaL = deltaL;
+      }
+      const scaleLValue = parseAdjustmentValue(formMode?.scaleL, fallbackMode?.scaleL);
+      if (scaleLValue !== undefined) {
+        adjustments.scaleL = scaleLValue;
+      }
+      const lValue = parseAdjustmentValue(formMode?.l, fallbackMode?.l);
+      if (lValue !== undefined) {
+        adjustments.l = lValue;
+      }
+      const deltaCValue = parseAdjustmentValue(formMode?.deltaC, fallbackMode?.deltaC);
+      if (deltaCValue !== undefined) {
+        adjustments.deltaC = deltaCValue;
+      }
+      const cValue = parseAdjustmentValue(formMode?.c, fallbackMode?.c);
+      if (cValue !== undefined) {
+        adjustments.c = cValue;
+      }
+      const scaleCValue = parseAdjustmentValue(formMode?.scaleC, fallbackMode?.scaleC);
+      if (scaleCValue !== undefined) {
+        adjustments.scaleC = scaleCValue;
+      }
+      const hValue = parseAdjustmentValue(formMode?.h, fallbackMode?.h);
+      if (hValue !== undefined) {
+        adjustments.h = hValue;
+      }
+      const deltaHValue = parseAdjustmentValue(formMode?.deltaH, fallbackMode?.deltaH);
+      if (deltaHValue !== undefined) {
+        adjustments.deltaH = deltaHValue;
+      }
+      const alphaValue = parseAdjustmentValue(formMode?.alpha, fallbackMode?.alpha);
+      if (alphaValue !== undefined) {
+        adjustments.alpha = alphaValue;
+      }
+      const deltaAlphaValue = parseAdjustmentValue(formMode?.deltaAlpha, fallbackMode?.deltaAlpha);
+      if (deltaAlphaValue !== undefined) {
+        adjustments.deltaAlpha = deltaAlphaValue;
+      }
+      const scaleAlphaValue = parseAdjustmentValue(formMode?.scaleAlpha, fallbackMode?.scaleAlpha);
+      if (scaleAlphaValue !== undefined) {
+        adjustments.scaleAlpha = scaleAlphaValue;
+      }
+      const valueOverride = parseOverrideString(formMode?.value, fallbackMode?.value);
+      if (valueOverride) {
+        adjustments.value = valueOverride;
+      }
+      const familyOverride = parseOverrideString(formMode?.family, fallbackMode?.family);
+      if (familyOverride) {
+        adjustments.family = familyOverride;
+      }
+
+      if (Object.keys(adjustments).length > 0) {
+        entry[mode] = adjustments;
+      }
+    }
+
+    tokens[tokenName] = entry;
+  }
+
+  return { families, tokens };
+}
+
+function resolveThemeModes(
+  parameters: NormalisedParameters,
+  modeKeys: ThemeModeKey[],
+): Record<ThemeModeKey, Record<string, string>> {
+  const modeSet = new Set<ThemeModeKey>(modeKeys);
+  modeSet.add(LIGHT_MODE);
+  modeSet.add(DARK_MODE);
+  for (const token of Object.values(parameters.tokens)) {
+    for (const key of Object.keys(token)) {
+      if (!RESERVED_PARAMETER_KEYS.has(key)) {
+        modeSet.add(key as ThemeModeKey);
+      }
+    }
+  }
+  const sortedModes = sortModeKeys(Array.from(modeSet));
+  const fallbackMode = sortedModes.includes(LIGHT_MODE)
+    ? LIGHT_MODE
+    : sortedModes[0];
+  const resolved: Record<ThemeModeKey, Record<string, string>> = {} as Record<ThemeModeKey, Record<string, string>>;
+
+  for (const mode of sortedModes) {
+    resolved[mode] = {};
+  }
+
+  for (const mode of sortedModes) {
+    for (const tokenName of Object.keys(parameters.tokens).sort((a, b) => a.localeCompare(b))) {
+      const definition = parameters.tokens[tokenName];
+      const baseFamily = definition.family;
+      const adjustments = (definition[mode] ?? {}) as TokenAdjustment;
+      const familyName = adjustments.family ?? baseFamily;
+      const familyModes = parameters.families[familyName] ?? parameters.families[baseFamily];
+      const baseColour =
+        familyModes?.[mode]
+          ?? (fallbackMode && familyModes ? familyModes[fallbackMode] : undefined)
+          ?? (familyModes ? Object.values(familyModes)[0] : undefined);
+      if (!baseColour) {
+        resolved[mode][tokenName] = "transparent";
+        continue;
+      }
+
+      if (typeof adjustments.value === "string" && adjustments.value.trim()) {
+        resolved[mode][tokenName] = adjustments.value.trim();
+        continue;
+      }
+
+      const colour: NumericOklch = { ...baseColour };
+      if (typeof adjustments.l === "number") {
+        colour.l = adjustments.l;
+      }
+      if (typeof adjustments.deltaL === "number") {
+        colour.l += adjustments.deltaL;
+      }
+      if (typeof adjustments.scaleL === "number") {
+        colour.l *= adjustments.scaleL;
+      }
+      if (typeof adjustments.c === "number") {
+        colour.c = adjustments.c;
+      }
+      if (typeof adjustments.deltaC === "number") {
+        colour.c += adjustments.deltaC;
+      }
+      if (typeof adjustments.scaleC === "number") {
+        colour.c *= adjustments.scaleC;
+      }
+      if (typeof adjustments.h === "number") {
+        colour.h = adjustments.h;
+      }
+      if (typeof adjustments.deltaH === "number") {
+        colour.h += adjustments.deltaH;
+      }
+      if (typeof adjustments.alpha === "number") {
+        colour.alpha = adjustments.alpha;
+      }
+      if (typeof adjustments.deltaAlpha === "number") {
+        colour.alpha += adjustments.deltaAlpha;
+      }
+      if (typeof adjustments.scaleAlpha === "number") {
+        colour.alpha *= adjustments.scaleAlpha;
+      }
+
+      resolved[mode][tokenName] = formatOklchValue(colour);
+    }
+  }
+
+  return resolved;
+}
+
+export type WebsiteThemeSettingsManagerProps = {
+  initialSettings: ClientWebsiteSettings;
+};
+
 export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSettingsManagerProps) {
   const [snapshot, setSnapshot] = useState<ClientWebsiteSettings>(initialSettings);
   const [siteTitle, setSiteTitle] = useState(initialSettings.siteTitle);
@@ -60,28 +674,53 @@ export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSet
   const [themeName, setThemeName] = useState(initialSettings.theme.name);
   const [themeDescription, setThemeDescription] = useState(initialSettings.theme.description ?? "");
   const [radius, setRadius] = useState(initialSettings.theme.tokens.radius.base);
-  const [modeValues, setModeValues] = useState<ModeValuesState>(() =>
-    buildModeValues(initialSettings.theme.tokens.modes),
+  const [familiesState, setFamiliesState] = useState<FamiliesState>(() =>
+    createFamilyFormState(
+      initialSettings.theme.tokens.parameters,
+      deriveModeKeysFromTokens(initialSettings.theme.tokens),
+    ),
+  );
+  const [tokensState, setTokensState] = useState<TokenFormState>(() =>
+    createTokenFormState(
+      initialSettings.theme.tokens.parameters,
+      deriveModeKeysFromTokens(initialSettings.theme.tokens),
+    ),
   );
   const [isSaving, setIsSaving] = useState(false);
 
-  const tokenKeys = useMemo(
-    () => Object.keys(snapshot.theme.tokens.modes[LIGHT_MODE]) as ThemeTokenKey[],
-    [snapshot],
+  const modeKeys = useMemo(
+    () => deriveModeKeysFromTokens(snapshot.theme.tokens),
+    [snapshot.theme.tokens],
+  );
+ 
+  const fallbackParameters = useMemo(
+    () => normaliseParameters(snapshot.theme.tokens, modeKeys),
+    [snapshot.theme.tokens, modeKeys],
   );
 
-  const previewTokens = useMemo(() => {
-    const modes = {} as ThemeTokens["modes"];
-    for (const mode of Object.keys(modeValues) as ThemeModeKey[]) {
-      modes[mode] = { ...modeValues[mode] } as ThemeTokens["modes"][ThemeModeKey];
-    }
-    return {
-      radius: { base: radius },
-      modes,
-      parameters: snapshot.theme.tokens.parameters,
-      meta: snapshot.theme.tokens.meta,
-    } satisfies ThemeTokens;
-  }, [modeValues, radius, snapshot.theme.tokens.meta, snapshot.theme.tokens.parameters]);
+  const parameters = useMemo(
+    () => buildNormalisedParameters(familiesState, tokensState, modeKeys, fallbackParameters),
+    [familiesState, tokensState, modeKeys, fallbackParameters],
+  );
+
+  const previewModes = useMemo(
+    () => resolveThemeModes(parameters, modeKeys),
+    [parameters, modeKeys],
+  );
+
+  const previewTokens = useMemo<ThemeTokens>(
+    () =>
+      ({
+        radius: { base: radius },
+        parameters: parameters as unknown as ThemeTokens["parameters"],
+        modes: previewModes as unknown as ThemeTokens["modes"],
+        meta: {
+          ...(snapshot.theme.tokens.meta ?? {}),
+          modes: modeKeys,
+        },
+      }) as ThemeTokens,
+    [parameters, previewModes, radius, snapshot.theme.tokens.meta, modeKeys],
+  );
 
   const lastSavedIso = snapshot.theme.updatedAt ?? snapshot.updatedAt;
   const lastSavedLabel = lastSavedIso
@@ -89,8 +728,7 @@ export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSet
     : "Noch nie gespeichert";
 
   const isDirty = useMemo(() => {
-    const normalizedSiteTitle = siteTitle.trim();
-    if (normalizedSiteTitle !== snapshot.siteTitle.trim()) {
+    if (siteTitle.trim() !== snapshot.siteTitle.trim()) {
       return true;
     }
     if (colorMode !== snapshot.colorMode) {
@@ -105,17 +743,20 @@ export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSet
     if (radius.trim() !== snapshot.theme.tokens.radius.base.trim()) {
       return true;
     }
-    for (const mode of Object.keys(snapshot.theme.tokens.modes) as ThemeModeKey[]) {
-      const snapshotTokens = snapshot.theme.tokens.modes[mode];
-      const currentTokens = modeValues[mode];
-      for (const token of Object.keys(snapshotTokens) as ThemeTokenKey[]) {
-        if (currentTokens[token] !== snapshotTokens[token]) {
-          return true;
-        }
-      }
+    if (JSON.stringify(parameters) !== JSON.stringify(fallbackParameters)) {
+      return true;
     }
     return false;
-  }, [siteTitle, colorMode, themeName, themeDescription, radius, modeValues, snapshot]);
+  }, [
+    siteTitle,
+    colorMode,
+    themeName,
+    themeDescription,
+    radius,
+    parameters,
+    fallbackParameters,
+    snapshot,
+  ]);
 
   useEffect(() => {
     const styleElement = document.getElementById("website-theme-style") as HTMLStyleElement | null;
@@ -160,24 +801,92 @@ export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSet
     };
   }, [snapshot.colorMode]);
 
+  const familyNames = useMemo(
+    () => Object.keys(familiesState).sort((a, b) => a.localeCompare(b)),
+    [familiesState],
+  );
+  const tokenNames = useMemo(
+    () => Object.keys(tokensState).sort((a, b) => a.localeCompare(b)),
+    [tokensState],
+  );
+
   function applySettings(next: ClientWebsiteSettings, updateSnapshot = false) {
     setSiteTitle(next.siteTitle);
     setColorMode(next.colorMode);
     setThemeName(next.theme.name);
     setThemeDescription(next.theme.description ?? "");
     setRadius(next.theme.tokens.radius.base);
-    setModeValues(buildModeValues(next.theme.tokens.modes));
+    const nextModeKeys = deriveModeKeysFromTokens(next.theme.tokens);
+    setFamiliesState(createFamilyFormState(next.theme.tokens.parameters, nextModeKeys));
+    setTokensState(createTokenFormState(next.theme.tokens.parameters, nextModeKeys));
     if (updateSnapshot) {
       setSnapshot(next);
     }
   }
 
-  function handleTokenChange(mode: ThemeModeKey, token: ThemeTokenKey, value: string) {
-    setModeValues((prev) => ({
+  function handleFamilyChange(
+    familyName: string,
+    mode: ThemeModeKey,
+    field: keyof FamilyFormFields,
+    value: string,
+  ) {
+    setFamiliesState((prev) => ({
       ...prev,
-      [mode]: {
-        ...prev[mode],
-        [token]: value,
+      [familyName]: {
+        ...(prev[familyName] ?? {}),
+        [mode]: {
+          ...(prev[familyName]?.[mode] ?? { l: "", c: "", h: "", alpha: "" }),
+          [field]: value,
+        },
+      },
+    }));
+  }
+
+  function handleTokenFamilyChange(tokenName: string, family: string) {
+    setTokensState((prev) => ({
+      ...prev,
+      [tokenName]: {
+        ...(prev[tokenName] ?? { family: "", modes: {} as Record<ThemeModeKey, TokenModeFields>, meta: {} }),
+        family,
+      },
+    }));
+  }
+
+  function handleTokenAdjustmentChange(
+    tokenName: string,
+    mode: ThemeModeKey,
+    field: keyof TokenModeFields,
+    value: string,
+  ) {
+    setTokensState((prev) => ({
+      ...prev,
+      [tokenName]: {
+        ...(prev[tokenName] ?? {
+          family: "",
+          modes: {} as Record<ThemeModeKey, TokenModeFields>,
+          meta: {},
+        }),
+        modes: {
+          ...(prev[tokenName]?.modes ?? {}),
+          [mode]: {
+            ...(prev[tokenName]?.modes?.[mode] ?? {
+              l: "",
+              deltaL: "",
+              scaleL: "",
+              c: "",
+              deltaC: "",
+              scaleC: "",
+              h: "",
+              deltaH: "",
+              alpha: "",
+              deltaAlpha: "",
+              scaleAlpha: "",
+              value: "",
+              family: "",
+            }),
+            [field]: value,
+          },
+        },
       },
     }));
   }
@@ -197,7 +906,16 @@ export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSet
             id: snapshot.theme.id,
             name: themeName,
             description: themeDescription.length > 0 ? themeDescription : null,
-            tokens: previewTokens,
+            tokens: {
+              radius: { base: radius },
+              parameters,
+              modes: previewModes,
+              meta: {
+                ...(snapshot.theme.tokens.meta ?? {}),
+                modes: modeKeys,
+                generatedAt: new Date().toISOString(),
+              },
+            },
           },
         }),
       });
@@ -264,12 +982,12 @@ export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSet
 
       <Card>
         <CardHeader className="space-y-2">
-          <CardTitle>Theme-Farben</CardTitle>
+          <CardTitle>Parametrische Theme-Farben</CardTitle>
           <p className="text-sm text-muted-foreground">
-            Passe die Farbwerte für Light- und Dark-Mode an. Änderungen werden live angewendet.
+            Steuere zuerst die OKLCH-Basiswerte der Farbfamilien und passe anschließend die semantischen Token pro Modus an.
           </p>
         </CardHeader>
-        <CardContent className="space-y-6">
+        <CardContent className="space-y-8">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="theme-name">Theme-Name</Label>
@@ -303,46 +1021,383 @@ export function WebsiteThemeSettingsManager({ initialSettings }: WebsiteThemeSet
               placeholder="Optionaler Hinweis zum Theme"
             />
           </div>
-          <Tabs defaultValue={LIGHT_MODE}>
-            <TabsList>
-              <TabsTrigger value={LIGHT_MODE}>Light</TabsTrigger>
-              <TabsTrigger value={DARK_MODE}>Dark</TabsTrigger>
-            </TabsList>
-            <TabsContent value={LIGHT_MODE} className="space-y-4 pt-4">
-              {tokenKeys.map((token) => (
-                <div key={`light-${token}`} className="grid gap-3 sm:grid-cols-[180px_minmax(0,1fr)]">
-                  <Label className="flex items-center gap-3 text-sm font-medium">
-                    <span
-                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border/60"
-                      style={{ backgroundColor: modeValues[LIGHT_MODE][token] }}
-                    />
-                    {formatTokenLabel(token)}
-                  </Label>
-                  <Input
-                    value={modeValues[LIGHT_MODE][token]}
-                    onChange={(event) => handleTokenChange(LIGHT_MODE, token, event.target.value)}
-                  />
+
+          <section className="space-y-4">
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold">Farbfamilien</h3>
+              <p className="text-sm text-muted-foreground">
+                Definiere die OKLCH-Ausgangswerte pro Familie und Modus. Diese Werte bilden die Grundlage für alle Ableitungen.
+              </p>
+            </div>
+            <div className="space-y-4">
+              {familyNames.map((family) => (
+                <div key={family} className="space-y-4 rounded-lg border p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <span className="text-sm font-medium">{formatFamilyLabel(family)}</span>
+                    <div className="flex gap-2">
+                      {modeKeys.map((mode) => (
+                        <span
+                          key={`${family}-${mode}-swatch`}
+                          className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border/60"
+                          style={{
+                            backgroundColor: formatOklchValue(parameters.families[family]?.[mode] ?? {
+                              l: 0.5,
+                              c: 0,
+                              h: 0,
+                              alpha: 1,
+                            }),
+                          }}
+                          aria-label={`${formatFamilyLabel(family)} ${getModeLabel(mode)} Vorschau`}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {modeKeys.map((mode) => {
+                      const modeState = familiesState[family]?.[mode];
+                      const baseId = `${family}-${mode}`;
+                      return (
+                        <div key={`${family}-${mode}`} className="space-y-3 rounded-md border p-3">
+                          <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <span>{getModeLabel(mode)}</span>
+                          </div>
+                          <div className="grid grid-cols-2 gap-3">
+                            <div className="space-y-1">
+                              <Label htmlFor={`${baseId}-l`} className="text-xs">
+                                L
+                              </Label>
+                              <Input
+                                id={`${baseId}-l`}
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                max="1"
+                                value={modeState?.l ?? ""}
+                                onChange={(event) =>
+                                  handleFamilyChange(family, mode, "l", event.target.value)
+                                }
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label htmlFor={`${baseId}-c`} className="text-xs">
+                                Chroma
+                              </Label>
+                              <Input
+                                id={`${baseId}-c`}
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                value={modeState?.c ?? ""}
+                                onChange={(event) =>
+                                  handleFamilyChange(family, mode, "c", event.target.value)
+                                }
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label htmlFor={`${baseId}-h`} className="text-xs">
+                                Hue
+                              </Label>
+                              <Input
+                                id={`${baseId}-h`}
+                                type="number"
+                                step="0.1"
+                                value={modeState?.h ?? ""}
+                                onChange={(event) =>
+                                  handleFamilyChange(family, mode, "h", event.target.value)
+                                }
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label htmlFor={`${baseId}-alpha`} className="text-xs">
+                                Alpha
+                              </Label>
+                              <Input
+                                id={`${baseId}-alpha`}
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                max="1"
+                                value={modeState?.alpha ?? ""}
+                                onChange={(event) =>
+                                  handleFamilyChange(family, mode, "alpha", event.target.value)
+                                }
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
                 </div>
               ))}
-            </TabsContent>
-            <TabsContent value={DARK_MODE} className="space-y-4 pt-4">
-              {tokenKeys.map((token) => (
-                <div key={`dark-${token}`} className="grid gap-3 sm:grid-cols-[180px_minmax(0,1fr)]">
-                  <Label className="flex items-center gap-3 text-sm font-medium">
-                    <span
-                      className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border/60"
-                      style={{ backgroundColor: modeValues[DARK_MODE][token] }}
-                    />
-                    {formatTokenLabel(token)}
-                  </Label>
-                  <Input
-                    value={modeValues[DARK_MODE][token]}
-                    onChange={(event) => handleTokenChange(DARK_MODE, token, event.target.value)}
-                  />
-                </div>
-              ))}
-            </TabsContent>
-          </Tabs>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div className="space-y-1">
+              <h3 className="text-base font-semibold">Semantische Token</h3>
+              <p className="text-sm text-muted-foreground">
+                Weise jeder Rolle eine Farbfamilie zu und definiere die per Modus geltenden Anpassungen. Die resultierenden Werte siehst du links im Interface.
+              </p>
+            </div>
+            <div className="space-y-6">
+              {tokenNames.map((token) => {
+                const tokenState = tokensState[token];
+                return (
+                  <div key={token} className="space-y-4 rounded-lg border p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="space-y-1">
+                        <Label className="text-sm font-medium">{formatTokenLabel(token)}</Label>
+                        <p className="text-xs text-muted-foreground">
+                          Basisfamilie und Ableitungen für {formatTokenLabel(token)}.
+                        </p>
+                      </div>
+                      <Select
+                        value={tokenState?.family ?? ""}
+                        onValueChange={(value) => handleTokenFamilyChange(token, value)}
+                      >
+                        <SelectTrigger className="w-[220px]">
+                          <SelectValue placeholder="Familie wählen" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {familyNames.map((family) => (
+                            <SelectItem key={`${token}-${family}`} value={family}>
+                              {formatFamilyLabel(family)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      {modeKeys.map((mode) => {
+                        const modeState = tokenState?.modes?.[mode];
+                        const baseId = `${token}-${mode}`;
+                        return (
+                          <div key={`${token}-${mode}`} className="space-y-3 rounded-md border p-3">
+                            <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                              <span>{getModeLabel(mode)}</span>
+                              <span
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-border/60"
+                                style={{ backgroundColor: previewModes[mode]?.[token] ?? "transparent" }}
+                                aria-label={`${formatTokenLabel(token)} ${getModeLabel(mode)} Vorschau`}
+                              />
+                            </div>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-l`} className="text-xs">
+                                  L
+                                </Label>
+                                <Input
+                                  id={`${baseId}-l`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.l ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "l", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-deltaL`} className="text-xs">
+                                  ΔL
+                                </Label>
+                                <Input
+                                  id={`${baseId}-deltaL`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.deltaL ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "deltaL", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1 sm:col-span-2">
+                                <Label htmlFor={`${baseId}-scaleL`} className="text-xs">
+                                  Scale L
+                                </Label>
+                                <Input
+                                  id={`${baseId}-scaleL`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.scaleL ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "scaleL", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-c`} className="text-xs">
+                                  Chroma
+                                </Label>
+                                <Input
+                                  id={`${baseId}-c`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.c ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "c", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-deltaC`} className="text-xs">
+                                  ΔChroma
+                                </Label>
+                                <Input
+                                  id={`${baseId}-deltaC`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.deltaC ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "deltaC", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1 sm:col-span-2">
+                                <Label htmlFor={`${baseId}-scaleC`} className="text-xs">
+                                  Scale Chroma
+                                </Label>
+                                <Input
+                                  id={`${baseId}-scaleC`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.scaleC ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "scaleC", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-h`} className="text-xs">
+                                  Hue
+                                </Label>
+                                <Input
+                                  id={`${baseId}-h`}
+                                  type="number"
+                                  step="0.1"
+                                  value={modeState?.h ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "h", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-deltaH`} className="text-xs">
+                                  ΔHue
+                                </Label>
+                                <Input
+                                  id={`${baseId}-deltaH`}
+                                  type="number"
+                                  step="0.1"
+                                  value={modeState?.deltaH ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "deltaH", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-alpha`} className="text-xs">
+                                  Alpha
+                                </Label>
+                                <Input
+                                  id={`${baseId}-alpha`}
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  max="1"
+                                  value={modeState?.alpha ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "alpha", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor={`${baseId}-deltaAlpha`} className="text-xs">
+                                  ΔAlpha
+                                </Label>
+                                <Input
+                                  id={`${baseId}-deltaAlpha`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.deltaAlpha ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "deltaAlpha", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1 sm:col-span-2">
+                                <Label htmlFor={`${baseId}-scaleAlpha`} className="text-xs">
+                                  Scale Alpha
+                                </Label>
+                                <Input
+                                  id={`${baseId}-scaleAlpha`}
+                                  type="number"
+                                  step="0.01"
+                                  value={modeState?.scaleAlpha ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "scaleAlpha", event.target.value)
+                                  }
+                                />
+                              </div>
+                              <div className="space-y-1 sm:col-span-2">
+                                <Label htmlFor={`${baseId}-value`} className="text-xs">
+                                  Direktwert
+                                </Label>
+                                <Input
+                                  id={`${baseId}-value`}
+                                  value={modeState?.value ?? ""}
+                                  onChange={(event) =>
+                                    handleTokenAdjustmentChange(token, mode, "value", event.target.value)
+                                  }
+                                  placeholder="Optionaler CSS-Wert, überschreibt LCH"
+                                />
+                              </div>
+                              <div className="space-y-1 sm:col-span-2">
+                                <Label htmlFor={`${baseId}-family`} className="text-xs">
+                                  Familien-Override
+                                </Label>
+                                <Select
+                                  value={
+                                    modeState?.family && modeState.family.trim().length > 0
+                                      ? modeState.family
+                                      : FAMILY_INHERIT_VALUE
+                                  }
+                                  onValueChange={(value) =>
+                                    handleTokenAdjustmentChange(
+                                      token,
+                                      mode,
+                                      "family",
+                                      value === FAMILY_INHERIT_VALUE ? "" : value,
+                                    )
+                                  }
+                                >
+                                  <SelectTrigger id={`${baseId}-family`}>
+                                    <SelectValue placeholder="Basis nutzen" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value={FAMILY_INHERIT_VALUE}>Basisfamilie verwenden</SelectItem>
+                                    {familyNames.map((familyOption) => (
+                                      <SelectItem key={`${baseId}-family-${familyOption}`} value={familyOption}>
+                                        {formatFamilyLabel(familyOption)}
+                                      </SelectItem>
+                                    ))}
+                                    {modeState?.family && modeState.family.trim().length > 0 &&
+                                    !familyNames.includes(modeState.family) ? (
+                                      <SelectItem value={modeState.family}>{modeState.family}</SelectItem>
+                                    ) : null}
+                                  </SelectContent>
+                                </Select>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
         </CardContent>
       </Card>
 

--- a/src/lib/theme-css.ts
+++ b/src/lib/theme-css.ts
@@ -1,11 +1,24 @@
 import type { ThemeModeKey, ThemeTokenKey, ThemeTokens } from "@/lib/website-settings";
 
-function toVariableLines(record: Record<ThemeTokenKey, string>, tokenKeys: ThemeTokenKey[]) {
-  return tokenKeys.map((token) => `  --${token}: ${record[token]};`).join("\n");
+function toVariableLines(
+  record: Record<ThemeTokenKey, string>,
+  fallback: Record<ThemeTokenKey, string>,
+  tokenKeys: ThemeTokenKey[],
+) {
+  return tokenKeys
+    .map((token) => {
+      const value = record[token] ?? fallback[token] ?? "transparent";
+      return `  --${token}: ${value};`;
+    })
+    .join("\n");
 }
 
 export function createThemeCss(tokens: ThemeTokens) {
-  const modeKeys = Object.keys(tokens.modes) as ThemeModeKey[];
+  const modeKeys = Object.keys(tokens.modes).map((key) => key as ThemeModeKey);
+  if (modeKeys.length === 0) {
+    return "";
+  }
+
   const baseMode: ThemeModeKey = modeKeys.includes("light" as ThemeModeKey)
     ? ("light" as ThemeModeKey)
     : modeKeys[0];
@@ -13,7 +26,16 @@ export function createThemeCss(tokens: ThemeTokens) {
     ? ("dark" as ThemeModeKey)
     : modeKeys.find((key) => key !== baseMode) ?? null;
 
-  const tokenKeys = Object.keys(tokens.modes[baseMode]) as ThemeTokenKey[];
+  const baseTokens = (tokens.modes[baseMode] ?? {}) as Record<ThemeTokenKey, string>;
+  const tokenKeySet = new Set<ThemeTokenKey>(
+    Object.keys(baseTokens).map((key) => key as ThemeTokenKey),
+  );
+  if (darkMode) {
+    for (const key of Object.keys(tokens.modes[darkMode] ?? {})) {
+      tokenKeySet.add(key as ThemeTokenKey);
+    }
+  }
+  const tokenKeys = Array.from(tokenKeySet);
   const lines: string[] = [];
 
   lines.push("/* dynamically generated website theme */");
@@ -21,17 +43,17 @@ export function createThemeCss(tokens: ThemeTokens) {
   if (tokens.radius?.base) {
     lines.push(`  --radius: ${tokens.radius.base};`);
   }
-  lines.push(toVariableLines(tokens.modes[baseMode] as Record<ThemeTokenKey, string>, tokenKeys));
+  const baseFallbackMode = darkMode
+    ? ((tokens.modes[darkMode] ?? {}) as Record<ThemeTokenKey, string>)
+    : {};
+  lines.push(toVariableLines(baseTokens, baseFallbackMode, tokenKeys));
   lines.push("}");
 
   if (darkMode) {
     lines.push("");
     lines.push(".dark {");
-    const darkTokens = tokens.modes[darkMode] as Record<ThemeTokenKey, string>;
-    for (const token of tokenKeys) {
-      const value = darkTokens[token] ?? tokens.modes[baseMode][token];
-      lines.push(`  --${token}: ${value};`);
-    }
+    const darkTokens = (tokens.modes[darkMode] ?? {}) as Record<ThemeTokenKey, string>;
+    lines.push(toVariableLines(darkTokens, baseTokens, tokenKeys));
     lines.push("}");
   }
 

--- a/src/lib/website-settings.ts
+++ b/src/lib/website-settings.ts
@@ -10,27 +10,397 @@ export const DEFAULT_COLOR_MODE = "dark" as const;
 export const THEME_COLOR_MODES = ["light", "dark"] as const;
 export type ThemeColorMode = (typeof THEME_COLOR_MODES)[number];
 
-export type ThemeTokens = typeof designTokens;
-export type ThemeModeKey = keyof ThemeTokens["modes"];
-export type ThemeTokenKey = keyof ThemeTokens["modes"]["light"];
+type BrandedString<Brand extends string> = string & { readonly __brand: Brand };
 
-const INTERNAL_MODE_KEYS = Object.keys(designTokens.modes) as ThemeModeKey[];
-const INTERNAL_TOKEN_KEYS = Object.keys(designTokens.modes.light) as ThemeTokenKey[];
+export type ThemeModeKey = BrandedString<"ThemeModeKey">;
+export type ThemeTokenKey = BrandedString<"ThemeTokenKey">;
 
-export const THEME_MODE_KEYS: ThemeModeKey[] = [...INTERNAL_MODE_KEYS];
-export const THEME_TOKEN_KEYS: ThemeTokenKey[] = [...INTERNAL_TOKEN_KEYS];
+export type ThemeFamilyValue = {
+  l: number;
+  c: number;
+  h: number;
+  alpha?: number;
+};
 
-function cloneThemeTokens(tokens: ThemeTokens): ThemeTokens {
-  const modes = {} as ThemeTokens["modes"];
-  for (const mode of Object.keys(tokens.modes) as ThemeModeKey[]) {
-    modes[mode] = { ...tokens.modes[mode] };
+export type ThemeFamilies = Record<string, Record<ThemeModeKey, ThemeFamilyValue>>;
+
+export type ThemeTokenAdjustment = {
+  deltaL?: number;
+  l?: number;
+  scaleL?: number;
+  deltaC?: number;
+  c?: number;
+  scaleC?: number;
+  h?: number;
+  deltaH?: number;
+  alpha?: number;
+  deltaAlpha?: number;
+  scaleAlpha?: number;
+  value?: string;
+  family?: string;
+};
+
+export type ThemeSemanticTokenDefinition = {
+  family: string;
+  description?: string;
+  notes?: string;
+  tags?: string[];
+  [mode: string]: unknown;
+};
+
+export type ThemeParameters = {
+  families: ThemeFamilies;
+  tokens: Record<string, ThemeSemanticTokenDefinition>;
+};
+
+export type ThemeTokens = {
+  radius: { base: string };
+  parameters?: ThemeParameters;
+  modes: Record<ThemeModeKey, Record<ThemeTokenKey, string>>;
+  meta?: Record<string, unknown>;
+};
+
+const DEFAULT_MODE_KEYS = Object.keys(designTokens.modes).map((key) => key as ThemeModeKey);
+
+function deepClone<T>(value: T): T {
+  if (value === undefined || value === null) {
+    return value;
   }
-  return {
-    radius: { base: tokens.radius.base },
-    parameters: designTokens.parameters,
-    modes,
-    meta: tokens.meta ?? designTokens.meta,
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+const RESERVED_PARAMETER_KEYS = new Set(["family", "description", "notes", "tags"]);
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function sanitiseFamilyValue(
+  value: unknown,
+  fallback: { l: number; c: number; h: number; alpha?: number },
+) {
+  const base = {
+    l: typeof fallback.l === "number" ? clamp(fallback.l, 0, 1) : 0.5,
+    c: typeof fallback.c === "number" ? Math.max(fallback.c, 0) : 0,
+    h: typeof fallback.h === "number" ? fallback.h : 0,
+    alpha: typeof fallback.alpha === "number" ? clamp(fallback.alpha, 0, 1) : 1,
   };
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return base;
+  }
+
+  const record = value as Record<string, unknown>;
+  const l = Number(record.l);
+  if (Number.isFinite(l)) {
+    base.l = clamp(l, 0, 1);
+  }
+
+  const c = Number(record.c);
+  if (Number.isFinite(c)) {
+    base.c = Math.max(c, 0);
+  }
+
+  const h = Number(record.h);
+  if (Number.isFinite(h)) {
+    base.h = h;
+  }
+
+  const alpha = Number(record.alpha);
+  if (Number.isFinite(alpha)) {
+    base.alpha = clamp(alpha, 0, 1);
+  }
+
+  return base;
+}
+
+function sanitiseFamilies(
+  value: unknown,
+  fallbackFamilies: ThemeFamilies,
+): ThemeFamilies {
+  const result: ThemeFamilies = {};
+  const fallbackRecord = fallbackFamilies ?? {};
+  const candidateRecord =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+  const familyNames = new Set<string>([
+    ...Object.keys(fallbackRecord),
+    ...Object.keys(candidateRecord),
+  ]);
+
+  for (const familyName of familyNames) {
+    const fallbackModes = fallbackRecord[familyName] ?? {};
+    const candidateModesRaw = candidateRecord[familyName];
+    const candidateModes =
+      candidateModesRaw && typeof candidateModesRaw === "object" && !Array.isArray(candidateModesRaw)
+        ? (candidateModesRaw as Record<string, unknown>)
+        : {};
+
+    const modeNames = new Set<ThemeModeKey>(DEFAULT_MODE_KEYS);
+    for (const key of Object.keys(fallbackModes)) {
+      modeNames.add(key as ThemeModeKey);
+    }
+    for (const key of Object.keys(candidateModes)) {
+      modeNames.add(key as ThemeModeKey);
+    }
+
+    const modeRecord: Record<ThemeModeKey, ThemeFamilyValue> = {};
+    for (const modeKey of modeNames) {
+      const fallbackValue = fallbackModes[modeKey] ?? { l: 0.5, c: 0, h: 0, alpha: 1 };
+      const candidateValue = candidateModes[modeKey];
+      modeRecord[modeKey] = sanitiseFamilyValue(candidateValue, fallbackValue);
+    }
+
+    result[familyName] = modeRecord;
+  }
+
+  return result;
+}
+
+type SanitisedAdjustment = ThemeTokenAdjustment;
+
+function sanitiseAdjustment(
+  value: unknown,
+  fallback: Record<string, unknown> | undefined,
+): SanitisedAdjustment {
+  const result: SanitisedAdjustment = {};
+  const candidate = value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+  const base = fallback && typeof fallback === "object" && !Array.isArray(fallback)
+    ? fallback
+    : {};
+
+  const numericKeys = [
+    "deltaL",
+    "l",
+    "scaleL",
+    "deltaC",
+    "c",
+    "scaleC",
+    "h",
+    "deltaH",
+    "alpha",
+    "deltaAlpha",
+    "scaleAlpha",
+  ] as const;
+  for (const key of numericKeys) {
+    const candidateValue = Number(candidate[key]);
+    if (Number.isFinite(candidateValue)) {
+      const valueToSet =
+        key === "alpha"
+          ? clamp(candidateValue, 0, 1)
+          : key === "c"
+            ? Math.max(candidateValue, 0)
+            : candidateValue;
+      switch (key) {
+        case "deltaL":
+          result.deltaL = valueToSet;
+          break;
+        case "l":
+          result.l = valueToSet;
+          break;
+        case "scaleL":
+          result.scaleL = valueToSet;
+          break;
+        case "deltaC":
+          result.deltaC = valueToSet;
+          break;
+        case "c":
+          result.c = valueToSet;
+          break;
+        case "scaleC":
+          result.scaleC = valueToSet;
+          break;
+        case "h":
+          result.h = valueToSet;
+          break;
+        case "deltaH":
+          result.deltaH = valueToSet;
+          break;
+        case "alpha":
+          result.alpha = valueToSet;
+          break;
+        case "deltaAlpha":
+          result.deltaAlpha = valueToSet;
+          break;
+        case "scaleAlpha":
+          result.scaleAlpha = valueToSet;
+          break;
+      }
+      continue;
+    }
+
+    const fallbackValue = Number((base as Record<string, unknown>)[key]);
+    if (Number.isFinite(fallbackValue)) {
+      const valueToSet =
+        key === "alpha"
+          ? clamp(fallbackValue, 0, 1)
+          : key === "c"
+            ? Math.max(fallbackValue, 0)
+            : fallbackValue;
+      switch (key) {
+        case "deltaL":
+          result.deltaL = valueToSet;
+          break;
+        case "l":
+          result.l = valueToSet;
+          break;
+        case "scaleL":
+          result.scaleL = valueToSet;
+          break;
+        case "deltaC":
+          result.deltaC = valueToSet;
+          break;
+        case "c":
+          result.c = valueToSet;
+          break;
+        case "scaleC":
+          result.scaleC = valueToSet;
+          break;
+        case "h":
+          result.h = valueToSet;
+          break;
+        case "deltaH":
+          result.deltaH = valueToSet;
+          break;
+        case "alpha":
+          result.alpha = valueToSet;
+          break;
+        case "deltaAlpha":
+          result.deltaAlpha = valueToSet;
+          break;
+        case "scaleAlpha":
+          result.scaleAlpha = valueToSet;
+          break;
+      }
+    }
+  }
+
+  const candidateValue = candidate.value ?? (base as Record<string, unknown>).value;
+  if (typeof candidateValue === "string" && candidateValue.trim()) {
+    result.value = candidateValue.trim().slice(0, 200);
+  }
+
+  const familyOverride = candidate.family ?? (base as Record<string, unknown>).family;
+  if (typeof familyOverride === "string" && familyOverride.trim()) {
+    result.family = familyOverride.trim();
+  }
+
+  return result;
+}
+
+function sanitiseTokenDefinition(
+  value: unknown,
+  fallback: ThemeSemanticTokenDefinition | undefined,
+): ThemeSemanticTokenDefinition {
+  const baseRecord = fallback && typeof fallback === "object" && !Array.isArray(fallback)
+    ? (fallback as Record<string, unknown>)
+    : {};
+  const candidateRecord = value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+  const result: Record<string, unknown> = {};
+
+  const fallbackFamily = typeof baseRecord.family === "string" && baseRecord.family.trim()
+    ? baseRecord.family.trim()
+    : "neutral";
+  if (typeof candidateRecord.family === "string" && candidateRecord.family.trim()) {
+    result.family = candidateRecord.family.trim();
+  } else {
+    result.family = fallbackFamily;
+  }
+
+  const description = candidateRecord.description ?? baseRecord.description;
+  if (typeof description === "string" && description.trim()) {
+    result.description = description.trim().slice(0, 200);
+  }
+
+  const notes = candidateRecord.notes ?? baseRecord.notes;
+  if (typeof notes === "string" && notes.trim()) {
+    result.notes = notes.trim();
+  }
+
+  const tags = candidateRecord.tags ?? baseRecord.tags;
+  if (Array.isArray(tags)) {
+    result.tags = tags
+      .map((tag) => (typeof tag === "string" ? tag.trim() : String(tag)))
+      .filter(Boolean)
+      .slice(0, 20);
+  }
+
+  const modeKeys = new Set<string>();
+  for (const key of Object.keys(baseRecord)) {
+    if (!RESERVED_PARAMETER_KEYS.has(key)) {
+      modeKeys.add(key);
+    }
+  }
+  for (const key of Object.keys(candidateRecord)) {
+    if (!RESERVED_PARAMETER_KEYS.has(key)) {
+      modeKeys.add(key);
+    }
+  }
+
+  for (const modeKey of Array.from(modeKeys)) {
+    const sanitised = sanitiseAdjustment(
+      candidateRecord[modeKey],
+      baseRecord[modeKey] as Record<string, unknown> | undefined,
+    );
+    if (Object.keys(sanitised).length > 0) {
+      result[modeKey] = sanitised;
+    }
+  }
+
+  return result as ThemeSemanticTokenDefinition;
+}
+
+function sanitiseParameters(value: unknown, fallback: ThemeParameters): ThemeParameters {
+  const base = deepClone(fallback ?? {});
+
+  const candidate = value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+  base.families = sanitiseFamilies(candidate.families, fallback.families);
+
+  const fallbackTokensRecord = (fallback.tokens ?? {}) as Record<
+    string,
+    ThemeSemanticTokenDefinition
+  >;
+  const candidateTokens = candidate.tokens && typeof candidate.tokens === "object" && !Array.isArray(candidate.tokens)
+    ? (candidate.tokens as Record<string, unknown>)
+    : {};
+
+  const tokenNames = new Set<string>([
+    ...Object.keys(fallbackTokensRecord),
+    ...Object.keys(candidateTokens),
+  ]);
+
+  const resultTokens: Record<string, ThemeSemanticTokenDefinition> = {};
+  for (const tokenName of Array.from(tokenNames)) {
+    resultTokens[tokenName] = sanitiseTokenDefinition(
+      candidateTokens[tokenName],
+      fallbackTokensRecord[tokenName] as ThemeSemanticTokenDefinition | undefined,
+    );
+  }
+
+  base.tokens = resultTokens as ThemeParameters["tokens"];
+
+  return base;
+}
+
+function cloneThemeTokens(tokens: ThemeTokens | typeof designTokens): ThemeTokens {
+  const clone = deepClone(tokens) as ThemeTokens;
+  if (!clone.parameters && designTokens.parameters) {
+    clone.parameters = deepClone(designTokens.parameters);
+  }
+  if (!clone.meta && designTokens.meta) {
+    clone.meta = deepClone(designTokens.meta);
+  }
+  return clone;
 }
 
 function cloneDefaultTokens(): ThemeTokens {
@@ -76,30 +446,56 @@ export function sanitiseThemeTokens(value: unknown): ThemeTokens {
     base.radius.base = sanitiseCssValue(radiusRecord.base, base.radius.base);
   }
 
-  const modesCandidate = record.modes;
-  if (!modesCandidate || typeof modesCandidate !== "object" || Array.isArray(modesCandidate)) {
-    return base;
+  if (base.parameters) {
+    base.parameters = sanitiseParameters(record.parameters, base.parameters);
   }
 
-  const modesRecord = modesCandidate as Record<string, unknown>;
-  for (const modeKey of INTERNAL_MODE_KEYS) {
-    const defaultModeTokens = designTokens.modes[modeKey];
-    const targetModeTokens = base.modes[modeKey];
-    const candidate = modesRecord[modeKey];
-    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
-      for (const tokenKey of INTERNAL_TOKEN_KEYS) {
-        targetModeTokens[tokenKey] = defaultModeTokens[tokenKey];
-      }
-      continue;
+  const modesCandidate = record.modes;
+  if (modesCandidate && typeof modesCandidate === "object" && !Array.isArray(modesCandidate)) {
+    const modesRecord = modesCandidate as Record<string, unknown>;
+    const defaultModes = designTokens.modes as Record<string, Record<string, string>>;
+    const modeNames = new Set<ThemeModeKey>(DEFAULT_MODE_KEYS);
+    for (const key of Object.keys(modesRecord)) {
+      modeNames.add(key as ThemeModeKey);
     }
 
-    const candidateRecord = candidate as Record<string, unknown>;
-    for (const tokenKey of INTERNAL_TOKEN_KEYS) {
-      targetModeTokens[tokenKey] = sanitiseCssValue(
-        candidateRecord[tokenKey],
-        defaultModeTokens[tokenKey],
+    for (const modeKey of modeNames) {
+      const candidate = modesRecord[modeKey];
+      const fallbackRecord = (base.modes[modeKey] as Record<string, string> | undefined)
+        ?? (defaultModes[modeKey] as Record<string, string> | undefined)
+        ?? {};
+
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        base.modes[modeKey] = { ...fallbackRecord } as Record<ThemeTokenKey, string>;
+        continue;
+      }
+
+      const candidateRecord = candidate as Record<string, unknown>;
+      const tokenNames = new Set<ThemeTokenKey>(
+        Object.keys(fallbackRecord).map((key) => key as ThemeTokenKey),
       );
+      for (const key of Object.keys(candidateRecord)) {
+        tokenNames.add(key as ThemeTokenKey);
+      }
+
+      const resolvedTokens: Record<ThemeTokenKey, string> = {};
+      for (const tokenKey of tokenNames) {
+        const fallbackValue = fallbackRecord[tokenKey];
+        const fallbackString =
+          typeof fallbackValue === "string" && fallbackValue.trim().length > 0
+            ? fallbackValue
+            : "transparent";
+        resolvedTokens[tokenKey] = sanitiseCssValue(candidateRecord[tokenKey], fallbackString);
+      }
+
+      base.modes[modeKey] = resolvedTokens;
     }
+  }
+
+  const metaCandidate = record.meta;
+  if (metaCandidate && typeof metaCandidate === "object" && !Array.isArray(metaCandidate)) {
+    const metaRecord = metaCandidate as Record<string, unknown>;
+    base.meta = { ...(base.meta ?? {}), ...metaRecord } as ThemeTokens["meta"];
   }
 
   return base;


### PR DESCRIPTION
## Summary
- introduce branded theme token keys and broaden sanitisation so parametric families/deltas survive persistence
- relax settings API/schema and CSS builder to accept arbitrary mode/token maps with per-mode family overrides
- expose full parametric controls (deltas, scales, family overrides) in the member theme manager UI

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1b3aee088832d86c1fae4b58eea11