### PR TITLE
Adjust mobile sidebar sheet width

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -205,7 +205,10 @@ const Sidebar = React.forwardRef<
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"
-            className="w-[var(--sidebar-width)] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+            className={cn(
+              "bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden",
+              "w-[min(100dvw,var(--sidebar-width))] max-w-[100dvw]",
+            )}
             style={{ "--sidebar-width": SIDEBAR_WIDTH_MOBILE } as React.CSSProperties}
             side={side}
           >


### PR DESCRIPTION
## Summary
- allow the mobile sidebar sheet to size itself with `min(100dvw, var(--sidebar-width))` and cap the maximum width at the viewport to avoid overflow on very small screens

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d305636700832da915ec8926d3303e