### PR TITLE
Restore members header and footer

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -1,13 +1,80 @@
 import React from "react";
 import { cookies } from "next/headers";
+import { execSync } from "node:child_process";
+
+import { MysticBackground } from "@/components/mystic-background";
+import { SiteFooter } from "@/components/site-footer";
+import { SiteHeader } from "@/components/site-header";
 import type { AssignmentFocus } from "@/components/members-nav";
 import { MembersPermissionsProvider } from "@/components/members/permissions-context";
 import { MembersAppShell } from "@/components/members/members-app-shell";
 import { SidebarProvider, SIDEBAR_COOKIE_NAME } from "@/components/ui/sidebar";
-import { requireAuth } from "@/lib/rbac";
-import { getUserPermissionKeys } from "@/lib/permissions";
 import { getActiveProduction } from "@/lib/active-production";
 import { prisma } from "@/lib/prisma";
+import { getUserPermissionKeys } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { readWebsiteSettings, resolveWebsiteSettings } from "@/lib/website-settings";
+
+type CommitInfo = {
+  short: string;
+  full: string;
+};
+
+type BuildInfo = {
+  commit: CommitInfo | null;
+  timestamp: string;
+  isoTimestamp: string;
+};
+
+function getBuildInfo(): BuildInfo {
+  const buildDate = new Date();
+  const timestamp = new Intl.DateTimeFormat("de-DE", {
+    timeZone: "Europe/Berlin",
+    dateStyle: "short",
+    timeStyle: "medium",
+  }).format(buildDate);
+  const isoTimestamp = buildDate.toISOString();
+
+  const commit = getCommitInfo();
+
+  return {
+    commit,
+    timestamp,
+    isoTimestamp,
+  } satisfies BuildInfo;
+}
+
+function getCommitInfo(): CommitInfo | null {
+  const envCommit =
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ??
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    process.env.GITHUB_SHA ??
+    process.env.COMMIT_REF ??
+    null;
+
+  if (envCommit) {
+    const normalizedCommit = envCommit.trim();
+
+    return {
+      short: normalizedCommit.slice(0, 7),
+      full: normalizedCommit,
+    } satisfies CommitInfo;
+  }
+
+  try {
+    const fullCommitHash = execSync("git rev-parse HEAD").toString().trim();
+
+    return {
+      short: fullCommitHash.slice(0, 7),
+      full: fullCommitHash,
+    } satisfies CommitInfo;
+  } catch {
+    return null;
+  }
+}
+
+const buildInfo = getBuildInfo();
+const isDevBuild = process.env.NODE_ENV === "development";
 
 export default async function MembersLayout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies();
@@ -18,6 +85,21 @@ export default async function MembersLayout({ children }: { children: React.Reac
   const session = await requireAuth();
   const permissions = await getUserPermissionKeys(session.user);
   const activeProduction = await getActiveProduction();
+
+  let resolvedSettings = resolveWebsiteSettings(null);
+
+  if (process.env.DATABASE_URL) {
+    try {
+      const record = await readWebsiteSettings();
+      if (record) {
+        resolvedSettings = resolveWebsiteSettings(record);
+      }
+    } catch (error) {
+      console.error("Failed to load website settings", error);
+    }
+  }
+
+  const siteTitle = resolvedSettings.siteTitle;
 
   let assignmentFocus: AssignmentFocus = "none";
   const userId = session.user?.id;
@@ -43,19 +125,38 @@ export default async function MembersLayout({ children }: { children: React.Reac
 
   const hasDepartmentMemberships = departmentAssignmentCount > 0;
 
+  const layoutStyle = {
+    ["--members-topbar-offset" as const]: "var(--header-height)",
+  } as React.CSSProperties;
+
   return (
-    <SidebarProvider defaultOpen={defaultSidebarOpen} className="bg-background">
-      <MembersPermissionsProvider permissions={permissions}>
-        <MembersAppShell
-          permissions={permissions}
-          activeProduction={activeProduction ?? undefined}
-          assignmentFocus={assignmentFocus}
-          hasDepartmentMemberships={hasDepartmentMemberships}
+    <div className="app-shell bg-background">
+      <MysticBackground />
+      <SiteHeader siteTitle={siteTitle} />
+      <main className="relative z-10 flex min-h-0 flex-col pt-[var(--header-height)]">
+        <SidebarProvider
+          defaultOpen={defaultSidebarOpen}
+          className="flex-1 min-h-0 bg-background"
+          style={layoutStyle}
         >
-          {children}
-        </MembersAppShell>
-      </MembersPermissionsProvider>
-    </SidebarProvider>
+          <MembersPermissionsProvider permissions={permissions}>
+            <MembersAppShell
+              permissions={permissions}
+              activeProduction={activeProduction ?? undefined}
+              assignmentFocus={assignmentFocus}
+              hasDepartmentMemberships={hasDepartmentMemberships}
+            >
+              {children}
+            </MembersAppShell>
+          </MembersPermissionsProvider>
+        </SidebarProvider>
+      </main>
+      <SiteFooter
+        buildInfo={buildInfo}
+        isDevBuild={isDevBuild}
+        siteTitle={siteTitle}
+      />
+    </div>
   );
 }
 

--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -190,6 +190,10 @@ const INITIAL_TOPBAR: MembersTopbarSlots = {
   status: null,
 };
 
+const MEMBERS_TOPBAR_STICKY_STYLE: React.CSSProperties = {
+  top: "var(--members-topbar-offset, 0px)",
+};
+
 interface MembersAppShellContextValue {
   setTopbarContent: (content: MembersTopbarSlots | null) => void;
   setContentHeader: (content: React.ReactNode | null) => void;
@@ -240,7 +244,10 @@ function MembersTopbarContent({
   const hasBreadcrumbs = Boolean(content.breadcrumbs);
 
   return (
-    <header className="sticky top-0 z-30 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header
+      className="sticky top-0 z-30 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      style={MEMBERS_TOPBAR_STICKY_STYLE}
+    >
       <div
         className={cn(
           "flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12",


### PR DESCRIPTION
## Summary
- wrap the members layout with the shared site header, footer, and mystic background
- load website settings to reuse the public site title and expose build info for the footer
- offset the members topbar to sit below the restored header

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2d75ef91c832dbd6c45b6da6c8d9c