### PR TITLE
Add homepage countdown with admin editing

### DIFF
--- a/prisma/migrations/20270320120000_homepage_countdown/migration.sql
+++ b/prisma/migrations/20270320120000_homepage_countdown/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "public"."HomepageCountdown" (
+    "id" TEXT NOT NULL DEFAULT 'public',
+    "countdownTarget" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "HomepageCountdown_pkey" PRIMARY KEY ("id")
+);
+
+-- Seed default countdown
+INSERT INTO "public"."HomepageCountdown" ("id", "countdownTarget")
+VALUES ('public', '2026-06-18T17:00:00.000Z')
+ON CONFLICT ("id") DO UPDATE SET
+    "countdownTarget" = EXCLUDED."countdownTarget",
+    "updatedAt" = CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -513,6 +513,13 @@ model Clue {
   @@index([showId, published, releaseAt])
 }
 
+model HomepageCountdown {
+  id              String   @id @default("public")
+  countdownTarget DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}
+
 model MysterySettings {
   id                 String   @id @default("default")
   countdownTarget    DateTime?

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -80,6 +80,17 @@ async function main() {
     },
   });
 
+  await prisma.homepageCountdown.upsert({
+    where: { id: "public" },
+    update: {
+      countdownTarget: new Date("2026-06-18T17:00:00.000Z"),
+    },
+    create: {
+      id: "public",
+      countdownTarget: new Date("2026-06-18T17:00:00.000Z"),
+    },
+  });
+
   // --- Chronik: use ONLY the provided Altroßthal data below ---
 
   // Altroßthal data provided (curated demo -> replace with real assets later)

