### PR TITLE
Fix JSON import syntax for Node 24

### DIFF
--- a/src/data/chronik-fallback.ts
+++ b/src/data/chronik-fallback.ts
@@ -1,6 +1,6 @@
 import type { Show } from "@prisma/client";
 
-import rawChronikAltrossthal from "./chronik-altrossthal.json";
+import rawChronikAltrossthal from "./chronik-altrossthal.json" with { type: "json" };
 
 type RawChronikCastEntry = {
   role?: string | null;

--- a/src/design-system/index.ts
+++ b/src/design-system/index.ts
@@ -1,4 +1,4 @@
-import tokens from "./tokens.json";
+import tokens from "./tokens.json" with { type: "json" };
 
 type Modes = typeof tokens.modes;
 

--- a/src/lib/server-analytics.ts
+++ b/src/lib/server-analytics.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import { setTimeout as wait } from "node:timers/promises";
 
-import staticAnalyticsData from "@/data/server-analytics-static.json";
+import staticAnalyticsData from "@/data/server-analytics-static.json" with { type: "json" };
 import {
   applyPagePerformanceMetrics,
   loadDeviceBreakdownFromDatabase,


### PR DESCRIPTION
## Summary
- switch JSON module imports to the `with { type: "json" }` syntax so they remain compatible with Node 24+ runtime expectations

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68d1d84309b0832d912b58fe1d027a4b