### PR TITLE
Refactor realtime server helpers and add tests

### DIFF
--- a/realtime-server/package.json
+++ b/realtime-server/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "start": "node src/server.js"
+    "start": "node src/server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "socket.io": "^4.8.1"

--- a/realtime-server/src/__tests__/analytics.test.js
+++ b/realtime-server/src/__tests__/analytics.test.js
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createAnalyticsManager } from '../analytics.js';
+
+test('analytics manager refreshes snapshots with fallback data', async () => {
+  const staticData = {
+    resourceUsage: [],
+    deviceBreakdown: [{ label: 'Mobile', value: 50 }],
+    publicPages: [{ path: '/home', ttfb: 120 }],
+    memberPages: [{ path: '/members', ttfb: 140 }],
+  };
+
+  let currentTime = 1_000;
+  let resourceCalls = 0;
+
+  const toISO = (value) => new Date(value).toISOString();
+
+  const manager = createAnalyticsManager({
+    logger: { warn: () => {}, error: () => {} },
+    intervalMs: 2_500,
+    maxAgeMs: 5_000,
+    toISO,
+    now: () => currentTime,
+    loadStaticData: () => JSON.parse(JSON.stringify(staticData)),
+    collectResourceUsage: async ({ previousResourceUsage }) => {
+      assert.ok(previousResourceUsage instanceof Map);
+      resourceCalls += 1;
+      return [
+        {
+          id: 'app-cpu',
+          label: 'CPU',
+          usagePercent: 37.5,
+          capacity: '2 cores',
+        },
+      ];
+    },
+    importAnalyticsModule: async () => {
+      const error = new Error('not found');
+      error.code = 'ERR_MODULE_NOT_FOUND';
+      throw error;
+    },
+    getDatabaseUrl: () => null,
+  });
+
+  const firstSnapshot = await manager.refresh();
+  assert.equal(firstSnapshot.generatedAt, toISO(1_000));
+  assert.deepEqual(firstSnapshot.resourceUsage, [
+    {
+      id: 'app-cpu',
+      label: 'CPU',
+      usagePercent: 37.5,
+      capacity: '2 cores',
+    },
+  ]);
+  assert.deepEqual(firstSnapshot.deviceBreakdown, [{ label: 'Mobile', value: 50 }]);
+  assert.equal(resourceCalls, 1);
+
+  const cachedSnapshot = await manager.getSnapshot();
+  assert.strictEqual(cachedSnapshot, firstSnapshot);
+  assert.equal(resourceCalls, 1);
+
+  currentTime = 7_000;
+  const refreshedSnapshot = await manager.getSnapshot();
+  assert.equal(refreshedSnapshot.generatedAt, toISO(7_000));
+  assert.equal(resourceCalls, 2);
+
+  firstSnapshot.deviceBreakdown[0].value = 0;
+  currentTime = 12_000;
+  const nextSnapshot = await manager.refresh();
+  assert.equal(nextSnapshot.generatedAt, toISO(12_000));
+  assert.equal(nextSnapshot.deviceBreakdown[0].value, 50);
+  assert.equal(resourceCalls, 3);
+});