--- a/src/app/(site)/_components/homepage-countdown.tsx
+++ b/src/app/(site)/_components/homepage-countdown.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Countdown } from "@/components/countdown";
+import { useFrontendEditing } from "@/components/frontend-editing/frontend-editing-provider";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Heading, Text } from "@/components/ui/typography";
+
+type HomepageCountdownProps = {
+  initialCountdownTarget: string | null;
+  effectiveCountdownTarget: string;
+  defaultCountdownTarget: string;
+  updatedAt: string | null;
+  hasCustomCountdown: boolean;
+};
+
+type CountdownSettingsState = {
+  countdownTarget: string | null;
+  effectiveCountdownTarget: string;
+  updatedAt: string | null;
+  hasCustomCountdown: boolean;
+};
+
+type SavedSettingsResponse = {
+  settings?: {
+    countdownTarget: string | null;
+    effectiveCountdownTarget: string;
+    updatedAt: string | null;
+    hasCustomCountdown: boolean;
+  };
+  error?: string;
+};
+
+const COUNTDOWN_LABEL_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "full",
+  timeStyle: "short",
+  timeZone: "Europe/Berlin",
+});
+
+const UPDATED_AT_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "Europe/Berlin",
+});
+
+function isoToLocalInputValue(iso: string | null) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const timezoneOffset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - timezoneOffset * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+function localInputToIso(value: string) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Date(date.getTime()).toISOString();
+}
+
+function formatIsoForDisplay(iso: string | null, formatter: Intl.DateTimeFormat) {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return formatter.format(date);
+}
+
+export function HomepageCountdown({
+  initialCountdownTarget,
+  effectiveCountdownTarget,
+  defaultCountdownTarget,
+  updatedAt,
+  hasCustomCountdown,
+}: HomepageCountdownProps) {
+  const { hasFeature, openFeature, closeFeature, activeFeature } = useFrontendEditing();
+  const canEdit = hasFeature("site.countdown");
+  const editorOpen = canEdit && activeFeature === "site.countdown";
+
+  const [settings, setSettings] = useState<CountdownSettingsState>(() => ({
+    countdownTarget: initialCountdownTarget,
+    effectiveCountdownTarget,
+    updatedAt,
+    hasCustomCountdown,
+  }));
+  const [countdownInputValue, setCountdownInputValue] = useState(() => isoToLocalInputValue(initialCountdownTarget));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSettings({
+      countdownTarget: initialCountdownTarget,
+      effectiveCountdownTarget,
+      updatedAt,
+      hasCustomCountdown,
+    });
+    setCountdownInputValue(isoToLocalInputValue(initialCountdownTarget));
+  }, [initialCountdownTarget, effectiveCountdownTarget, updatedAt, hasCustomCountdown]);
+
+  useEffect(() => {
+    if (!editorOpen) {
+      setError(null);
+      setSuccess(null);
+    }
+  }, [editorOpen]);
+
+  const countdownLabel = useMemo(
+    () => formatIsoForDisplay(settings.effectiveCountdownTarget, COUNTDOWN_LABEL_FORMATTER),
+    [settings.effectiveCountdownTarget],
+  );
+
+  const defaultCountdownLabel = useMemo(
+    () => formatIsoForDisplay(defaultCountdownTarget, COUNTDOWN_LABEL_FORMATTER),
+    [defaultCountdownTarget],
+  );
+
+  const updatedAtLabel = useMemo(
+    () => formatIsoForDisplay(settings.updatedAt, UPDATED_AT_FORMATTER),
+    [settings.updatedAt],
+  );
+
+  const countdownReached = useMemo(() => {
+    const target = new Date(settings.effectiveCountdownTarget);
+    if (Number.isNaN(target.getTime())) return false;
+    return target.getTime() <= Date.now();
+  }, [settings.effectiveCountdownTarget]);
+
+  function handleToggleEditor() {
+    if (!canEdit) return;
+    if (editorOpen) {
+      closeFeature();
+    } else {
+      openFeature("site.countdown");
+    }
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const isoCountdown = countdownInputValue ? localInputToIso(countdownInputValue) : null;
+    if (countdownInputValue && !isoCountdown) {
+      setError("Bitte gib ein gültiges Datum für den Countdown an.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await fetch("/api/homepage/countdown", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ countdownTarget: isoCountdown }),
+      });
+      const data = (await response.json().catch(() => ({}))) as SavedSettingsResponse;
+
+      if (!response.ok || !data?.settings) {
+        throw new Error(data?.error || "Der Countdown konnte nicht gespeichert werden.");
+      }
+
+      const nextCountdownInput = isoToLocalInputValue(data.settings.countdownTarget ?? null);
+      setSettings({
+        countdownTarget: data.settings.countdownTarget ?? null,
+        effectiveCountdownTarget: data.settings.effectiveCountdownTarget,
+        updatedAt: data.settings.updatedAt ?? null,
+        hasCustomCountdown: data.settings.hasCustomCountdown,
+      });
+      setCountdownInputValue(nextCountdownInput);
+      setSuccess("Der Premieren-Countdown wurde gespeichert.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unbekannter Fehler beim Speichern.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-col items-center gap-5 text-center">
+      <div className="flex flex-col items-center gap-5">
+        <Heading level="h3" align="center">
+          {countdownReached ? "Premierenwochenende" : "Premiere in"}
+        </Heading>
+        {countdownReached ? (
+          <Text variant="lead" tone="success" className="font-semibold">
+            Das Ensemble steht auf der Bühne – wir sehen uns im Schlosspark!
+          </Text>
+        ) : (
+          <Countdown targetDate={settings.effectiveCountdownTarget} />
+        )}
+        <Text variant="small" tone="muted">
+          {countdownLabel
+            ? countdownReached
+              ? `Gestartet am ${countdownLabel}.`
+              : `Erste Aufführung am ${countdownLabel}.`
+            : "Das genaue Datum geben wir in Kürze bekannt."}
+        </Text>
+        {canEdit ? (
+          <Button
+            size="sm"
+            variant={editorOpen ? "secondary" : "outline"}
+            onClick={handleToggleEditor}
+            aria-pressed={editorOpen}
+          >
+            {editorOpen ? "Einstellungen schließen" : "Countdown bearbeiten"}
+          </Button>
+        ) : null}
+      </div>
+
+      <Dialog
+        open={editorOpen}
+        onOpenChange={(open) => {
+          if (!canEdit) return;
+          if (open) {
+            openFeature("site.countdown");
+          } else {
+            closeFeature();
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Premieren-Countdown einstellen</DialogTitle>
+            <DialogDescription>
+              Setze Datum und Uhrzeit für die erste Aufführung. Der Countdown ist direkt auf der Startseite sichtbar.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="homepage-countdown">Datum &amp; Uhrzeit</Label>
+              <Input
+                id="homepage-countdown"
+                type="datetime-local"
+                value={countdownInputValue}
+                onChange={(event) => setCountdownInputValue(event.target.value)}
+                aria-describedby="homepage-countdown-description"
+              />
+              <Text id="homepage-countdown-description" variant="small" tone="muted">
+                Zeiten werden als lokale Zeit gespeichert. Besucher*innen sehen den Countdown in ihrer Systemsprache.
+              </Text>
+              <Text variant="small" tone="muted">
+                {settings.hasCustomCountdown
+                  ? countdownLabel
+                    ? `Aktuelles Veröffentlichungsdatum: ${countdownLabel}`
+                    : "Aktuelles Veröffentlichungsdatum ist gesetzt."
+                  : defaultCountdownLabel
+                      ? `Kein eigenes Datum hinterlegt – Standard: ${defaultCountdownLabel}`
+                      : "Kein eigenes Datum hinterlegt."}
+              </Text>
+            </div>
+
+            {updatedAtLabel ? (
+              <Text variant="small" tone="muted">
+                Zuletzt aktualisiert: {updatedAtLabel}
+              </Text>
+            ) : null}
+
+            {error ? <Text tone="destructive">{error}</Text> : null}
+            {success ? <Text tone="success">{success}</Text> : null}
+
+            <DialogFooter className="gap-2">
+              <Button type="submit" disabled={saving} aria-busy={saving}>
+                {saving ? "Speichern…" : "Einstellungen speichern"}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={saving}
+                onClick={() => setCountdownInputValue(isoToLocalInputValue(null))}
+              >
+                Zurücksetzen (Standard)
+              </Button>
+              <DialogClose asChild>
+                <Button type="button" variant="outline" disabled={saving}>
+                  Schließen
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/(site)/mystery/_components/mystery-countdown-card.tsx
+++ b/src/app/(site)/mystery/_components/mystery-countdown-card.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Text } from "@/components/ui/typography";
-import { Countdown } from "./countdown";
+import { Countdown } from "@/components/countdown";
 import { useFrontendEditing } from "@/components/frontend-editing/frontend-editing-provider";
 import {
   type MysteryTimerFormSavedSettings,

--- a/src/app/api/homepage/countdown/route.ts
+++ b/src/app/api/homepage/countdown/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  DEFAULT_HOMEPAGE_COUNTDOWN_ISO,
+  readHomepageCountdown,
+  resolveHomepageCountdown,
+  saveHomepageCountdown,
+} from "@/lib/homepage-countdown";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+const updateSchema = z.object({
+  countdownTarget: z
+    .union([z.string().datetime({ offset: true }), z.null()])
+    .transform((value) => (value ? new Date(value) : null)),
+});
+
+function serializeSettings(record: Awaited<ReturnType<typeof readHomepageCountdown>>) {
+  const resolved = resolveHomepageCountdown(record);
+  return {
+    countdownTarget: record?.countdownTarget ? record.countdownTarget.toISOString() : null,
+    effectiveCountdownTarget: resolved.effectiveCountdownTarget.toISOString(),
+    updatedAt: resolved.updatedAt ? resolved.updatedAt.toISOString() : null,
+    hasCustomCountdown: resolved.hasCustomCountdown,
+    defaultCountdownTarget: DEFAULT_HOMEPAGE_COUNTDOWN_ISO,
+  } as const;
+}
+
+export async function GET() {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.website.countdown"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  try {
+    const record = await readHomepageCountdown();
+    return NextResponse.json({ settings: serializeSettings(record) });
+  } catch (error) {
+    console.error("Failed to load homepage countdown", error);
+    return NextResponse.json({ error: "Einstellungen konnten nicht geladen werden." }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const session = await requireAuth();
+  if (!(await hasPermission(session.user, "mitglieder.website.countdown"))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: "Datenbank ist nicht konfiguriert." }, { status: 500 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const parsed = updateSchema.safeParse(payload);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const message = issue?.message ?? "Ungültige Eingabe.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  try {
+    const saved = await saveHomepageCountdown({ countdownTarget: parsed.data.countdownTarget });
+    return NextResponse.json({ settings: serializeSettings(saved) });
+  } catch (error) {
+    console.error("Failed to save homepage countdown", error);
+    return NextResponse.json({ error: "Der Countdown konnte nicht gespeichert werden." }, { status: 500 });
+  }
+}

--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -29,7 +29,10 @@ function getTimeRemaining(targetTimestamp: number): CountdownState {
   const totalSeconds = Math.floor(totalMilliseconds / MILLISECONDS_PER_SECOND);
 
   const days = Math.floor(totalSeconds / (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE));
-  const hours = Math.floor((totalSeconds % (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE)) / (MINUTES_PER_HOUR * SECONDS_PER_MINUTE));
+  const hours = Math.floor(
+    (totalSeconds % (HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE)) /
+      (MINUTES_PER_HOUR * SECONDS_PER_MINUTE),
+  );
   const minutes = Math.floor((totalSeconds % (MINUTES_PER_HOUR * SECONDS_PER_MINUTE)) / SECONDS_PER_MINUTE);
   const seconds = totalSeconds % SECONDS_PER_MINUTE;
 

--- a/src/lib/frontend-editing.ts
+++ b/src/lib/frontend-editing.ts
@@ -1,6 +1,6 @@
 import { hasPermission } from "@/lib/permissions";
 
-export type FrontendEditingFeatureKey = "mystery.timer";
+export type FrontendEditingFeatureKey = "mystery.timer" | "site.countdown";
 
 export type FrontendEditingFeature = {
   key: FrontendEditingFeatureKey;
@@ -18,6 +18,12 @@ const FEATURE_DEFINITIONS: FeatureDefinition[] = [
     label: "Mystery-Timer",
     description: "Countdown und Hinweistext für die Mystery-Startseite verwalten.",
     permissionKey: "mitglieder.mystery.timer",
+  },
+  {
+    key: "site.countdown",
+    label: "Premieren-Countdown",
+    description: "Countdown für die öffentliche Startseite anpassen.",
+    permissionKey: "mitglieder.website.countdown",
   },
 ];
 

--- a/src/lib/homepage-countdown.ts
+++ b/src/lib/homepage-countdown.ts
@@ -1,0 +1,41 @@
+import { prisma } from "@/lib/prisma";
+import type { HomepageCountdown } from "@prisma/client";
+
+export const HOMEPAGE_COUNTDOWN_ID = "public";
+export const DEFAULT_HOMEPAGE_COUNTDOWN_ISO = "2026-06-18T17:00:00.000Z";
+
+export type HomepageCountdownRecord = HomepageCountdown | null;
+
+function getDefaultCountdownDate() {
+  return new Date(DEFAULT_HOMEPAGE_COUNTDOWN_ISO);
+}
+
+export function resolveHomepageCountdown(record: HomepageCountdownRecord) {
+  const defaultCountdown = getDefaultCountdownDate();
+  const storedCountdown = record?.countdownTarget ?? null;
+  const effectiveCountdownTarget = storedCountdown ?? defaultCountdown;
+
+  return {
+    countdownTarget: storedCountdown,
+    effectiveCountdownTarget,
+    updatedAt: record?.updatedAt ?? null,
+    hasCustomCountdown: storedCountdown !== null,
+  } as const;
+}
+
+export async function readHomepageCountdown() {
+  return prisma.homepageCountdown.findUnique({ where: { id: HOMEPAGE_COUNTDOWN_ID } });
+}
+
+export async function saveHomepageCountdown(data: { countdownTarget: Date | null }) {
+  return prisma.homepageCountdown.upsert({
+    where: { id: HOMEPAGE_COUNTDOWN_ID },
+    update: {
+      countdownTarget: data.countdownTarget,
+    },
+    create: {
+      id: HOMEPAGE_COUNTDOWN_ID,
+      countdownTarget: data.countdownTarget,
+    },
+  });
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -179,6 +179,12 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     category: "membership",
   },
   {
+    key: "mitglieder.website.countdown",
+    label: "Premieren-Countdown verwalten",
+    description: "Countdown zur ersten Aufführung auf der öffentlichen Startseite einstellen.",
+    category: "membership",
+  },
+  {
     key: "mitglieder.fotoerlaubnisse",
     label: "Fotoerlaubnisse verwalten",
     description: "Bereich zum Prüfen und Freigeben von Fotoeinverständniserklärungen.",


### PR DESCRIPTION
## Summary
- add homepage countdown component with modal editing hooks on the public landing page
- expose homepage countdown data via Prisma helpers and a protected API backed by a new table and seed defaults
- register a shared countdown UI component, new frontend-editing feature and permission for administrators

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d291089f34832db41733babc9f2a32