### PR TITLE
Fix members sidebar auto-close on mobile

### DIFF
--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -223,13 +223,17 @@ function useMembersAppShellContext() {
 
 function SidebarMobileAutoClose() {
   const pathname = usePathname();
-  const { isMobile, openMobile, setOpenMobile } = useSidebar();
+  const { isMobile, setOpenMobile } = useSidebar();
 
   React.useEffect(() => {
-    if (isMobile && openMobile) {
-      setOpenMobile(false);
+    if (!isMobile) {
+      return;
     }
-  }, [isMobile, openMobile, pathname, setOpenMobile]);
+
+    // Close the mobile sheet after navigation so the menu remains usable while
+    // it is open and collapses once a new page is shown.
+    setOpenMobile(false);
+  }, [isMobile, pathname, setOpenMobile]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- keep the members sidebar sheet open while browsing on mobile devices by only closing it after navigation
- prevent the auto-close effect from firing immediately when the menu is toggled so portrait layouts work reliably

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2e1d99380832dbf4b769a0fcb0330