### PR TITLE
refactor: centralize mystery tip prisma helpers

### DIFF
--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -2,11 +2,23 @@ import { NextResponse } from "next/server";
 
 import { endOfWeek, startOfWeek } from "date-fns";
 
+import { Prisma } from "@prisma/client";
 import { hasRole, requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProductionId } from "@/lib/active-production";
 import { buildProfileChecklist } from "@/lib/profile-completion";
+
+const onboardingProfileSelect = Prisma.validator<Prisma.MemberOnboardingProfileSelect>()({
+  focus: true,
+  background: true,
+  backgroundClass: true,
+  notes: true,
+  createdAt: true,
+  updatedAt: true,
+  dietaryPreference: true,
+  dietaryPreferenceStrictness: true,
+});
 
 export async function GET() {
   try {
@@ -117,45 +129,9 @@ export async function GET() {
           },
         },
       }),
-      (
-        prisma as unknown as {
-          memberOnboardingProfile: {
-            findUnique: (args: {
-              where: { userId: string };
-              select: {
-                focus: true;
-                background: true;
-                backgroundClass: true;
-                notes: true;
-                createdAt: true;
-                updatedAt: true;
-                dietaryPreference: true;
-                dietaryPreferenceStrictness: true;
-              };
-            }) => Promise<{
-              focus: string;
-              background: string | null;
-              backgroundClass: string | null;
-              notes: string | null;
-              createdAt: Date;
-              updatedAt: Date;
-              dietaryPreference: string | null;
-              dietaryPreferenceStrictness: string | null;
-            } | null>;
-          };
-        }
-      ).memberOnboardingProfile.findUnique({
+      prisma.memberOnboardingProfile.findUnique({
         where: { userId },
-        select: {
-          focus: true,
-          background: true,
-          backgroundClass: true,
-          notes: true,
-          createdAt: true,
-          updatedAt: true,
-          dietaryPreference: true,
-          dietaryPreferenceStrictness: true,
-        },
+        select: onboardingProfileSelect,
       }),
       prisma.memberRolePreference.findMany({
         where: { userId },

--- a/src/lib/prisma-helpers.ts
+++ b/src/lib/prisma-helpers.ts
@@ -1,0 +1,92 @@
+import { Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+type PlayerScoreboardGroupByArgs = Prisma.MysteryTipSubmissionGroupByArgs & {
+  by: ["playerName"];
+  _sum: { score: true };
+  _count: { _all: true };
+  _max: { updatedAt: true };
+};
+
+const playerScoreboardGroupByArgs = Prisma.validator<PlayerScoreboardGroupByArgs>()({
+  by: ["playerName"],
+  _sum: { score: true },
+  _count: { _all: true },
+  _max: { updatedAt: true },
+});
+
+type PlayerScoreboardAggregateArgs = Prisma.MysteryTipSubmissionAggregateArgs & {
+  _sum: { score: true };
+  _count: true;
+  _max: { updatedAt: true };
+};
+
+const playerScoreboardAggregateArgs = Prisma.validator<PlayerScoreboardAggregateArgs>()({
+  _sum: { score: true },
+  _count: true,
+  _max: { updatedAt: true },
+});
+
+const clueSummarySelect = Prisma.validator<Prisma.ClueSelect>()({
+  id: true,
+  index: true,
+  points: true,
+  releaseAt: true,
+  published: true,
+});
+
+const tipSummarySelect = Prisma.validator<Prisma.MysteryTipSelect>()({
+  text: true,
+  count: true,
+});
+
+const tipCountSelect = Prisma.validator<Prisma.MysteryTipSelect>()({
+  count: true,
+});
+
+export const mysterySubmissionWithRelationsInclude =
+  Prisma.validator<Prisma.MysteryTipSubmissionInclude>()({
+    tip: { select: tipSummarySelect },
+    clue: { select: clueSummarySelect },
+  });
+
+export const mysterySubmissionWithCountsInclude =
+  Prisma.validator<Prisma.MysteryTipSubmissionInclude>()({
+    tip: { select: tipCountSelect },
+    clue: { select: clueSummarySelect },
+  });
+
+export type MysterySubmissionWithRelations = Prisma.MysteryTipSubmissionGetPayload<{
+  include: typeof mysterySubmissionWithRelationsInclude;
+}>;
+
+export type MysterySubmissionWithCounts = Prisma.MysteryTipSubmissionGetPayload<{
+  include: typeof mysterySubmissionWithCountsInclude;
+}>;
+
+export function groupMysteryTipSubmissionsByPlayer(
+  where?: Prisma.MysteryTipSubmissionWhereInput,
+) {
+  return prisma.mysteryTipSubmission.groupBy({
+    ...playerScoreboardGroupByArgs,
+    ...(where ? { where } : {}),
+  });
+}
+
+export type MysteryScoreboardGroupRow = Awaited<
+  ReturnType<typeof groupMysteryTipSubmissionsByPlayer>
+>[number];
+
+export function aggregateMysteryTipSubmissionScores(
+  where: Prisma.MysteryTipSubmissionWhereInput,
+) {
+  return prisma.mysteryTipSubmission.aggregate({
+    ...playerScoreboardAggregateArgs,
+    where,
+  });
+}
+
+export type MysteryTipSubmissionAggregateResult = Awaited<
+  ReturnType<typeof aggregateMysteryTipSubmissionScores>
+>;


### PR DESCRIPTION
## Summary
- add prisma helper utilities for mystery tip submissions to encapsulate groupBy, aggregate, and shared include selections
- refactor mystery tip scoreboard logic and submission APIs to consume the shared helpers instead of manual casts and duplicated interfaces
- simplify dashboard overview onboarding profile select typing via Prisma.validator

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2568f9f10832d876141cf72a5f7f1