### PR TITLE
Improve light theme card surfaces

### DIFF
--- a/src/app/design-tokens.css
+++ b/src/app/design-tokens.css
@@ -8,9 +8,9 @@
   --accent: oklch(0.83 0.08 208);
   --accent-foreground: oklch(0.22 0.028 255);
   --background: oklch(0.99 0.01 255);
-  --border: oklch(0.89 0.018 255);
-  --card: oklch(0.98 0.012 255);
-  --card-foreground: oklch(0.19 0.03 255);
+  --border: oklch(0.86 0.02 255);
+  --card: oklch(0.95 0.012 255);
+  --card-foreground: oklch(0.18 0.03 255);
   --chart-1: oklch(0.62 0.18 63.3);
   --chart-2: oklch(0.66 0.19 155);
   --chart-3: oklch(0.58 0.22 25);
@@ -22,7 +22,7 @@
   --info: oklch(0.74 0.18 230);
   --info-foreground: oklch(0.18 0.028 255);
   --input: oklch(0.89 0.018 255);
-  --muted: oklch(0.92 0.02 255);
+  --muted: oklch(0.93 0.02 255);
   --muted-foreground: oklch(0.51 0.028 255);
   --popover: oklch(0.985 0.012 255);
   --popover-foreground: oklch(0.19 0.03 255);

