### PR TITLE
Add dev-only screenshot reminder to agents guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@
 ## Dokumentation & Kommunikation
 - README, `docs/**` und `.env.example` bei relevanten Änderungen aktualisieren. Architektur- oder Designentscheidungen bitte im passenden Dokument notieren.
 - Tickets oder PR-Beschreibungen sollten Kontext, Entscheidungspunkte und QA-Schritte enthalten. Verweise auf Monitoring/Analytics ergänzen, falls betroffen.
+- Beachte die "Dev only Screenshot"-Sektion in den systemweiten Vorgaben: Bei wahrnehmbaren UI-Änderungen und vorhandener Dev-Server-Anleitung einen Screenshot für den Abschlussbericht aufnehmen.
 - Diese `AGENTS.md` bei Bedarf fortschreiben, wenn bessere Kollaborationsmuster oder neue Tooling-Standards entstehen. Änderungen nachvollziehbar begründen.
 
 ## Ausnahmen & Sonderfälle


### PR DESCRIPTION
## Summary
- add a reminder to AGENTS.md about the global "Dev only Screenshot" instructions for UI updates

## Testing
- not run (documentation only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2be59a6c4832db6f0d2916ee11a2f