### PR TITLE
Fix countdown hydration with stable server timestamp

### DIFF
--- a/src/app/(site)/_components/homepage-countdown.tsx
+++ b/src/app/(site)/_components/homepage-countdown.tsx
@@ -24,6 +24,7 @@ type HomepageCountdownProps = {
   defaultCountdownTarget: string;
   updatedAt: string | null;
   hasCustomCountdown: boolean;
+  initialNow: number;
 };
 
 type CountdownSettingsState = {
@@ -84,6 +85,7 @@ export function HomepageCountdown({
   defaultCountdownTarget,
   updatedAt,
   hasCustomCountdown,
+  initialNow,
 }: HomepageCountdownProps) {
   const { hasFeature, openFeature, closeFeature, activeFeature } = useFrontendEditing();
   const canEdit = hasFeature("site.countdown");
@@ -198,7 +200,7 @@ export function HomepageCountdown({
             Das Ensemble steht auf der Bühne – wir sehen uns im Schlosspark!
           </Text>
         ) : (
-          <Countdown targetDate={settings.effectiveCountdownTarget} />
+          <Countdown targetDate={settings.effectiveCountdownTarget} initialNow={initialNow} />
         )}
         <Text variant="small" tone="muted">
           {countdownLabel

--- a/src/app/(site)/mystery/_components/mystery-countdown-card.tsx
+++ b/src/app/(site)/mystery/_components/mystery-countdown-card.tsx
@@ -36,6 +36,7 @@ type MysteryCountdownCardProps = {
   hasCustomCountdown: boolean;
   hasCustomMessage: boolean;
   isFirstRiddleReleased: boolean;
+  initialNow: number;
 };
 
 type TimerState = {
@@ -61,6 +62,7 @@ export function MysteryCountdownCard({
   hasCustomCountdown,
   hasCustomMessage,
   isFirstRiddleReleased,
+  initialNow,
 }: MysteryCountdownCardProps) {
   const router = useRouter();
   const { hasFeature, toggleFeature, activeFeature } = useFrontendEditing();
@@ -142,7 +144,7 @@ export function MysteryCountdownCard({
       <CardContent className="space-y-4">
         {showCountdown ? (
           <>
-            <Countdown targetDate={state.effectiveCountdownTarget} />
+            <Countdown targetDate={state.effectiveCountdownTarget} initialNow={initialNow} />
             {countdownLabel ? (
               <Text variant="small" tone="muted">
                 Start am {countdownLabel}

--- a/src/app/(site)/mystery/page.tsx
+++ b/src/app/(site)/mystery/page.tsx
@@ -83,6 +83,7 @@ export const revalidate = 30;
 
 export default async function MysteryPage() {
   const now = new Date();
+  const initialNow = now.getTime();
   let clues: Clue[] = [];
   let tips: MysteryTipModel[] = [];
   let settingsRecord: Awaited<ReturnType<typeof readMysterySettings>> = null;
@@ -176,6 +177,7 @@ export default async function MysteryPage() {
             hasCustomCountdown={resolvedSettings.hasCustomCountdown}
             hasCustomMessage={resolvedSettings.hasCustomMessage}
             isFirstRiddleReleased={isFirstRiddleReleased}
+            initialNow={initialNow}
           />
           <Card className="flex flex-col">
             <CardHeader>

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -26,6 +26,7 @@ export default async function Home() {
     }
   }
   const resolvedCountdown = resolveHomepageCountdown(countdownRecord);
+  const countdownInitialNow = Date.now();
   const effectiveCountdownTargetIso = resolvedCountdown.effectiveCountdownTarget.toISOString();
   const initialCountdownTargetIso = resolvedCountdown.countdownTarget
     ? resolvedCountdown.countdownTarget.toISOString()
@@ -74,6 +75,7 @@ export default async function Home() {
               defaultCountdownTarget={DEFAULT_HOMEPAGE_COUNTDOWN_ISO}
               updatedAt={updatedAtIso}
               hasCustomCountdown={resolvedCountdown.hasCustomCountdown}
+              initialNow={countdownInitialNow}
             />
             <Text variant="bodyLg" align="center" tone="muted">
               Ein einziges Wochenende. Ein Sommer. Ein Stück.

--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -7,6 +7,7 @@ import { Text } from "@/components/ui/typography";
 
 type CountdownProps = {
   targetDate: string;
+  initialNow: number;
   className?: string;
 };
 
@@ -23,8 +24,15 @@ const SECONDS_PER_MINUTE = 60;
 const MINUTES_PER_HOUR = 60;
 const HOURS_PER_DAY = 24;
 
-function getTimeRemaining(targetTimestamp: number): CountdownState {
-  const now = Date.now();
+const EMPTY_COUNTDOWN_STATE: CountdownState = {
+  totalMilliseconds: 0,
+  days: 0,
+  hours: 0,
+  minutes: 0,
+  seconds: 0,
+};
+
+function getTimeRemaining(targetTimestamp: number, now: number): CountdownState {
   const totalMilliseconds = Math.max(0, targetTimestamp - now);
   const totalSeconds = Math.floor(totalMilliseconds / MILLISECONDS_PER_SECOND);
 
@@ -49,20 +57,30 @@ function formatNumber(value: number) {
   return value.toString().padStart(2, "0");
 }
 
-export function Countdown({ targetDate, className }: CountdownProps) {
+export function Countdown({ targetDate, initialNow, className }: CountdownProps) {
   const targetTimestamp = useMemo(() => new Date(targetDate).getTime(), [targetDate]);
-  const [state, setState] = useState<CountdownState>(() => getTimeRemaining(targetTimestamp));
+  const [state, setState] = useState<CountdownState>(() => {
+    if (Number.isNaN(targetTimestamp) || !Number.isFinite(initialNow)) {
+      return EMPTY_COUNTDOWN_STATE;
+    }
+
+    return getTimeRemaining(targetTimestamp, initialNow);
+  });
 
   useEffect(() => {
     if (Number.isNaN(targetTimestamp)) {
       return;
     }
 
-    setState(getTimeRemaining(targetTimestamp));
+    const update = () => {
+      setState(getTimeRemaining(targetTimestamp, Date.now()));
+    };
+
+    update();
 
     const interval = window.setInterval(() => {
       setState((previous) => {
-        const next = getTimeRemaining(targetTimestamp);
+        const next = getTimeRemaining(targetTimestamp, Date.now());
         if (next.totalMilliseconds === 0 && previous.totalMilliseconds === 0) {
           window.clearInterval(interval);
         }


### PR DESCRIPTION
## Summary
- provide countdown components with a server-rendered time snapshot to avoid SSR/CSR drift
- pass the snapshot through homepage and mystery countdown containers
- refactor countdown state initialization to use the provided timestamp while keeping live updates after hydration

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2a8ec83e4832d98b9b70bedeea2a8