### PR TITLE
Revamp members area layout scaffolding

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -85,6 +85,45 @@ Weitere Layout-Konstanten:
 
 ## Komponentenrichtlinien
 
+### Mitgliederbereich: App Shell & Seitenaufbau
+
+- `MembersAppShell` organisiert den Mitgliederbereich nun semantisch: Die Topbar sitzt oberhalb eines `main`-Containers, der konsequent in `header`, `section` und `footer` gegliedert ist. Alle Bereiche nutzen weiterhin die etablierten Containerbreiten (`max-w-screen-2xl`, `px-4` → `sm:px-6` → `lg:px-8`).
+- Die Topbar wird über `MembersTopbar` konfiguriert und stellt Slots für Brotkrumen (`MembersTopbarBreadcrumbs`), den Seitentitel (`MembersTopbarTitle`), optionale Schnellaktionen (`MembersTopbarQuickActions`) sowie Status-Badges (`MembersTopbarStatus`) bereit. Unterhalb von `lg` erscheint der Sidebar-Trigger automatisch, auf größeren Viewports rückt an dessen Stelle der Titel.
+- Seiten können ihren Header deklarativ über `MembersContentHeader` und `MembersPageActions` aufbauen. Der Bereich landet automatisch im semantischen `header` des Layouts und behält dadurch konsistente Abstände.
+- Ein optionaler `MembersContentFooter` ermöglicht nachgelagerte Hinweise oder sekundäre Aktionen, die am Ende der Seite stehen sollen.
+- Der Mitglieder-spezifische `PageHeader` (`@/components/members/page-header`) registriert Topbar- und Header-Inhalte automatisch, solange `variant="page"` verwendet wird. Für abschnittsweise Zwischenüberschriften kann `variant="section"` gesetzt werden – dann bleibt der Eintrag lokal im Content.
+
+**Beispiel:**
+
+```tsx
+<MembersTopbar>
+  <MembersTopbarBreadcrumbs>Mitglieder · Probenplanung</MembersTopbarBreadcrumbs>
+  <MembersTopbarTitle>Probenplanung</MembersTopbarTitle>
+  <MembersTopbarStatus>
+    <Badge variant="info">Planung aktiv</Badge>
+  </MembersTopbarStatus>
+  <MembersTopbarQuickActions>
+    <Button size="sm">Neue Probe</Button>
+  </MembersTopbarQuickActions>
+</MembersTopbar>
+
+<MembersContentHeader>
+  <PageHeader>
+    <div className="space-y-1.5">
+      <PageHeaderTitle>Probenplanung</PageHeaderTitle>
+      <PageHeaderDescription>
+        Termine anlegen, veröffentlichen und Rückmeldungen im Blick behalten.
+      </PageHeaderDescription>
+    </div>
+  </PageHeader>
+</MembersContentHeader>
+
+{/* Hauptinhalt folgt im Section-Bereich */}
+<div className="space-y-6">
+  …
+</div>
+```
+
 ### Buttons (`@/components/ui/button`)
 - **Varianten:** `primary` (alias `default`), `secondary`, `accent`, `outline`, `ghost`, `subtle`, `link`, `destructive`, `success`, `info`.
 - **States:** Hover reduziert Deckkraft bzw. hebt Konturen hervor; `focus-visible` nutzt `ring` + Offset, `disabled` setzt `opacity-60` und deaktiviert Pointer Events.

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -12,12 +12,18 @@ import { useOnlineStats } from "@/hooks/useOnlineStats";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  MembersContentHeader,
+  MembersTopbar,
+  MembersTopbarStatus,
+  MembersTopbarTitle,
+} from "@/components/members/members-app-shell";
 import { useMembersPermissions } from "@/components/members/permissions-context";
 import {
   KeyMetricCard,
   KeyMetricGrid,
   PageHeader,
-  PageHeaderActions,
+  PageHeaderDescription,
   PageHeaderStatus,
   PageHeaderTitle,
 } from "@/design-system/patterns";
