### PR TITLE
Improve guidance around the Endprobenwoche shopping list

### DIFF
--- a/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
@@ -417,8 +417,8 @@ export default async function FinalRehearsalDutyPlanPage() {
             <div className="flex items-start gap-3 rounded-lg border border-warning/40 bg-warning/5 p-3 text-xs text-warning">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
               <div>
-                Hinterlege in der Produktionsplanung den Start der Endprobenwoche, um den Dienstplan zeitlich
-                einzuordnen.
+                Hinterlege bei der Produktionserstellung im Bereich „Produktionen“ den Start der Endprobenwoche, um den
+                Dienstplan zeitlich einzuordnen.
               </div>
             </div>
           ) : null}
@@ -558,8 +558,8 @@ export default async function FinalRehearsalDutyPlanPage() {
           </CardHeader>
           <CardContent className="text-sm text-muted-foreground">
             <p>
-              Hinterlege in der Produktionsplanung den Beginn der Endprobenwoche. Danach kannst du die Dienste pro
-              Tag strukturieren und Verantwortliche zuweisen.
+              Hinterlege bei der Produktionserstellung im Bereich „Produktionen“ den Beginn der Endprobenwoche. Danach
+              kannst du die Dienste pro Tag strukturieren und Verantwortliche zuweisen.
             </p>
           </CardContent>
         </Card>

--- a/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
@@ -1,7 +1,9 @@
-import { Share2 } from "lucide-react";
+import Link from "next/link";
+import { ChefHat, Share2 } from "lucide-react";
 
 import { PageHeader } from "@/components/members/page-header";
 import { ShoppingListBoard } from "@/components/members/shopping-list-board";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
@@ -44,6 +46,7 @@ export default async function EinkaufslistePage() {
     recipes: DISH_LIBRARY,
     participantCount: defaultParticipantCount,
   });
+  const hasGeneratedItems = shoppingList.length > 0;
 
   return (
     <div className="space-y-6">
@@ -51,15 +54,51 @@ export default async function EinkaufslistePage() {
         title="Einkaufsliste"
         description="Die automatisch aggregierten Mengen aus der Essensplanung – inklusive eigener Ergänzungen und optionalem Sharing-Link."
         quickActions={
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Share2 className="h-4 w-4" />
-            <span>{shoppingList.length} Artikel · {totalParticipants} versorgte Personen</span>
-          </div>
+          hasGeneratedItems ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Share2 className="h-4 w-4" />
+              <span>{shoppingList.length} Artikel · {totalParticipants} versorgte Personen</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <ChefHat className="h-4 w-4" />
+              <span>Noch keine Rezepte fixiert – starte in der Essensplanung.</span>
+            </div>
+          )
         }
       />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,0.65fr)_minmax(0,0.35fr)] xl:items-start">
         <div className="space-y-4">
+          {!hasGeneratedItems ? (
+            <Card className="border border-dashed border-border/60 bg-background/80">
+              <CardHeader className="space-y-2">
+                <div className="flex items-center gap-2 text-primary">
+                  <ChefHat className="h-5 w-5" />
+                  <CardTitle className="text-base font-semibold text-primary">Noch keine Einkaufsliste verfügbar</CardTitle>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Aktuell wurden noch keine Menüs für die Endprobenwoche festgelegt. Sobald du in der Essensplanung konkrete
+                  Gerichte fixierst, erzeugen wir automatisch eine gebündelte Einkaufsliste.
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p>
+                  Den Zeitraum der Endprobenwoche definierst du direkt bei der Produktionserstellung im Bereich{' '}
+                  <Link
+                    href="/mitglieder/produktionen"
+                    className="font-medium text-foreground underline-offset-4 hover:underline"
+                  >
+                    „Produktionen“
+                  </Link>
+                  .
+                </p>
+                <Button asChild size="sm" variant="outline" className="w-fit">
+                  <Link href="/mitglieder/endproben-woche/essenplanung">Essensplanung öffnen</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          ) : null}
           <ShoppingListBoard initialItems={shoppingList} />
         </div>
         <div className="space-y-4">

--- a/src/components/members/shopping-list-board.tsx
+++ b/src/components/members/shopping-list-board.tsx
@@ -370,7 +370,8 @@ export function ShoppingListBoard({ initialItems }: ShoppingListBoardProps) {
       <CardContent className="space-y-6">
         {categoryBuckets.length === 0 ? (
           <p className="rounded-lg border border-dashed border-border/60 bg-background/70 p-6 text-center text-sm text-muted-foreground">
-            Aktuell sind keine Einträge vorhanden. Füge neue Positionen hinzu oder lade eine geteilte Liste.
+            Aktuell sind keine Einträge vorhanden. Sobald du in der Essensplanung konkrete Gerichte festlegst, füllen wir
+            die Einkaufsliste automatisch. Eigene Ergänzungen oder geteilte Listen kannst du anschließend ergänzen.
           </p>
         ) : (
           categoryBuckets.map((bucket) => (


### PR DESCRIPTION
## Summary
- guide members on the shopping list page when no recipes are fixed yet and link to meal planning / production creation
- adjust the shopping list board empty state text to reference committing meals first
- clarify on the duty plan page that the Endprobenwoche start is defined during production creation

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2ac3a4218832da1c1c74fefdcf453