### PR TITLE
Improve theme management UX and presets

### DIFF
--- a/docs/website-theme-management.md
+++ b/docs/website-theme-management.md
@@ -1,0 +1,114 @@
+# API: Website-Theme-Verwaltung
+
+## Überblick
+
+- Mitglieder mit der Berechtigung `mitglieder.website.settings` können mehrere Website-Themes parallel verwalten.
+- Themes lassen sich neu anlegen, aus bestehenden Varianten duplizieren, umbenennen und gezielt aktivieren.
+- Die Website-Einstellungen akzeptieren weiterhin den bisherigen Payload, unterstützen jetzt aber optional das direkte Speichern eines Themes samt Aktivierung.
+
+## Voreingestellte Themes
+
+Beim ersten Zugriff werden mehrere Presets automatisch angelegt, falls sie noch nicht vorhanden sind.
+
+| ID | Name | Beschreibung |
+| --- | --- | --- |
+| `theatre-sunset-glow` | Sommertheater Sonnenuntergang | Warme Orange- und Goldtöne für stimmungsvolle Abendvorstellungen. |
+| `theatre-night-sky` | Sommertheater Nachtblau | Kühle Blaunuancen mit hoher Kontrastwirkung für nächtliche Events. |
+| `theatre-pastel-dream` | Sommertheater Pastell | Sanfte Pastellfarben für festliche Sommermatineen. |
+| `theatre-forest-canopy` | Sommertheater Waldlichtung | Natürliche Grün- und Moostöne für Freilicht-Bühnenbilder. |
+| `theatre-velvet-spotlight` | Sommertheater Samt & Scheinwerfer | Dramatische Purpurakzente für Gala-Abende und Premieren. |
+| `theatre-festival-lights` | Sommertheater Festivallichter | Strahlende Festivalfarben mit verspieltem Charakter für Sommerfeste. |
+
+Die Presets werden als normale Datenbankeinträge gespeichert und können auf Wunsch dupliziert oder als Basis für eigene Anpassungen verwendet werden.
+
+## Endpunkte
+
+### `GET /api/website/themes`
+
+Liefert alle Themes als kompakte Zusammenfassungen.
+
+```json
+{
+  "themes": [
+    {
+      "id": "theatre-night-sky",
+      "name": "Sommertheater Nachtblau",
+      "description": "…",
+      "isDefault": false,
+      "updatedAt": "2024-05-01T18:21:00.000Z"
+    }
+  ]
+}
+```
+
+### `POST /api/website/themes`
+
+Erstellt ein neues Theme. Der Body ist optional und entspricht dem Schema
+
+```json
+{
+  "name": "Neues Theme",
+  "description": "Optionaler Beschreibungstext",
+  "sourceThemeId": "uuid-oder-preset-id"
+}
+```
+
+- Ohne `sourceThemeId` wird mit den aktuellen Standard-Tokens gestartet.
+- Mit `sourceThemeId` wird das angegebene Theme (Preset oder eigenes) dupliziert.
+- Die Antwort enthält das vollständige Theme (`theme`) sowie eine verkürzte Zusammenfassung (`summary`).
+
+### `GET /api/website/themes/[themeId]`
+
+Lädt ein einzelnes Theme inklusive aller Tokens.
+
+### `PUT /api/website/themes/[themeId]`
+
+Aktualisiert Name, Beschreibung und Tokens eines bestehenden Themes. Beispiel-Payload:
+
+```json
+{
+  "name": "Sommernachts-Traum",
+  "description": "angepasst",
+  "tokens": { "radius": { "base": "0.75rem" } }
+}
+```
+
+> [!NOTE]
+> Das Standard-Theme (`isDefault: true`) bleibt in seiner ursprünglichen Form erhalten und kann nicht umbenannt werden.
+
+### `PUT /api/website/settings`
+
+Dieser Endpunkt bündelt Website- und Theme-Updates. Der Payload besteht aus drei optionalen Objekten:
+
+```json
+{
+  "settings": {
+    "siteTitle": "Sommerbühne 2024",
+    "colorMode": "dark",
+    "themeId": "uuid"
+  },
+  "theme": {
+    "id": "uuid",
+    "name": "Sommernachts-Traum",
+    "description": "angepasst",
+    "tokens": { "modes": { "light": { "button-primary": "#ffab00" } } }
+  },
+  "activateTheme": true
+}
+```
+
+- `settings.themeId` aktiviert ein vorhandenes Theme ohne es zu verändern.
+- Wird gleichzeitig ein `theme` übermittelt, speichert die Route zuerst das Theme und verknüpft es anschließend mit den Website-Einstellungen.
+- `activateTheme` erzwingt die Aktivierung des übermittelten Themes. Lässt man die Eigenschaft weg, wird automatisch aktiviert, sobald `theme` gesetzt ist oder `settings.themeId` explizit übertragen wurde.
+
+Die Antwort enthält stets die aktuellen Website-Einstellungen (`settings`) und – falls ein Theme gespeichert wurde – das aktualisierte Theme-Objekt (`theme`).
+
+## Berechtigungen & Sicherheit
+
+Alle oben genannten Endpunkte verlangen eine angemeldete Sitzung mit der Berechtigung `mitglieder.website.settings`. Ohne gültige Datenbankverbindung antworten die Routen mit `500`.
+
+## Zusätzliche Hinweise
+
+- Themes werden nach `name` sortiert, das Standard-Theme steht immer an erster Stelle.
+- Presets werden automatisch nachgezogen, wenn neue Varianten im Code ergänzt werden.
+- Beim Löschen oder Zurücksetzen eines Themes muss anschließend ein anderes Theme aktiv ausgewählt werden, damit die Website konsistente Tokens erhält.