@@ -877,49 +883,59 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
   }
 
   return (
-    <div className="space-y-6 p-4 sm:p-6 lg:space-y-8 lg:p-0 lg:pt-2 lg:pb-10">
-      <PageHeader>
-        <div className="space-y-1.5">
-          <PageHeaderTitle>Mitglieder-Dashboard</PageHeaderTitle>
-        </div>
-        <PageHeaderActions>
+    <>
+      <MembersTopbar>
+        <MembersTopbarTitle>Mitglieder-Dashboard</MembersTopbarTitle>
+        <MembersTopbarStatus>
           <PageHeaderStatus state={connectionMeta.state} icon={connectionMeta.icon}>
             {connectionMeta.label}
           </PageHeaderStatus>
-        </PageHeaderActions>
-      </PageHeader>
+        </MembersTopbarStatus>
+      </MembersTopbar>
 
-      {profileCompletion && !profileCompletion.complete ? (
-        <div className="rounded-2xl border border-warning/45 bg-warning/10 p-4 text-sm text-warning shadow-[0_18px_48px_rgba(253,176,34,0.12)]">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p className="font-semibold">Profilangaben unvollständig</p>
-              <p className="text-xs text-warning/90">
-                {`Du hast ${Math.max(
-                  profileCompletion.total - profileCompletion.completed,
-                  0,
-                )} von ${profileCompletion.total} Aufgaben offen.`}
-              </p>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="border-warning/40 text-warning hover:bg-warning/10"
-              asChild
-            >
-              <Link href="/mitglieder/profil">Profil aktualisieren</Link>
-            </Button>
+      <MembersContentHeader>
+        <PageHeader>
+          <div className="space-y-1.5">
+            <PageHeaderTitle>Mitglieder-Dashboard</PageHeaderTitle>
+            <PageHeaderDescription>
+              Aktuelle Kennzahlen, Aktivitäten und Schnellzugriffe auf einen Blick.
+            </PageHeaderDescription>
           </div>
-        </div>
-      ) : null}
+        </PageHeader>
+      </MembersContentHeader>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.6fr)_minmax(0,0.4fr)] xl:items-start">
-        <div className="space-y-4">
-          <Card className="h-full bg-gradient-to-br from-accent/20 to-transparent">
-            <CardContent className="flex h-full flex-col gap-4 pt-6 md:flex-row md:items-center md:justify-between xl:gap-6">
+      <div className="space-y-6 lg:space-y-8">
+        {profileCompletion && !profileCompletion.complete ? (
+          <div className="rounded-2xl border border-warning/45 bg-warning/10 p-4 text-sm text-warning shadow-[0_18px_48px_rgba(253,176,34,0.12)]">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <div className="text-sm text-muted-foreground">Willkommen zurück</div>
+                <p className="font-semibold">Profilangaben unvollständig</p>
+                <p className="text-xs text-warning/90">
+                  {`Du hast ${Math.max(
+                    profileCompletion.total - profileCompletion.completed,
+                    0,
+                  )} von ${profileCompletion.total} Aufgaben offen.`}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-warning/40 text-warning hover:bg-warning/10"
+                asChild
+              >
+                <Link href="/mitglieder/profil">Profil aktualisieren</Link>
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,0.6fr)_minmax(0,0.4fr)] xl:items-start">
+          <div className="space-y-4">
+            <Card className="h-full bg-gradient-to-br from-accent/20 to-transparent">
+              <CardContent className="flex h-full flex-col gap-4 pt-6 md:flex-row md:items-center md:justify-between xl:gap-6">
+                <div>
+                  <div className="text-sm text-muted-foreground">Willkommen zurück</div>
                 <h2 className="text-xl font-semibold">
                   {session?.user?.name || session?.user?.email || "Mitglied"}
                 </h2>
@@ -1047,7 +1063,8 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
             )}
           </CardContent>
         </Card>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -11,6 +11,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { MembersNav, type AssignmentFocus } from "@/components/members-nav";
