### PR TITLE
Configure Geist fonts for app layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "geist": "^1.5.1",
     "http-proxy": "^1.18.1",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      geist:
+        specifier: ^1.5.1
+        version: 1.5.1(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1
@@ -2267,6 +2270,11 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  geist@1.5.1:
+    resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -5732,6 +5740,10 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  geist@1.5.1(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
+    dependencies:
+      next: 15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
 
   get-caller-file@2.0.5: {}
 

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,0 +1,5 @@
+import { GeistSans as GeistSansFont } from "geist/font/sans";
+import { GeistMono as GeistMonoFont } from "geist/font/mono";
+
+export const geistSans = GeistSansFont;
+export const geistMono = GeistMonoFont;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,11 +7,13 @@ import { MysticBackground } from "@/components/mystic-background";
 import type { Viewport } from "next";
 import { execSync } from "node:child_process";
 import { ThemeStyleRegistry } from "@/components/theme/theme-style-registry";
+import { geistSans, geistMono } from "./fonts";
 import {
   DEFAULT_SITE_TITLE,
   readWebsiteSettings,
   resolveWebsiteSettings,
 } from "@/lib/website-settings";
+import { cn } from "@/lib/utils";
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXTAUTH_URL || "http://localhost:3000"),
@@ -130,7 +132,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     }
   }
 
-  const htmlClassName = resolvedSettings.colorMode === "dark" ? "dark" : undefined;
+  const htmlClassName = cn(
+    resolvedSettings.colorMode === "dark" ? "dark" : undefined,
+    geistSans.variable,
+    geistMono.variable,
+  );
   const siteTitle = resolvedSettings.siteTitle;
   const themeTokens = resolvedSettings.theme.tokens;
 


### PR DESCRIPTION
## Summary
- add the `geist` package and expose configured font exports from `src/app/fonts.ts`
- apply the Geist font variables on the root layout so CSS variables resolve correctly

## Testing
- pnpm lint
- pnpm test *(fails: Vitest cannot execute realtime-server node:test suites)*
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d27259eaa4832d944efc1006f2aa22