### PR TITLE
Fix JSON imports for Node 24 runtime

### DIFF
--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -4,9 +4,12 @@ import {
   CharacterCastingType,
   BreakdownStatus,
 } from "@prisma/client";
+import { createRequire } from "node:module";
 import bcrypt from "bcryptjs";
-import chronikAltrossthal from "../src/data/chronik-altrossthal.json" assert { type: "json" };
-import designTokens from "../src/design-system/tokens.json" assert { type: "json" };
+
+const require = createRequire(import.meta.url);
+const chronikAltrossthal = require("../src/data/chronik-altrossthal.json");
+const designTokens = require("../src/design-system/tokens.json");
 const prisma = new PrismaClient();
 
 function splitFullName(value) {

--- a/realtime-server/src/createRealtimeServer.js
+++ b/realtime-server/src/createRealtimeServer.js
@@ -5,8 +5,10 @@ import os from 'node:os';
 import { setTimeout as wait } from 'node:timers/promises';
 import { Server } from 'socket.io';
 import { URL } from 'url';
+import { createRequire } from 'node:module';
 
-import analyticsStaticData from '../../src/data/server-analytics-static.json' assert { type: 'json' };
+const require = createRequire(import.meta.url);
+const analyticsStaticData = require('../../src/data/server-analytics-static.json');
 
 const fallbackAnalyticsModule = {
   applyPagePerformanceMetrics(baseEntries = []) {


### PR DESCRIPTION
## Summary
- replace JSON module import assertions in the Prisma seed script with Node's createRequire helper so seeding works on Node 24
- load realtime analytics static data with createRequire instead of deprecated import assertions to unblock the realtime server startup

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1d5e0552c832d9852bd1887382583