--- a/src/app/(members)/mitglieder/website/page.tsx
+++ b/src/app/(members)/mitglieder/website/page.tsx
@@ -2,6 +2,8 @@ import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 import {
   ensureWebsiteSettingsRecord,
+  ensurePresetWebsiteThemes,
+  listWebsiteThemes,
   resolveWebsiteSettings,
   toClientWebsiteSettings,
 } from "@/lib/website-settings";
@@ -25,9 +27,11 @@ export default async function WebsiteSettingsPage() {
   }
 
   try {
+    await ensurePresetWebsiteThemes();
     const record = await ensureWebsiteSettingsRecord();
     const resolved = resolveWebsiteSettings(record);
     const clientSettings = toClientWebsiteSettings(resolved);
+    const themes = await listWebsiteThemes();
 
     return (
       <div className="space-y-8">
@@ -37,7 +41,10 @@ export default async function WebsiteSettingsPage() {
             Passe Farben, Branding und Darstellung der öffentlichen Website an. Änderungen werden sofort im aktuellen Fenster sichtbar.
           </p>
         </div>
-        <WebsiteThemeSettingsManager initialSettings={clientSettings} />
+        <WebsiteThemeSettingsManager
+          initialSettings={clientSettings}
+          initialThemes={themes}
+        />
       </div>
     );
   } catch (error) {

--- a/src/app/api/website/theme-schemas.ts
+++ b/src/app/api/website/theme-schemas.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+export const themeIdSchema = z.string().trim().min(1);
+
+export function createModeSchema() {
+  return z
+    .record(z.string().trim().min(1), z.string().trim().min(1).max(200))
+    .refine((value) => Object.keys(value).length > 0, {
+      message: "Jeder Modus benötigt mindestens ein Token.",
+    });
+}
+
+const oklchSchema = z.object({
+  l: z.number(),
+  c: z.number(),
+  h: z.number(),
+  alpha: z.number().min(0).max(1).optional(),
+});
+
+const familyModesSchema = z.record(z.string().min(1), oklchSchema);
+
+const familiesSchema = z.record(z.string().min(1), familyModesSchema);
+
+export const tokenAdjustmentSchema = z.object({
+  deltaL: z.number().optional(),
+  l: z.number().optional(),
+  scaleL: z.number().optional(),
+  deltaC: z.number().optional(),
+  c: z.number().optional(),
+  scaleC: z.number().optional(),
+  h: z.number().optional(),
+  deltaH: z.number().optional(),
+  alpha: z.number().optional(),
+  deltaAlpha: z.number().optional(),
+  scaleAlpha: z.number().optional(),
+  value: z.string().trim().min(1).optional(),
+  family: z.string().trim().min(1).optional(),
+});
+
+const tokenMetaSchema = z.object({
+  description: z.string().trim().max(400).optional(),
+  notes: z.string().trim().max(1000).optional(),
+  tags: z.array(z.string().trim().min(1).max(40)).max(20).optional(),
+});
+
+const semanticTokenSchema = tokenMetaSchema
+  .extend({ family: z.string().trim().min(1) })
+  .catchall(tokenAdjustmentSchema);
+
+export const parametersSchema = z.object({
+  families: familiesSchema,
+  tokens: z.record(z.string().min(1), semanticTokenSchema),
+});
+
+const tokensMetaSchema = z
+  .object({
+    modes: z.array(z.string().trim().min(1)).optional(),
+    generatedAt: z.string().trim().optional(),
+  })
+  .catchall(z.any())
+  .optional();
+
+const modeValuesSchema = createModeSchema();
+
+const themeModesSchema = z
+  .object({
+    light: modeValuesSchema.optional(),
+    dark: modeValuesSchema.optional(),
+  })
+  .catchall(modeValuesSchema)
+  .optional();
+
+export const themeTokensSchema = z.object({
+  radius: z.object({ base: z.string().trim().min(1).max(120) }),
+  parameters: parametersSchema,
+  modes: themeModesSchema,
+  meta: tokensMetaSchema,
+});
+
+export const themeNameSchema = z.string().trim().min(2).max(120);
+
+export const themeDescriptionSchema = z.string().trim().max(500).optional().nullable();

--- a/src/app/api/website/themes/[themeId]/route.ts
+++ b/src/app/api/website/themes/[themeId]/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { themeDescriptionSchema, themeNameSchema, themeTokensSchema } from "../../theme-schemas";
+
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { getWebsiteTheme, saveWebsiteTheme } from "@/lib/website-settings";
+
+const updateThemeSchema = z
+  .object({
+    name: themeNameSchema.optional(),
+    description: themeDescriptionSchema,
+    tokens: themeTokensSchema.optional(),
+  })
+  .optional();
+
+async function ensurePermission() {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.website.settings"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ themeId: string }> }) {
+  const { themeId } = await params;
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  const theme = await getWebsiteTheme(themeId);
+  if (!theme) {
+    return NextResponse.json({ error: "Theme nicht gefunden." }, { status: 404 });
+  }
+
+  return NextResponse.json({ theme });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ themeId: string }> }) {
+  const { themeId } = await params;
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    payload = undefined;
+  }
+
+  const parsed = updateThemeSchema.safeParse(payload);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json({ error: issue?.message ?? "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const input = parsed.data ?? {};
+  if (!input.name && !input.description && !input.tokens) {
+    return NextResponse.json({ error: "Keine Änderungen übermittelt." }, { status: 400 });
+  }
+
+  try {
+    const updated = await saveWebsiteTheme(themeId, {
+      name: input.name ?? undefined,
+      description: input.description ?? undefined,
+      tokens: input.tokens ?? undefined,
+    });
+
+    return NextResponse.json({ theme: await getWebsiteTheme(updated.id) });
+  } catch (error) {
+    console.error("Failed to update website theme", error);
+    return NextResponse.json({ error: "Theme konnte nicht aktualisiert werden." }, { status: 500 });
+  }
+}

--- a/src/app/api/website/themes/route.ts
+++ b/src/app/api/website/themes/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { themeDescriptionSchema, themeIdSchema, themeNameSchema } from "../theme-schemas";
+
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { createWebsiteTheme, listWebsiteThemes, type ClientWebsiteThemeSummary } from "@/lib/website-settings";
+
+const createThemeSchema = z
+  .object({
+    name: themeNameSchema.optional(),
+    description: themeDescriptionSchema,
+    sourceThemeId: themeIdSchema.optional(),
+  })
+  .optional();
+
+async function ensurePermission() {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.website.settings"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET() {
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  try {
+    const themes = await listWebsiteThemes();
+    return NextResponse.json({ themes });
+  } catch (error) {
+    console.error("Failed to list website themes", error);
+    return NextResponse.json({ error: "Themes konnten nicht geladen werden." }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const permissionResponse = await ensurePermission();
+  if (permissionResponse) {
+    return permissionResponse;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    payload = undefined;
+  }
+
+  const parsed = createThemeSchema.safeParse(payload);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return NextResponse.json({ error: issue?.message ?? "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  try {
+    const theme = await createWebsiteTheme(parsed.data ?? {});
+    const summary: ClientWebsiteThemeSummary = {
+      id: theme.id,
+      name: theme.name,
+      description: theme.description,
+      isDefault: theme.isDefault,
+      updatedAt: theme.updatedAt,
+    };
+    return NextResponse.json({ theme, summary });
+  } catch (error) {
+    console.error("Failed to create website theme", error);
+    return NextResponse.json({ error: "Theme konnte nicht erstellt werden." }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- prevent renaming of the default website theme in the member UI and surface a tooltip explaining why
- add three additional preset themes and update the preset list seeding
- document the multi-theme API contract including the new preset inventory

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d25169ca7c832db7381298b391ed5a