### PR TITLE
Limit members footer to content width

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -145,17 +145,19 @@ export default async function MembersLayout({ children }: { children: React.Reac
               activeProduction={activeProduction ?? undefined}
               assignmentFocus={assignmentFocus}
               hasDepartmentMemberships={hasDepartmentMemberships}
+              globalFooter={
+                <SiteFooter
+                  buildInfo={buildInfo}
+                  isDevBuild={isDevBuild}
+                  siteTitle={siteTitle}
+                />
+              }
             >
               {children}
             </MembersAppShell>
           </MembersPermissionsProvider>
         </SidebarProvider>
       </main>
-      <SiteFooter
-        buildInfo={buildInfo}
-        isDevBuild={isDevBuild}
-        siteTitle={siteTitle}
-      />
     </div>
   );
 }

--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -177,6 +177,7 @@ interface MembersAppShellProps {
   assignmentFocus: AssignmentFocus;
   hasDepartmentMemberships: boolean;
   contentLayout?: MembersContentLayoutConfig;
+  globalFooter?: React.ReactNode;
 }
 
 interface MembersTopbarSlots {
@@ -338,6 +339,7 @@ export function MembersAppShell({
   assignmentFocus,
   hasDepartmentMemberships,
   contentLayout,
+  globalFooter,
 }: MembersAppShellProps) {
   const [topbarContent, setTopbarContentState] =
     React.useState<MembersTopbarSlots>(INITIAL_TOPBAR);
@@ -466,6 +468,7 @@ export function MembersAppShell({
               </footer>
             ) : null}
           </main>
+          {globalFooter}
         </SidebarInset>
       </MembersAppShellContext.Provider>
     </>


### PR DESCRIPTION
## Summary
- render the global footer inside the members app shell so it only spans the content area
- pass the shared footer into the members shell via a new optional prop instead of mounting it outside the sidebar layout

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2e3098460832dad3eaf271b219a0f