### PR TITLE
feat: redesign meal planning experience

### DIFF
--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
@@ -1,4 +1,14 @@
-import { ChefHat, CheckCircle2, ListPlus, Sparkles } from "lucide-react";
+import {
+  CalendarDays,
+  ChefHat,
+  NotebookPen,
+  Palette,
+  ShieldAlert,
+  Sparkles,
+  Users2,
+  UserCheck,
+  type LucideIcon,
+} from "lucide-react";
 import Link from "next/link";
 import type { AllergyLevel } from "@prisma/client";
 
@@ -32,6 +42,14 @@ const ALLERGY_LEVEL_STYLES: Record<AllergyLevel, string> = {
   MODERATE: "border-amber-300/60 bg-amber-500/10 text-amber-500",
   SEVERE: "border-orange-400/60 bg-orange-500/15 text-orange-500",
   LETHAL: "border-red-500/70 bg-red-500/15 text-red-500",
+};
+
+type Metric = {
+  label: string;
+  value: string;
+  hint: string;
+  icon: LucideIcon;
+  accent: string;
 };
 
 export default async function EssensplanungPage() {
@@ -72,16 +90,20 @@ export default async function EssensplanungPage() {
     ? `${new Intl.DateTimeFormat("de-DE", { day: "2-digit", month: "2-digit" }).format(finalWeekStart)} – ${new Intl.DateTimeFormat("de-DE", { day: "2-digit", month: "2-digit" }).format(finalWeekEnd)}`
     : null;
 
-  const metrics = [
+  const metrics: Metric[] = [
     {
       label: "Profile erfasst",
       value: numberFormatter.format(totalParticipants),
       hint: `${numberFormatter.format(strictParticipants)} strikt • ${numberFormatter.format(participantsWithRestrictions)} Allergieprofile`,
+      icon: Users2,
+      accent: "border-sky-400/40 bg-sky-500/10 text-sky-500 ring-sky-500/20",
     },
     {
       label: "Kritische Unverträglichkeiten",
       value: numberFormatter.format(criticalRestrictionCount),
       hint: `${numberFormatter.format(criticalAllergens.length)} sensible Allergene`,
+      icon: ShieldAlert,
+      accent: "border-red-400/40 bg-red-500/10 text-red-500 ring-red-500/20",
     },
     {
       label: "Ernährungscluster",
@@ -89,100 +111,192 @@ export default async function EssensplanungPage() {
       hint: styleSummaries.length
         ? `${styleSummaries[0].label} führt mit ${styleSummaries[0].share}%`
         : "Noch keine Angaben",
+      icon: Palette,
+      accent: "border-emerald-400/40 bg-emerald-500/10 text-emerald-500 ring-emerald-500/20",
     },
     {
       label: finalWeekCountdown !== null ? "Countdown" : "Finale Woche",
       value: finalWeekCountdown !== null ? numberFormatter.format(finalWeekCountdown) : "Offen",
       hint: finalWeekCountdown !== null ? "Tage bis Start" : "Bitte Termin definieren",
+      icon: CalendarDays,
+      accent: "border-primary/40 bg-primary/10 text-primary ring-primary/20",
     },
   ];
+
   const breadcrumbs = [
     membersNavigationBreadcrumb("/mitglieder/endproben-woche/essenplanung"),
   ];
 
+  const highlightedAllergens = criticalAllergens.slice(0, 4);
+
+  const quickActions = (
+    <div className="flex flex-wrap items-center gap-2">
+      {finalWeekRangeLabel ? (
+        <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
+          <CalendarDays className="h-3.5 w-3.5" />
+          <span>{finalWeekRangeLabel}</span>
+        </Badge>
+      ) : (
+        <Badge variant="outline" className="border-warning/60 bg-warning/10 text-warning">
+          <CalendarDays className="h-3.5 w-3.5" />
+          <span>Zeitraum festlegen</span>
+        </Badge>
+      )}
+      <Badge variant="outline" className="border-border/60 bg-background/90 text-muted-foreground">
+        <Users2 className="h-3.5 w-3.5" />
+        <span>{numberFormatter.format(totalParticipants)} Profile</span>
+      </Badge>
+    </div>
+  );
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-8 xl:space-y-10">
       <PageHeader
         title="Essensplanung"
-        description={`Plane kompakt die Verpflegung der Endprobenwoche – gebündelt nach Ernährungsstilen, Strengegraden und Allergierisiken. Dienste und Verantwortliche koordinierst du im Bereich "Dienstplan".`}
+        description="Plane die Verpflegung der Endprobenwoche abgestimmt auf Ernährungsstile, Allergien und Portionen – inklusive eigener Rezeptideen."
         breadcrumbs={breadcrumbs}
+        quickActions={quickActions}
       />
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.66fr)_minmax(0,0.34fr)] xl:items-start">
-        <div className="space-y-4">
-          <Card className="border-primary/30 bg-gradient-to-br from-primary/10 via-background to-background/80 shadow-[0_25px_60px_rgba(59,130,246,0.18)]">
-            <CardHeader className="space-y-3">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <CardTitle className="flex items-center gap-2 text-lg font-semibold">
-                  <ChefHat className="h-5 w-5 text-primary" />
-                  Finale Essensmatrix
-                </CardTitle>
-                {finalWeekStartLabel ? (
-                  <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
-                    Start {finalWeekStartLabel}
-                  </Badge>
-                ) : (
-                  <Badge variant="outline" className="border-warning/60 bg-warning/10 text-warning">
-                    Datum fehlt
-                  </Badge>
-                )}
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.68fr)_minmax(0,0.32fr)] xl:items-start">
+        <div className="space-y-6">
+          <Card className="relative overflow-hidden border border-primary/30 bg-background/95 shadow-[0_30px_80px_rgba(59,130,246,0.15)]">
+            <div className="pointer-events-none absolute inset-0">
+              <div className="absolute -left-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-primary/20 blur-3xl" />
+              <div className="absolute -right-12 top-10 h-48 w-48 rounded-full bg-sky-500/15 blur-3xl" />
+            </div>
+            <CardHeader className="relative space-y-4">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="space-y-2">
+                  <CardTitle className="flex items-center gap-2 text-xl font-semibold text-primary">
+                    <ChefHat className="h-5 w-5" />
+                    Finale Essensmatrix
+                  </CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Die Kennzahlen basieren auf aktuellen Onboarding-Profilen und aktiven Allergieeinträgen. Nutze sie als Ausgangspunkt für die Menüplanung und Dienstverteilung.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  {finalWeekStartLabel ? (
+                    <Badge variant="outline" className="border-primary/50 bg-primary/10 text-primary">
+                      <CalendarDays className="h-4 w-4" />
+                      <span>Start {finalWeekStartLabel}</span>
+                    </Badge>
+                  ) : (
+                    <Badge variant="outline" className="border-warning/60 bg-warning/10 text-warning">
+                      <CalendarDays className="h-4 w-4" />
+                      <span>Datum fehlt</span>
+                    </Badge>
+                  )}
+                  {finalWeekCountdown !== null ? (
+                    <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
+                      <Sparkles className="h-4 w-4" />
+                      <span>{numberFormatter.format(finalWeekCountdown)} Tage</span>
+                    </Badge>
+                  ) : null}
+                </div>
               </div>
