### PR TITLE
Add responsive sizes to Chronik image components

### DIFF
--- a/src/app/chronik/fullframes.tsx
+++ b/src/app/chronik/fullframes.tsx
@@ -175,7 +175,13 @@ export function ChronikFullframes({ items }: { items: ChronikItem[] }) {
                       return (
                         <div key={i} className="relative h-28 sm:h-32 md:h-36 rounded overflow-hidden border border-border/40">
                           {isImg ? (
-                            <Image src={url} alt={`${s.title ?? s.year} – Bild ${i + 1}`} fill className="object-cover" />
+                            <Image
+                              src={url}
+                              alt={`${s.title ?? s.year} – Bild ${i + 1}`}
+                              fill
+                              sizes="(min-width: 1280px) 400px, (min-width: 640px) 33vw, 50vw"
+                              className="object-cover"
+                            />
                           ) : (
                             <a
                               href={url}
@@ -192,7 +198,13 @@ export function ChronikFullframes({ items }: { items: ChronikItem[] }) {
                     })
                   ) : posterSources.length > 0 ? (
                     <div className="relative col-span-2 sm:col-span-3 h-56 md:h-72 rounded overflow-hidden border border-border/40">
-                      <Image src={posterSources[0]} alt={s.title ?? String(s.year)} fill className="object-cover" />
+                      <Image
+                        src={posterSources[0]}
+                        alt={s.title ?? String(s.year)}
+                        fill
+                        sizes="100vw"
+                        className="object-cover"
+                      />
                     </div>
                   ) : null}
                 </div>

--- a/src/app/chronik/poster-slideshow.tsx
+++ b/src/app/chronik/poster-slideshow.tsx
@@ -81,6 +81,7 @@ export function PosterSlideshow({
           src={src}
           alt={alt}
           fill
+          sizes="100vw"
           priority={priority && index === 0}
           className={cn(
             "object-cover transition-opacity duration-1000 ease-in-out",


### PR DESCRIPTION
## Summary
- add a responsive `sizes` attribute to the chronik poster slideshow so background images report their layout width
- extend the chronik fullframes gallery and fallback images with tailored `sizes` hints for thumbnails and the large poster backup

## Testing
- pnpm lint
- pnpm test *(fails: realtime-server/src/__tests__/analytics.test.js and realtime-server/src/__tests__/handshake.test.js report “No test suite found”)*
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2726417e0832db89aafd7a1a2db09