### PR TITLE
Adjust site header container padding

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -66,7 +66,7 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
       />
       <nav
         aria-label="Hauptnavigation"
-        className="layout-container flex flex-wrap items-center gap-3 px-3 py-3 sm:gap-4 md:gap-6 md:py-4"
+        className="layout-container flex flex-wrap items-center gap-3 py-3 sm:gap-4 md:gap-6 md:py-4"
       >
         <Link
           className={`font-serif text-lg transition-all duration-300 sm:text-xl ${


### PR DESCRIPTION
## Summary
- remove the redundant horizontal padding utility on the layout container used by the site header navigation

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d255624e38832d9579e87108a44bab