### PR TITLE
Remove gallery link from public navigation

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -16,11 +16,6 @@ export const primaryNavigation: NavigationItem[] = [
     description: "Tauche in die Welt hinter dem mystischen Vorhang ein.",
   },
   {
-    label: "Archiv und Bilder",
-    href: "/galerie",
-    description: "Alle Infos zum geschützten Medienarchiv mit Fotos und Videos vergangener Jahre.",
-  },
-  {
     label: "Unsere Schulkatze",
     href: "/unsere-schulkatze",
     description: "Lerne Minna kennen – Pausenbegleiterin und Herz unserer Schule.",


### PR DESCRIPTION
## Summary
- remove the Archiv und Bilder item from the publicly visible navigation configuration so it only remains in the members area

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2f8507d9c832dab6f734f81caaeda