### PR TITLE
Fix mobile sidebar toggle detection

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -96,7 +96,17 @@ const SidebarProvider = React.forwardRef<
     );
 
     const toggleSidebar = React.useCallback(() => {
-      return isMobile ? setOpenMobile((next) => !next) : setOpen((next) => !next);
+      const shouldUseMobile =
+        isMobile ||
+        (typeof window !== "undefined" &&
+          window.matchMedia(SIDEBAR_MOBILE_BREAKPOINT).matches);
+
+      if (shouldUseMobile) {
+        setOpenMobile((next) => !next);
+        return;
+      }
+
+      setOpen((next) => !next);
     }, [isMobile, setOpen, setOpenMobile]);
 
     React.useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure the sidebar toggle checks the current mobile breakpoint with matchMedia to avoid stale detection
- keep desktop toggling behaviour unchanged while opening the mobile sheet when the viewport matches the mobile query

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2ec70d1cc832d969da6ad5111bc68