### PR TITLE
Fix countdown hydration mismatch by reusing server timestamp

### DIFF
--- a/src/app/(site)/mystery/page.tsx
+++ b/src/app/(site)/mystery/page.tsx
@@ -176,6 +176,7 @@ export default async function MysteryPage() {
             hasCustomCountdown={resolvedSettings.hasCustomCountdown}
             hasCustomMessage={resolvedSettings.hasCustomMessage}
             isFirstRiddleReleased={isFirstRiddleReleased}
+            serverNow={now.toISOString()}
           />
           <Card className="flex flex-col">
             <CardHeader>

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -31,6 +31,7 @@ export default async function Home() {
     ? resolvedCountdown.countdownTarget.toISOString()
     : null;
   const updatedAtIso = resolvedCountdown.updatedAt ? resolvedCountdown.updatedAt.toISOString() : null;
+  const serverNowIso = new Date().toISOString();
   const faqs = [
     {
       question: "Was ist das Sommertheater im Schlosspark?",
@@ -74,6 +75,7 @@ export default async function Home() {
               defaultCountdownTarget={DEFAULT_HOMEPAGE_COUNTDOWN_ISO}
               updatedAt={updatedAtIso}
               hasCustomCountdown={resolvedCountdown.hasCustomCountdown}
+              serverNow={serverNowIso}
             />
             <Text variant="bodyLg" align="center" tone="muted">
               Ein einziges Wochenende. Ein Sommer. Ein Stück.


### PR DESCRIPTION
## Summary
- add an optional `initialNow` prop to the countdown component so server and client share the same initial time state
- pass the render timestamp into the homepage and mystery countdown cards and derive countdown state from it to prevent hydration mismatches

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2a888b208832da8e27302a9ffbe9a