### PR TITLE
Restore quick dev login shortcuts on /login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/theater?schema=public
 
 # Mirror to the client to avoid hydration mismatches ("1" enables dev-only login)
 NEXT_PUBLIC_AUTH_DEV_NO_DB=0
+# Optional: Override the quick login buttons shown on /login in dev/test environments.
+#NEXT_PUBLIC_AUTH_DEV_TEST_USERS=member@example.com,cast@example.com,tech@example.com
 
 # Optional: ICS feed for sächsische Schulferien. Wird genutzt, um die Sperrliste zu annotieren.
 #SAXONY_HOLIDAYS_ICS_URL=https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics

--- a/src/lib/auth-dev-test-users.ts
+++ b/src/lib/auth-dev-test-users.ts
@@ -1,0 +1,27 @@
+import { ROLE_LABELS, type Role } from "@/lib/roles";
+
+export type DevTestUser = {
+  email: string;
+  role: Role;
+  label: string;
+};
+
+export const DEV_TEST_USERS: DevTestUser[] = [
+  { email: "member@example.com", role: "member", label: ROLE_LABELS.member },
+  { email: "cast@example.com", role: "cast", label: ROLE_LABELS.cast },
+  { email: "tech@example.com", role: "tech", label: ROLE_LABELS.tech },
+  { email: "board@example.com", role: "board", label: ROLE_LABELS.board },
+  { email: "finance@example.com", role: "finance", label: ROLE_LABELS.finance },
+  { email: "admin@example.com", role: "admin", label: ROLE_LABELS.admin },
+  { email: "owner@example.com", role: "owner", label: ROLE_LABELS.owner },
+];
+
+export const DEV_TEST_USER_EMAILS = DEV_TEST_USERS.map((user) => user.email);
+
+export const DEV_TEST_USER_ROLE_MAP: Record<string, Role> = DEV_TEST_USERS.reduce(
+  (acc, user) => {
+    acc[user.email] = user.role;
+    return acc;
+  },
+  {} as Record<string, Role>,
+);


### PR DESCRIPTION
## Summary
- add a shared definition for dev/test login accounts including labels and roles
- surface the quick test login buttons again in development by falling back to the shared list when no env override is set
- reuse the shared constants inside the credentials provider and document the optional override in `.env.example`

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d29ab87548832db6c1abf42e432e9c