### PR TITLE
Add breadcrumb support to members area

### DIFF
--- a/src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx
+++ b/src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx
@@ -10,6 +10,7 @@ import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { GalleryMediaType } from "@prisma/client";
 import { getGalleryYearDescription, isValidGalleryYear } from "@/lib/gallery";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 export default async function ArchiveYearPage({ params }: { params: { year: string } }) {
   const session = await requireAuth();
@@ -26,12 +27,17 @@ export default async function ArchiveYearPage({ params }: { params: { year: stri
     hasPermission(session.user, "mitglieder.galerie.delete"),
   ]);
 
+  const baseBreadcrumb = membersNavigationBreadcrumb(
+    "/mitglieder/archiv-und-bilder",
+  );
+
   if (!canView) {
     return (
       <div className="space-y-6">
         <PageHeader
           title={`Archiv und Bilder ${year}`}
           description="Du benötigst eine spezielle Berechtigung, um auf diesen Jahrgang zuzugreifen."
+          breadcrumbs={[baseBreadcrumb, { id: `year-${year}`, label: String(year) }]}
           actions={
             <Button asChild variant="outline">
               <Link href="/mitglieder/archiv-und-bilder">
@@ -76,6 +82,7 @@ export default async function ArchiveYearPage({ params }: { params: { year: stri
       <PageHeader
         title={`Archiv und Bilder ${year}`}
         description={description}
+        breadcrumbs={[baseBreadcrumb, { id: `year-${year}`, label: String(year), isCurrent: true }]}
         actions={
           <Button asChild variant="outline">
             <Link href="/mitglieder/archiv-und-bilder">

--- a/src/app/(members)/mitglieder/archiv-und-bilder/page.tsx
+++ b/src/app/(members)/mitglieder/archiv-und-bilder/page.tsx
@@ -16,6 +16,7 @@ import {
   getGalleryYearDescription,
 } from "@/lib/gallery";
 import { GalleryMediaType } from "@prisma/client";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 export const metadata: Metadata = {
   title: "Archiv und Bilder",
@@ -52,12 +53,15 @@ export default async function ArchiveOverviewPage() {
     hasPermission(session.user, "mitglieder.galerie.delete"),
   ]);
 
+  const baseBreadcrumb = membersNavigationBreadcrumb("/mitglieder/archiv-und-bilder");
+
   if (!canView) {
     return (
       <div className="space-y-6">
         <PageHeader
           title="Archiv und Bilder"
           description="Du benötigst eine spezielle Berechtigung, um auf das Archiv zuzugreifen. Bitte wende dich an das Team für die Freischaltung."
+          breadcrumbs={[baseBreadcrumb]}
         />
         <Card>
           <CardContent className="py-10 text-sm text-muted-foreground">
@@ -136,6 +140,7 @@ export default async function ArchiveOverviewPage() {
       <PageHeader
         title="Archiv und Bilder"
         description="Ordne Bilder und Videos den passenden Jahrgängen zu, entdecke Erinnerungen vergangener Spielzeiten und ergänze das Archiv gemeinsam mit dem Team."
+        breadcrumbs={[baseBreadcrumb]}
       />
 
       <Card>

--- a/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 import {
   createFinalRehearsalDutyAction,
@@ -323,6 +324,9 @@ export default async function FinalRehearsalDutyPlanPage() {
         new Date(finalWeekStart.getTime() + 6 * 86_400_000),
       )}`
     : null;
+  const breadcrumbs = [
+    membersNavigationBreadcrumb("/mitglieder/endproben-woche/dienstplan"),
+  ];
 
   if (!show) {
     return (
@@ -330,6 +334,7 @@ export default async function FinalRehearsalDutyPlanPage() {
         <PageHeader
           title="Dienstplan"
           description="Organisiere Aufgaben und Verantwortlichkeiten für die Endprobenwoche."
+          breadcrumbs={breadcrumbs}
         />
         <Card className="border border-dashed border-border/60 bg-background/70">
           <CardHeader>
@@ -356,6 +361,7 @@ export default async function FinalRehearsalDutyPlanPage() {
       <PageHeader
         title="Dienstplan"
         description="Koordiniere Dienste, Verantwortlichkeiten und Tagesaufgaben der Endprobenwoche."
+        breadcrumbs={breadcrumbs}
       />
 
       <Card className="border-primary/30 bg-gradient-to-br from-primary/10 via-background to-background/80 shadow-[0_25px_60px_rgba(59,130,246,0.18)]">

--- a/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
@@ -15,6 +15,7 @@ import {
   STYLE_BADGE_VARIANTS,
   loadMealPlanningContext,
 } from "../essenplanung/meal-plan-context";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 export const dynamic = "force-dynamic";
 
@@ -47,12 +48,16 @@ export default async function EinkaufslistePage() {
     participantCount: defaultParticipantCount,
   });
   const hasGeneratedItems = shoppingList.length > 0;
+  const breadcrumbs = [
+    membersNavigationBreadcrumb("/mitglieder/endproben-woche/einkaufsliste"),
+  ];
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Einkaufsliste"
         description="Die automatisch aggregierten Mengen aus der Essensplanung – inklusive eigener Ergänzungen und optionalem Sharing-Link."
+        breadcrumbs={breadcrumbs}
         quickActions={
           hasGeneratedItems ? (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
@@ -15,6 +15,7 @@ import {
   loadMealPlanningContext,
 } from "./meal-plan-context";
 import { cn } from "@/lib/utils";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 export const dynamic = "force-dynamic";
 
@@ -96,12 +97,16 @@ export default async function EssensplanungPage() {
       hint: finalWeekCountdown !== null ? "Tage bis Start" : "Bitte Termin definieren",
     },
   ];
+  const breadcrumbs = [
+    membersNavigationBreadcrumb("/mitglieder/endproben-woche/essenplanung"),
+  ];
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Essensplanung"
         description={`Plane kompakt die Verpflegung der Endprobenwoche – gebündelt nach Ernährungsstilen, Strengegraden und Allergierisiken. Dienste und Verantwortliche koordinierst du im Bereich "Dienstplan".`}
+        breadcrumbs={breadcrumbs}
       />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,0.66fr)_minmax(0,0.34fr)] xl:items-start">

--- a/src/app/(members)/mitglieder/issues/page.tsx
+++ b/src/app/(members)/mitglieder/issues/page.tsx
@@ -6,6 +6,7 @@ import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import type { Prisma } from "@prisma/client";
 import { mapIssueSummary } from "@/app/api/issues/utils";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 function createEmptyCounts(): IssueStatusCounts {
   return {
@@ -66,12 +67,14 @@ export default async function IssuesPage() {
   }, createEmptyCounts());
 
   const initialIssues: IssueSummary[] = issuesRaw.map(mapIssueSummary);
+  const breadcrumbs = [membersNavigationBreadcrumb("/mitglieder/issues")];
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Feedback & Support"
         description="Melde Probleme, Bugs oder Verbesserungsvorschläge und verfolge den Bearbeitungsstand im Mitglieder-Issue-Board."
+        breadcrumbs={breadcrumbs}
       />
       <IssueOverview
         initialIssues={initialIssues}

--- a/src/app/(members)/mitglieder/koerpermasse/page.tsx
+++ b/src/app/(members)/mitglieder/koerpermasse/page.tsx
@@ -5,6 +5,7 @@ import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 import { sortRoles, type Role } from "@/lib/roles";
 import type { MeasurementType, MeasurementUnit } from "@/data/measurements";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 export default async function MemberMeasurementsPage() {
   const session = await requireAuth();
@@ -73,11 +74,14 @@ export default async function MemberMeasurementsPage() {
     })),
   }));
 
+  const breadcrumbs = [membersNavigationBreadcrumb("/mitglieder/koerpermasse")];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Körpermaße"
         description="Futuristisches Control Center für das Kostüm-Team: Synchronisiere, vergleiche und aktualisiere die Körpermaße des gesamten Ensembles in einem Blick."
+        breadcrumbs={breadcrumbs}
       />
       <MemberMeasurementsControlCenter members={normalizedMembers} />
     </div>

--- a/src/app/(members)/mitglieder/meine-proben/page.tsx
+++ b/src/app/(members)/mitglieder/meine-proben/page.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { hasRole, requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 type AttendanceStatus = "yes" | "no" | "emergency" | "maybe";
 const STATUS_KEYS = ["yes", "no", "emergency", "maybe"] as const satisfies readonly AttendanceStatus[];
@@ -207,14 +208,16 @@ export default async function MeineProbenPage() {
 
   const pendingDeadlines = upcoming
     .filter((item) => !item.myStatus && item.registrationDeadline && item.registrationDeadline > now)
-    .sort((a, b) => (a.registrationDeadline!.getTime() - b.registrationDeadline!.getTime()));
+    .sort((a, b) => a.registrationDeadline!.getTime() - b.registrationDeadline!.getTime());
   const nextPendingDeadline = pendingDeadlines[0] ?? null;
+  const breadcrumbs = [membersNavigationBreadcrumb("/mitglieder/meine-proben")];
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Meine Proben"
         description="Persönliche Übersicht über deine nächsten Probentermine, Fristen und Rückmeldungen."
+        breadcrumbs={breadcrumbs}
       />
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,0.68fr)_minmax(0,0.32fr)] xl:gap-8">

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils";
 import { formatRelativeFromNow } from "@/lib/datetime";
 import { getUserDisplayName } from "@/lib/names";
 import { MemberTestNotificationCard } from "@/components/members/member-test-notification-card";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "long" });
 const dateTimeFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" });
@@ -617,12 +618,17 @@ export default async function MemberProfileAdminPage({ params }: PageProps) {
   const deactivatedAtLabel = formatDateTime(deactivatedAt);
 
   const pageTitle = `Profil von ${displayName}`;
+  const breadcrumbs = [
+    membersNavigationBreadcrumb("/mitglieder/mitgliederverwaltung"),
+    { id: member.id, label: displayName, isCurrent: true },
+  ];
 
   return (
     <div className="space-y-8">
       <PageHeader
         title={pageTitle}
         description="Einblick in Kontaktdaten, Rollen und Engagement des Mitglieds."
+        breadcrumbs={breadcrumbs}
         actions={
           <Button
             asChild

--- a/src/app/(members)/mitglieder/proben/[rehearsalId]/page.tsx
+++ b/src/app/(members)/mitglieder/proben/[rehearsalId]/page.tsx
@@ -8,6 +8,7 @@ import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 import { getUserDisplayName } from "@/lib/names";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 const STATUS_LABELS: Record<string, string> = {
   PLANNED: "Geplant",
@@ -112,11 +113,17 @@ export default async function RehearsalDetailPage({ params }: { params: { rehear
     };
   });
 
+  const breadcrumbs = [
+    membersNavigationBreadcrumb("/mitglieder/meine-proben"),
+    { id: rehearsal.id, label: rehearsal.title || "Probe", isCurrent: true },
+  ];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title={rehearsal.title || "Probe"}
         description="Alle Details, Teilnehmer und Rückmeldungen zu diesem Termin."
+        breadcrumbs={breadcrumbs}
       />
 
       <Card>

--- a/src/app/(members)/mitglieder/probenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "./rehearsal-calendar";
 import { RehearsalList, type RehearsalLite } from "./rehearsal-list";
 import { combineNameParts } from "@/lib/names";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 export default async function ProbenplanungPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.probenplanung");
@@ -106,12 +107,14 @@ export default async function ProbenplanungPage() {
   const now = new Date();
   const total = publishedRehearsals.length;
   const upcoming = publishedRehearsals.filter((r) => r.start >= now).length;
+  const breadcrumbs = [membersNavigationBreadcrumb("/mitglieder/probenplanung")];
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Probenplanung"
         description="Lege neue Proben an, verwalte Termine und Einladungen."
+        breadcrumbs={breadcrumbs}
       />
 
       <div className="rounded-xl border bg-card/60 p-4 shadow-sm">

--- a/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
@@ -6,6 +6,7 @@ import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 
 import { RehearsalEditor } from "../../rehearsal-editor";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 type MemberOption = {
   id: string;
@@ -70,6 +71,11 @@ export default async function RehearsalEditorPage({ params }: { params: { rehear
     extraRoles: member.roles.map((entry) => entry.role),
   }));
 
+  const breadcrumbs = [
+    membersNavigationBreadcrumb("/mitglieder/probenplanung"),
+    { id: rehearsal.id, label: rehearsal.title || "Probe", isCurrent: true },
+  ];
+
   return (
     <div className="space-y-6">
       <PageHeader
@@ -79,6 +85,7 @@ export default async function RehearsalEditorPage({ params }: { params: { rehear
             ? "Passe Titel, Termine, Beschreibung und Teilnehmer deines Entwurfs an."
             : "Bearbeite diese veröffentlichte Probe. Alle Teilnehmer erhalten eine Benachrichtigung über Änderungen."
         }
+        breadcrumbs={breadcrumbs}
       />
 
       <RehearsalEditor

--- a/src/app/(members)/mitglieder/sperrliste/page.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/sperrliste-settings";
 import { SperrlistePageClient } from "./page-client";
 import type { OverviewMember } from "./block-overview";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
 export default async function SperrlistePage() {
   const session = await requireAuth();
@@ -92,11 +93,14 @@ export default async function SperrlistePage() {
     })),
   }));
 
+  const breadcrumbs = [membersNavigationBreadcrumb("/mitglieder/sperrliste")];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Sperrliste"
         description="Markiere Tage, an denen du nicht verfügbar bist, damit das Team die Planung im Blick behält."
+        breadcrumbs={breadcrumbs}
       />
       <SperrlistePageClient
         initialBlockedDays={initialBlockedDays}

--- a/src/components/members/breadcrumbs.tsx
+++ b/src/components/members/breadcrumbs.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { MembersBreadcrumbItem } from "@/lib/members-breadcrumbs";
+
+const ROOT_ID = "__members-root";
+
+interface MembersBreadcrumbsProps {
+  items: readonly MembersBreadcrumbItem[];
+  includeRoot?: boolean;
+  rootLabel?: MembersBreadcrumbItem["label"];
+  rootHref?: string;
+  className?: string;
+}
+
+function renderBreadcrumbContent(item: MembersBreadcrumbItem) {
+  const hasIcon = Boolean(item.icon);
+
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      {hasIcon ? (
+        <span className="flex flex-shrink-0 items-center text-muted-foreground/70">
+          {item.icon}
+        </span>
+      ) : null}
+      <span className="truncate">{item.label}</span>
+    </span>
+  );
+}
+
+export function MembersBreadcrumbs({
+  items,
+  includeRoot = true,
+  rootLabel = "Mitgliederbereich",
+  rootHref = "/mitglieder",
+  className,
+}: MembersBreadcrumbsProps) {
+  const normalizedItems = includeRoot
+    ? ([
+        { id: ROOT_ID, label: rootLabel, href: rootHref } satisfies MembersBreadcrumbItem,
+        ...items,
+      ] as MembersBreadcrumbItem[])
+    : [...items];
+
+  if (normalizedItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <ol className={cn("flex min-w-0 items-center gap-2", className)}>
+      {normalizedItems.map((item, index) => {
+        const key = item.id ?? item.href ?? `crumb-${index}`;
+        const isCurrent = item.isCurrent ?? index === normalizedItems.length - 1;
+        const content = renderBreadcrumbContent(item);
+
+        return (
+          <li key={key} className="flex min-w-0 items-center gap-2">
+            {index > 0 ? (
+              <ChevronRight
+                aria-hidden="true"
+                className="h-3 w-3 flex-shrink-0 text-muted-foreground/60"
+              />
+            ) : null}
+            {item.href && !isCurrent ? (
+              <Link
+                href={item.href}
+                aria-label={item.ariaLabel}
+                className={cn(
+                  "flex min-w-0 items-center gap-1.5 text-muted-foreground transition hover:text-foreground focus-visible:text-foreground focus-visible:underline",
+                  item.className,
+                )}
+              >
+                {content}
+              </Link>
+            ) : (
+              <span
+                aria-current={isCurrent ? "page" : undefined}
+                className={cn(
+                  "flex min-w-0 items-center gap-1.5",
+                  isCurrent
+                    ? "text-foreground"
+                    : "text-muted-foreground/80",
+                  item.className,
+                )}
+              >
+                {content}
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/src/components/members/page-header.tsx
+++ b/src/components/members/page-header.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 
+import { MembersBreadcrumbs } from "@/components/members/breadcrumbs";
 import {
   MembersContentHeader,
   MembersPageActions,
@@ -11,6 +12,10 @@ import {
   MembersTopbarStatus,
   MembersTopbarTitle,
 } from "@/components/members/members-app-shell";
+import {
+  createMembersBreadcrumbItems,
+  type MembersBreadcrumbItem,
+} from "@/lib/members-breadcrumbs";
 import { Heading, Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 
@@ -18,7 +23,9 @@ interface PageHeaderProps {
   title: string;
   description?: React.ReactNode;
   actions?: React.ReactNode;
-  breadcrumbs?: React.ReactNode;
+  breadcrumbs?:
+    | readonly (MembersBreadcrumbItem | null | undefined | false)[]
+    | null;
   quickActions?: React.ReactNode;
   status?: React.ReactNode;
   variant?: "page" | "section";
@@ -35,6 +42,15 @@ export function PageHeader({
   variant = "page",
   className,
 }: PageHeaderProps) {
+  const breadcrumbItems = React.useMemo(
+    () =>
+      breadcrumbs
+        ? createMembersBreadcrumbItems(breadcrumbs)
+        : ([] as MembersBreadcrumbItem[]),
+    [breadcrumbs],
+  );
+  const hasBreadcrumbs = breadcrumbItems.length > 0;
+
   if (variant === "section") {
     return (
       <div
@@ -78,8 +94,10 @@ export function PageHeader({
   return (
     <>
       <MembersTopbar>
-        {breadcrumbs ? (
-          <MembersTopbarBreadcrumbs>{breadcrumbs}</MembersTopbarBreadcrumbs>
+        {hasBreadcrumbs ? (
+          <MembersTopbarBreadcrumbs>
+            <MembersBreadcrumbs items={breadcrumbItems} />
+          </MembersTopbarBreadcrumbs>
         ) : null}
         <MembersTopbarTitle>{title}</MembersTopbarTitle>
         {status ? <MembersTopbarStatus>{status}</MembersTopbarStatus> : null}

--- a/src/lib/members-breadcrumbs.ts
+++ b/src/lib/members-breadcrumbs.ts
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+import { findMembersNavigationItem } from "@/lib/members-navigation";
+
+export interface MembersBreadcrumbItem {
+  id?: string;
+  label: ReactNode;
+  href?: string | null;
+  icon?: ReactNode;
+  isCurrent?: boolean;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function isMembersBreadcrumbItem(
+  value: MembersBreadcrumbItem | null | undefined | false,
+): value is MembersBreadcrumbItem {
+  return Boolean(value);
+}
+
+export function createMembersBreadcrumbItems(
+  items: readonly (MembersBreadcrumbItem | null | undefined | false)[],
+): MembersBreadcrumbItem[] {
+  return items.filter(isMembersBreadcrumbItem);
+}
+
+export function membersNavigationBreadcrumb(
+  href: string,
+  options?: { label?: ReactNode; ariaLabel?: string },
+): MembersBreadcrumbItem | null {
+  const match = findMembersNavigationItem(href);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    id: match.item.href,
+    label: options?.label ?? match.item.label,
+    href: match.item.href,
+    ariaLabel: options?.ariaLabel ?? match.item.ariaLabel,
+  };
+}

--- a/src/lib/members-navigation.ts
+++ b/src/lib/members-navigation.ts
@@ -170,3 +170,24 @@ export function filterMembersNavigationByQuery(
   const flat = filteredGroups.flatMap((group) => group.items);
   return { groups: filteredGroups, flat };
 }
+
+export interface MembersNavigationItemMatch {
+  group: MembersNavGroup;
+  item: MembersNavItem;
+}
+
+export function findMembersNavigationItem(
+  href: string,
+  options: { groups?: readonly MembersNavGroup[] } = {},
+): MembersNavigationItemMatch | null {
+  const groupsToSearch = options.groups ?? membersNavigation;
+
+  for (const group of groupsToSearch) {
+    const item = group.items.find((candidate) => candidate.href === href);
+    if (item) {
+      return { group, item };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add breadcrumb utilities and a reusable component to render members breadcrumbs consistently
- enhance the members page header to accept structured breadcrumb definitions
- wire breadcrumbs through core members pages such as Archiv & Bilder, Finalwoche-Planung, Körpermaße, Proben & Verwaltung for improved navigation context

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2d4402a70832dace1e2a0f14bafe8