### PR TITLE
Increase dark mode card contrast

### DIFF
--- a/src/app/design-tokens.css
+++ b/src/app/design-tokens.css
@@ -50,7 +50,7 @@
   --accent-foreground: oklch(0.95 0.02 255);
   --background: oklch(0.13 0.03 255);
   --border: oklch(0.28 0.024 255);
-  --card: oklch(0.18 0.02 255);
+  --card: oklch(0.28 0.02 255);
   --card-foreground: oklch(0.95 0.02 255);
   --chart-1: oklch(0.74 0.19 63.3);
   --chart-2: oklch(0.64 0.19 155);
@@ -65,7 +65,7 @@
   --input: oklch(0.28 0.024 255);
   --muted: oklch(0.27 0.024 255);
   --muted-foreground: oklch(0.75 0.02 255);
-  --popover: oklch(0.18 0.02 255);
+  --popover: oklch(0.28 0.02 255);
   --popover-foreground: oklch(0.95 0.02 255);
   --primary: oklch(0.72 0.19 63.3);
   --primary-foreground: oklch(0.95 0.02 255);

--- a/src/design-system/tokens.json
+++ b/src/design-system/tokens.json
@@ -143,7 +143,7 @@
           "c": 0.012
         },
         "dark": {
-          "deltaL": -0.08,
+          "deltaL": 0.02,
           "c": 0.02
         }
       },
@@ -165,7 +165,7 @@
           "c": 0.012
         },
         "dark": {
-          "deltaL": -0.08,
+          "deltaL": 0.02,
           "c": 0.02
         }
       },
@@ -522,7 +522,7 @@
       "accent-foreground": "oklch(0.95 0.02 255)",
       "background": "oklch(0.13 0.03 255)",
       "border": "oklch(0.28 0.024 255)",
-      "card": "oklch(0.18 0.02 255)",
+      "card": "oklch(0.28 0.02 255)",
       "card-foreground": "oklch(0.95 0.02 255)",
       "chart-1": "oklch(0.74 0.19 63.3)",
       "chart-2": "oklch(0.64 0.19 155)",
@@ -537,7 +537,7 @@
       "input": "oklch(0.28 0.024 255)",
       "muted": "oklch(0.27 0.024 255)",
       "muted-foreground": "oklch(0.75 0.02 255)",
-      "popover": "oklch(0.18 0.02 255)",
+      "popover": "oklch(0.28 0.02 255)",
       "popover-foreground": "oklch(0.95 0.02 255)",
       "primary": "oklch(0.72 0.19 63.3)",
       "primary-foreground": "oklch(0.95 0.02 255)",
@@ -599,7 +599,7 @@
     }
   },
   "meta": {
-    "generatedAt": "2025-09-22T20:49:28.368Z",
+    "generatedAt": "2025-09-23T17:55:27.547Z",
     "modes": [
       "dark",
       "light"


### PR DESCRIPTION
## Summary
- raise the dark-mode `card` token lightness to create clearer separation from the base background
- mirror the same contrast update for popover surfaces and regenerate the design token CSS

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2dd7033fc832da2c346a26d11314a