### PR TITLE
feat: show dynamic ensemble count on about page

### DIFF
--- a/src/app/(site)/ueber-uns/page.tsx
+++ b/src/app/(site)/ueber-uns/page.tsx
@@ -12,6 +12,7 @@ import {
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Heading, Text } from "@/components/ui/typography";
+import { getCurrentProductionEnsembleStats } from "@/lib/ensemble";
 
 export const metadata: Metadata = {
   title: "Über uns",
@@ -29,7 +30,15 @@ export const metadata: Metadata = {
   },
 };
 
-const highlights = [
+type Highlight = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+const NUMBER_FORMATTER = new Intl.NumberFormat("de-DE");
+
+const baseHighlights: Highlight[] = [
   {
     label: "Gründung",
     value: "2009",
@@ -142,8 +151,20 @@ const engagement = [
   },
 ];
 
-export default function AboutPage() {
+export default async function AboutPage() {
   const baseUrl = (process.env.NEXTAUTH_URL || "http://localhost:3000").replace(/\/$/, "");
+  const ensembleStats = await getCurrentProductionEnsembleStats();
+  const highlights = baseHighlights.map<Highlight>((item) => {
+    if (item.label !== "Ensemble" || !ensembleStats) {
+      return item;
+    }
+
+    return {
+      ...item,
+      value: NUMBER_FORMATTER.format(ensembleStats.memberCount),
+      detail: "Mitglieder in der aktuellen Produktion – Darstellende, Musiker:innen und helfende Hände",
+    };
+  });
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "PerformingGroup",

--- a/src/lib/ensemble.ts
+++ b/src/lib/ensemble.ts
@@ -1,0 +1,48 @@
+import { cache } from "react";
+
+import { prisma } from "@/lib/prisma";
+
+type CurrentProductionEnsembleStats = {
+  showId: string;
+  year: number;
+  title: string | null;
+  memberCount: number;
+};
+
+export const getCurrentProductionEnsembleStats = cache(async (): Promise<CurrentProductionEnsembleStats | null> => {
+  if (!process.env.DATABASE_URL) {
+    return null;
+  }
+
+  const latestShow = await prisma.show.findFirst({
+    orderBy: [
+      { year: "desc" },
+      { revealedAt: "desc" },
+    ],
+    select: {
+      id: true,
+      year: true,
+      title: true,
+    },
+  });
+
+  if (!latestShow) {
+    return null;
+  }
+
+  const participants = await prisma.characterCasting.findMany({
+    where: {
+      character: { showId: latestShow.id },
+      user: { deactivatedAt: null },
+    },
+    select: { userId: true },
+    distinct: ["userId"],
+  });
+
+  return {
+    showId: latestShow.id,
+    year: latestShow.year,
+    title: latestShow.title ?? null,
+    memberCount: participants.length,
+  };
+});


### PR DESCRIPTION
## Summary
- add a Prisma-backed helper to count ensemble participants for the latest production
- surface the live participant count on the public “Über uns” page with a fallback when no database is configured
- keep the highlight detail text aligned with the new dynamic data

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d292207ac0832da9ae9b8305111c17