-              <p className="text-sm text-muted-foreground">
-                Die Kennzahlen basieren auf aktuellen Onboarding-Profilen und aktiven Allergieeinträgen. Nutze sie als Startpunkt für die Menüplanung.
-              </p>
             </CardHeader>
-            <CardContent>
+            <CardContent className="relative space-y-5">
               <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                {metrics.map((metric) => (
-                  <div
-                    key={metric.label}
-                    className="rounded-xl border border-primary/20 bg-background/80 p-3 shadow-sm backdrop-blur"
-                  >
-                    <div className="text-[11px] font-semibold uppercase tracking-wide text-primary/70">
-                      {metric.label}
+                {metrics.map((metric) => {
+                  const Icon = metric.icon;
+                  return (
+                    <div
+                      key={metric.label}
+                      className="relative overflow-hidden rounded-2xl border border-border/50 bg-background/95 p-4 shadow-sm transition hover:border-primary/40 hover:shadow-md"
+                    >
+                      <div className="absolute -right-10 top-0 h-20 w-20 rounded-full bg-primary/5 blur-2xl" aria-hidden />
+                      <div className="relative flex items-start gap-3">
+                        <div
+                          className={cn(
+                            "flex h-10 w-10 items-center justify-center rounded-full border text-primary ring-4",
+                            metric.accent,
+                          )}
+                        >
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            {metric.label}
+                          </p>
+                          <p className="text-2xl font-semibold text-foreground">{metric.value}</p>
+                          <p className="text-xs text-muted-foreground">{metric.hint}</p>
+                        </div>
+                      </div>
                     </div>
-                    <div className="mt-1 text-2xl font-semibold text-foreground">{metric.value}</div>
-                    <p className="mt-1 text-xs text-muted-foreground">{metric.hint}</p>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
               {finalWeekRangeLabel ? (
-                <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                  <Sparkles className="h-4 w-4 text-primary" />
-                  <span>Geplante Versorgungsphase: {finalWeekRangeLabel}</span>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <CalendarDays className="h-4 w-4 text-primary" />
+                  <span>Versorgungsphase: {finalWeekRangeLabel}</span>
+                </div>
+              ) : (
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                  <span>Lege den Zeitraum der Endprobenwoche fest, um Einkaufslisten zu präzisieren.</span>
+                </div>
+              )}
+              {highlightedAllergens.length ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="destructive" size="sm" className="gap-1">
+                    <ShieldAlert className="h-3.5 w-3.5" />
+                    Hochsensibel
+                  </Badge>
+                  {highlightedAllergens.map((allergen) => (
+                    <span
+                      key={allergen}
+                      className="rounded-full border border-destructive/40 bg-destructive/10 px-3 py-1 text-xs text-destructive"
+                    >
+                      {allergen}
+                    </span>
+                  ))}
+                  {criticalAllergens.length > highlightedAllergens.length ? (
+                    <span className="text-xs text-muted-foreground">
+                      +{criticalAllergens.length - highlightedAllergens.length} weitere
+                    </span>
+                  ) : null}
                 </div>
               ) : null}
             </CardContent>
           </Card>
 
-          <Card className="border border-border/60 bg-background/70">
-            <CardHeader className="space-y-2">
-              <CardTitle className="flex items-center gap-2 text-lg font-semibold">
-                <ListPlus className="h-5 w-5 text-primary" />
-                Eigene Rezepte planen
-              </CardTitle>
+          <Card className="relative overflow-hidden border border-border/70 bg-background/90 shadow-sm">
+            <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
+            <CardHeader className="relative space-y-3">
+              <div className="flex items-center gap-2 text-primary">
+                <NotebookPen className="h-5 w-5" />
+                <CardTitle className="text-base font-semibold">Individuelle Rezeptplanung</CardTitle>
+              </div>
               <p className="text-sm text-muted-foreground">
-                Statt automatischer Vorschläge setzt du jetzt auf eure eigene Kreativität: Mit der Rezeptwerkbank lassen sich individuelle Menüs, Mengen und Abläufe zusammenstellen.
+                Kombiniere Bibliotheksrezepte mit euren eigenen Kreationen. Mengen und Einkaufslisten skalieren automatisch auf eure Gruppengröße.
               </p>
             </CardHeader>
-            <CardContent className="space-y-4">
-              <ul className="space-y-2 text-sm text-muted-foreground">
-                <li className="flex items-start gap-2">
-                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
-                  <span>Lege Zutaten, Portionen und Beschreibungen exakt für eure Gruppe fest.</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
-                  <span>Kombiniere Rezepte aus der Bibliothek mit komplett eigenen Kreationen.</span>
-                </li>
-                <li className="flex items-start gap-2">
-                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
-                  <span>Automatisch generierte Einkaufslisten helfen beim Delegieren der Aufgaben.</span>
-                </li>
-              </ul>
-              <Button asChild className="w-full sm:w-auto">
-                <Link href="#rezeptwerkbank">Rezept erstellen</Link>
-              </Button>
+            <CardContent className="relative space-y-4">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <Sparkles className="mt-0.5 h-4 w-4 text-primary" />
+                  <span>Eigene Rezepte werden nach dem Speichern direkt im Dropdown &bdquo;Eigene Rezepte&ldquo; verfügbar.</span>
+                </div>
+                <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <ShieldAlert className="mt-0.5 h-4 w-4 text-warning" />
+                  <span>Berücksichtige strikte Profile, um Stationen oder Kennzeichnungen rechtzeitig einzuplanen.</span>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button asChild className="gap-2">
+                  <Link href="#rezeptwerkbank">
+                    <NotebookPen className="h-4 w-4" /> Rezeptwerkbank öffnen
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm" className="gap-2">
+                  <Link href="/mitglieder/endproben-woche/einkaufsliste">
+                    <Sparkles className="h-3.5 w-3.5" /> Einkaufslisten ansehen
+                  </Link>
+                </Button>
+              </div>
             </CardContent>
           </Card>
 
@@ -197,46 +311,53 @@ export default async function EssensplanungPage() {
           </section>
         </div>
 
-        <div className="space-y-4">
-          <Card className="border border-border/60 bg-background/70">
-            <CardHeader className="space-y-2">
-              <CardTitle className="text-lg font-semibold">Ernährungscluster</CardTitle>
+        <div className="space-y-6">
+          <Card className="border border-border/70 bg-background/90 shadow-sm">
+            <CardHeader className="space-y-3 pb-0">
+              <div className="flex items-center gap-2 text-primary">
+                <Palette className="h-5 w-5" />
+                <CardTitle className="text-base font-semibold">Ernährungscluster</CardTitle>
+              </div>
               <p className="text-sm text-muted-foreground">
-                Verteilung der gemeldeten Ernährungsstile inklusive dominanter Strengegrade. Nutze sie, um Buffet-Linien zu priorisieren.
+                Verteilung der gemeldeten Ernährungsstile inklusive dominanter Strengegrade. Nutze sie, um Buffet-Linien und Testverkostungen zu priorisieren.
               </p>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="space-y-3 pt-0">
               {styleSummaries.length === 0 ? (
-                <p className="rounded-lg border border-dashed border-border/60 bg-background/60 p-4 text-sm text-muted-foreground">
+                <p className="rounded-xl border border-dashed border-border/60 bg-background/80 p-4 text-sm text-muted-foreground">
                   Noch keine Angaben vorhanden.
                 </p>
               ) : (
                 styleSummaries.map((summary) => (
                   <div
                     key={summary.key}
-                    className="rounded-xl border border-border/60 bg-background/80 p-3 shadow-sm"
+                    className="group relative overflow-hidden rounded-xl border border-border/60 bg-background/95 p-4 shadow-sm"
                   >
-                    <div className="flex items-start justify-between gap-3">
+                    <div className="absolute inset-y-0 left-0 w-1 rounded-l-xl bg-gradient-to-b from-primary/50 via-primary/20 to-transparent" aria-hidden />
+                    <div className="relative flex items-start justify-between gap-3">
                       <div>
                         <p className="text-sm font-semibold text-foreground">{summary.label}</p>
                         <p className="text-xs text-muted-foreground">
                           Strenge: {summary.dominantStrictnessLabel} ({summary.dominantStrictnessShare}%)
                         </p>
                       </div>
-                      <Badge variant="outline" className="border-border/60 bg-background px-2 py-0.5 text-xs text-muted-foreground">
+                      <Badge variant="outline" className="border-primary/30 bg-primary/10 text-primary">
                         {summary.count} Personen · {summary.share}%
                       </Badge>
                     </div>
-                    <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted/40">
+                    <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-muted/40">
                       <div
-                        className="h-full rounded-full bg-gradient-to-r from-primary/60 via-primary/40 to-transparent"
+                        className="h-full rounded-full bg-gradient-to-r from-primary/70 via-primary/45 to-transparent"
                         style={{ width: `${summary.share}%` }}
                       />
                     </div>
                     {summary.sampleNames.length ? (
-                      <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+                      <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
                         {summary.sampleNames.map((name) => (
-                          <span key={name} className="rounded-full border border-border/50 bg-background/80 px-2 py-0.5">
+                          <span
+                            key={name}
+                            className="rounded-full border border-border/50 bg-background/80 px-2 py-0.5"
+                          >
                             {name}
                           </span>
                         ))}
@@ -248,16 +369,19 @@ export default async function EssensplanungPage() {
             </CardContent>
           </Card>
 
-          <Card className="border border-border/60 bg-background/70">
-            <CardHeader className="space-y-2">
-              <CardTitle className="text-lg font-semibold">Allergie-Watchlist</CardTitle>
+          <Card className="border border-border/70 bg-background/90 shadow-sm">
+            <CardHeader className="space-y-3 pb-0">
+              <div className="flex items-center gap-2 text-destructive">
+                <ShieldAlert className="h-5 w-5" />
+                <CardTitle className="text-base font-semibold text-foreground">Allergie-Watchlist</CardTitle>
+              </div>
               <p className="text-sm text-muted-foreground">
-                Kritische Allergene mit betroffenen Personen und Schweregrad. Plane getrennte Ausgabestationen oder Zusatzbeschilderung.
+                Kritische Allergene mit betroffenen Personen und Schweregrad. Plane getrennte Ausgabestationen oder zusätzliche Kennzeichnungen ein.
               </p>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="space-y-3 pt-0">
               {allergenSummaries.length === 0 ? (
-                <p className="rounded-lg border border-dashed border-border/60 bg-background/60 p-4 text-sm text-muted-foreground">
+                <p className="rounded-xl border border-dashed border-border/60 bg-background/80 p-4 text-sm text-muted-foreground">
                   Keine aktiven Allergiehinweise.
                 </p>
               ) : (
@@ -265,19 +389,22 @@ export default async function EssensplanungPage() {
                   const levelBadges = (Object.keys(entry.levels) as AllergyLevel[])
                     .filter((level) => entry.levels[level] > 0)
                     .map((level) => (
-                      <span
+                      <Badge
                         key={`${entry.key}-${level}`}
-                        className="rounded-full border border-border/50 bg-background/80 px-2 py-0.5 text-[11px] text-muted-foreground"
+                        variant="outline"
+                        size="sm"
+                        className="border-border/50 bg-background/90 text-[11px] text-muted-foreground"
                       >
                         {ALLERGY_LEVEL_LABELS[level]}: {entry.levels[level]}
-                      </span>
+                      </Badge>
                     ));
                   return (
                     <div
                       key={entry.key}
-                      className="rounded-xl border border-border/60 bg-background/80 p-3 shadow-sm"
+                      className="relative overflow-hidden rounded-xl border border-destructive/30 bg-destructive/5 p-4 shadow-sm"
                     >
-                      <div className="flex items-start justify-between gap-3">
+                      <div className="absolute inset-y-0 right-0 w-24 bg-gradient-to-l from-destructive/15 via-transparent to-transparent blur-2xl" aria-hidden />
+                      <div className="relative flex items-start justify-between gap-3">
                         <div>
                           <p className="text-sm font-semibold text-foreground">{entry.name}</p>
                           <p className="text-xs text-muted-foreground">
@@ -287,14 +414,14 @@ export default async function EssensplanungPage() {
                         <Badge
                           variant="outline"
                           className={cn(
-                            "px-2 py-0.5 text-xs",
+                            "px-3 py-0.5 text-xs",
                             ALLERGY_LEVEL_STYLES[entry.highestLevel] ?? "border-border/60 bg-muted/40 text-muted-foreground",
                           )}
                         >
                           {ALLERGY_LEVEL_LABELS[entry.highestLevel]}
                         </Badge>
                       </div>
-                      <div className="mt-2 flex flex-wrap gap-2">{levelBadges}</div>
+                      <div className="relative mt-3 flex flex-wrap gap-2">{levelBadges}</div>
                     </div>
                   );
                 })
@@ -302,16 +429,19 @@ export default async function EssensplanungPage() {
             </CardContent>
           </Card>
 
-          <Card className="border border-border/60 bg-background/70">
-            <CardHeader className="space-y-2">
-              <CardTitle className="text-lg font-semibold">Priorisierte Profile</CardTitle>
+          <Card className="border border-border/70 bg-background/90 shadow-sm">
+            <CardHeader className="space-y-3 pb-0">
+              <div className="flex items-center gap-2 text-primary">
+                <UserCheck className="h-5 w-5" />
+                <CardTitle className="text-base font-semibold">Priorisierte Profile</CardTitle>
+              </div>
               <p className="text-sm text-muted-foreground">
                 Mitglieder mit strikten Ernährungsangaben oder hohen Allergiestufen – ideal für individuelles Briefing und Testverkostungen.
               </p>
             </CardHeader>
-            <CardContent>
+            <CardContent className="space-y-3 pt-0">
               {priorityProfiles.length === 0 ? (
-                <p className="rounded-lg border border-dashed border-border/60 bg-background/60 p-4 text-sm text-muted-foreground">
+                <p className="rounded-xl border border-dashed border-border/60 bg-background/80 p-4 text-sm text-muted-foreground">
                   Keine kritischen Profile hervorgehoben.
                 </p>
               ) : (
@@ -321,9 +451,10 @@ export default async function EssensplanungPage() {
                     return (
                       <li
                         key={profile.userId}
-                        className="rounded-xl border border-border/60 bg-background/80 p-3 shadow-sm"
+                        className="relative overflow-hidden rounded-xl border border-border/60 bg-background/95 p-4 shadow-sm"
                       >
-                        <div className="flex items-start justify-between gap-3">
+                        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" aria-hidden />
+                        <div className="relative flex items-start justify-between gap-3">
                           <div>
                             <p className="text-sm font-semibold text-foreground">{profile.name}</p>
                             <p className="text-xs text-muted-foreground">{profile.strictnessLabel}</p>
@@ -338,19 +469,21 @@ export default async function EssensplanungPage() {
                             {profile.styleLabel}
                           </Badge>
                         </div>
-                        <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+                        <div className="relative mt-3 flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
                           {profile.restrictions.slice(0, 3).map((restriction, index) => (
-                            <span
+                            <Badge
                               key={`${profile.userId}-${restriction.allergen}-${index}`}
-                              className="rounded-full border border-border/50 bg-background/80 px-2 py-0.5"
+                              variant="outline"
+                              size="sm"
+                              className="border-border/40 bg-background/90"
                             >
                               {restriction.allergen} · {ALLERGY_LEVEL_LABELS[restriction.level]}
-                            </span>
+                            </Badge>
                           ))}
                           {remaining > 0 ? (
-                            <span className="rounded-full border border-border/40 bg-background/70 px-2 py-0.5">
+                            <Badge variant="ghost" size="sm" className="border-border/30 bg-background/70 text-muted-foreground">
                               +{remaining} weitere
-                            </span>
+                            </Badge>
                           ) : null}
                         </div>
                       </li>


### PR DESCRIPTION
## Summary
- refresh the final rehearsal meal planning page with a richer hero, contextual metrics, and reworked insights for styles, allergens, and priority profiles
- modernize the recipe planning workbench UI, add grouping for library versus custom recipes, and surface saved creations directly in the workflow
- improve ingredient scaling and caution highlighting while keeping the generated shopping list aligned with the new design

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d2fa42ea64832daa817b44579a62a3