### PR TITLE
docs: align setup docs with proxy configuration

### DIFF
--- a/docs/dev-proxy.md
+++ b/docs/dev-proxy.md
@@ -4,13 +4,16 @@ Wenn der Entwicklungsstack über einen Reverse Proxy wie Traefik erreichbar gema
 werden Anmelde-Weiterleitungen standardmäßig auf `http://localhost:3000` gesetzt. Der Grund: `NEXTAUTH_URL` ist in der
 Dev-Compose-Datei auf `http://localhost:3000` voreingestellt und NextAuth verwendet diesen Wert für Callback-URLs.
 
-Damit Weiterleitungen auf die externe Domain zeigen, setze vor dem Start von `docker compose` den gewünschten Host:
+Damit Weiterleitungen und Links auf die externe Domain zeigen, setze vor dem Start von `docker compose` die relevanten
+Hosts (ohne abschließenden Slash):
 
 ```bash
 export NEXTAUTH_URL="https://theater.local"
-# optional: .env Datei mit NEXTAUTH_URL=...
+export NEXT_PUBLIC_BASE_URL="https://theater.local"
+export NEXT_PUBLIC_REALTIME_URL="https://theater.local/realtime" # optional, z. B. bei anderem Pfad
+# alternativ: .env-Datei mit den gleichen Variablen pflegen
 ```
 
-Durch die Änderung in `docker-compose.yml` wird dieser Wert jetzt durchgereicht. Der Realtime-Server übernimmt denselben
-Origin für CORS. Ohne gesetzte Variable bleibt das Standardverhalten (`http://localhost:3000`) für lokale Entwicklung
-bestehen.
+Durch die Änderung in `docker-compose.yml` werden diese Werte durchgereicht. Der Realtime-Server übernimmt denselben
+Origin für CORS und generierte Links. Ohne gesetzte Variablen bleibt das Standardverhalten (`http://localhost:3000`) für
+lokale Entwicklung bestehen.


### PR DESCRIPTION
## Summary
- refresh the top-level README with pnpm-focused setup steps, environment guidance, and updated docker usage notes
- extend the reverse proxy development guide to cover NEXT_PUBLIC_BASE_URL and realtime host configuration

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d28cc482a0832da9ccf6ec70c7dd0a