+import { cn } from "@/lib/utils";
 
 interface MembersAppShellProps {
   children: React.ReactNode;
@@ -18,6 +19,40 @@ interface MembersAppShellProps {
   activeProduction?: { id: string; title: string | null; year: number };
   assignmentFocus: AssignmentFocus;
   hasDepartmentMemberships: boolean;
+}
+
+interface MembersTopbarSlots {
+  breadcrumbs: React.ReactNode | null;
+  title: React.ReactNode | null;
+  quickActions: React.ReactNode | null;
+  status: React.ReactNode | null;
+}
+
+const INITIAL_TOPBAR: MembersTopbarSlots = {
+  breadcrumbs: null,
+  title: null,
+  quickActions: null,
+  status: null,
+};
+
+interface MembersAppShellContextValue {
+  setTopbarContent: (content: MembersTopbarSlots | null) => void;
+  setContentHeader: (content: React.ReactNode | null) => void;
+  setContentFooter: (content: React.ReactNode | null) => void;
+}
+
+const MembersAppShellContext =
+  React.createContext<MembersAppShellContextValue | null>(null);
+
+function useMembersAppShellContext() {
+  const context = React.useContext(MembersAppShellContext);
+  if (!context) {
+    throw new Error(
+      "Members layout helpers must be used within MembersAppShell.",
+    );
+  }
+
+  return context;
 }
 
 function SidebarMobileAutoClose() {
@@ -33,6 +68,72 @@ function SidebarMobileAutoClose() {
   return null;
 }
 
+function MembersTopbarContent({
+  content,
+}: {
+  content: MembersTopbarSlots;
+}) {
+  const { isMobile } = useSidebar();
+  const hasQuickActions = Boolean(content.quickActions);
+  const hasStatus = Boolean(content.status);
+  const hasBreadcrumbs = Boolean(content.breadcrumbs);
+
+  return (
+    <header className="sticky top-0 z-30 border-b border-border/60 bg-background/85 backdrop-blur supports-[backdrop-filter]:bg-background/75">
+      <div className="mx-auto w-full max-w-screen-2xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-3 py-3 sm:py-4">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            {isMobile ? (
+              <SidebarTrigger
+                className="-ml-1 inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 text-muted-foreground transition hover:border-primary/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                aria-label="Navigationsmenü öffnen"
+              />
+            ) : null}
+            <div className="min-w-0 flex flex-col gap-1">
+              {hasBreadcrumbs ? (
+                <div className="truncate text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  {content.breadcrumbs}
+                </div>
+              ) : null}
+              <div className="min-w-0 truncate text-sm font-semibold text-foreground">
+                {content.title ?? (
+                  <span className="truncate text-sm font-semibold text-foreground">
+                    Mitgliederbereich
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          {!isMobile && (hasStatus || hasQuickActions) ? (
+            <div className="flex flex-shrink-0 items-center gap-2">
+              {hasStatus ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  {content.status}
+                </div>
+              ) : null}
+              {hasQuickActions ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  {content.quickActions}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+          {isMobile && hasQuickActions ? (
+            <div className="flex flex-shrink-0 items-center gap-2">
+              {content.quickActions}
+            </div>
+          ) : null}
+        </div>
+        {isMobile && hasStatus ? (
+          <div className="flex flex-wrap items-center gap-2 pb-3">
+            {content.status}
+          </div>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
 export function MembersAppShell({
   children,
   permissions,
@@ -40,6 +141,34 @@ export function MembersAppShell({
   assignmentFocus,
   hasDepartmentMemberships,
 }: MembersAppShellProps) {
+  const [topbarContent, setTopbarContentState] =
+    React.useState<MembersTopbarSlots>(INITIAL_TOPBAR);
+  const [contentHeader, setContentHeaderState] =
+    React.useState<React.ReactNode>(null);
+  const [contentFooter, setContentFooterState] =
+    React.useState<React.ReactNode>(null);
+
+  const setTopbarContent = React.useCallback((value: MembersTopbarSlots | null) => {
+    setTopbarContentState(value ?? INITIAL_TOPBAR);
+  }, []);
+
+  const setContentHeader = React.useCallback((value: React.ReactNode | null) => {
+    setContentHeaderState(value ?? null);
+  }, []);
+
+  const setContentFooter = React.useCallback((value: React.ReactNode | null) => {
+    setContentFooterState(value ?? null);
+  }, []);
+
+  const contextValue = React.useMemo(
+    () => ({
+      setTopbarContent,
+      setContentHeader,
+      setContentFooter,
+    }),
+    [setTopbarContent, setContentHeader, setContentFooter],
+  );
+
   return (
     <>
       <SidebarMobileAutoClose />
@@ -52,19 +181,243 @@ export function MembersAppShell({
         />
         <SidebarRail />
       </Sidebar>
-      <SidebarInset id="main">
-        <div className="flex min-h-svh flex-col">
-          <header className="sticky top-0 z-20 flex h-16 items-center gap-3 border-b border-border/60 bg-background/90 px-4 backdrop-blur-sm sm:px-6 lg:px-8">
-            <SidebarTrigger className="-ml-1 text-foreground/80 hover:text-foreground" />
-            <div className="text-sm font-semibold text-foreground">Mitgliederbereich</div>
-          </header>
-          <div className="flex-1 pb-12 pt-6 sm:pt-8">
-            <div className="mx-auto w-full max-w-screen-2xl space-y-8 px-4 sm:px-6 lg:px-8 xl:px-10 2xl:px-12">
-              {children}
-            </div>
+      <MembersAppShellContext.Provider value={contextValue}>
+        <SidebarInset id="main">
+          <div className="flex min-h-svh flex-col">
+            <MembersTopbarContent content={topbarContent} />
+            <main className="flex-1 pb-12">
+              {contentHeader ? (
+                <header className="border-b border-border/60 bg-background/60">
+                  <div className="mx-auto w-full max-w-screen-2xl px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+                    {contentHeader}
+                  </div>
+                </header>
+              ) : null}
+              <section className="py-6 sm:py-8">
+                <div className="mx-auto w-full max-w-screen-2xl space-y-8 px-4 sm:px-6 lg:px-8">
+                  {children}
+                </div>
+              </section>
+              {contentFooter ? (
+                <footer className="border-t border-border/60 bg-background/60">
+                  <div className="mx-auto w-full max-w-screen-2xl px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+                    {contentFooter}
+                  </div>
+                </footer>
+              ) : null}
+            </main>
           </div>
-        </div>
-      </SidebarInset>
+        </SidebarInset>
+      </MembersAppShellContext.Provider>
     </>
   );
+}
+
+interface MembersTopbarProps {
+  children: React.ReactNode;
+}
+
+function combineSlot(
+  current: React.ReactNode | null,
+  next: React.ReactNode,
+): React.ReactNode {
+  if (!current) return next;
+  return (
+    <>
+      {current}
+      {next}
+    </>
+  );
+}
+
+function collectTopbarSlots(children: React.ReactNode): MembersTopbarSlots {
+  const slots: MembersTopbarSlots = { ...INITIAL_TOPBAR };
+
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return;
+    }
+
+    if (child.type === MembersTopbarBreadcrumbs) {
+      slots.breadcrumbs = combineSlot(slots.breadcrumbs, child);
+      return;
+    }
+
+    if (child.type === MembersTopbarTitle) {
+      slots.title = combineSlot(slots.title, child);
+      return;
+    }
+
+    if (child.type === MembersTopbarQuickActions) {
+      slots.quickActions = combineSlot(slots.quickActions, child);
+      return;
+    }
+
+    if (child.type === MembersTopbarStatus) {
+      slots.status = combineSlot(slots.status, child);
+    }
+  });
+
+  return slots;
+}
+
+export function MembersTopbar({ children }: MembersTopbarProps) {
+  const { setTopbarContent } = useMembersAppShellContext();
+  const slots = React.useMemo(() => collectTopbarSlots(children), [children]);
+
+  React.useEffect(() => {
+    setTopbarContent(slots);
+    return () => setTopbarContent(null);
+  }, [setTopbarContent, slots]);
+
+  return null;
+}
+
+interface MembersTopbarBreadcrumbsProps
+  extends React.HTMLAttributes<HTMLElement> {
+  ariaLabel?: string;
+}
+
+export function MembersTopbarBreadcrumbs({
+  ariaLabel,
+  className,
+  children,
+  ...props
+}: MembersTopbarBreadcrumbsProps) {
+  return (
+    <nav
+      aria-label={ariaLabel ?? "Brotkrumen"}
+      className={cn(
+        "flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </nav>
+  );
+}
+
+interface MembersTopbarTitleProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function MembersTopbarTitle({
+  children,
+  className,
+}: MembersTopbarTitleProps) {
+  return (
+    <span className={cn("truncate text-sm font-semibold text-foreground", className)}>
+      {children}
+    </span>
+  );
+}
+
+interface MembersTopbarQuickActionsProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function MembersTopbarQuickActions({
+  children,
+  className,
+}: MembersTopbarQuickActionsProps) {
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      {children}
+    </div>
+  );
+}
+
+interface MembersTopbarStatusProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function MembersTopbarStatus({
+  children,
+  className,
+}: MembersTopbarStatusProps) {
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>{children}</div>
+  );
+}
+
+interface MembersContentHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function MembersContentHeader({
+  children,
+  className,
+}: MembersContentHeaderProps) {
+  const { setContentHeader } = useMembersAppShellContext();
+  const content = React.useMemo(
+    () => (
+      <div
+        className={cn(
+          "flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between lg:gap-6",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    ),
+    [children, className],
+  );
+
+  React.useEffect(() => {
+    setContentHeader(content);
+    return () => setContentHeader(null);
+  }, [content, setContentHeader]);
+
+  return null;
+}
+
+interface MembersPageActionsProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function MembersPageActions({
+  children,
+  className,
+}: MembersPageActionsProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2 sm:justify-end",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface MembersContentFooterProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function MembersContentFooter({
+  children,
+  className,
+}: MembersContentFooterProps) {
+  const { setContentFooter } = useMembersAppShellContext();
+  const content = React.useMemo(
+    () => (
+      <div className={cn("flex flex-col gap-4", className)}>{children}</div>
+    ),
+    [children, className],
+  );
+
+  React.useEffect(() => {
+    setContentFooter(content);
+    return () => setContentFooter(null);
+  }, [content, setContentFooter]);
+
+  return null;
 }

--- a/src/components/members/page-header.tsx
+++ b/src/components/members/page-header.tsx
@@ -1,22 +1,101 @@
-import React from "react";
+"use client";
+
+import * as React from "react";
+
+import {
+  MembersContentHeader,
+  MembersPageActions,
+  MembersTopbar,
+  MembersTopbarBreadcrumbs,
+  MembersTopbarQuickActions,
+  MembersTopbarStatus,
+  MembersTopbarTitle,
+} from "@/components/members/members-app-shell";
+import { Heading, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  title: string;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+  breadcrumbs?: React.ReactNode;
+  quickActions?: React.ReactNode;
+  status?: React.ReactNode;
+  variant?: "page" | "section";
+  className?: string;
+}
 
 export function PageHeader({
   title,
   description,
   actions,
-}: {
-  title: string;
-  description?: string;
-  actions?: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-      <div>
-        <h1 className="font-serif text-2xl md:text-3xl">{title}</h1>
-        {description && <p className="text-sm text-foreground/80">{description}</p>}
+  breadcrumbs,
+  quickActions,
+  status,
+  variant = "page",
+  className,
+}: PageHeaderProps) {
+  if (variant === "section") {
+    return (
+      <div
+        className={cn(
+          "flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-6",
+          className,
+        )}
+      >
+        <div className="space-y-1.5">
+          <Heading level="h2" className="text-2xl md:text-3xl">
+            {title}
+          </Heading>
+          {description
+            ? typeof description === "string"
+              ? (
+                  <Text tone="muted" variant="body">
+                    {description}
+                  </Text>
+                )
+              : description
+            : null}
+        </div>
+        {actions ? (
+          <div className="flex flex-wrap items-center gap-2">{actions}</div>
+        ) : null}
       </div>
-      {actions ? <div className="flex gap-2">{actions}</div> : null}
-    </div>
+    );
+  }
+
+  const descriptionNode =
+    description === undefined || description === null
+      ? null
+      : typeof description === "string"
+        ? (
+            <Text tone="muted" variant="body">
+              {description}
+            </Text>
+          )
+        : description;
+
+  return (
+    <>
+      <MembersTopbar>
+        {breadcrumbs ? (
+          <MembersTopbarBreadcrumbs>{breadcrumbs}</MembersTopbarBreadcrumbs>
+        ) : null}
+        <MembersTopbarTitle>{title}</MembersTopbarTitle>
+        {status ? <MembersTopbarStatus>{status}</MembersTopbarStatus> : null}
+        {quickActions ? (
+          <MembersTopbarQuickActions>{quickActions}</MembersTopbarQuickActions>
+        ) : null}
+      </MembersTopbar>
+      <MembersContentHeader className={className}>
+        <div className="space-y-2">
+          <Heading level="h1" className="text-3xl sm:text-4xl">
+            {title}
+          </Heading>
+          {descriptionNode}
+        </div>
+        {actions ? <MembersPageActions>{actions}</MembersPageActions> : null}
+      </MembersContentHeader>
+    </>
   );
 }
-

--- a/src/components/members/profile-page-client.tsx
+++ b/src/components/members/profile-page-client.tsx
@@ -349,6 +349,7 @@ export function ProfilePageClient({
         />
         <section className="rounded-3xl border border-border/60 bg-background/90 px-6 py-8 shadow-lg shadow-primary/10 sm:px-8">
           <PageHeader
+            variant="section"
             title="Mein Profil"
             description="Halte deine Angaben aktuell, damit Teams und Kolleg:innen optimal planen können."
           />


### PR DESCRIPTION
## Summary
- restructure the members app shell with a configurable topbar, semantic main layout and helper components for downstream pages
- rework the members page header to feed the new slots and adjust key pages (dashboard, profile) to the updated scaffold
- document the layout pattern in the design system guide

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d28735ff98832dbeb4c71499a21415