--- a/realtime-server/src/__tests__/handshake.test.js
+++ b/realtime-server/src/__tests__/handshake.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { test } from 'node:test';
+import { parseHandshakeToken, verifyHandshake } from '../handshake.js';
+
+test('verifyHandshake accepts valid tokens', () => {
+  const secret = 'super-secret';
+  const userId = 'user-123';
+  const issuedAt = 1_000_000;
+  const expiresAt = issuedAt + 10_000;
+  const base = `${userId}:${issuedAt}:${expiresAt}`;
+  const signature = createHmac('sha256', secret).update(base).digest('hex');
+  const token = `${issuedAt}.${expiresAt}.${signature}`;
+
+  const result = verifyHandshake({ userId, token, secret, now: () => issuedAt + 1_000 });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.issuedAt, issuedAt);
+  assert.equal(result.expiresAt, expiresAt);
+});
+
+test('verifyHandshake rejects expired tokens', () => {
+  const secret = 'another-secret';
+  const userId = 'user-456';
+  const issuedAt = 2_000_000;
+  const expiresAt = issuedAt + 5_000;
+  const base = `${userId}:${issuedAt}:${expiresAt}`;
+  const signature = createHmac('sha256', secret).update(base).digest('hex');
+  const token = `${issuedAt}.${expiresAt}.${signature}`;
+
+  const result = verifyHandshake({ userId, token, secret, now: () => expiresAt + 1 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'Token expired');
+});
+
+test('parseHandshakeToken returns null for malformed tokens', () => {
+  assert.equal(parseHandshakeToken('not-a-token'), null);
+  assert.equal(parseHandshakeToken('1.two.three.four'), null);
+  assert.equal(parseHandshakeToken('1.two'), null);
+});

--- a/realtime-server/src/analytics.js
+++ b/realtime-server/src/analytics.js
@@ -1,0 +1,483 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import { setTimeout as wait } from 'node:timers/promises';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const analyticsStaticData = require('../../src/data/server-analytics-static.json');
+
+const fallbackAnalyticsModule = {
+  applyPagePerformanceMetrics(baseEntries = []) {
+    if (!Array.isArray(baseEntries)) {
+      return [];
+    }
+    return baseEntries.map((entry) => ({ ...entry }));
+  },
+  mergeDeviceBreakdown(baseEntries = []) {
+    if (!Array.isArray(baseEntries)) {
+      return [];
+    }
+    return baseEntries.map((entry) => ({ ...entry }));
+  },
+};
+
+function cloneStaticAnalyticsData() {
+  return JSON.parse(JSON.stringify(analyticsStaticData));
+}
+
+function clamp(value, min, max) {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+}
+
+function readCpuTimes() {
+  return os.cpus().reduce(
+    (accumulator, cpu) => {
+      const times = cpu.times;
+      const total = times.user + times.nice + times.sys + times.idle + times.irq;
+      return {
+        idle: accumulator.idle + times.idle,
+        total: accumulator.total + total,
+      };
+    },
+    { idle: 0, total: 0 },
+  );
+}
+
+async function measureCpuUsagePercent(intervalMs = 200) {
+  const start = readCpuTimes();
+  if (start.total === 0) {
+    return 0;
+  }
+
+  await wait(intervalMs);
+
+  const end = readCpuTimes();
+  const totalDelta = end.total - start.total;
+  if (totalDelta <= 0) {
+    return 0;
+  }
+
+  const idleDelta = end.idle - start.idle;
+  const usage = 1 - idleDelta / totalDelta;
+  if (!Number.isFinite(usage) || usage < 0) {
+    return 0;
+  }
+
+  return clamp(usage * 100, 0, 100);
+}
+
+function getMemoryUsageSnapshot() {
+  const total = os.totalmem();
+  const free = os.freemem();
+
+  const totalBytes = clamp(total, 0, Number.MAX_SAFE_INTEGER);
+  const freeBytes = clamp(Math.min(free, totalBytes), 0, totalBytes);
+  const usedBytes = Math.max(totalBytes - freeBytes, 0);
+  const usagePercent = totalBytes > 0 ? (usedBytes / totalBytes) * 100 : 0;
+
+  return {
+    usagePercent,
+    totalBytes,
+    freeBytes,
+  };
+}
+
+async function getDiskUsageSnapshot(path) {
+  const stats = await fs.statfs(path);
+
+  const blockSize = clamp(stats.bsize ?? 0, 0, Number.MAX_SAFE_INTEGER);
+  const totalBlocks = clamp(stats.blocks ?? 0, 0, Number.MAX_SAFE_INTEGER);
+  const availableBlocksValue = typeof stats.bavail === 'number' && stats.bavail >= 0 ? stats.bavail : stats.bfree ?? 0;
+  const availableBlocks = clamp(availableBlocksValue, 0, totalBlocks);
+
+  const totalBytes = blockSize * totalBlocks;
+  const freeBytes = blockSize * availableBlocks;
+  const usedBytes = Math.max(totalBytes - freeBytes, 0);
+  const usagePercent = totalBytes > 0 ? (usedBytes / totalBytes) * 100 : 0;
+
+  return {
+    usagePercent,
+    totalBytes,
+    freeBytes,
+    path,
+  };
+}
+
+function calculateChangePercent(previousUsageMap, id, currentValue) {
+  const previous = previousUsageMap.get(id);
+  previousUsageMap.set(id, currentValue);
+
+  if (previous === undefined || previous <= 0) {
+    return 0;
+  }
+
+  const change = (currentValue - previous) / previous;
+  if (!Number.isFinite(change)) {
+    return 0;
+  }
+
+  return clamp(change, -5, 5);
+}
+
+function finalizeResourceMeasurement(previousUsageMap, measurement) {
+  const sanitizedUsage = clamp(measurement.usagePercent, 0, 100);
+  const roundedUsage = Math.round(sanitizedUsage * 10) / 10;
+  const changePercent =
+    Math.round(calculateChangePercent(previousUsageMap, measurement.id, roundedUsage) * 100) / 100;
+
+  return {
+    ...measurement,
+    usagePercent: roundedUsage,
+    changePercent,
+  };
+}
+
+async function collectSystemResourceUsage({ previousResourceUsage, logError, diskPath }) {
+  const resources = [];
+
+  const cpuCount = Math.max(os.cpus().length, 1);
+  const loadAverages = os.loadavg();
+  const loadOneMinuteRaw = loadAverages.length > 0 ? loadAverages[0] : 0;
+  const loadOneMinute = Number.isFinite(loadOneMinuteRaw) ? loadOneMinuteRaw : 0;
+
+  const targetDiskPath = diskPath || process.cwd();
+
+  const [cpuUsagePercent, diskUsage] = await Promise.all([
+    measureCpuUsagePercent().catch((error) => {
+      logError('[server-analytics] CPU usage probe failed', error);
+      return null;
+    }),
+    getDiskUsageSnapshot(targetDiskPath).catch((error) => {
+      logError(`[server-analytics] Disk usage probe failed for ${targetDiskPath}`, error);
+      return null;
+    }),
+  ]);
+
+  if (cpuUsagePercent !== null) {
+    resources.push({
+      id: 'app-cpu',
+      label: 'App-Server CPU',
+      usagePercent: cpuUsagePercent,
+      capacity: `${cpuCount} Kern${cpuCount === 1 ? '' : 'e'} · Load 1m ${loadOneMinute.toFixed(2)}`,
+    });
+  }
+
+  const memoryUsage = getMemoryUsageSnapshot();
+  resources.push({
+    id: 'app-ram',
+    label: 'Arbeitsspeicher',
+    usagePercent: memoryUsage.usagePercent,
+    capacity: `${formatBytes(memoryUsage.totalBytes)} gesamt · ${formatBytes(memoryUsage.freeBytes)} frei`,
+  });
+
+  if (diskUsage !== null) {
+    const normalizedPath = diskUsage.path === '' ? '/' : diskUsage.path;
+    resources.push({
+      id: 'app-disk',
+      label: `Dateisystem (${normalizedPath})`,
+      usagePercent: diskUsage.usagePercent,
+      capacity: `${formatBytes(diskUsage.totalBytes)} gesamt · ${formatBytes(diskUsage.freeBytes)} frei`,
+    });
+  }
+
+  if (resources.length === 0) {
+    throw new Error('Keine Systemressourcen konnten ermittelt werden');
+  }
+
+  return resources.map((resource) => finalizeResourceMeasurement(previousResourceUsage, resource));
+}
+
+function isModuleNotFoundError(error) {
+  if (!error) {
+    return false;
+  }
+  return error.code === 'ERR_MODULE_NOT_FOUND' || error.code === 'MODULE_NOT_FOUND';
+}
+
+export function createAnalyticsManager({
+  logger = console,
+  intervalMs = 2000,
+  maxAgeMs,
+  importAnalyticsModule = () => import('../../src/lib/server-analytics-data.js'),
+  loadStaticData = () => cloneStaticAnalyticsData(),
+  collectResourceUsage,
+  getDatabaseUrl = () => process.env.DATABASE_URL,
+  now = () => Date.now(),
+  toISO = (value) => new Date(value).toISOString(),
+  diskPath = process.cwd(),
+} = {}) {
+  const state = {
+    latestAnalytics: null,
+    refreshPromise: null,
+    modulePromise: null,
+    moduleMissingLogged: false,
+    moduleErrorLogged: false,
+    previousResourceUsage: new Map(),
+    intervalId: null,
+  };
+
+  const logError =
+    typeof logger?.error === 'function' ? (...args) => logger.error(...args) : (...args) => console.error(...args);
+  const logWarn =
+    typeof logger?.warn === 'function' ? (...args) => logger.warn(...args) : (...args) => console.warn(...args);
+
+  const resolvedInterval = Math.max(Number(intervalMs) || 0, 2000);
+  const resolvedMaxAge = Math.max(Number(maxAgeMs) || resolvedInterval * 1.5, resolvedInterval);
+
+  const resourceUsageCollector =
+    typeof collectResourceUsage === 'function'
+      ? collectResourceUsage
+      : ({ previousResourceUsage }) =>
+          collectSystemResourceUsage({ previousResourceUsage, logError, diskPath });
+
+  function logMissingAnalyticsModule(message, error) {
+    if (state.moduleMissingLogged) {
+      return;
+    }
+    state.moduleMissingLogged = true;
+    if (error) {
+      logWarn(message, error);
+      return;
+    }
+    logWarn(message);
+  }
+
+  function logAnalyticsModuleError(error) {
+    if (state.moduleErrorLogged) {
+      return;
+    }
+    state.moduleErrorLogged = true;
+    logError('[Realtime] Failed to load optional server analytics module', error);
+  }
+
+  async function resolveAnalyticsModule() {
+    if (!state.modulePromise) {
+      state.modulePromise = importAnalyticsModule()
+        .then((module) => {
+          if (
+            !module ||
+            typeof module.applyPagePerformanceMetrics !== 'function' ||
+            typeof module.mergeDeviceBreakdown !== 'function'
+          ) {
+            logMissingAnalyticsModule(
+              '[Realtime] server-analytics-data module is missing expected exports. Falling back to static analytics.',
+            );
+            return null;
+          }
+          return module;
+        })
+        .catch((error) => {
+          if (isModuleNotFoundError(error)) {
+            logMissingAnalyticsModule(
+              '[Realtime] server-analytics-data module not found. Falling back to static analytics.',
+              error,
+            );
+            return null;
+          }
+          logAnalyticsModuleError(error);
+          return null;
+        });
+    }
+
+    return state.modulePromise;
+  }
+
+  function createFallbackSnapshot() {
+    const base = loadStaticData();
+    return { generatedAt: toISO(now()), ...base };
+  }
+
+  async function collectAnalyticsSnapshot() {
+    const base = loadStaticData();
+    let resourceUsage = base.resourceUsage;
+    try {
+      resourceUsage = await resourceUsageCollector({
+        previousResourceUsage: state.previousResourceUsage,
+        logError,
+        diskPath,
+      });
+    } catch (error) {
+      logError('[Realtime] Verwende statische Ressourcenwerte für Server-Analytics', error);
+    }
+
+    let deviceBreakdown = base.deviceBreakdown ?? [];
+    let publicPages = base.publicPages ?? [];
+    let memberPages = base.memberPages ?? [];
+
+    const analyticsModule = await resolveAnalyticsModule();
+    const mergeDeviceBreakdownFn =
+      typeof analyticsModule?.mergeDeviceBreakdown === 'function'
+        ? analyticsModule.mergeDeviceBreakdown
+        : fallbackAnalyticsModule.mergeDeviceBreakdown;
+    const applyPagePerformanceMetricsFn =
+      typeof analyticsModule?.applyPagePerformanceMetrics === 'function'
+        ? analyticsModule.applyPagePerformanceMetrics
+        : fallbackAnalyticsModule.applyPagePerformanceMetrics;
+    const loadDeviceBreakdownFromDatabaseFn =
+      typeof analyticsModule?.loadDeviceBreakdownFromDatabase === 'function'
+        ? analyticsModule.loadDeviceBreakdownFromDatabase
+        : null;
+    const loadPagePerformanceMetricsFn =
+      typeof analyticsModule?.loadPagePerformanceMetrics === 'function'
+        ? analyticsModule.loadPagePerformanceMetrics
+        : null;
+
+    if (getDatabaseUrl() && loadDeviceBreakdownFromDatabaseFn && loadPagePerformanceMetricsFn) {
+      const [deviceOverrides, pageMetrics] = await Promise.all([
+        loadDeviceBreakdownFromDatabaseFn().catch((error) => {
+          logError('[Realtime] Failed to load device analytics', error);
+          return null;
+        }),
+        loadPagePerformanceMetricsFn().catch((error) => {
+          logError('[Realtime] Failed to load page performance metrics', error);
+          return [];
+        }),
+      ]);
+
+      deviceBreakdown = mergeDeviceBreakdownFn(deviceBreakdown, deviceOverrides ?? undefined);
+
+      if (Array.isArray(pageMetrics) && pageMetrics.length > 0) {
+        publicPages = applyPagePerformanceMetricsFn(publicPages, pageMetrics, 'public');
+        memberPages = applyPagePerformanceMetricsFn(memberPages, pageMetrics, 'members');
+      } else {
+        publicPages = publicPages.map((entry) => ({ ...entry }));
+        memberPages = memberPages.map((entry) => ({ ...entry }));
+      }
+    } else {
+      deviceBreakdown = mergeDeviceBreakdownFn(deviceBreakdown);
+      publicPages = applyPagePerformanceMetricsFn(publicPages, [], 'public');
+      memberPages = applyPagePerformanceMetricsFn(memberPages, [], 'members');
+    }
+
+    return {
+      generatedAt: toISO(now()),
+      ...base,
+      resourceUsage,
+      deviceBreakdown,
+      publicPages,
+      memberPages,
+    };
+  }
+
+  function analyticsIsFresh() {
+    if (!state.latestAnalytics) {
+      return false;
+    }
+    const timestamp = Date.parse(state.latestAnalytics.generatedAt);
+    if (!Number.isFinite(timestamp)) {
+      return false;
+    }
+    const currentTime = Number(now());
+    if (!Number.isFinite(currentTime)) {
+      return false;
+    }
+    return currentTime - timestamp < resolvedMaxAge;
+  }
+
+  async function refreshAnalytics() {
+    if (state.refreshPromise) {
+      return state.refreshPromise;
+    }
+
+    state.refreshPromise = collectAnalyticsSnapshot()
+      .then((snapshot) => {
+        state.latestAnalytics = snapshot;
+        return snapshot;
+      })
+      .catch((error) => {
+        logError('[Realtime] Failed to refresh analytics snapshot', error);
+        if (state.latestAnalytics) {
+          return state.latestAnalytics;
+        }
+        const fallback = createFallbackSnapshot();
+        state.latestAnalytics = fallback;
+        return fallback;
+      })
+      .finally(() => {
+        state.refreshPromise = null;
+      });
+
+    return state.refreshPromise;
+  }
+
+  async function getAnalyticsSnapshot() {
+    if (analyticsIsFresh()) {
+      return state.latestAnalytics;
+    }
+    return refreshAnalytics();
+  }
+
+  function emitAnalytics(target, analytics) {
+    if (!analytics || typeof target?.emit !== 'function') {
+      return;
+    }
+    target.emit('server_analytics_update', {
+      type: 'server_analytics_update',
+      timestamp: analytics.generatedAt ?? toISO(now()),
+      analytics,
+    });
+  }
+
+  async function broadcastOnce(io) {
+    try {
+      const analytics = await refreshAnalytics();
+      emitAnalytics(io, analytics);
+    } catch (error) {
+      logError('[Realtime] Failed to broadcast analytics update', error);
+    }
+  }
+
+  function start(io) {
+    if (!io) {
+      throw new Error('Socket server instance is required to schedule analytics updates');
+    }
+    stop();
+    state.intervalId = setInterval(() => {
+      broadcastOnce(io);
+    }, resolvedInterval);
+    if (typeof state.intervalId?.unref === 'function') {
+      state.intervalId.unref();
+    }
+    refreshAnalytics().catch((error) => {
+      logError('[Realtime] Initial analytics snapshot failed', error);
+    });
+  }
+
+  function stop() {
+    if (state.intervalId) {
+      clearInterval(state.intervalId);
+      state.intervalId = null;
+    }
+  }
+
+  return {
+    start,
+    stop,
+    refresh: refreshAnalytics,
+    getSnapshot: getAnalyticsSnapshot,
+    emit: emitAnalytics,
+    isFresh: analyticsIsFresh,
+    state,
+  };
+}

--- a/realtime-server/src/createRealtimeServer.js
+++ b/realtime-server/src/createRealtimeServer.js
@@ -1,92 +1,9 @@
-import fs from 'node:fs/promises';
-import { createHmac, timingSafeEqual } from 'node:crypto';
 import { createServer } from 'http';
-import os from 'node:os';
-import { setTimeout as wait } from 'node:timers/promises';
 import { Server } from 'socket.io';
 import { URL } from 'url';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const analyticsStaticData = require('../../src/data/server-analytics-static.json');
-
-const fallbackAnalyticsModule = {
-  applyPagePerformanceMetrics(baseEntries = []) {
-    if (!Array.isArray(baseEntries)) {
-      return [];
-    }
-    return baseEntries.map((entry) => ({ ...entry }));
-  },
-  mergeDeviceBreakdown(baseEntries = []) {
-    if (!Array.isArray(baseEntries)) {
-      return [];
-    }
-    return baseEntries.map((entry) => ({ ...entry }));
-  },
-};
-
-let analyticsModulePromise = null;
-let analyticsModuleMissingLogged = false;
-let analyticsModuleErrorLogged = false;
-
-function isModuleNotFoundError(error) {
-  if (!error) {
-    return false;
-  }
-  return error.code === 'ERR_MODULE_NOT_FOUND' || error.code === 'MODULE_NOT_FOUND';
-}
-
-function logMissingAnalyticsModule(message, error) {
-  if (analyticsModuleMissingLogged) {
-    return;
-  }
-  analyticsModuleMissingLogged = true;
-  if (error) {
-    console.warn(message, error);
-    return;
-  }
-  console.warn(message);
-}
-
-function logAnalyticsModuleError(error) {
-  if (analyticsModuleErrorLogged) {
-    return;
-  }
-  analyticsModuleErrorLogged = true;
-  console.error('[Realtime] Failed to load optional server analytics module', error);
-}
-
-function resolveAnalyticsModule() {
-  if (!analyticsModulePromise) {
-    analyticsModulePromise = import('../../src/lib/server-analytics-data.js')
-      .then((module) => {
-        if (
-          !module ||
-          typeof module.applyPagePerformanceMetrics !== 'function' ||
-          typeof module.mergeDeviceBreakdown !== 'function'
-        ) {
-          logMissingAnalyticsModule(
-            '[Realtime] server-analytics-data module is missing expected exports. Falling back to static analytics.',
-          );
-          return null;
-        }
-        return module;
-      })
-      .catch((error) => {
-        if (isModuleNotFoundError(error)) {
-          logMissingAnalyticsModule(
-            '[Realtime] server-analytics-data module not found. Falling back to static analytics.',
-            error,
-          );
-          return null;
-        }
-        logAnalyticsModuleError(error);
-        return null;
-      });
-  }
-
-  return analyticsModulePromise;
-}
+import { createAnalyticsManager } from './analytics.js';
+import { verifyHandshake } from './handshake.js';
+import { createEventHandlers } from './events.js';
 
 function toISO(date) {
   return new Date(date).toISOString();
@@ -96,18 +13,6 @@ function createJsonResponse(res, statusCode, payload) {
   res.statusCode = statusCode;
   res.setHeader('Content-Type', 'application/json');
   res.end(JSON.stringify(payload));
-}
-
-function parseHandshakeToken(token) {
-  if (typeof token !== 'string') return null;
-  const parts = token.split('.');
-  if (parts.length !== 3) return null;
-  const [issuedAtRaw, expiresAtRaw, signature] = parts;
-  const issuedAt = Number(issuedAtRaw);
-  const expiresAt = Number(expiresAtRaw);
-  if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt)) return null;
-  if (!signature || typeof signature !== 'string') return null;
-  return { issuedAt, expiresAt, signature };
 }
 
 function normalizePath(path, fallback = '/') {
@@ -129,194 +34,6 @@ function resolveNumber(value, fallback) {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
-const previousResourceUsage = new Map();
-
-function cloneStaticAnalyticsData() {
-  return JSON.parse(JSON.stringify(analyticsStaticData));
-}
-
-function clamp(value, min, max) {
-  if (!Number.isFinite(value)) {
-    return min;
-  }
-  return Math.min(Math.max(value, min), max);
-}
-
-function formatBytes(bytes) {
-  if (!Number.isFinite(bytes) || bytes <= 0) {
-    return '0 B';
-  }
-
-  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
-  let value = bytes;
-  let unitIndex = 0;
-
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024;
-    unitIndex += 1;
-  }
-
-  const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2;
-  return `${value.toFixed(decimals)} ${units[unitIndex]}`;
-}
-
-function readCpuTimes() {
-  return os.cpus().reduce(
-    (accumulator, cpu) => {
-      const times = cpu.times;
-      const total = times.user + times.nice + times.sys + times.idle + times.irq;
-      return {
-        idle: accumulator.idle + times.idle,
-        total: accumulator.total + total,
-      };
-    },
-    { idle: 0, total: 0 },
-  );
-}
-
-async function measureCpuUsagePercent(intervalMs = 200) {
-  const start = readCpuTimes();
-  if (start.total === 0) {
-    return 0;
-  }
-
-  await wait(intervalMs);
-
-  const end = readCpuTimes();
-  const totalDelta = end.total - start.total;
-  if (totalDelta <= 0) {
-    return 0;
-  }
-
-  const idleDelta = end.idle - start.idle;
-  const usage = 1 - idleDelta / totalDelta;
-  if (!Number.isFinite(usage) || usage < 0) {
-    return 0;
-  }
-
-  return clamp(usage * 100, 0, 100);
-}
-
-function getMemoryUsageSnapshot() {
-  const total = os.totalmem();
-  const free = os.freemem();
-
-  const totalBytes = clamp(total, 0, Number.MAX_SAFE_INTEGER);
-  const freeBytes = clamp(Math.min(free, totalBytes), 0, totalBytes);
-  const usedBytes = Math.max(totalBytes - freeBytes, 0);
-  const usagePercent = totalBytes > 0 ? (usedBytes / totalBytes) * 100 : 0;
-
-  return {
-    usagePercent,
-    totalBytes,
-    freeBytes,
-  };
-}
-
-async function getDiskUsageSnapshot(path) {
-  const stats = await fs.statfs(path);
-
-  const blockSize = clamp(stats.bsize ?? 0, 0, Number.MAX_SAFE_INTEGER);
-  const totalBlocks = clamp(stats.blocks ?? 0, 0, Number.MAX_SAFE_INTEGER);
-  const availableBlocksValue = typeof stats.bavail === 'number' && stats.bavail >= 0 ? stats.bavail : stats.bfree ?? 0;
-  const availableBlocks = clamp(availableBlocksValue, 0, totalBlocks);
-
-  const totalBytes = blockSize * totalBlocks;
-  const freeBytes = blockSize * availableBlocks;
-  const usedBytes = Math.max(totalBytes - freeBytes, 0);
-  const usagePercent = totalBytes > 0 ? (usedBytes / totalBytes) * 100 : 0;
-
-  return {
-    usagePercent,
-    totalBytes,
-    freeBytes,
-    path,
-  };
-}
-
-function calculateChangePercent(id, currentValue) {
-  const previous = previousResourceUsage.get(id);
-  previousResourceUsage.set(id, currentValue);
-
-  if (previous === undefined || previous <= 0) {
-    return 0;
-  }
-
-  const change = (currentValue - previous) / previous;
-  if (!Number.isFinite(change)) {
-    return 0;
-  }
-
-  return clamp(change, -5, 5);
-}
-
-function finalizeResourceMeasurement(measurement) {
-  const sanitizedUsage = clamp(measurement.usagePercent, 0, 100);
-  const roundedUsage = Math.round(sanitizedUsage * 10) / 10;
-  const changePercent = Math.round(calculateChangePercent(measurement.id, roundedUsage) * 100) / 100;
-
-  return {
-    ...measurement,
-    usagePercent: roundedUsage,
-    changePercent,
-  };
-}
-
-async function collectSystemResourceUsage(logError = console.error) {
-  const resources = [];
-
-  const cpuCount = Math.max(os.cpus().length, 1);
-  const loadAverages = os.loadavg();
-  const loadOneMinuteRaw = loadAverages.length > 0 ? loadAverages[0] : 0;
-  const loadOneMinute = Number.isFinite(loadOneMinuteRaw) ? loadOneMinuteRaw : 0;
-
-  const diskPath = process.cwd();
-
-  const [cpuUsagePercent, diskUsage] = await Promise.all([
-    measureCpuUsagePercent().catch((error) => {
-      logError('[server-analytics] CPU usage probe failed', error);
-      return null;
-    }),
-    getDiskUsageSnapshot(diskPath).catch((error) => {
-      logError(`[server-analytics] Disk usage probe failed for ${diskPath}`, error);
-      return null;
-    }),
-  ]);
-
-  if (cpuUsagePercent !== null) {
-    resources.push({
-      id: 'app-cpu',
-      label: 'App-Server CPU',
-      usagePercent: cpuUsagePercent,
-      capacity: `${cpuCount} Kern${cpuCount === 1 ? '' : 'e'} · Load 1m ${loadOneMinute.toFixed(2)}`,
-    });
-  }
-
-  const memoryUsage = getMemoryUsageSnapshot();
-  resources.push({
-    id: 'app-ram',
-    label: 'Arbeitsspeicher',
-    usagePercent: memoryUsage.usagePercent,
-    capacity: `${formatBytes(memoryUsage.totalBytes)} gesamt · ${formatBytes(memoryUsage.freeBytes)} frei`,
-  });
-
-  if (diskUsage !== null) {
-    const normalizedPath = diskUsage.path === '' ? '/' : diskUsage.path;
-    resources.push({
-      id: 'app-disk',
-      label: `Dateisystem (${normalizedPath})`,
-      usagePercent: diskUsage.usagePercent,
-      capacity: `${formatBytes(diskUsage.totalBytes)} gesamt · ${formatBytes(diskUsage.freeBytes)} frei`,
-    });
-  }
-
-  if (resources.length === 0) {
-    throw new Error('Keine Systemressourcen konnten ermittelt werden');
-  }
-
-  return resources.map(finalizeResourceMeasurement);
-}
-
 export function createRealtimeServer(options = {}) {
   const {
     server,
@@ -333,6 +50,13 @@ export function createRealtimeServer(options = {}) {
     analyticsIntervalMs: explicitAnalyticsIntervalMs,
     analyticsMaxAgeMs: explicitAnalyticsMaxAgeMs,
   } = options;
+
+  const logError =
+    typeof logger?.error === 'function' ? (...args) => logger.error(...args) : (...args) => console.error(...args);
+  const logWarn =
+    typeof logger?.warn === 'function' ? (...args) => logger.warn(...args) : (...args) => console.warn(...args);
+  const logInfo =
+    typeof logger?.log === 'function' ? (...args) => logger.log(...args) : (...args) => console.log(...args);
 
   const port = Number.isFinite(explicitPort) ? Number(explicitPort) : Number(process.env.PORT || 4001);
   const socketPath = normalizePath(
@@ -365,13 +89,11 @@ export function createRealtimeServer(options = {}) {
   ).trim();
 
   if (!resolvedAuthToken) {
-    logger.warn(
-      '[Realtime] REALTIME_AUTH_TOKEN is not configured. Admin event requests without a token will be rejected.',
-    );
+    logWarn('[Realtime] REALTIME_AUTH_TOKEN is not configured. Admin event requests without a token will be rejected.');
   }
 
   if (!resolvedHandshakeSecret) {
-    logger.warn(
+    logWarn(
       '[Realtime] REALTIME_HANDSHAKE_SECRET/REALTIME_AUTH_TOKEN is not configured. Socket handshakes will be rejected.',
     );
   }
@@ -393,8 +115,6 @@ export function createRealtimeServer(options = {}) {
         },
   });
 
-  const logError = typeof logger.error === 'function' ? (...args) => logger.error(...args) : (...args) => console.error(...args);
-
   const defaultAnalyticsInterval = 2000;
   const analyticsIntervalMsRaw = resolveNumber(
     explicitAnalyticsIntervalMs,
@@ -408,405 +128,24 @@ export function createRealtimeServer(options = {}) {
   );
   const analyticsMaxAgeMs = Math.max(analyticsMaxAgeMsRaw, analyticsIntervalMs);
 
-  let latestAnalytics = null;
-  let analyticsRefreshPromise = null;
-  let analyticsIntervalId = null;
-
-  async function collectAnalyticsSnapshot() {
-    const base = cloneStaticAnalyticsData();
-    let resourceUsage = base.resourceUsage;
-    try {
-      resourceUsage = await collectSystemResourceUsage(logError);
-    } catch (error) {
-      logError('[Realtime] Verwende statische Ressourcenwerte für Server-Analytics', error);
-    }
-
-    let deviceBreakdown = base.deviceBreakdown ?? [];
-    let publicPages = base.publicPages ?? [];
-    let memberPages = base.memberPages ?? [];
-
-    const analyticsModule = await resolveAnalyticsModule();
-    const mergeDeviceBreakdownFn =
-      typeof analyticsModule?.mergeDeviceBreakdown === 'function'
-        ? analyticsModule.mergeDeviceBreakdown
-        : fallbackAnalyticsModule.mergeDeviceBreakdown;
-    const applyPagePerformanceMetricsFn =
-      typeof analyticsModule?.applyPagePerformanceMetrics === 'function'
-        ? analyticsModule.applyPagePerformanceMetrics
-        : fallbackAnalyticsModule.applyPagePerformanceMetrics;
-    const loadDeviceBreakdownFromDatabaseFn =
-      typeof analyticsModule?.loadDeviceBreakdownFromDatabase === 'function'
-        ? analyticsModule.loadDeviceBreakdownFromDatabase
-        : null;
-    const loadPagePerformanceMetricsFn =
-      typeof analyticsModule?.loadPagePerformanceMetrics === 'function'
-        ? analyticsModule.loadPagePerformanceMetrics
-        : null;
-
-    if (process.env.DATABASE_URL && loadDeviceBreakdownFromDatabaseFn && loadPagePerformanceMetricsFn) {
-      const [deviceOverrides, pageMetrics] = await Promise.all([
-        loadDeviceBreakdownFromDatabaseFn().catch((error) => {
-          logError('[Realtime] Failed to load device analytics', error);
-          return null;
-        }),
-        loadPagePerformanceMetricsFn().catch((error) => {
-          logError('[Realtime] Failed to load page performance metrics', error);
-          return [];
-        }),
-      ]);
-
-      deviceBreakdown = mergeDeviceBreakdownFn(deviceBreakdown, deviceOverrides ?? undefined);
-
-      if (Array.isArray(pageMetrics) && pageMetrics.length > 0) {
-        publicPages = applyPagePerformanceMetricsFn(publicPages, pageMetrics, 'public');
-        memberPages = applyPagePerformanceMetricsFn(memberPages, pageMetrics, 'members');
-      } else {
-        publicPages = publicPages.map((entry) => ({ ...entry }));
-        memberPages = memberPages.map((entry) => ({ ...entry }));
-      }
-    } else {
-      deviceBreakdown = mergeDeviceBreakdownFn(deviceBreakdown);
-      publicPages = applyPagePerformanceMetricsFn(publicPages, [], 'public');
-      memberPages = applyPagePerformanceMetricsFn(memberPages, [], 'members');
-    }
-
-    return {
-      generatedAt: toISO(Date.now()),
-      ...base,
-      resourceUsage,
-      deviceBreakdown,
-      publicPages,
-      memberPages,
-    };
-  }
-
-  function analyticsIsFresh() {
-    if (!latestAnalytics) {
-      return false;
-    }
-    const timestamp = Date.parse(latestAnalytics.generatedAt);
-    if (!Number.isFinite(timestamp)) {
-      return false;
-    }
-    return Date.now() - timestamp < analyticsMaxAgeMs;
-  }
-
-  async function refreshAnalytics() {
-    if (analyticsRefreshPromise) {
-      return analyticsRefreshPromise;
-    }
-
-    analyticsRefreshPromise = collectAnalyticsSnapshot()
-      .then((snapshot) => {
-        latestAnalytics = snapshot;
-        return snapshot;
-      })
-      .catch((error) => {
-        logError('[Realtime] Failed to refresh analytics snapshot', error);
-        if (latestAnalytics) {
-          return latestAnalytics;
-        }
-        const fallback = { generatedAt: toISO(Date.now()), ...cloneStaticAnalyticsData() };
-        latestAnalytics = fallback;
-        return fallback;
-      })
-      .finally(() => {
-        analyticsRefreshPromise = null;
-      });
-
-    return analyticsRefreshPromise;
-  }
-
-  async function getAnalyticsSnapshot() {
-    if (analyticsIsFresh()) {
-      return latestAnalytics;
-    }
-    return refreshAnalytics();
-  }
-
-  function emitAnalytics(target, analytics) {
-    if (!analytics || typeof target.emit !== 'function') {
-      return;
-    }
-    target.emit('server_analytics_update', {
-      type: 'server_analytics_update',
-      timestamp: analytics.generatedAt ?? toISO(Date.now()),
-      analytics,
-    });
-  }
-
-  function scheduleAnalyticsBroadcast() {
-    refreshAnalytics()
-      .then((analytics) => {
-        emitAnalytics(io, analytics);
-      })
-      .catch((error) => {
-        logError('[Realtime] Failed to broadcast analytics update', error);
-      });
-  }
-
-  analyticsIntervalId = setInterval(scheduleAnalyticsBroadcast, analyticsIntervalMs);
-  if (typeof analyticsIntervalId.unref === 'function') {
-    analyticsIntervalId.unref();
-  }
-
-  refreshAnalytics().catch((error) => {
-    logError('[Realtime] Initial analytics snapshot failed', error);
+  const analyticsManager = createAnalyticsManager({
+    logger,
+    intervalMs: analyticsIntervalMs,
+    maxAgeMs: analyticsMaxAgeMs,
+    toISO,
   });
 
-  const onlineUsers = new Map();
+  const {
+    broadcastOnlineStats,
+    emitUserPresence,
+    emitRehearsalUsersList,
+    registerUser,
+    unregisterUser,
+    handleServerEvent,
+    validateRoom,
+  } = createEventHandlers({ io, logger, toISO });
 
-  function verifyHandshake(userId, token) {
-    if (!resolvedHandshakeSecret) {
-      return { ok: false, reason: 'Handshake secret not configured' };
-    }
-    if (typeof userId !== 'string' || !userId.trim()) {
-      return { ok: false, reason: 'Missing userId' };
-    }
-    if (typeof token !== 'string' || !token.trim()) {
-      return { ok: false, reason: 'Missing token' };
-    }
-
-    const parsed = parseHandshakeToken(token);
-    if (!parsed) {
-      return { ok: false, reason: 'Invalid token format' };
-    }
-
-    if (parsed.expiresAt < Date.now()) {
-      return { ok: false, reason: 'Token expired' };
-    }
-
-    const base = `${userId}:${parsed.issuedAt}:${parsed.expiresAt}`;
-    const expectedSignature = createHmac('sha256', resolvedHandshakeSecret).update(base).digest('hex');
-
-    try {
-      const providedBuffer = Buffer.from(parsed.signature, 'hex');
-      const expectedBuffer = Buffer.from(expectedSignature, 'hex');
-      if (providedBuffer.length !== expectedBuffer.length) {
-        return { ok: false, reason: 'Invalid token signature' };
-      }
-      if (!timingSafeEqual(providedBuffer, expectedBuffer)) {
-        return { ok: false, reason: 'Invalid token signature' };
-      }
-    } catch {
-      return { ok: false, reason: 'Invalid token signature' };
-    }
-
-    return { ok: true, issuedAt: parsed.issuedAt, expiresAt: parsed.expiresAt };
-  }
-
-  function isValidRoomIdentifier(room, prefixLength) {
-    if (typeof room !== 'string') return false;
-    if (room.length > 200) return false;
-    if (prefixLength >= room.length) return false;
-    const identifier = room.slice(prefixLength);
-    return /^[A-Za-z0-9_-]+$/.test(identifier);
-  }
-
-  function isAllowedRoom(room, socket) {
-    if (typeof room !== 'string' || !room) return false;
-    if (room === 'global') return true;
-    if (room.startsWith('user_')) {
-      const expectedRoom = `user_${socket.data.userId}`;
-      return expectedRoom === room;
-    }
-    if (room.startsWith('rehearsal_')) {
-      return isValidRoomIdentifier(room, 'rehearsal_'.length);
-    }
-    if (room.startsWith('show_')) {
-      return isValidRoomIdentifier(room, 'show_'.length);
-    }
-    return false;
-  }
-
-  function broadcastOnlineStats() {
-    const snapshot = {
-      totalOnline: onlineUsers.size,
-      onlineUsers: Array.from(onlineUsers.entries()).map(([userId, info]) => ({
-        id: userId,
-        name: info.name,
-        lastSeen: toISO(info.lastSeen),
-      })),
-    };
-
-    io.emit('online_stats_update', {
-      type: 'online_stats_update',
-      timestamp: toISO(Date.now()),
-      stats: snapshot,
-    });
-  }
-
-  function emitUserPresence(room, socket, action) {
-    const userId = socket.data.userId;
-    if (!userId) return;
-    const payload = {
-      type: 'user_presence',
-      timestamp: toISO(Date.now()),
-      action,
-      room,
-      user: {
-        id: userId,
-        name: socket.data.userName,
-      },
-    };
-    socket.to(room).emit('user_presence', payload);
-  }
-
-  function emitRehearsalUsersList(rehearsalId, socket) {
-    const roomName = `rehearsal_${rehearsalId}`;
-    const room = io.sockets.adapter.rooms.get(roomName);
-    if (!room) {
-      socket.emit('rehearsal_users_list', {
-        type: 'rehearsal_users_list',
-        timestamp: toISO(Date.now()),
-        rehearsalId,
-        users: [],
-      });
-      return;
-    }
-
-    const users = [];
-    for (const socketId of room) {
-      const member = io.sockets.sockets.get(socketId);
-      if (member?.data?.userId) {
-        users.push({
-          id: member.data.userId,
-          name: member.data.userName,
-        });
-      }
-    }
-
-    socket.emit('rehearsal_users_list', {
-      type: 'rehearsal_users_list',
-      timestamp: toISO(Date.now()),
-      rehearsalId,
-      users,
-    });
-  }
-
-  function registerUser(socket) {
-    const userId = socket.data.userId;
-    const name = socket.data.userName;
-    const existing = onlineUsers.get(userId);
-    if (existing) {
-      existing.sockets.add(socket.id);
-      existing.lastSeen = Date.now();
-    } else {
-      onlineUsers.set(userId, {
-        name,
-        lastSeen: Date.now(),
-        sockets: new Set([socket.id]),
-      });
-      io.emit('user_joined', {
-        type: 'user_joined',
-        timestamp: toISO(Date.now()),
-        user: { id: userId, name },
-      });
-    }
-    broadcastOnlineStats();
-  }
-
-  function unregisterUser(socket) {
-    const userId = socket.data.userId;
-    const existing = onlineUsers.get(userId);
-    if (!existing) return;
-
-    existing.sockets.delete(socket.id);
-    if (existing.sockets.size === 0) {
-      onlineUsers.delete(userId);
-      io.emit('user_left', {
-        type: 'user_left',
-        timestamp: toISO(Date.now()),
-        user: { id: userId, name: socket.data.userName },
-      });
-    } else {
-      existing.lastSeen = Date.now();
-    }
-    broadcastOnlineStats();
-  }
-
-  function broadcastAttendanceUpdate(payload) {
-    if (!payload || !payload.rehearsalId) return false;
-    const event = {
-      type: 'attendance_updated',
-      rehearsalId: payload.rehearsalId,
-      targetUserId: payload.targetUserId,
-      status: payload.status ?? null,
-      comment: payload.comment,
-      actorUserId: payload.actorUserId,
-      timestamp: toISO(Date.now()),
-    };
-
-    io.to(`rehearsal_${payload.rehearsalId}`).emit('attendance_updated', event);
-    if (payload.targetUserId) {
-      io.to(`user_${payload.targetUserId}`).emit('attendance_updated', event);
-    }
-    return true;
-  }
-
-  function broadcastRehearsalCreated(payload) {
-    if (!payload || !payload.rehearsal) return false;
-    const event = {
-      type: 'rehearsal_created',
-      rehearsal: payload.rehearsal,
-      targetUserIds: Array.isArray(payload.targetUserIds) ? payload.targetUserIds : [],
-      timestamp: toISO(Date.now()),
-    };
-
-    if (event.targetUserIds.length) {
-      event.targetUserIds.forEach((userId) => {
-        io.to(`user_${userId}`).emit('rehearsal_created', event);
-      });
-    } else {
-      io.emit('rehearsal_created', event);
-    }
-    return true;
-  }
-
-  function broadcastRehearsalUpdated(payload) {
-    if (!payload || !payload.rehearsalId) return false;
-    const event = {
-      type: 'rehearsal_updated',
-      rehearsalId: payload.rehearsalId,
-      changes: payload.changes || {},
-      targetUserIds: Array.isArray(payload.targetUserIds) ? payload.targetUserIds : [],
-      timestamp: toISO(Date.now()),
-    };
-
-    io.to(`rehearsal_${payload.rehearsalId}`).emit('rehearsal_updated', event);
-    event.targetUserIds.forEach((userId) => {
-      io.to(`user_${userId}`).emit('rehearsal_updated', event);
-    });
-    return true;
-  }
-
-  function sendNotification(payload) {
-    if (!payload || !payload.targetUserId || !payload.notification) return false;
-    const event = {
-      type: 'notification_created',
-      notification: payload.notification,
-      targetUserId: payload.targetUserId,
-      timestamp: toISO(Date.now()),
-    };
-
-    io.to(`user_${payload.targetUserId}`).emit('notification_created', event);
-    return true;
-  }
-
-  function handleServerEvent(eventType, data) {
-    switch (eventType) {
-      case 'attendance_updated':
-        return broadcastAttendanceUpdate(data);
-      case 'rehearsal_created':
-        return broadcastRehearsalCreated(data);
-      case 'rehearsal_updated':
-        return broadcastRehearsalUpdated(data);
-      case 'notification_created':
-        return sendNotification(data);
-      default:
-        return false;
-    }
-  }
+  analyticsManager.start(io);
 
   function handleAdminEventRequest(req, res) {
     let body = '';
@@ -825,7 +164,7 @@ export function createRealtimeServer(options = {}) {
         const data = payload?.payload;
 
         if (!resolvedAuthToken || token !== resolvedAuthToken) {
-          logger.warn('[Realtime] Rejected admin event request due to missing or invalid auth token.');
+          logWarn('[Realtime] Rejected admin event request due to missing or invalid auth token.');
           createJsonResponse(res, 401, { error: 'Unauthorized' });
           return;
         }
@@ -838,7 +177,7 @@ export function createRealtimeServer(options = {}) {
 
         createJsonResponse(res, 200, { ok: true });
       } catch (error) {
-        logger.error('[Realtime] Failed to handle admin event', error);
+        logError('[Realtime] Failed to handle admin event', error);
         createJsonResponse(res, 400, { error: 'Invalid payload' });
       }
     });
@@ -905,9 +244,9 @@ export function createRealtimeServer(options = {}) {
     const token = typeof auth.token === 'string' ? auth.token : null;
     const rawName = typeof auth.userName === 'string' ? auth.userName : null;
 
-    const validation = verifyHandshake(rawUserId, token);
+    const validation = verifyHandshake({ userId: rawUserId, token, secret: resolvedHandshakeSecret });
     if (!validation.ok) {
-      logger.warn(`[Realtime] Rejected socket ${socket.id} handshake: ${validation.reason}`);
+      logWarn(`[Realtime] Rejected socket ${socket.id} handshake: ${validation.reason}`);
       return next(new Error('Unauthorized'));
     }
 
@@ -931,9 +270,10 @@ export function createRealtimeServer(options = {}) {
 
     registerUser(socket);
 
-    getAnalyticsSnapshot()
+    analyticsManager
+      .getSnapshot()
       .then((analytics) => {
-        emitAnalytics(socket, analytics);
+        analyticsManager.emit(socket, analytics);
       })
       .catch((error) => {
         logError(`[Realtime] Failed to deliver analytics snapshot to socket ${socket.id}`, error);
@@ -943,8 +283,7 @@ export function createRealtimeServer(options = {}) {
     socket.data.rooms.add('global');
 
     socket.on('join_room', (room) => {
-      if (!isAllowedRoom(room, socket)) {
-        logger.warn(`[Realtime] socket ${socket.id} attempted to join unauthorized room: ${room}`);
+      if (!validateRoom(room, socket)) {
         return;
       }
       if (socket.data.rooms.has(room)) {
@@ -982,9 +321,10 @@ export function createRealtimeServer(options = {}) {
     });
 
     socket.on('get_server_analytics', () => {
-      getAnalyticsSnapshot()
+      analyticsManager
+        .getSnapshot()
         .then((analytics) => {
-          emitAnalytics(socket, analytics);
+          analyticsManager.emit(socket, analytics);
         })
         .catch((error) => {
           logError(`[Realtime] Failed to refresh analytics for socket ${socket.id}`, error);
@@ -1015,16 +355,13 @@ export function createRealtimeServer(options = {}) {
     await new Promise((resolve) => {
       httpServer.listen(listenPort, hostname, resolve);
     });
-    logger.log(`Realtime server listening on port ${listenPort}`);
+    logInfo(`Realtime server listening on port ${listenPort}`);
   }
 
   async function close() {
     if (closed) return;
     closed = true;
-    if (analyticsIntervalId) {
-      clearInterval(analyticsIntervalId);
-      analyticsIntervalId = null;
-    }
+    analyticsManager.stop();
     await new Promise((resolve, reject) => {
       io.close((error) => {
         if (error) {

--- a/realtime-server/src/events.js
+++ b/realtime-server/src/events.js
@@ -1,0 +1,246 @@
+export function createEventHandlers({ io, logger, toISO }) {
+  if (!io) {
+    throw new Error('Socket server instance is required');
+  }
+
+  const formatTimestamp = typeof toISO === 'function' ? toISO : (value) => new Date(value).toISOString();
+  const logWarn =
+    typeof logger?.warn === 'function' ? (...args) => logger.warn(...args) : (...args) => console.warn(...args);
+
+  const onlineUsers = new Map();
+
+  function broadcastOnlineStats() {
+    const snapshot = {
+      totalOnline: onlineUsers.size,
+      onlineUsers: Array.from(onlineUsers.entries()).map(([userId, info]) => ({
+        id: userId,
+        name: info.name,
+        lastSeen: formatTimestamp(info.lastSeen),
+      })),
+    };
+
+    io.emit('online_stats_update', {
+      type: 'online_stats_update',
+      timestamp: formatTimestamp(Date.now()),
+      stats: snapshot,
+    });
+  }
+
+  function emitUserPresence(room, socket, action) {
+    const userId = socket.data.userId;
+    if (!userId) return;
+    const payload = {
+      type: 'user_presence',
+      timestamp: formatTimestamp(Date.now()),
+      action,
+      room,
+      user: {
+        id: userId,
+        name: socket.data.userName,
+      },
+    };
+    socket.to(room).emit('user_presence', payload);
+  }
+
+  function emitRehearsalUsersList(rehearsalId, socket) {
+    const roomName = `rehearsal_${rehearsalId}`;
+    const room = io.sockets.adapter.rooms.get(roomName);
+    if (!room) {
+      socket.emit('rehearsal_users_list', {
+        type: 'rehearsal_users_list',
+        timestamp: formatTimestamp(Date.now()),
+        rehearsalId,
+        users: [],
+      });
+      return;
+    }
+
+    const users = [];
+    for (const socketId of room) {
+      const member = io.sockets.sockets.get(socketId);
+      if (member?.data?.userId) {
+        users.push({
+          id: member.data.userId,
+          name: member.data.userName,
+        });
+      }
+    }
+
+    socket.emit('rehearsal_users_list', {
+      type: 'rehearsal_users_list',
+      timestamp: formatTimestamp(Date.now()),
+      rehearsalId,
+      users,
+    });
+  }
+
+  function registerUser(socket) {
+    const userId = socket.data.userId;
+    const name = socket.data.userName;
+    const existing = onlineUsers.get(userId);
+    if (existing) {
+      existing.sockets.add(socket.id);
+      existing.lastSeen = Date.now();
+    } else {
+      onlineUsers.set(userId, {
+        name,
+        lastSeen: Date.now(),
+        sockets: new Set([socket.id]),
+      });
+      io.emit('user_joined', {
+        type: 'user_joined',
+        timestamp: formatTimestamp(Date.now()),
+        user: { id: userId, name },
+      });
+    }
+    broadcastOnlineStats();
+  }
+
+  function unregisterUser(socket) {
+    const userId = socket.data.userId;
+    const existing = onlineUsers.get(userId);
+    if (!existing) return;
+
+    existing.sockets.delete(socket.id);
+    if (existing.sockets.size === 0) {
+      onlineUsers.delete(userId);
+      io.emit('user_left', {
+        type: 'user_left',
+        timestamp: formatTimestamp(Date.now()),
+        user: { id: userId, name: socket.data.userName },
+      });
+    } else {
+      existing.lastSeen = Date.now();
+    }
+    broadcastOnlineStats();
+  }
+
+  function broadcastAttendanceUpdate(payload) {
+    if (!payload || !payload.rehearsalId) return false;
+    const event = {
+      type: 'attendance_updated',
+      rehearsalId: payload.rehearsalId,
+      targetUserId: payload.targetUserId,
+      status: payload.status ?? null,
+      comment: payload.comment,
+      actorUserId: payload.actorUserId,
+      timestamp: formatTimestamp(Date.now()),
+    };
+
+    io.to(`rehearsal_${payload.rehearsalId}`).emit('attendance_updated', event);
+    if (payload.targetUserId) {
+      io.to(`user_${payload.targetUserId}`).emit('attendance_updated', event);
+    }
+    return true;
+  }
+
+  function broadcastRehearsalCreated(payload) {
+    if (!payload || !payload.rehearsal) return false;
+    const event = {
+      type: 'rehearsal_created',
+      rehearsal: payload.rehearsal,
+      targetUserIds: Array.isArray(payload.targetUserIds) ? payload.targetUserIds : [],
+      timestamp: formatTimestamp(Date.now()),
+    };
+
+    if (event.targetUserIds.length) {
+      event.targetUserIds.forEach((userId) => {
+        io.to(`user_${userId}`).emit('rehearsal_created', event);
+      });
+    } else {
+      io.emit('rehearsal_created', event);
+    }
+    return true;
+  }
+
+  function broadcastRehearsalUpdated(payload) {
+    if (!payload || !payload.rehearsalId) return false;
+    const event = {
+      type: 'rehearsal_updated',
+      rehearsalId: payload.rehearsalId,
+      changes: payload.changes || {},
+      targetUserIds: Array.isArray(payload.targetUserIds) ? payload.targetUserIds : [],
+      timestamp: formatTimestamp(Date.now()),
+    };
+
+    io.to(`rehearsal_${payload.rehearsalId}`).emit('rehearsal_updated', event);
+    event.targetUserIds.forEach((userId) => {
+      io.to(`user_${userId}`).emit('rehearsal_updated', event);
+    });
+    return true;
+  }
+
+  function sendNotification(payload) {
+    if (!payload || !payload.targetUserId || !payload.notification) return false;
+    const event = {
+      type: 'notification_created',
+      notification: payload.notification,
+      targetUserId: payload.targetUserId,
+      timestamp: formatTimestamp(Date.now()),
+    };
+
+    io.to(`user_${payload.targetUserId}`).emit('notification_created', event);
+    return true;
+  }
+
+  function handleServerEvent(eventType, data) {
+    switch (eventType) {
+      case 'attendance_updated':
+        return broadcastAttendanceUpdate(data);
+      case 'rehearsal_created':
+        return broadcastRehearsalCreated(data);
+      case 'rehearsal_updated':
+        return broadcastRehearsalUpdated(data);
+      case 'notification_created':
+        return sendNotification(data);
+      default:
+        return false;
+    }
+  }
+
+  function isValidRoomIdentifier(room, prefixLength) {
+    if (typeof room !== 'string') return false;
+    if (room.length > 200) return false;
+    if (prefixLength >= room.length) return false;
+    const identifier = room.slice(prefixLength);
+    return /^[A-Za-z0-9_-]+$/.test(identifier);
+  }
+
+  function isAllowedRoom(room, socket) {
+    if (typeof room !== 'string' || !room) return false;
+    if (room === 'global') return true;
+    if (room.startsWith('user_')) {
+      const expectedRoom = `user_${socket.data.userId}`;
+      return expectedRoom === room;
+    }
+    if (room.startsWith('rehearsal_')) {
+      return isValidRoomIdentifier(room, 'rehearsal_'.length);
+    }
+    if (room.startsWith('show_')) {
+      return isValidRoomIdentifier(room, 'show_'.length);
+    }
+    return false;
+  }
+
+  function validateRoom(room, socket) {
+    if (!isAllowedRoom(room, socket)) {
+      logWarn(`[Realtime] socket ${socket.id} attempted to join unauthorized room: ${room}`);
+      return false;
+    }
+    return true;
+  }
+
+  return {
+    broadcastOnlineStats,
+    emitUserPresence,
+    emitRehearsalUsersList,
+    registerUser,
+    unregisterUser,
+    broadcastAttendanceUpdate,
+    broadcastRehearsalCreated,
+    broadcastRehearsalUpdated,
+    sendNotification,
+    handleServerEvent,
+    validateRoom,
+  };
+}

--- a/realtime-server/src/handshake.js
+++ b/realtime-server/src/handshake.js
@@ -1,0 +1,57 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export function parseHandshakeToken(token) {
+  if (typeof token !== 'string') return null;
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [issuedAtRaw, expiresAtRaw, signature] = parts;
+  const issuedAt = Number(issuedAtRaw);
+  const expiresAt = Number(expiresAtRaw);
+  if (!Number.isFinite(issuedAt) || !Number.isFinite(expiresAt)) return null;
+  if (!signature || typeof signature !== 'string') return null;
+  return { issuedAt, expiresAt, signature };
+}
+
+export function verifyHandshake({ userId, token, secret, now = Date.now }) {
+  if (!secret) {
+    return { ok: false, reason: 'Handshake secret not configured' };
+  }
+  if (typeof userId !== 'string' || !userId.trim()) {
+    return { ok: false, reason: 'Missing userId' };
+  }
+  if (typeof token !== 'string' || !token.trim()) {
+    return { ok: false, reason: 'Missing token' };
+  }
+
+  const parsed = parseHandshakeToken(token);
+  if (!parsed) {
+    return { ok: false, reason: 'Invalid token format' };
+  }
+
+  let currentTime = typeof now === 'function' ? now() : now;
+  if (!Number.isFinite(currentTime)) {
+    currentTime = Date.now();
+  }
+
+  if (parsed.expiresAt < currentTime) {
+    return { ok: false, reason: 'Token expired' };
+  }
+
+  const base = `${userId}:${parsed.issuedAt}:${parsed.expiresAt}`;
+  const expectedSignature = createHmac('sha256', secret).update(base).digest('hex');
+
+  try {
+    const providedBuffer = Buffer.from(parsed.signature, 'hex');
+    const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+    if (providedBuffer.length !== expectedBuffer.length) {
+      return { ok: false, reason: 'Invalid token signature' };
+    }
+    if (!timingSafeEqual(providedBuffer, expectedBuffer)) {
+      return { ok: false, reason: 'Invalid token signature' };
+    }
+  } catch {
+    return { ok: false, reason: 'Invalid token signature' };
+  }
+
+  return { ok: true, issuedAt: parsed.issuedAt, expiresAt: parsed.expiresAt };
+}


### PR DESCRIPTION
## Summary
- extract analytics, handshake, and event helper logic into dedicated modules and simplify `createRealtimeServer` orchestration
- add unit tests that exercise handshake token verification and analytics refresh behavior
- expose a `node --test` script for the realtime server package to run the new checks

## Testing
- pnpm --dir realtime-server test

------
https://chatgpt.com/codex/tasks/task_e_68d25bdb220c832da623f689a665cc24