### PR TITLE
Refactor members navigation config and selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,19 @@ you can instead run:
 pnpm run start:proxy
 ```
 
+## Members navigation configuration
+
+The sidebar for the members area is configured centrally in
+`@/config/members-navigation.ts`. The file exports typed groups and items
+(`MembersNavGroup`, `MembersNavItem`) including icon components, permission
+keys and optional accessibility helpers such as `ariaLabel` or badges. Dynamic
+entries – for example the department todo list or active production shortcuts –
+are injected by `selectMembersNavigation` from `@/lib/members-navigation` based
+on the user context. When adding new sections, extend the configuration and
+consider updating `selectMembersNavigation` plus the accompanying tests in
+`src/lib/__tests__/members-navigation.test.ts` so typical roles (finance, only
+departments, etc.) remain covered.
+
 ## Creating the initial owner account
 
 On a fresh database the application does not contain any users yet. During the

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -3,6 +3,7 @@
 import { useId, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+
 import {
   SidebarContent,
   SidebarGroup,
@@ -16,331 +17,27 @@ import {
   SidebarSeparator,
   useSidebar,
 } from "@/components/ui/sidebar";
+import {
+  MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
+  defaultMembersNavIcon,
+  membersNavigation,
+} from "@/config/members-navigation";
+import {
+  filterMembersNavigationByPermissions,
+  filterMembersNavigationByQuery,
+  resolveAssignmentsGroupLabel,
+  selectMembersNavigation,
+  type ActiveProductionNavInfo,
+  type AssignmentFocus,
+} from "@/lib/members-navigation";
 import { cn } from "@/lib/utils";
 
-type Item = { href: string; label: string; permissionKey?: string };
-type Group = { label: string; items: Item[] };
-type ActiveProductionNavInfo = { id: string; title: string | null; year: number };
-export type AssignmentFocus = "none" | "rehearsals" | "departments" | "both";
-
-const GENERAL_ITEMS: Item[] = [
-  { href: "/mitglieder", label: "Dashboard", permissionKey: "mitglieder.dashboard" },
-  { href: "/mitglieder/profil", label: "Profil", permissionKey: "mitglieder.profil" },
-  { href: "/mitglieder/archiv-und-bilder", label: "Archiv und Bilder", permissionKey: "mitglieder.galerie" },
-  { href: "/mitglieder/sperrliste", label: "Sperrliste", permissionKey: "mitglieder.sperrliste" },
-  { href: "/mitglieder/issues", label: "Feedback & Support", permissionKey: "mitglieder.issues" },
-];
-
-const ASSIGNMENT_ITEMS: Item[] = [
-  { href: "/mitglieder/meine-proben", label: "Meine Proben", permissionKey: "mitglieder.meine-proben" },
-  { href: "/mitglieder/meine-gewerke", label: "Meine Gewerke", permissionKey: "mitglieder.meine-gewerke" },
-  { href: "/mitglieder/koerpermasse", label: "Körpermaße", permissionKey: "mitglieder.koerpermasse" },
-  { href: "/mitglieder/probenplanung", label: "Probenplanung", permissionKey: "mitglieder.probenplanung" },
-];
-
-const FINAL_WEEK_ITEMS: Item[] = [
-  {
-    href: "/mitglieder/endproben-woche/dienstplan",
-    label: "Dienstplan",
-    permissionKey: "mitglieder.endprobenwoche",
-  },
-  {
-    href: "/mitglieder/endproben-woche/essenplanung",
-    label: "Essensplanung",
-    permissionKey: "mitglieder.essenplanung",
-  },
-];
-
-const DEPARTMENT_TODO_ITEM: Item = {
-  href: "/mitglieder/meine-gewerke/todos",
-  label: "Meine Gewerke-Aufgaben",
-  permissionKey: "mitglieder.meine-gewerke",
-};
-
-const PRODUCTION_ITEMS: Item[] = [
-  { href: "/mitglieder/produktionen", label: "Übersicht", permissionKey: "mitglieder.produktionen" },
-  { href: "/mitglieder/produktionen/gewerke", label: "Gewerke & Teams", permissionKey: "mitglieder.produktionen" },
-  {
-    href: "/mitglieder/produktionen/besetzung",
-    label: "Rollen & Besetzung",
-    permissionKey: "mitglieder.produktionen",
-  },
-  {
-    href: "/mitglieder/produktionen/szenen",
-    label: "Szenen & Breakdowns",
-    permissionKey: "mitglieder.produktionen",
-  },
-];
-
-const FINANCE_ITEMS: Item[] = [
-  { href: "/mitglieder/finanzen", label: "Finanz-Dashboard", permissionKey: "mitglieder.finanzen" },
-  { href: "/mitglieder/finanzen/buchungen", label: "Buchungen", permissionKey: "mitglieder.finanzen" },
-  { href: "/mitglieder/finanzen/budgets", label: "Budgets", permissionKey: "mitglieder.finanzen" },
-  { href: "/mitglieder/finanzen/export", label: "Exporte", permissionKey: "mitglieder.finanzen.export" },
-];
-
-const ADMIN_ITEMS: Item[] = [
-  { href: "/mitglieder/mitgliederverwaltung", label: "Mitgliederverwaltung", permissionKey: "mitglieder.rollenverwaltung" },
-  { href: "/mitglieder/onboarding-analytics", label: "Onboarding Analytics", permissionKey: "mitglieder.onboarding.analytics" },
-  { href: "/mitglieder/server-analytics", label: "Server-Statistiken", permissionKey: "mitglieder.server.analytics" },
-  { href: "/mitglieder/rechte", label: "Rechteverwaltung", permissionKey: "mitglieder.rechte" },
-  { href: "/mitglieder/fotoerlaubnisse", label: "Fotoerlaubnisse", permissionKey: "mitglieder.fotoerlaubnisse" },
-  { href: "/mitglieder/website", label: "Website & Theme", permissionKey: "mitglieder.website.settings" },
-];
-
-function resolveAssignmentLabel(focus: AssignmentFocus, permissions: readonly string[] | Set<string>) {
-  if (focus === "both") return "Proben & Gewerke";
-  if (focus === "departments") return "Gewerke";
-  if (focus === "rehearsals") return "Proben";
-  const permissionSet = permissions instanceof Set ? permissions : new Set(permissions);
-  const canSeeRehearsals = permissionSet.has("mitglieder.meine-proben");
-  const canSeeDepartments = permissionSet.has("mitglieder.meine-gewerke");
-  if (canSeeRehearsals && canSeeDepartments) return "Proben & Gewerke";
-  if (canSeeDepartments) return "Gewerke";
-  return "Proben";
-}
+export type { AssignmentFocus } from "@/lib/members-navigation";
 
 function isActive(pathname: string, href: string) {
   if (pathname === href) return true;
   if (href === "/mitglieder") return false;
   return pathname.startsWith(`${href}/`);
-}
-
-function NavIcon({ name, className }: { name: string; className?: string }) {
-  const cls = cn("h-4 w-4", className);
-  switch (name) {
-    case "/mitglieder":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M3 13h8V3H3zM13 21h8v-8h-8zM13 3v8h8V3zM3 21h8v-4H3z" />
-        </svg>
-      );
-    case "/mitglieder/profil":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="8" r="4" />
-          <path d="M6 20c0-3.314 2.686-6 6-6s6 2.686 6 6" />
-        </svg>
-      );
-    case "/mitglieder/archiv-und-bilder":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M3 8a2 2 0 0 1 2-2h2l1.2-2h5.6L15 6h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
-          <circle cx="12" cy="12" r="3" />
-          <path d="M7 8h2" />
-        </svg>
-      );
-    case "/mitglieder/issues":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M21 15a2 2 0 0 1-2 2H9l-4 4v-4H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" />
-          <path d="M9 7h6" />
-          <path d="M9 11h6" />
-        </svg>
-      );
-    case "/mitglieder/meine-proben":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M4 6a2 2 0 0 1 2-2h6" />
-          <path d="M20 10v8a2 2 0 0 1-2 2h-6" />
-          <circle cx="9" cy="10" r="3" />
-          <path d="M4 20c0-2.761 2.239-5 5-5" />
-          <path d="m15 5 2 2 4-4" />
-          <path d="M14 9h6" />
-        </svg>
-      );
-    case "/mitglieder/meine-gewerke":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="5" y="4" width="14" height="16" rx="2" />
-          <path d="M9 2h6" />
-          <path d="M12 2v2" />
-          <path d="M8 10h8" />
-          <path d="M8 14h8" />
-          <path d="M8 18h5" />
-          <path d="m6 15 1.8 1.8L10 14" />
-        </svg>
-      );
-    case "/mitglieder/meine-gewerke/todos":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M4 6l1.5 1.5L7 6" />
-          <path d="M4 12l1.5 1.5L7 12" />
-          <path d="M4 18l1.5 1.5L7 18" />
-          <path d="M9 6h11" />
-          <path d="M9 12h11" />
-          <path d="M9 18h11" />
-        </svg>
-      );
-    case "/mitglieder/koerpermasse":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="3" y="6" width="18" height="12" rx="2" />
-          <path d="M6 10h.01" />
-          <path d="M9 10h.01" />
-          <path d="M12 10h.01" />
-          <path d="M15 10h.01" />
-          <path d="M18 10h.01" />
-          <path d="M6 14h6" />
-          <path d="M6 18v2" />
-          <path d="M18 18v2" />
-        </svg>
-      );
-    case "/mitglieder/sperrliste":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="12" r="9" />
-          <path d="m5 5 14 14" />
-        </svg>
-      );
-    case "/mitglieder/probenplanung":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="3" y="4" width="18" height="18" rx="2" />
-          <path d="M16 2v4M8 2v4M3 10h18" />
-        </svg>
-      );
-    case "/mitglieder/endproben-woche/dienstplan":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="4" y="5" width="16" height="16" rx="2" />
-          <path d="M9 3v4" />
-          <path d="M15 3v4" />
-          <path d="M4 11h16" />
-          <path d="m9 16 2 2 4-4" />
-        </svg>
-      );
-    case "/mitglieder/endproben-woche/essenplanung":
-    case "/mitglieder/essenplanung":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="m16 2-2.3 2.3a3 3 0 0 0 0 4.2l1.8 1.8a3 3 0 0 0 4.2 0L22 8" />
-          <path d="M15 15 3.3 3.3a4.2 4.2 0 0 0 0 6l7.3 7.3c.7.7 2 .7 2.8 0L15 15Zm0 0 7 7" />
-          <path d="m2.1 21.8 6.4-6.3" />
-          <path d="m19 5-7 7" />
-        </svg>
-      );
-    case "/mitglieder/produktionen":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M3 4h18v4H3z" />
-          <path d="M5 8v12h14V8" />
-          <path d="M9 12h6" />
-          <path d="M9 16h6" />
-        </svg>
-      );
-    case "/mitglieder/produktionen/gewerke":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="7" cy="7" r="2.5" />
-          <circle cx="17" cy="7" r="2.5" />
-          <circle cx="12" cy="17" r="2.5" />
-          <path d="M9.5 7h5" />
-          <path d="M9.4 8.6L12 12" />
-          <path d="M14.6 8.6 12 12" />
-          <path d="M12 14.5V12" />
-        </svg>
-      );
-    case "/mitglieder/produktionen/besetzung":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="9" cy="8" r="3" />
-          <path d="M4 20c0-3 2.239-5.5 5-5.5S14 17 14 20" />
-          <path d="M17 11a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
-          <path d="M20.5 20c0-2.485-2.015-4.5-4.5-4.5" />
-        </svg>
-      );
-    case "/mitglieder/produktionen/szenen":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M3 9h18v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-          <path d="M3 9l2.5-5h5L8 9" />
-          <path d="M8 9l2.5-5h5L13 9" />
-          <path d="M3 13h18" />
-        </svg>
-      );
-    case "/mitglieder/mitgliederverwaltung":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M16 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
-          <circle cx="9" cy="7" r="4" />
-          <path d="m20 8 1 1 2-2" />
-        </svg>
-      );
-    case "/mitglieder/rechte":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M12 22s8-3 8-10V5l-8-3-8 3v7c0 7 8 10 8 10Z" />
-        </svg>
-      );
-    case "/mitglieder/fotoerlaubnisse":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M21 19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h3l2-3h4l2 3h3a2 2 0 0 1 2 2Z" />
-          <circle cx="12" cy="14" r="3" />
-        </svg>
-      );
-    case "/mitglieder/website":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M12 22c4.97 0 9-3.6 9-8a7 7 0 0 0-7-7 4 4 0 0 1-4-4 9 9 0 0 0-9 9c0 4.4 4.03 8 9 8Z" />
-          <circle cx="6.5" cy="11.5" r="1.5" />
-          <circle cx="9.5" cy="7.5" r="1.5" />
-          <circle cx="14.5" cy="7.5" r="1.5" />
-          <circle cx="17.5" cy="11.5" r="1.5" />
-        </svg>
-      );
-    case "/mitglieder/server-analytics":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M4 20h16" />
-          <path d="M6 16l4-6 3 4 4-7 3 5" />
-        </svg>
-      );
-    case "/mitglieder/finanzen":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="3" y="6" width="18" height="12" rx="2" />
-          <path d="M7 10h10" />
-          <path d="M7 14h6" />
-          <circle cx="9" cy="10" r="0.5" fill="currentColor" />
-          <circle cx="15" cy="14" r="0.5" fill="currentColor" />
-        </svg>
-      );
-    case "/mitglieder/finanzen/buchungen":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M4 6h16v4H4z" />
-          <path d="M7 10v8a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-8" />
-          <path d="M9 14h6" />
-          <path d="M9 18h4" />
-        </svg>
-      );
-    case "/mitglieder/finanzen/budgets":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M4 19h16" />
-          <path d="M7 19v-7" />
-          <path d="M12 19v-11" />
-          <path d="M17 19v-5" />
-          <path d="M5 8h14l-2-3H7z" />
-        </svg>
-      );
-    case "/mitglieder/finanzen/export":
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M12 3v12" />
-          <path d="m8 11 4 4 4-4" />
-          <path d="M4 19h16" />
-        </svg>
-      );
-    default:
-      return (
-        <svg className={cls} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="12" r="2" />
-        </svg>
-      );
-  }
 }
 
 export function MembersNav({
@@ -364,69 +61,42 @@ export function MembersNav({
   const isCollapsed = !isMobile && state === "collapsed";
 
   const assignmentLabel = useMemo(
-    () => resolveAssignmentLabel(assignmentFocus, permissions ?? []),
+    () => resolveAssignmentsGroupLabel(assignmentFocus, permissions ?? []),
     [assignmentFocus, permissions],
   );
 
-  const assignmentItems = useMemo(() => {
-    if (!hasDepartmentMemberships) {
-      return ASSIGNMENT_ITEMS;
-    }
-
-    const items = [...ASSIGNMENT_ITEMS];
-    const alreadyIncluded = items.some((item) => item.href === DEPARTMENT_TODO_ITEM.href);
-    if (!alreadyIncluded) {
-      const baseIndex = items.findIndex((item) => item.href === "/mitglieder/meine-gewerke");
-      if (baseIndex >= 0) {
-        items.splice(baseIndex + 1, 0, DEPARTMENT_TODO_ITEM);
-      } else {
-        items.push(DEPARTMENT_TODO_ITEM);
-      }
-    }
-
-    return items;
-  }, [hasDepartmentMemberships]);
-
-  const groupedConfig = useMemo<Group[]>(
-    () => [
-      { label: "Allgemein", items: GENERAL_ITEMS },
-      { label: assignmentLabel, items: assignmentItems },
-      { label: "Endproben Woche", items: FINAL_WEEK_ITEMS },
-      { label: "Produktion", items: PRODUCTION_ITEMS },
-      { label: "Finanzen", items: FINANCE_ITEMS },
-      { label: "Verwaltung", items: ADMIN_ITEMS },
-    ],
-    [assignmentLabel, assignmentItems],
+  const baseGroups = useMemo(
+    () =>
+      selectMembersNavigation({
+        groups: membersNavigation,
+        hasDepartmentMemberships,
+        activeProduction: activeProduction ?? null,
+      }),
+    [activeProduction, hasDepartmentMemberships],
   );
 
-  const { groups: availableGroups, flat: availableFlat } = useMemo(() => {
-    const permissionSet = new Set(permissions ?? []);
-    const groups = groupedConfig
-      .map((g) => ({
-        label: g.label,
-        items: g.items.filter((i) => !i.permissionKey || permissionSet.has(i.permissionKey!)),
-      }))
-      .filter((g) => g.items.length > 0);
-    const flat = groups.flatMap((g) => g.items);
-    return { groups, flat } as { groups: Group[]; flat: Item[] };
-  }, [groupedConfig, permissions]);
+  const labelledGroups = useMemo(
+    () =>
+      baseGroups.map((group) =>
+        group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID
+          ? { ...group, label: assignmentLabel }
+          : group,
+      ),
+    [assignmentLabel, baseGroups],
+  );
+
+  const { groups: permittedGroups, flat: permittedFlat } = useMemo(
+    () => filterMembersNavigationByPermissions(labelledGroups, permissions),
+    [labelledGroups, permissions],
+  );
 
   const { groups, flat } = useMemo(() => {
     if (!isFiltering) {
-      return { groups: availableGroups, flat: availableFlat };
+      return { groups: permittedGroups, flat: permittedFlat };
     }
 
-    const filteredGroups = availableGroups
-      .map((group) => ({
-        label: group.label,
-        items: group.items.filter((item) => item.label.toLowerCase().includes(normalizedQuery)),
-      }))
-      .filter((group) => group.items.length > 0);
-
-    const filteredFlat = filteredGroups.flatMap((group) => group.items);
-
-    return { groups: filteredGroups, flat: filteredFlat };
-  }, [availableFlat, availableGroups, isFiltering, normalizedQuery]);
+    return filterMembersNavigationByQuery(permittedGroups, normalizedQuery);
+  }, [permittedFlat, permittedGroups, isFiltering, normalizedQuery]);
 
   const emptyStateMessage = isFiltering
     ? "Keine Bereiche gefunden. Passe die Suche an."
@@ -515,12 +185,17 @@ export function MembersNav({
           </div>
         ) : (
           groups.map((group) => (
-            <SidebarGroup key={group.label}>
+            <SidebarGroup key={group.id}>
               <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
                   {group.items.map((item) => {
                     const active = isActive(pathname, item.href);
+                    const Icon = item.icon ?? defaultMembersNavIcon;
+                    const badgeContent = item.badge;
+                    const showBadge =
+                      !isCollapsed && badgeContent !== undefined && badgeContent !== null && badgeContent !== false;
+
                     return (
                       <SidebarMenuItem key={item.href}>
                         <SidebarMenuButton
@@ -529,17 +204,23 @@ export function MembersNav({
                           tooltip={item.label}
                           className={cn("gap-2", isCollapsed && "justify-center")}
                         >
-                          <Link href={item.href} aria-label={item.label}>
-                            <NavIcon
-                              name={item.href}
+                          <Link href={item.href} aria-label={item.ariaLabel ?? item.label}>
+                            <Icon
                               className={cn(
                                 "h-4 w-4 shrink-0 transition-opacity",
                                 active ? "opacity-100" : "opacity-70",
                               )}
                             />
-                            <span className={cn("truncate", isCollapsed && "sr-only")}>
-                              {item.label}
-                            </span>
+                            <span className={cn("truncate", isCollapsed && "sr-only")}>{item.label}</span>
+                            {showBadge ? (
+                              typeof badgeContent === "string" || typeof badgeContent === "number" ? (
+                                <span className="ml-auto inline-flex items-center rounded-full border border-sidebar-border/60 bg-sidebar/50 px-2 text-[11px] font-semibold uppercase tracking-wide text-sidebar-foreground/70">
+                                  {badgeContent}
+                                </span>
+                              ) : (
+                                <span className="ml-auto flex items-center">{badgeContent}</span>
+                              )
+                            ) : null}
                           </Link>
                         </SidebarMenuButton>
                       </SidebarMenuItem>
@@ -554,4 +235,3 @@ export function MembersNav({
     </>
   );
 }
-

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -1,0 +1,479 @@
+import React from "react";
+import type { ComponentType, ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export type MembersNavIconProps = { className?: string };
+export type MembersNavIcon = ComponentType<MembersNavIconProps>;
+
+export type MembersNavGroupId =
+  | "general"
+  | "assignments"
+  | "final-week"
+  | "production"
+  | "finance"
+  | "admin";
+
+export const MEMBERS_NAV_ASSIGNMENTS_GROUP_ID: MembersNavGroupId = "assignments";
+export const MEMBERS_NAV_PRODUCTION_GROUP_ID: MembersNavGroupId = "production";
+
+export interface MembersNavItem {
+  href: string;
+  label: string;
+  icon?: MembersNavIcon;
+  permissionKey?: string;
+  ariaLabel?: string;
+  badge?: ReactNode;
+}
+
+export interface MembersNavGroup {
+  id: MembersNavGroupId;
+  label: string;
+  items: readonly MembersNavItem[];
+}
+
+function createMembersNavIcon(children: ReactNode): MembersNavIcon {
+  const Icon: MembersNavIcon = ({ className }) => (
+    <svg
+      className={cn("h-4 w-4", className)}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+  Icon.displayName = "MembersNavIcon";
+  return Icon;
+}
+
+const DashboardIcon = createMembersNavIcon(
+  <>
+    <path d="M3 13h8V3H3z" />
+    <path d="M13 21h8v-8h-8z" />
+    <path d="M13 3v8h8V3z" />
+    <path d="M3 21h8v-4H3z" />
+  </>,
+);
+
+const ProfileIcon = createMembersNavIcon(
+  <>
+    <circle cx="12" cy="8" r="4" />
+    <path d="M6 20c0-3.314 2.686-6 6-6s6 2.686 6 6" />
+  </>,
+);
+
+const ArchiveIcon = createMembersNavIcon(
+  <>
+    <path d="M3 8a2 2 0 0 1 2-2h2l1.2-2h5.6L15 6h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+    <circle cx="12" cy="12" r="3" />
+    <path d="M7 8h2" />
+  </>,
+);
+
+const IssuesIcon = createMembersNavIcon(
+  <>
+    <path d="M21 15a2 2 0 0 1-2 2H9l-4 4v-4H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" />
+    <path d="M9 7h6" />
+    <path d="M9 11h6" />
+  </>,
+);
+
+const RehearsalsIcon = createMembersNavIcon(
+  <>
+    <path d="M4 6a2 2 0 0 1 2-2h6" />
+    <path d="M20 10v8a2 2 0 0 1-2 2h-6" />
+    <circle cx="9" cy="10" r="3" />
+    <path d="M4 20c0-2.761 2.239-5 5-5" />
+    <path d="m15 5 2 2 4-4" />
+    <path d="M14 9h6" />
+  </>,
+);
+
+const DepartmentsIcon = createMembersNavIcon(
+  <>
+    <rect x="5" y="4" width="14" height="16" rx="2" />
+    <path d="M9 2h6" />
+    <path d="M12 2v2" />
+    <path d="M8 10h8" />
+    <path d="M8 14h8" />
+    <path d="M8 18h5" />
+    <path d="m6 15 1.8 1.8L10 14" />
+  </>,
+);
+
+const DepartmentTodosIcon = createMembersNavIcon(
+  <>
+    <path d="M4 6l1.5 1.5L7 6" />
+    <path d="M4 12l1.5 1.5L7 12" />
+    <path d="M4 18l1.5 1.5L7 18" />
+    <path d="M9 6h11" />
+    <path d="M9 12h11" />
+    <path d="M9 18h11" />
+  </>,
+);
+
+const BodyMeasurementsIcon = createMembersNavIcon(
+  <>
+    <rect x="3" y="6" width="18" height="12" rx="2" />
+    <path d="M6 10h.01" />
+    <path d="M9 10h.01" />
+    <path d="M12 10h.01" />
+    <path d="M15 10h.01" />
+    <path d="M18 10h.01" />
+    <path d="M6 14h6" />
+    <path d="M6 18v2" />
+    <path d="M18 18v2" />
+  </>,
+);
+
+const BlacklistIcon = createMembersNavIcon(
+  <>
+    <circle cx="12" cy="12" r="9" />
+    <path d="m5 5 14 14" />
+  </>,
+);
+
+const RehearsalPlanningIcon = createMembersNavIcon(
+  <>
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <path d="M16 2v4" />
+    <path d="M8 2v4" />
+    <path d="M3 10h18" />
+  </>,
+);
+
+const DutyRosterIcon = createMembersNavIcon(
+  <>
+    <rect x="4" y="5" width="16" height="16" rx="2" />
+    <path d="M9 3v4" />
+    <path d="M15 3v4" />
+    <path d="M4 11h16" />
+    <path d="m9 16 2 2 4-4" />
+  </>,
+);
+
+const CateringIcon = createMembersNavIcon(
+  <>
+    <path d="m16 2-2.3 2.3a3 3 0 0 0 0 4.2l1.8 1.8a3 3 0 0 0 4.2 0L22 8" />
+    <path d="M15 15 3.3 3.3a4.2 4.2 0 0 0 0 6l7.3 7.3c.7.7 2 .7 2.8 0L15 15Zm0 0 7 7" />
+    <path d="m2.1 21.8 6.4-6.3" />
+    <path d="m19 5-7 7" />
+  </>,
+);
+
+const ProductionIcon = createMembersNavIcon(
+  <>
+    <path d="M3 4h18v4H3z" />
+    <path d="M5 8v12h14V8" />
+    <path d="M9 12h6" />
+    <path d="M9 16h6" />
+  </>,
+);
+
+const DepartmentsOverviewIcon = createMembersNavIcon(
+  <>
+    <circle cx="7" cy="7" r="2.5" />
+    <circle cx="17" cy="7" r="2.5" />
+    <circle cx="12" cy="17" r="2.5" />
+    <path d="M9.5 7h5" />
+    <path d="M9.4 8.6 12 12" />
+    <path d="M14.6 8.6 12 12" />
+    <path d="M12 14.5V12" />
+  </>,
+);
+
+const CastIcon = createMembersNavIcon(
+  <>
+    <circle cx="9" cy="8" r="3" />
+    <path d="M4 20c0-3 2.239-5.5 5-5.5S14 17 14 20" />
+    <path d="M17 11a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
+    <path d="M20.5 20c0-2.485-2.015-4.5-4.5-4.5" />
+  </>,
+);
+
+const ScenesIcon = createMembersNavIcon(
+  <>
+    <path d="M3 9h18v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    <path d="M3 9l2.5-5h5L8 9" />
+    <path d="M8 9l2.5-5h5L13 9" />
+    <path d="M3 13h18" />
+  </>,
+);
+
+const MembersAdminIcon = createMembersNavIcon(
+  <>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H7a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="m20 8 1 1 2-2" />
+  </>,
+);
+
+const PermissionsIcon = createMembersNavIcon(
+  <path d="M12 22s8-3 8-10V5l-8-3-8 3v7c0 7 8 10 8 10Z" />
+);
+
+const PhotoConsentIcon = createMembersNavIcon(
+  <>
+    <path d="M21 19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h3l2-3h4l2 3h3a2 2 0 0 1 2 2Z" />
+    <circle cx="12" cy="14" r="3" />
+  </>,
+);
+
+const WebsiteIcon = createMembersNavIcon(
+  <>
+    <path d="M12 22c4.97 0 9-3.6 9-8a7 7 0 0 0-7-7 4 4 0 0 1-4-4 9 9 0 0 0-9 9c0 4.4 4.03 8 9 8Z" />
+    <circle cx="6.5" cy="11.5" r="1.5" />
+    <circle cx="9.5" cy="7.5" r="1.5" />
+    <circle cx="14.5" cy="7.5" r="1.5" />
+    <circle cx="17.5" cy="11.5" r="1.5" />
+  </>,
+);
+
+const ServerAnalyticsIcon = createMembersNavIcon(
+  <>
+    <path d="M4 20h16" />
+    <path d="M6 16l4-6 3 4 4-7 3 5" />
+  </>,
+);
+
+const FinanceDashboardIcon = createMembersNavIcon(
+  <>
+    <rect x="3" y="6" width="18" height="12" rx="2" />
+    <path d="M7 10h10" />
+    <path d="M7 14h6" />
+    <circle cx="9" cy="10" r="0.5" fill="currentColor" />
+    <circle cx="15" cy="14" r="0.5" fill="currentColor" />
+  </>,
+);
+
+const FinanceBookingsIcon = createMembersNavIcon(
+  <>
+    <path d="M4 6h16v4H4z" />
+    <path d="M7 10v8a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2v-8" />
+    <path d="M9 14h6" />
+    <path d="M9 18h4" />
+  </>,
+);
+
+const FinanceBudgetsIcon = createMembersNavIcon(
+  <>
+    <path d="M4 19h16" />
+    <path d="M7 19v-7" />
+    <path d="M12 19v-11" />
+    <path d="M17 19v-5" />
+    <path d="M5 8h14l-2-3H7z" />
+  </>,
+);
+
+const FinanceExportIcon = createMembersNavIcon(
+  <>
+    <path d="M12 3v12" />
+    <path d="m8 11 4 4 4-4" />
+    <path d="M4 19h16" />
+  </>,
+);
+
+const DefaultIcon = createMembersNavIcon(<circle cx="12" cy="12" r="2" />);
+
+export const membersAssignmentsTodoItem: MembersNavItem = {
+  href: "/mitglieder/meine-gewerke/todos",
+  label: "Meine Gewerke-Aufgaben",
+  permissionKey: "mitglieder.meine-gewerke",
+  icon: DepartmentTodosIcon,
+};
+
+export const membersNavigation = [
+  {
+    id: "general",
+    label: "Allgemein",
+    items: [
+      {
+        href: "/mitglieder",
+        label: "Dashboard",
+        permissionKey: "mitglieder.dashboard",
+        icon: DashboardIcon,
+      },
+      {
+        href: "/mitglieder/profil",
+        label: "Profil",
+        permissionKey: "mitglieder.profil",
+        icon: ProfileIcon,
+      },
+      {
+        href: "/mitglieder/archiv-und-bilder",
+        label: "Archiv und Bilder",
+        permissionKey: "mitglieder.galerie",
+        icon: ArchiveIcon,
+      },
+      {
+        href: "/mitglieder/sperrliste",
+        label: "Sperrliste",
+        permissionKey: "mitglieder.sperrliste",
+        icon: BlacklistIcon,
+      },
+      {
+        href: "/mitglieder/issues",
+        label: "Feedback & Support",
+        permissionKey: "mitglieder.issues",
+        icon: IssuesIcon,
+      },
+    ],
+  },
+  {
+    id: "assignments",
+    label: "Proben & Gewerke",
+    items: [
+      {
+        href: "/mitglieder/meine-proben",
+        label: "Meine Proben",
+        permissionKey: "mitglieder.meine-proben",
+        icon: RehearsalsIcon,
+      },
+      {
+        href: "/mitglieder/meine-gewerke",
+        label: "Meine Gewerke",
+        permissionKey: "mitglieder.meine-gewerke",
+        icon: DepartmentsIcon,
+      },
+      {
+        href: "/mitglieder/koerpermasse",
+        label: "Körpermaße",
+        permissionKey: "mitglieder.koerpermasse",
+        icon: BodyMeasurementsIcon,
+      },
+      {
+        href: "/mitglieder/probenplanung",
+        label: "Probenplanung",
+        permissionKey: "mitglieder.probenplanung",
+        icon: RehearsalPlanningIcon,
+      },
+    ],
+  },
+  {
+    id: "final-week",
+    label: "Endproben Woche",
+    items: [
+      {
+        href: "/mitglieder/endproben-woche/dienstplan",
+        label: "Dienstplan",
+        permissionKey: "mitglieder.endprobenwoche",
+        icon: DutyRosterIcon,
+      },
+      {
+        href: "/mitglieder/endproben-woche/essenplanung",
+        label: "Essensplanung",
+        permissionKey: "mitglieder.essenplanung",
+        icon: CateringIcon,
+      },
+    ],
+  },
+  {
+    id: "production",
+    label: "Produktion",
+    items: [
+      {
+        href: "/mitglieder/produktionen",
+        label: "Übersicht",
+        permissionKey: "mitglieder.produktionen",
+        icon: ProductionIcon,
+      },
+      {
+        href: "/mitglieder/produktionen/gewerke",
+        label: "Gewerke & Teams",
+        permissionKey: "mitglieder.produktionen",
+        icon: DepartmentsOverviewIcon,
+      },
+      {
+        href: "/mitglieder/produktionen/besetzung",
+        label: "Rollen & Besetzung",
+        permissionKey: "mitglieder.produktionen",
+        icon: CastIcon,
+      },
+      {
+        href: "/mitglieder/produktionen/szenen",
+        label: "Szenen & Breakdowns",
+        permissionKey: "mitglieder.produktionen",
+        icon: ScenesIcon,
+      },
+    ],
+  },
+  {
+    id: "finance",
+    label: "Finanzen",
+    items: [
+      {
+        href: "/mitglieder/finanzen",
+        label: "Finanz-Dashboard",
+        permissionKey: "mitglieder.finanzen",
+        icon: FinanceDashboardIcon,
+      },
+      {
+        href: "/mitglieder/finanzen/buchungen",
+        label: "Buchungen",
+        permissionKey: "mitglieder.finanzen",
+        icon: FinanceBookingsIcon,
+      },
+      {
+        href: "/mitglieder/finanzen/budgets",
+        label: "Budgets",
+        permissionKey: "mitglieder.finanzen",
+        icon: FinanceBudgetsIcon,
+      },
+      {
+        href: "/mitglieder/finanzen/export",
+        label: "Exporte",
+        permissionKey: "mitglieder.finanzen.export",
+        icon: FinanceExportIcon,
+      },
+    ],
+  },
+  {
+    id: "admin",
+    label: "Verwaltung",
+    items: [
+      {
+        href: "/mitglieder/mitgliederverwaltung",
+        label: "Mitgliederverwaltung",
+        permissionKey: "mitglieder.rollenverwaltung",
+        icon: MembersAdminIcon,
+      },
+      {
+        href: "/mitglieder/onboarding-analytics",
+        label: "Onboarding Analytics",
+        permissionKey: "mitglieder.onboarding.analytics",
+        icon: DefaultIcon,
+      },
+      {
+        href: "/mitglieder/server-analytics",
+        label: "Server-Statistiken",
+        permissionKey: "mitglieder.server.analytics",
+        icon: ServerAnalyticsIcon,
+      },
+      {
+        href: "/mitglieder/rechte",
+        label: "Rechteverwaltung",
+        permissionKey: "mitglieder.rechte",
+        icon: PermissionsIcon,
+      },
+      {
+        href: "/mitglieder/fotoerlaubnisse",
+        label: "Fotoerlaubnisse",
+        permissionKey: "mitglieder.fotoerlaubnisse",
+        icon: PhotoConsentIcon,
+      },
+      {
+        href: "/mitglieder/website",
+        label: "Website & Theme",
+        permissionKey: "mitglieder.website.settings",
+        icon: WebsiteIcon,
+      },
+    ],
+  },
+] satisfies readonly MembersNavGroup[];
+
+export const defaultMembersNavIcon = DefaultIcon;

--- a/src/lib/__tests__/members-navigation.test.ts
+++ b/src/lib/__tests__/members-navigation.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
+  MEMBERS_NAV_PRODUCTION_GROUP_ID,
+  membersAssignmentsTodoItem,
+} from "@/config/members-navigation";
+import {
+  filterMembersNavigationByPermissions,
+  resolveAssignmentsGroupLabel,
+  selectMembersNavigation,
+  type ActiveProductionNavInfo,
+} from "@/lib/members-navigation";
+
+const BASE_PERMISSIONS = [
+  "mitglieder.dashboard",
+  "mitglieder.profil",
+  "mitglieder.galerie",
+  "mitglieder.sperrliste",
+  "mitglieder.issues",
+  "mitglieder.meine-proben",
+  "mitglieder.meine-gewerke",
+  "mitglieder.koerpermasse",
+  "mitglieder.probenplanung",
+  "mitglieder.endprobenwoche",
+  "mitglieder.essenplanung",
+  "mitglieder.produktionen",
+];
+
+describe("selectMembersNavigation", () => {
+  it("injects department todo item when memberships are present", () => {
+    const groups = selectMembersNavigation({ hasDepartmentMemberships: true });
+    const assignments = groups.find((group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID);
+
+    expect(assignments).toBeDefined();
+    const todoIndex = assignments!.items.findIndex(
+      (item) => item.href === membersAssignmentsTodoItem.href,
+    );
+    const departmentsIndex = assignments!.items.findIndex(
+      (item) => item.href === "/mitglieder/meine-gewerke",
+    );
+
+    expect(todoIndex).toBeGreaterThan(-1);
+    expect(todoIndex).toBe(departmentsIndex + 1);
+  });
+
+  it("omits the department todo item without memberships", () => {
+    const groups = selectMembersNavigation({ hasDepartmentMemberships: false });
+    const assignments = groups.find((group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID);
+
+    expect(assignments).toBeDefined();
+    const todoIndex = assignments!.items.findIndex(
+      (item) => item.href === membersAssignmentsTodoItem.href,
+    );
+
+    expect(todoIndex).toBe(-1);
+  });
+
+  it("adds an active production shortcut with badge and aria label", () => {
+    const activeProduction: ActiveProductionNavInfo = {
+      id: "show-123",
+      title: "Sommernachtstraum",
+      year: 2025,
+    };
+
+    const groups = selectMembersNavigation({ activeProduction });
+    const production = groups.find((group) => group.id === MEMBERS_NAV_PRODUCTION_GROUP_ID);
+
+    expect(production).toBeDefined();
+    const item = production!.items.find(
+      (entry) => entry.href === `/mitglieder/produktionen/${activeProduction.id}`,
+    );
+
+    expect(item).toBeDefined();
+    expect(item!.badge).toBe(String(activeProduction.year));
+    expect(item!.ariaLabel).toContain(activeProduction.title!);
+  });
+});
+
+describe("filterMembersNavigationByPermissions", () => {
+  it("hides finance navigation for members without finance permissions", () => {
+    const groups = selectMembersNavigation();
+    const { groups: filtered } = filterMembersNavigationByPermissions(groups, BASE_PERMISSIONS);
+
+    expect(filtered.some((group) => group.id === "finance")).toBe(false);
+  });
+
+  it("keeps only department related assignments for department-focused members", () => {
+    const groups = selectMembersNavigation({ hasDepartmentMemberships: true });
+    const permissions = ["mitglieder.meine-gewerke"] as const;
+    const { groups: filtered } = filterMembersNavigationByPermissions(groups, permissions);
+    const assignments = filtered.find((group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID);
+
+    expect(assignments).toBeDefined();
+    const hrefs = assignments!.items.map((item) => item.href);
+    expect(hrefs).toEqual([
+      "/mitglieder/meine-gewerke",
+      membersAssignmentsTodoItem.href,
+    ]);
+  });
+});
+
+describe("resolveAssignmentsGroupLabel", () => {
+  it("returns 'Gewerke' when focus is departments", () => {
+    expect(resolveAssignmentsGroupLabel("departments", [])).toBe("Gewerke");
+  });
+
+  it("infers label from permissions when focus is none", () => {
+    expect(
+      resolveAssignmentsGroupLabel("none", ["mitglieder.meine-gewerke", "mitglieder.meine-proben"]),
+    ).toBe("Proben & Gewerke");
+    expect(resolveAssignmentsGroupLabel("none", ["mitglieder.meine-gewerke"])).toBe("Gewerke");
+    expect(resolveAssignmentsGroupLabel("none", [])).toBe("Proben");
+  });
+});

--- a/src/lib/members-navigation.ts
+++ b/src/lib/members-navigation.ts
@@ -1,0 +1,172 @@
+import type { MembersNavGroup, MembersNavItem } from "@/config/members-navigation";
+import {
+  MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
+  MEMBERS_NAV_PRODUCTION_GROUP_ID,
+  defaultMembersNavIcon,
+  membersAssignmentsTodoItem,
+  membersNavigation,
+} from "@/config/members-navigation";
+
+export type AssignmentFocus = "none" | "rehearsals" | "departments" | "both";
+
+export interface ActiveProductionNavInfo {
+  id: string;
+  title: string | null;
+  year: number;
+}
+
+export interface MembersNavigationSelectorOptions {
+  groups?: readonly MembersNavGroup[];
+  hasDepartmentMemberships?: boolean;
+  activeProduction?: ActiveProductionNavInfo | null;
+}
+
+export interface MembersNavigationFilterResult {
+  groups: MembersNavGroup[];
+  flat: MembersNavItem[];
+}
+
+function cloneGroupItems(items: readonly MembersNavItem[]) {
+  return items.map((item) => ({ ...item }));
+}
+
+function ensureTodoItem(items: MembersNavItem[]) {
+  const todoHref = membersAssignmentsTodoItem.href;
+  const existingIndex = items.findIndex((item) => item.href === todoHref);
+  if (existingIndex !== -1) {
+    return items;
+  }
+
+  const baseIndex = items.findIndex((item) => item.href === "/mitglieder/meine-gewerke");
+  const todoItem: MembersNavItem = { ...membersAssignmentsTodoItem };
+  if (baseIndex >= 0) {
+    items.splice(baseIndex + 1, 0, todoItem);
+  } else {
+    items.push(todoItem);
+  }
+  return items;
+}
+
+function removeTodoItem(items: MembersNavItem[]) {
+  const todoHref = membersAssignmentsTodoItem.href;
+  const existingIndex = items.findIndex((item) => item.href === todoHref);
+  if (existingIndex !== -1) {
+    items.splice(existingIndex, 1);
+  }
+  return items;
+}
+
+export function selectMembersNavigation({
+  groups = membersNavigation,
+  hasDepartmentMemberships = false,
+  activeProduction = null,
+}: MembersNavigationSelectorOptions = {}): MembersNavGroup[] {
+  return groups.map((group) => {
+    if (group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID) {
+      const items = cloneGroupItems(group.items);
+      if (hasDepartmentMemberships) {
+        ensureTodoItem(items);
+      } else {
+        removeTodoItem(items);
+      }
+      return { ...group, items };
+    }
+
+    if (group.id === MEMBERS_NAV_PRODUCTION_GROUP_ID) {
+      const items = cloneGroupItems(group.items);
+      if (activeProduction) {
+        const href = `/mitglieder/produktionen/${activeProduction.id}`;
+        const alreadyIncluded = items.some((item) => item.href === href);
+        if (!alreadyIncluded) {
+          const ariaLabelSuffix =
+            activeProduction.title && activeProduction.title.trim()
+              ? activeProduction.title
+              : String(activeProduction.year);
+          const overviewIcon =
+            items.find((item) => item.href === "/mitglieder/produktionen")?.icon ??
+            defaultMembersNavIcon;
+
+          const activeItem: MembersNavItem = {
+            href,
+            label: "Aktive Produktion",
+            permissionKey: "mitglieder.produktionen",
+            icon: overviewIcon,
+            badge: String(activeProduction.year),
+            ariaLabel: `Aktive Produktion ${ariaLabelSuffix}`,
+          };
+
+          const overviewIndex = items.findIndex((item) => item.href === "/mitglieder/produktionen");
+          if (overviewIndex >= 0) {
+            items.splice(overviewIndex + 1, 0, activeItem);
+          } else {
+            items.unshift(activeItem);
+          }
+        }
+      }
+      return { ...group, items };
+    }
+
+    return { ...group, items: cloneGroupItems(group.items) };
+  });
+}
+
+export function resolveAssignmentsGroupLabel(
+  focus: AssignmentFocus,
+  permissions: readonly string[] | Set<string> | undefined,
+) {
+  if (focus === "both") return "Proben & Gewerke";
+  if (focus === "departments") return "Gewerke";
+  if (focus === "rehearsals") return "Proben";
+
+  const permissionSet =
+    permissions instanceof Set ? permissions : new Set(permissions ?? []);
+  const canSeeRehearsals = permissionSet.has("mitglieder.meine-proben");
+  const canSeeDepartments = permissionSet.has("mitglieder.meine-gewerke");
+
+  if (canSeeRehearsals && canSeeDepartments) return "Proben & Gewerke";
+  if (canSeeDepartments) return "Gewerke";
+  return "Proben";
+}
+
+export function filterMembersNavigationByPermissions(
+  groups: readonly MembersNavGroup[],
+  permissions: readonly string[] | undefined,
+): MembersNavigationFilterResult {
+  const permissionSet = permissions ? new Set(permissions) : null;
+
+  const filteredGroups = groups
+    .map((group) => {
+      const items = group.items.filter((item) => {
+        if (!item.permissionKey || !permissionSet) return true;
+        return permissionSet.has(item.permissionKey);
+      });
+      return { ...group, items };
+    })
+    .filter((group) => group.items.length > 0);
+
+  const flat = filteredGroups.flatMap((group) => group.items);
+  return { groups: filteredGroups, flat };
+}
+
+export function filterMembersNavigationByQuery(
+  groups: readonly MembersNavGroup[],
+  normalizedQuery: string,
+): MembersNavigationFilterResult {
+  if (!normalizedQuery) {
+    const clonedGroups = groups.map((group) => ({ ...group, items: cloneGroupItems(group.items) }));
+    const flat = clonedGroups.flatMap((group) => group.items);
+    return { groups: clonedGroups, flat };
+  }
+
+  const filteredGroups = groups
+    .map((group) => {
+      const items = group.items.filter((item) =>
+        item.label.toLowerCase().includes(normalizedQuery),
+      );
+      return { ...group, items };
+    })
+    .filter((group) => group.items.length > 0);
+
+  const flat = filteredGroups.flatMap((group) => group.items);
+  return { groups: filteredGroups, flat };
+}


### PR DESCRIPTION
## Summary
- extract the members navigation into a typed config with inline icons and permission metadata
- add helper selectors that inject context-specific links (e.g. department todos, active production) and expose filtering utilities
- simplify MembersNav rendering logic, add regression tests for role variants, and document the extension workflow in the README

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2910c231c832da876a400d650846a