### PR TITLE
Cache active production lookup per request

### DIFF
--- a/src/lib/active-production.ts
+++ b/src/lib/active-production.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { cookies } from "next/headers";
 
 import { prisma } from "@/lib/prisma";
@@ -10,7 +11,7 @@ export async function getActiveProductionId() {
   return value ?? null;
 }
 
-export async function getActiveProduction() {
+export const getActiveProduction = cache(async () => {
   const activeProductionId = await getActiveProductionId();
   if (!activeProductionId) {
     return null;
@@ -31,4 +32,4 @@ export async function getActiveProduction() {
   }
 
   return show;
-}
+});


### PR DESCRIPTION
## Summary
- wrap `getActiveProduction` in React's `cache` helper so Prisma only queries once per request
- keep `getActiveProductionId` available for existing imports while reusing it internally

## Testing
- pnpm lint
- pnpm test *(fails: No test suite found in realtime-server/src/__tests__/analytics.test.js and realtime-server/src/__tests__/handshake.test.js)*
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2726519e8832d9c815762804bccb6