### PR TITLE
Add shadcn checkbox component and migrate usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@hookform/resolvers": "^5.2.1",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "6.16.2",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@prisma/client':
         specifier: 6.16.2
         version: 6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2)
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -686,6 +689,19 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4036,6 +4052,22 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.13)(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -10,6 +11,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { RichTextEditor } from "@/components/ui/rich-text-editor";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { ROLE_LABELS, ROLES } from "@/lib/roles";
 import { cn } from "@/lib/utils";
 
@@ -166,13 +169,13 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
 
   const selectedSet = useMemo(() => new Set(selectedInvitees), [selectedInvitees]);
 
-  const toggleInvitee = useCallback((memberId: string) => {
+  const handleInviteeCheckedChange = useCallback((memberId: string, checked: CheckedState) => {
     setSelectedInvitees((prev) => {
       const set = new Set(prev);
-      if (set.has(memberId)) {
-        set.delete(memberId);
-      } else {
+      if (checked === true) {
         set.add(memberId);
+      } else {
+        set.delete(memberId);
       }
       return Array.from(set);
     });
@@ -452,18 +455,19 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
                     const extraRoles = Array.from(new Set(member.extraRoles)).filter((extra) => extra !== member.role);
 
                     return (
-                      <label
+                      <Label
                         key={member.id}
+                        htmlFor={`invitee-${member.id}`}
                         className={cn(
                           "flex cursor-pointer items-start gap-3 rounded-lg border bg-background/70 px-3 py-3 text-sm shadow-sm transition",
                           isSelected ? "border-primary/70 ring-1 ring-primary/40" : "border-border/60 hover:border-primary/40",
                         )}
                       >
-                        <input
-                          type="checkbox"
-                          className="mt-1 h-4 w-4"
+                        <Checkbox
+                          id={`invitee-${member.id}`}
+                          className="mt-1"
                           checked={isSelected}
-                          onChange={() => toggleInvitee(member.id)}
+                          onCheckedChange={(checked) => handleInviteeCheckedChange(member.id, checked)}
                         />
                         <div className="space-y-1">
                           <div className="flex flex-wrap items-center gap-2">
@@ -483,7 +487,7 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
                             </div>
                           )}
                         </div>
-                      </label>
+                      </Label>
                     );
                   })}
                 </div>

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-list.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { RehearsalCardWithActions } from "./rehearsal-card-with-actions";
 import { format } from "date-fns";
 import { de } from "date-fns/locale/de";
 import { Button } from "@/components/ui/button";
 import { getUserDisplayName } from "@/lib/names";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 
 type UserLite = {
   id: string;
@@ -32,6 +34,7 @@ export function RehearsalList({ initial }: { initial: RehearsalLite[] }) {
   const [onlyUpcoming, setOnlyUpcoming] = useState(false);
   const [expandAll, setExpandAll] = useState(false);
   const [resetKey, setResetKey] = useState(0);
+  const upcomingCheckboxId = useId();
 
   const filtered = useMemo(() => {
     const now = new Date();
@@ -86,15 +89,16 @@ export function RehearsalList({ initial }: { initial: RehearsalLite[] }) {
               onChange={(e) => setQuery(e.target.value)}
               className="h-9 w-64 rounded-md border border-border bg-background px-3 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             />
-            <label className="inline-flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                className="h-4 w-4 rounded border-border"
+            <div className="inline-flex items-center gap-2 text-sm">
+              <Checkbox
+                id={upcomingCheckboxId}
                 checked={onlyUpcoming}
-                onChange={(e) => setOnlyUpcoming(e.target.checked)}
+                onCheckedChange={(checked) => setOnlyUpcoming(checked === true)}
               />
-              Nur kommende
-            </label>
+              <Label htmlFor={upcomingCheckboxId} className="cursor-pointer text-sm">
+                Nur kommende
+              </Label>
+            </div>
           </div>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={handleCollapseAll}>Alle zuklappen</Button>

--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -17,6 +17,7 @@ import {
   createProductionAction,
   setActiveProductionAction,
 } from "./actions";
+import { FormCheckboxField } from "./set-active-checkbox";
 
 function formatShowTitle(show: { title: string | null; year: number }) {
   if (show.title && show.title.trim()) {
@@ -234,15 +235,11 @@ export default async function ProduktionenPage() {
               </details>
 
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <label className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <input
-                    type="checkbox"
-                    name="setActive"
-                    defaultChecked={shouldSetActiveByDefault}
-                    className="mt-1 h-4 w-4 rounded border border-border bg-background text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  />
-                  <span className="leading-snug">Nach dem Anlegen als aktive Produktion setzen</span>
-                </label>
+                <FormCheckboxField
+                  name="setActive"
+                  defaultChecked={shouldSetActiveByDefault}
+                  label="Nach dem Anlegen als aktive Produktion setzen"
+                />
                 <Button type="submit" className="sm:w-auto">
                   Produktion erstellen
                 </Button>

--- a/src/app/(members)/mitglieder/produktionen/set-active-checkbox.tsx
+++ b/src/app/(members)/mitglieder/produktionen/set-active-checkbox.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import * as React from "react";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+type FormCheckboxFieldProps = {
+  name: string;
+  defaultChecked?: boolean;
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  className?: string;
+};
+
+export function FormCheckboxField({
+  name,
+  defaultChecked = false,
+  label,
+  description,
+  className,
+}: FormCheckboxFieldProps) {
+  const id = React.useId();
+  const [checked, setChecked] = React.useState(defaultChecked);
+
+  return (
+    <div className={cn("flex items-start gap-2 text-sm text-muted-foreground", className)}>
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(state) => setChecked(state === true)}
+      />
+      <div className="space-y-1">
+        <Label
+          htmlFor={id}
+          className="cursor-pointer text-sm !font-normal leading-snug text-muted-foreground"
+        >
+          {label}
+        </Label>
+        {description ? (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      <input type="hidden" name={name} value={checked ? "on" : ""} />
+    </div>
+  );
+}

--- a/src/components/members/add-member-card.tsx
+++ b/src/components/members/add-member-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { describeRoles, ROLE_LABELS, ROLES, sortRoles, type Role } from "@/lib/roles";
@@ -7,6 +8,8 @@ import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { Modal } from "@/components/ui/modal";
 import { combineNameParts } from "@/lib/names";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 
 export function AddMemberModal() {
   const router = useRouter();
@@ -20,10 +23,17 @@ export function AddMemberModal() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const toggleRole = (role: Role) => {
+  const handleRoleCheckedChange = (role: Role, checked: CheckedState) => {
     setError(null);
     setRoles((prev) => {
-      const next = prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role];
+      const hasRole = prev.includes(role);
+      const shouldAdd = checked === true;
+      let next = prev;
+      if (shouldAdd && !hasRole) {
+        next = [...prev, role];
+      } else if (!shouldAdd && hasRole) {
+        next = prev.filter((r) => r !== role);
+      }
       return sortRoles(next.length ? next : ["member"]);
     });
   };
@@ -173,22 +183,22 @@ export function AddMemberModal() {
               {ROLES.map((role) => {
                 const active = roles.includes(role);
                 return (
-                  <label
+                  <Label
                     key={role}
+                    htmlFor={`add-member-role-${role}`}
                     className={`flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition ${
                       active
                         ? "border-primary bg-primary/10 text-primary"
                         : "border-border hover:bg-accent/30"
                     }`}
                   >
-                    <input
-                      type="checkbox"
-                      className="h-4 w-4 rounded border-border text-primary focus-visible:outline-none"
+                    <Checkbox
+                      id={`add-member-role-${role}`}
                       checked={active}
-                      onChange={() => toggleRole(role)}
+                      onCheckedChange={(checked) => handleRoleCheckedChange(role, checked)}
                     />
                     <span>{ROLE_LABELS[role] ?? role}</span>
-                  </label>
+                  </Label>
                 );
               })}
             </div>

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import type { Role } from "@prisma/client";
 import { ChevronDown, ChevronUp, Copy, Download, ExternalLink, Power, Trash2 } from "lucide-react";
+
+import type { CheckedState } from "@radix-ui/react-checkbox";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,6 +14,8 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Modal } from "@/components/ui/modal";
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { ROLE_LABELS, ROLES, sortRoles } from "@/lib/roles";
 import { cn } from "@/lib/utils";
 
@@ -309,10 +313,20 @@ export function MemberInviteManager() {
     setError(null);
   };
 
-  const toggleRole = (role: Role) => {
+  const formRoleIdPrefix = useId();
+
+  const handleRoleCheckedChange = (role: Role, checked: CheckedState) => {
     setForm((prev) => {
       const has = prev.roles.includes(role);
-      const nextRoles = has ? prev.roles.filter((r) => r !== role) : [...prev.roles, role];
+      const shouldAdd = checked === true;
+      let nextRoles = prev.roles;
+
+      if (shouldAdd && !has) {
+        nextRoles = [...prev.roles, role];
+      } else if (!shouldAdd && has) {
+        nextRoles = prev.roles.filter((r) => r !== role);
+      }
+
       const normalized = sortRoles(nextRoles.length ? nextRoles : ["member"]);
       return { ...prev, roles: normalized };
     });
@@ -897,21 +911,21 @@ export function MemberInviteManager() {
               {ASSIGNABLE_ROLES.map((role) => {
                 const checked = form.roles.includes(role);
                 return (
-                  <label
+                  <Label
                     key={role}
+                    htmlFor={`${formRoleIdPrefix}-${role}`}
                     className={cn(
                       "flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition",
                       checked ? "border-primary bg-primary/10 text-primary" : "border-border hover:border-primary/60",
                     )}
                   >
-                    <input
-                      type="checkbox"
+                    <Checkbox
+                      id={`${formRoleIdPrefix}-${role}`}
                       checked={checked}
-                      onChange={() => toggleRole(role)}
-                      className="h-4 w-4"
+                      onCheckedChange={(next) => handleRoleCheckedChange(role, next)}
                     />
                     <span>{ROLE_LABELS[role] ?? role}</span>
-                  </label>
+                  </Label>
                 );
               })}
             </div>

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useId } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import type { ChangeEvent, FormEvent } from "react";
@@ -11,6 +11,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import type { PhotoConsentSummary } from "@/types/photo-consent";
 
@@ -112,6 +114,7 @@ export function PhotoConsentCard({
   const [documentError, setDocumentError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const confirmCheckboxId = useId();
 
   useEffect(() => {
     onSummaryChange?.(summary);
@@ -373,18 +376,21 @@ export function PhotoConsentCard({
                 )}
 
                 <div className="rounded-xl border border-primary/25 bg-background/80 p-4 shadow-inner shadow-primary/5 backdrop-blur">
-                  <label className="flex items-start gap-3">
-                    <input
-                      type="checkbox"
+                  <Label
+                    htmlFor={confirmCheckboxId}
+                    className="flex cursor-pointer items-start gap-3 text-left text-sm !font-normal leading-relaxed text-foreground/80"
+                  >
+                    <Checkbox
+                      id={confirmCheckboxId}
+                      className="mt-1 h-5 w-5"
                       checked={confirm}
-                      onChange={(event) => setConfirm(event.target.checked)}
-                      className="mt-1 h-5 w-5 rounded border-border text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      onCheckedChange={(checked) => setConfirm(checked === true)}
                     />
-                    <span className="text-foreground/80">
+                    <span>
                       <span className="font-semibold text-foreground">Ja, ich bin einverstanden,</span>{" "}
                       dass im Rahmen unseres Schultheaters Fotos von mir erstellt und für interne sowie öffentliche Kommunikationszwecke genutzt werden dürfen.
                     </span>
-                  </label>
+                  </Label>
                   <p className="mt-3 text-xs text-foreground/60">Du kannst dein Okay hier jederzeit widerrufen.</p>
                 </div>
 

--- a/src/components/members/role-manager.tsx
+++ b/src/components/members/role-manager.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { EditIcon } from "@/components/ui/icons";
@@ -9,6 +10,8 @@ import { UserEditModal } from "@/components/members/user-edit-modal";
 import { RolePicker } from "@/components/members/role-picker";
 import { UserAvatar } from "@/components/user-avatar";
 import { combineNameParts } from "@/lib/names";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 
 export function RoleManager({
   userId,
@@ -213,26 +216,30 @@ export function RoleManager({
                 {availableCustomRoles.map((r) => {
                   const active = selectedCustomIds.includes(r.id);
                   return (
-                    <label
+                    <Label
                       key={r.id}
+                      htmlFor={`custom-role-${r.id}`}
                       className={`flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 text-sm transition-all ${
-                        active 
-                          ? "border-primary bg-primary/10 text-primary" 
+                        active
+                          ? "border-primary bg-primary/10 text-primary"
                           : "border-border hover:bg-accent hover:text-accent-foreground"
                       }`}
                     >
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-border text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      <Checkbox
+                        id={`custom-role-${r.id}`}
                         checked={active}
-                        onChange={() =>
-                          setSelectedCustomIds((prev) =>
-                            prev.includes(r.id) ? prev.filter((id) => id !== r.id) : [...prev, r.id],
-                          )
+                        onCheckedChange={(checked: CheckedState) =>
+                          setSelectedCustomIds((prev) => {
+                            const shouldAdd = checked === true;
+                            if (shouldAdd) {
+                              return prev.includes(r.id) ? prev : [...prev, r.id];
+                            }
+                            return prev.filter((id) => id !== r.id);
+                          })
                         }
                       />
                       <span className="font-medium">{r.name}</span>
-                    </label>
+                    </Label>
                   );
                 })}
               </div>

--- a/src/components/members/role-picker.tsx
+++ b/src/components/members/role-picker.tsx
@@ -1,7 +1,10 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { CheckedState } from "@radix-ui/react-checkbox";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { ROLE_BADGE_VARIANTS, ROLE_LABELS, ROLES, type Role } from "@/lib/roles";
 
 export function RolePicker({
@@ -38,10 +41,21 @@ export function RolePicker({
     return ROLES.filter((r) => (ROLE_LABELS[r] ?? r).toLowerCase().includes(q));
   }, [query]);
 
-  const toggle = (role: Role) => {
-    if (role === "owner" && !canEditOwner) return;
+  const roleIdPrefix = useId();
+
+  const handleRoleCheckedChange = (role: Role, checked: CheckedState) => {
+    if (role === "owner" && !canEditOwner) {
+      return;
+    }
+
+    const shouldAdd = checked === true;
     const isActive = selected.has(role);
-    const next = isActive ? value.filter((r) => r !== role) : [...value, role];
+
+    if (shouldAdd === isActive) {
+      return;
+    }
+
+    const next = shouldAdd ? [...value, role] : value.filter((r) => r !== role);
     onChange(next);
   };
 
@@ -85,18 +99,18 @@ export function RolePicker({
               const active = selected.has(role);
               const disabled = role === "owner" && !canEditOwner;
               return (
-                <label
+                <Label
                   key={role}
+                  htmlFor={`${roleIdPrefix}-${role}`}
                   className={`flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm hover:bg-accent/40 ${
-                    disabled ? "opacity-50 cursor-not-allowed" : ""
+                    disabled ? "cursor-not-allowed opacity-50" : ""
                   }`}
                 >
                   <div className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      className="h-4 w-4"
+                    <Checkbox
+                      id={`${roleIdPrefix}-${role}`}
                       checked={active}
-                      onChange={() => toggle(role)}
+                      onCheckedChange={(checked) => handleRoleCheckedChange(role, checked)}
                       disabled={disabled}
                     />
                     <span>{ROLE_LABELS[role] ?? role}</span>
@@ -104,7 +118,7 @@ export function RolePicker({
                   <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${ROLE_BADGE_VARIANTS[role]}`}>
                     {role}
                   </span>
-                </label>
+                </Label>
               );
             })}
             {filtered.length === 0 && (

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -21,6 +21,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
 const allergyLevelLabels: Record<AllergyLevel, string> = {
@@ -366,6 +368,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
   });
 
   const notesHelpId = useId();
+  const photoConsentCheckboxId = useId();
 
   useEffect(() => {
     let cancelled = false;
@@ -1629,22 +1632,27 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
             </p>
           </CardHeader>
           <CardContent className="space-y-5">
-            <label className="flex items-start gap-3 rounded-lg border border-border/70 p-4">
-              <input
-                type="checkbox"
+            <Label
+              htmlFor={photoConsentCheckboxId}
+              className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/70 p-4 text-sm"
+            >
+              <Checkbox
+                id={photoConsentCheckboxId}
                 checked={form.photoConsent.consent}
-                onChange={(event) =>
-                  setForm((prev) => ({ ...prev, photoConsent: { ...prev.photoConsent, consent: event.target.checked } }))
+                onCheckedChange={(checked) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    photoConsent: { ...prev.photoConsent, consent: checked === true },
+                  }))
                 }
-                className="mt-1 h-4 w-4"
               />
-              <div className="space-y-1 text-sm">
+              <div className="space-y-1">
                 <p className="font-medium">Ich bin einverstanden, dass Fotos/Videos von mir für das Schultheater genutzt werden.</p>
                 <p className="text-xs text-muted-foreground">
                   Die Zustimmung kann jederzeit im Profil angepasst werden.
                 </p>
               </div>
-            </label>
+            </Label>
 
             {isMinor ? (
               <div className="space-y-2 rounded-lg border border-amber-200 bg-amber-50/70 p-4 text-sm text-amber-900">

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className={cn("flex items-center justify-center text-current")}>
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };


### PR DESCRIPTION
## Summary
- add a shadcn/ui Checkbox component and a form-friendly wrapper for the productions form
- replace native checkboxes across member management, onboarding, and rehearsal flows with the new component and Radix state handling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d244ca5904832d94bcf9b40c8e7f65