--- a/src/components/members/profile-dietary-preferences.tsx
+++ b/src/components/members/profile-dietary-preferences.tsx
@@ -249,7 +249,7 @@ export function ProfileDietaryPreferences({
   };
 
   return (
-    <Card className="rounded-2xl border border-border/60 bg-background/85 shadow-lg shadow-primary/5">
+    <Card className="rounded-2xl border border-border bg-card shadow-lg shadow-primary/5">
       <CardHeader className="space-y-3 px-6 pb-4 pt-6 sm:px-7">
         <div className="text-xs font-semibold uppercase tracking-wider text-primary">
           Ernährung &amp; Verträglichkeiten
@@ -261,7 +261,7 @@ export function ProfileDietaryPreferences({
         </p>
       </CardHeader>
       <CardContent className="space-y-6 px-6 pb-6 sm:px-7">
-        <section className="space-y-4 rounded-xl border border-border/60 bg-background/90 p-4 shadow-sm">
+        <section className="space-y-4 rounded-xl border border-border bg-card p-4 shadow-sm">
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
               <label className="text-sm font-medium text-foreground/90">
@@ -328,7 +328,7 @@ export function ProfileDietaryPreferences({
               </div>
             ) : null}
           </div>
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-border/50 bg-muted/20 p-3 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed border-border bg-muted/20 p-3 text-xs text-muted-foreground">
             <div>
               <p className="font-medium text-foreground/80">Vorschau</p>
               <p>{preferenceLabel}</p>
@@ -354,7 +354,7 @@ export function ProfileDietaryPreferences({
           ) : null}
         </section>
 
-        <section className="space-y-4 rounded-xl border border-border/60 bg-background/90 p-4 shadow-sm">
+        <section className="space-y-4 rounded-xl border border-border bg-card p-4 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <h3 className="text-sm font-semibold text-foreground">
@@ -373,7 +373,7 @@ export function ProfileDietaryPreferences({
               {allergies.map((entry) => (
                 <li
                   key={entry.allergen}
-                  className="flex flex-col gap-3 rounded-lg border border-border/50 bg-background/80 p-3 sm:flex-row sm:items-center sm:justify-between"
+                  className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="space-y-1">
                     <div className="flex flex-wrap items-center gap-2">
@@ -438,7 +438,7 @@ export function ProfileDietaryPreferences({
               ))}
             </ul>
           ) : (
-            <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+            <div className="rounded-lg border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
               Noch keine Allergien hinterlegt.
             </div>
           )}

--- a/src/components/members/profile-page-client.tsx
+++ b/src/components/members/profile-page-client.tsx
@@ -136,10 +136,10 @@ function ProfileSection({
     <section
       id={sectionDomId}
       aria-labelledby={titleId}
-      className="group relative rounded-3xl border border-border/60 bg-background/90 shadow-lg shadow-primary/10 transition focus:outline-none"
+      className="group relative rounded-3xl border border-border bg-card shadow-lg shadow-primary/10 transition focus:outline-none"
       tabIndex={-1}
     >
-      <div className="flex flex-col gap-4 border-b border-border/60 px-6 pb-5 pt-6 sm:flex-row sm:items-start sm:justify-between sm:px-7">
+      <div className="flex flex-col gap-4 border-b border-border px-6 pb-5 pt-6 sm:flex-row sm:items-start sm:justify-between sm:px-7">
         <div className="space-y-2">
           <h3 id={titleId} className="text-lg font-semibold text-foreground">
             {title}
@@ -149,7 +149,7 @@ function ProfileSection({
         <button
           type="button"
           onClick={() => onOpenChange(!open)}
-          className="inline-flex items-center gap-2 self-start rounded-full border border-border/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground transition hover:border-primary/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          className="inline-flex items-center gap-2 self-start rounded-full border border-border px-3 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground transition hover:border-primary/60 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           aria-expanded={open}
           aria-controls={contentId}
         >
@@ -186,7 +186,7 @@ interface ProfilePageClientProps {
 function ProfileRolesCard({ roles }: { roles: Role[] }) {
   if (!roles.length) {
     return (
-      <Card className="rounded-2xl border border-border/60 bg-background/85 p-6 shadow-lg shadow-primary/10">
+      <Card className="rounded-2xl border border-border bg-card p-6 shadow-lg shadow-primary/10">
         <CardHeader className="px-0 pt-0">
           <CardTitle>Rollen &amp; Berechtigungen</CardTitle>
         </CardHeader>
@@ -200,7 +200,7 @@ function ProfileRolesCard({ roles }: { roles: Role[] }) {
   }
 
   return (
-    <Card className="rounded-2xl border border-border/60 bg-background/85 p-0 shadow-lg shadow-primary/10">
+    <Card className="rounded-2xl border border-border bg-card p-0 shadow-lg shadow-primary/10">
       <CardHeader className="space-y-2 px-6 pb-4 pt-6 sm:px-7">
         <CardTitle>Rollen &amp; Berechtigungen</CardTitle>
         <p className="text-sm text-muted-foreground">
@@ -229,7 +229,7 @@ function ProfileRolesCard({ roles }: { roles: Role[] }) {
             return (
               <li
                 key={role}
-                className="flex gap-3 rounded-xl border border-border/60 bg-background/70 p-3 shadow-sm backdrop-blur"
+                className="flex gap-3 rounded-xl border border-border bg-card p-3 shadow-sm"
               >
                 <div
                   className={cn(
@@ -347,7 +347,7 @@ export function ProfilePageClient({
           aria-hidden="true"
           className="pointer-events-none absolute -bottom-40 left-1/2 -z-10 h-72 w-72 -translate-x-1/2 rounded-full bg-secondary/15 blur-3xl dark:bg-secondary/20"
         />
-        <section className="rounded-3xl border border-border/60 bg-background/90 px-6 py-8 shadow-lg shadow-primary/10 sm:px-8">
+        <section className="rounded-3xl border border-border bg-card px-6 py-8 shadow-lg shadow-primary/10 sm:px-8">
           <PageHeader
             variant="section"
             title="Mein Profil"

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -4,7 +4,7 @@ export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElemen
   return (
     <div
       className={cn(
-        "rounded-lg border border-border/50 p-4 bg-card/60 backdrop-blur text-card-foreground shadow-sm",
+        "rounded-lg border border-border bg-card p-4 backdrop-blur text-card-foreground shadow-sm",
         className
       )}
       {...props}

--- a/src/design-system/tokens.json
+++ b/src/design-system/tokens.json
@@ -139,7 +139,7 @@
       "card": {
         "family": "neutral",
         "light": {
-          "deltaL": 0.04,
+          "l": 0.95,
           "c": 0.012
         },
         "dark": {
@@ -150,7 +150,7 @@
       "card-foreground": {
         "family": "neutral-strong",
         "light": {
-          "deltaL": -0.09,
+          "l": 0.18,
           "c": 0.03
         },
         "dark": {
@@ -225,7 +225,7 @@
       "muted": {
         "family": "neutral",
         "light": {
-          "deltaL": -0.02,
+          "l": 0.93,
           "c": 0.02
         },
         "dark": {
@@ -357,8 +357,8 @@
       "border": {
         "family": "neutral",
         "light": {
-          "deltaL": -0.05,
-          "c": 0.018
+          "l": 0.86,
+          "c": 0.02
         },
         "dark": {
           "deltaL": 0.02,
@@ -561,9 +561,9 @@
       "accent": "oklch(0.83 0.08 208)",
       "accent-foreground": "oklch(0.22 0.028 255)",
       "background": "oklch(0.99 0.01 255)",
-      "border": "oklch(0.89 0.018 255)",
-      "card": "oklch(0.98 0.012 255)",
-      "card-foreground": "oklch(0.19 0.03 255)",
+      "border": "oklch(0.86 0.02 255)",
+      "card": "oklch(0.95 0.012 255)",
+      "card-foreground": "oklch(0.18 0.03 255)",
       "chart-1": "oklch(0.62 0.18 63.3)",
       "chart-2": "oklch(0.66 0.19 155)",
       "chart-3": "oklch(0.58 0.22 25)",
@@ -575,7 +575,7 @@
       "info": "oklch(0.74 0.18 230)",
       "info-foreground": "oklch(0.18 0.028 255)",
       "input": "oklch(0.89 0.018 255)",
-      "muted": "oklch(0.92 0.02 255)",
+      "muted": "oklch(0.93 0.02 255)",
       "muted-foreground": "oklch(0.51 0.028 255)",
       "popover": "oklch(0.985 0.012 255)",
       "popover-foreground": "oklch(0.19 0.03 255)",
@@ -599,7 +599,7 @@
     }
   },
   "meta": {
-    "generatedAt": "2025-09-22T20:49:28.368Z",
+    "generatedAt": "2025-09-23T17:22:52.582Z",
     "modes": [
       "dark",
       "light"


### PR DESCRIPTION
## Summary
- darken light-mode card, card-foreground, border and muted tokens and regenerate the CSS exports
- update the base Card component to use the opaque card background and full-strength border color
- refresh profile card surfaces (profile page sections and dietary preferences) to rely on the new tokens for better contrast

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2d712c414832da03b01c9257a0785