### PR TITLE
feat: centralize relative time formatting utilities

### DIFF
--- a/src/app/(members)/mitglieder/archiv-und-bilder/page.tsx
+++ b/src/app/(members)/mitglieder/archiv-und-bilder/page.tsx
@@ -8,6 +8,7 @@ import { PageHeader } from "@/components/members/page-header";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
+import { formatRelativeWithAbsolute } from "@/lib/datetime";
 import {
   GALLERY_START_YEAR,
   createGalleryYearRange,
@@ -31,14 +32,16 @@ type FolderStats = {
   totalSize: number;
 };
 
+const latestUploadFormatter = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
 function formatRelative(date: Date | null) {
   if (!date) {
     return "Noch keine Uploads";
   }
-  return new Intl.DateTimeFormat("de-DE", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(date);
+  return formatRelativeWithAbsolute(date, { absoluteFormatter: latestUploadFormatter }).combined;
 }
 
 export default async function ArchiveOverviewPage() {

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -26,6 +26,7 @@ import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 import { ROLE_BADGE_VARIANTS, ROLE_LABELS, sortRoles, type Role } from "@/lib/roles";
 import { cn } from "@/lib/utils";
+import { formatRelativeFromNow } from "@/lib/datetime";
 import { getUserDisplayName } from "@/lib/names";
 import { MemberTestNotificationCard } from "@/components/members/member-test-notification-card";
 
@@ -38,7 +39,6 @@ const percentFormatter = new Intl.NumberFormat("de-DE", {
   maximumFractionDigits: 1,
 });
 const monthFormatter = new Intl.DateTimeFormat("de-DE", { month: "long", year: "numeric" });
-const relativeTimeFormatter = new Intl.RelativeTimeFormat("de-DE", { numeric: "auto" });
 
 const ATTENDANCE_STATUS_ORDER: AttendanceStatus[] = ["yes", "maybe", "no", "emergency"];
 
@@ -191,45 +191,7 @@ function describeAttendanceChange(
 
 function formatRelativeTime(value: Date | null | undefined) {
   if (!value) return null;
-  const now = Date.now();
-  const diffMs = value.getTime() - now;
-  const diffSeconds = Math.round(diffMs / 1000);
-  const absSeconds = Math.abs(diffSeconds);
-
-  const minute = 60;
-  const hour = minute * 60;
-  const day = hour * 24;
-  const week = day * 7;
-  const month = day * 30;
-  const year = day * 365;
-
-  let unit: Intl.RelativeTimeFormatUnit;
-  let valueToFormat: number;
-
-  if (absSeconds < minute) {
-    unit = "second";
-    valueToFormat = diffSeconds;
-  } else if (absSeconds < hour) {
-    unit = "minute";
-    valueToFormat = Math.round(diffSeconds / minute);
-  } else if (absSeconds < day) {
-    unit = "hour";
-    valueToFormat = Math.round(diffSeconds / hour);
-  } else if (absSeconds < week) {
-    unit = "day";
-    valueToFormat = Math.round(diffSeconds / day);
-  } else if (absSeconds < month) {
-    unit = "week";
-    valueToFormat = Math.round(diffSeconds / week);
-  } else if (absSeconds < year) {
-    unit = "month";
-    valueToFormat = Math.round(diffSeconds / month);
-  } else {
-    unit = "year";
-    valueToFormat = Math.round(diffSeconds / year);
-  }
-
-  return relativeTimeFormatter.format(valueToFormat, unit);
+  return formatRelativeFromNow(value);
 }
 
 type PageProps = { params: { userId: string | string[] } };

--- a/src/components/build-info-timestamp.tsx
+++ b/src/components/build-info-timestamp.tsx
@@ -2,63 +2,18 @@
 
 import { useEffect, useMemo, useState } from "react";
 
+import { formatRelativeFromNow } from "@/lib/datetime";
+
 type BuildInfoTimestampProps = {
   formattedTimestamp: string;
   isoTimestamp: string;
 };
-
-const SECOND = 1;
-const MINUTE = 60 * SECOND;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-const WEEK = 7 * DAY;
-const MONTH = 30.4375 * DAY;
-const YEAR = 365.25 * DAY;
-
-function formatRelativeTime(
-  targetDate: Date,
-  formatter: Intl.RelativeTimeFormat,
-): string {
-  const now = Date.now();
-  const diffInSeconds = (targetDate.getTime() - now) / 1000;
-  const absoluteDiff = Math.abs(diffInSeconds);
-
-  if (absoluteDiff < MINUTE) {
-    return formatter.format(Math.round(diffInSeconds / SECOND), "second");
-  }
-
-  if (absoluteDiff < HOUR) {
-    return formatter.format(Math.round(diffInSeconds / MINUTE), "minute");
-  }
-
-  if (absoluteDiff < DAY) {
-    return formatter.format(Math.round(diffInSeconds / HOUR), "hour");
-  }
-
-  if (absoluteDiff < WEEK) {
-    return formatter.format(Math.round(diffInSeconds / DAY), "day");
-  }
-
-  if (absoluteDiff < MONTH) {
-    return formatter.format(Math.round(diffInSeconds / WEEK), "week");
-  }
-
-  if (absoluteDiff < YEAR) {
-    return formatter.format(Math.round(diffInSeconds / MONTH), "month");
-  }
-
-  return formatter.format(Math.round(diffInSeconds / YEAR), "year");
-}
 
 export function BuildInfoTimestamp({
   formattedTimestamp,
   isoTimestamp,
 }: BuildInfoTimestampProps) {
   const buildDate = useMemo(() => new Date(isoTimestamp), [isoTimestamp]);
-  const relativeTimeFormatter = useMemo(
-    () => new Intl.RelativeTimeFormat("de", { numeric: "auto" }),
-    [],
-  );
   const isValidTimestamp = !Number.isNaN(buildDate.getTime());
   const [relativeTime, setRelativeTime] = useState<string | null>(null);
 
@@ -68,7 +23,7 @@ export function BuildInfoTimestamp({
     }
 
     const updateRelativeTime = () => {
-      setRelativeTime(formatRelativeTime(buildDate, relativeTimeFormatter));
+      setRelativeTime(formatRelativeFromNow(buildDate));
     };
 
     updateRelativeTime();
@@ -78,7 +33,7 @@ export function BuildInfoTimestamp({
     return () => {
       window.clearInterval(interval);
     };
-  }, [buildDate, isValidTimestamp, relativeTimeFormatter]);
+  }, [buildDate, isValidTimestamp]);
 
   if (!isValidTimestamp) {
     return <span>Stand {formattedTimestamp}</span>;

--- a/src/components/members/measurements/member-measurements-control-center.tsx
+++ b/src/components/members/measurements/member-measurements-control-center.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/data/measurements";
 import { ROLE_BADGE_VARIANTS, ROLE_LABELS, type Role } from "@/lib/roles";
 import { cn } from "@/lib/utils";
+import { formatRelativeWithAbsolute } from "@/lib/datetime";
 
 type MeasurementEntry = {
   id: string;
@@ -83,20 +84,6 @@ const ABSOLUTE_DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
   month: "2-digit",
   year: "numeric",
 });
-const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("de-DE", {
-  numeric: "auto",
-});
-
-const RELATIVE_TIME_UNITS: { unit: Intl.RelativeTimeFormatUnit; seconds: number }[] = [
-  { unit: "year", seconds: 60 * 60 * 24 * 365 },
-  { unit: "month", seconds: 60 * 60 * 24 * 30 },
-  { unit: "week", seconds: 60 * 60 * 24 * 7 },
-  { unit: "day", seconds: 60 * 60 * 24 },
-  { unit: "hour", seconds: 60 * 60 },
-  { unit: "minute", seconds: 60 },
-  { unit: "second", seconds: 1 },
-];
-
 export function MemberMeasurementsControlCenter({
   members,
 }: MemberMeasurementsControlCenterProps) {
@@ -676,15 +663,7 @@ function formatLastUpdated(value: string | null) {
   if (Number.isNaN(timestamp)) {
     return "Letzte Aktualisierung unbekannt";
   }
-  const now = Date.now();
-  const diffInSeconds = Math.round((timestamp - now) / 1000);
-  for (const { unit, seconds } of RELATIVE_TIME_UNITS) {
-    if (Math.abs(diffInSeconds) >= seconds || unit === "second") {
-      const relative = RELATIVE_TIME_FORMATTER.format(Math.round(diffInSeconds / seconds), unit);
-      const absolute = ABSOLUTE_DATE_FORMATTER.format(new Date(timestamp));
-      return `${relative} • ${absolute}`;
-    }
-  }
-  return ABSOLUTE_DATE_FORMATTER.format(new Date(timestamp));
+  const date = new Date(timestamp);
+  return formatRelativeWithAbsolute(date, { absoluteFormatter: ABSOLUTE_DATE_FORMATTER }).combined;
 }
 

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -21,6 +21,7 @@ import {
 import { DropdownMenu } from "@/components/ui/dropdown-menu";
 import { ROLE_LABELS, ROLES, sortRoles } from "@/lib/roles";
 import { cn } from "@/lib/utils";
+import { formatRelativeFromNow } from "@/lib/datetime";
 
 const ASSIGNABLE_ROLES = ROLES.filter((role) => role !== "admin" && role !== "owner");
 
@@ -31,52 +32,12 @@ const statusLabelMap = {
   exhausted: { label: "Verbraucht", variant: "outline" as const },
 };
 
-const RECENT_RELATIVE_FORMATTER = new Intl.RelativeTimeFormat("de-DE", { numeric: "auto" });
 const RECENT_ABSOLUTE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
   dateStyle: "medium",
   timeStyle: "short",
 });
 
-const SECOND = 1;
-const MINUTE = 60 * SECOND;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-const WEEK = 7 * DAY;
-const MONTH = 30.4375 * DAY;
-const YEAR = 365.25 * DAY;
-
 type RecentClickDescriptor = { iso: string; relative: string; absolute: string };
-
-function formatRelativeFromNow(date: Date) {
-  const diffInSeconds = (date.getTime() - Date.now()) / 1000;
-  const absoluteDiff = Math.abs(diffInSeconds);
-
-  if (absoluteDiff < MINUTE) {
-    return RECENT_RELATIVE_FORMATTER.format(Math.round(diffInSeconds / SECOND), "second");
-  }
-
-  if (absoluteDiff < HOUR) {
-    return RECENT_RELATIVE_FORMATTER.format(Math.round(diffInSeconds / MINUTE), "minute");
-  }
-
-  if (absoluteDiff < DAY) {
-    return RECENT_RELATIVE_FORMATTER.format(Math.round(diffInSeconds / HOUR), "hour");
-  }
-
-  if (absoluteDiff < WEEK) {
-    return RECENT_RELATIVE_FORMATTER.format(Math.round(diffInSeconds / DAY), "day");
-  }
-
-  if (absoluteDiff < MONTH) {
-    return RECENT_RELATIVE_FORMATTER.format(Math.round(diffInSeconds / WEEK), "week");
-  }
-
-  if (absoluteDiff < YEAR) {
-    return RECENT_RELATIVE_FORMATTER.format(Math.round(diffInSeconds / MONTH), "month");
-  }
-
-  return RECENT_RELATIVE_FORMATTER.format(Math.round(diffInSeconds / YEAR), "year");
-}
 
 function buildRecentClickDetails(timestamps: string[]): RecentClickDescriptor[] {
   return timestamps

--- a/src/lib/__tests__/datetime.test.ts
+++ b/src/lib/__tests__/datetime.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatRelativeBetween,
+  formatRelativeFromNow,
+  formatRelativeWithAbsolute,
+} from "@/lib/datetime";
+
+describe("datetime utilities", () => {
+  describe("formatRelativeFromNow", () => {
+    it("formats short past differences in seconds", () => {
+      const now = new Date("2024-06-01T12:00:00Z");
+      const past = new Date("2024-06-01T11:59:45Z");
+
+      expect(formatRelativeFromNow(past, { now })).toBe("vor 15 Sekunden");
+    });
+
+    it("formats future values using larger units", () => {
+      const now = new Date("2024-06-01T12:00:00Z");
+      const future = new Date("2024-06-01T14:30:00Z");
+
+      expect(formatRelativeFromNow(future, { now })).toBe("in 3 Stunden");
+    });
+
+    it("accepts numeric timestamps as the reference", () => {
+      const reference = Date.UTC(2024, 5, 1, 12, 0, 0);
+      const past = new Date(reference - 2 * 60 * 60 * 1000);
+
+      expect(formatRelativeFromNow(past, { now: reference })).toBe("vor 2 Stunden");
+    });
+  });
+
+  describe("formatRelativeBetween", () => {
+    it("honours custom formatters", () => {
+      const reference = new Date("2024-01-01T00:00:00Z");
+      const target = new Date("2024-01-02T00:00:00Z");
+      const englishFormatter = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+      expect(
+        formatRelativeBetween(target, reference, { formatter: englishFormatter }),
+      ).toBe("tomorrow");
+    });
+  });
+
+  describe("formatRelativeWithAbsolute", () => {
+    it("combines relative and absolute representations", () => {
+      const now = new Date("2024-01-10T12:00:00Z");
+      const past = new Date("2024-01-08T10:30:00Z");
+      const absoluteFormatter = new Intl.DateTimeFormat("de-DE", {
+        dateStyle: "medium",
+        timeStyle: "short",
+        timeZone: "UTC",
+      });
+
+      const result = formatRelativeWithAbsolute(past, {
+        now,
+        absoluteFormatter,
+        separator: " / ",
+      });
+
+      expect(result.relative).toBe("vorgestern");
+      expect(result.absolute).toBe("08.01.2024, 10:30");
+      expect(result.combined).toBe("vorgestern / 08.01.2024, 10:30");
+    });
+  });
+});

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,117 @@
+const SECONDS_PER_SECOND = 1;
+const SECONDS_PER_MINUTE = 60 * SECONDS_PER_SECOND;
+const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR;
+const SECONDS_PER_WEEK = 7 * SECONDS_PER_DAY;
+const SECONDS_PER_MONTH = 30.4375 * SECONDS_PER_DAY;
+const SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY;
+
+export type RelativeTimeSegment = {
+  unit: Intl.RelativeTimeFormatUnit;
+  threshold: number;
+  divisor: number;
+};
+
+export const RELATIVE_TIME_SEGMENTS = [
+  { unit: "second", threshold: SECONDS_PER_MINUTE, divisor: SECONDS_PER_SECOND },
+  { unit: "minute", threshold: SECONDS_PER_HOUR, divisor: SECONDS_PER_MINUTE },
+  { unit: "hour", threshold: SECONDS_PER_DAY, divisor: SECONDS_PER_HOUR },
+  { unit: "day", threshold: SECONDS_PER_WEEK, divisor: SECONDS_PER_DAY },
+  { unit: "week", threshold: SECONDS_PER_MONTH, divisor: SECONDS_PER_WEEK },
+  { unit: "month", threshold: SECONDS_PER_YEAR, divisor: SECONDS_PER_MONTH },
+  { unit: "year", threshold: Number.POSITIVE_INFINITY, divisor: SECONDS_PER_YEAR },
+] as const satisfies readonly RelativeTimeSegment[];
+
+export const DEFAULT_RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("de-DE", {
+  numeric: "auto",
+});
+
+export const DEFAULT_ABSOLUTE_DATETIME_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+type RelativeTimeOptions = {
+  formatter?: Intl.RelativeTimeFormat;
+  segments?: readonly RelativeTimeSegment[];
+  roundingMethod?: (value: number) => number;
+};
+
+type RelativeFromNowOptions = RelativeTimeOptions & {
+  now?: Date | number;
+};
+
+type RelativeWithAbsoluteOptions = RelativeFromNowOptions & {
+  absoluteFormatter?: Intl.DateTimeFormat;
+  separator?: string;
+};
+
+function resolveReferenceDate(now?: Date | number): Date {
+  if (now instanceof Date) {
+    return now;
+  }
+
+  if (typeof now === "number") {
+    return new Date(now);
+  }
+
+  return new Date();
+}
+
+function selectSegment(
+  diffInSeconds: number,
+  segments: readonly RelativeTimeSegment[],
+): { unit: Intl.RelativeTimeFormatUnit; value: number } {
+  const absolute = Math.abs(diffInSeconds);
+
+  for (const segment of segments) {
+    if (absolute < segment.threshold) {
+      return {
+        unit: segment.unit,
+        value: diffInSeconds / segment.divisor,
+      };
+    }
+  }
+
+  const fallback = segments[segments.length - 1];
+  return {
+    unit: fallback.unit,
+    value: diffInSeconds / fallback.divisor,
+  };
+}
+
+export function formatRelativeBetween(
+  target: Date,
+  reference: Date,
+  options: RelativeTimeOptions = {},
+): string {
+  const { formatter = DEFAULT_RELATIVE_TIME_FORMATTER, segments = RELATIVE_TIME_SEGMENTS, roundingMethod = Math.round } =
+    options;
+  const diffInSeconds = (target.getTime() - reference.getTime()) / 1000;
+  const { unit, value } = selectSegment(diffInSeconds, segments);
+  return formatter.format(roundingMethod(value), unit);
+}
+
+export function formatRelativeFromNow(
+  date: Date,
+  options: RelativeFromNowOptions = {},
+): string {
+  const { now, ...rest } = options;
+  const reference = resolveReferenceDate(now);
+  return formatRelativeBetween(date, reference, rest);
+}
+
+export function formatRelativeWithAbsolute(
+  date: Date,
+  options: RelativeWithAbsoluteOptions = {},
+): { relative: string; absolute: string; combined: string } {
+  const { absoluteFormatter = DEFAULT_ABSOLUTE_DATETIME_FORMATTER, separator = " • ", ...relativeOptions } = options;
+  const relative = formatRelativeFromNow(date, relativeOptions);
+  const absolute = absoluteFormatter.format(date);
+
+  return {
+    relative,
+    absolute,
+    combined: `${relative}${separator}${absolute}`,
+  };
+}


### PR DESCRIPTION
## Summary
- add shared relative time helpers under `src/lib/datetime.ts`
- switch build info, member invite manager, archive overview, measurements dashboard and member management to the shared helpers
- document the new API with dedicated Vitest coverage

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2590ce77c832dbef76bf14ba0c5d3