### PR TITLE
Adjust desktop sidebar height below site header

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -220,7 +220,7 @@ const Sidebar = React.forwardRef<
       >
         <div
           className={cn(
-            "relative w-[--sidebar-width] bg-transparent transition-[width] duration-200 ease-linear",
+            "relative w-[--sidebar-width] min-h-[calc(100dvh-var(--header-height))] bg-transparent transition-[width] duration-200 ease-linear",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
@@ -230,7 +230,7 @@ const Sidebar = React.forwardRef<
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear lg:flex",
+            "fixed bottom-0 top-[var(--header-height)] z-10 hidden h-[calc(100dvh-var(--header-height))] w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear lg:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",


### PR DESCRIPTION
## Summary
- offset the fixed desktop sidebar below the global header by using top/bottom positioning and a dynamic height tied to the header token
- ensure the desktop sidebar placeholder shares the same calculated minimum height so scrollable content respects the new viewport space

## Testing
- `pnpm lint`
- `pnpm test`
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68d25f4d6bb4832db454555f0b6b8cb4