### PR TITLE
Add system color mode handling

### DIFF
--- a/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
+++ b/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
@@ -30,6 +30,7 @@ const LIGHT_MODE = "light" as ThemeModeKey;
 const DARK_MODE = "dark" as ThemeModeKey;
 
 const COLOR_MODE_OPTIONS: { value: ThemeColorMode; label: string }[] = [
+  { value: "system", label: "Systemmodus" },
   { value: "dark", label: "Dunkelmodus" },
   { value: "light", label: "Hellmodus" },
 ];
@@ -891,25 +892,13 @@ export function WebsiteThemeSettingsManager({ initialSettings, initialThemes }: 
 
   useEffect(() => {
     const root = document.documentElement;
-    if (colorMode === "dark") {
-      root.classList.add("dark");
-      root.style.colorScheme = "dark";
-    } else {
-      root.classList.remove("dark");
-      root.style.colorScheme = "light";
-    }
+    root.setAttribute("data-color-mode", colorMode);
   }, [colorMode]);
 
   useEffect(() => {
-    const root = document.documentElement;
+    const modeOnUnmount = siteSnapshot.colorMode;
     return () => {
-      if (siteSnapshot.colorMode === "dark") {
-        root.classList.add("dark");
-        root.style.colorScheme = "dark";
-      } else {
-        root.classList.remove("dark");
-        root.style.colorScheme = "light";
-      }
+      document.documentElement.setAttribute("data-color-mode", modeOnUnmount);
     };
   }, [siteSnapshot.colorMode]);
 

--- a/src/app/api/website/settings/route.ts
+++ b/src/app/api/website/settings/route.ts
@@ -16,7 +16,7 @@ import {
   toClientWebsiteTheme,
 } from "@/lib/website-settings";
 
-const colorModeSchema = z.enum(["light", "dark"]);
+const colorModeSchema = z.enum(["light", "dark", "system"]);
 
 const updateSchema = z.object({
   settings: z

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import type { Viewport } from "next";
 import { getServerSession } from "next-auth";
 import type { Session } from "next-auth";
+import { ColorModeScript } from "@/components/theme/color-mode-script";
 import { ThemeStyleRegistry } from "@/components/theme/theme-style-registry";
 import { geistSans, geistMono } from "./fonts";
 import {
@@ -55,7 +56,7 @@ export const viewport: Viewport = {
     { media: "(prefers-color-scheme: dark)", color: "oklch(0.75 0.14 63.3)" },
     { color: "oklch(0.78 0.146 63.3)" },
   ],
-  colorScheme: "dark",
+  colorScheme: "light dark",
 };
 
 export const dynamic = "force-dynamic";
@@ -88,9 +89,18 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   );
   const themeTokens = resolvedSettings.theme.tokens;
 
+  const initialColorScheme =
+    resolvedSettings.colorMode === "system" ? "light dark" : resolvedSettings.colorMode;
+
   return (
-    <html lang="de" className={htmlClassName}>
+    <html
+      lang="de"
+      className={htmlClassName}
+      data-color-mode={resolvedSettings.colorMode}
+      style={{ colorScheme: initialColorScheme }}
+    >
       <head>
+        <ColorModeScript mode={resolvedSettings.colorMode} />
         <ThemeStyleRegistry tokens={themeTokens} />
       </head>
       <body className="antialiased bg-background text-foreground">

--- a/src/components/theme/color-mode-script.tsx
+++ b/src/components/theme/color-mode-script.tsx
@@ -1,0 +1,83 @@
+import { DEFAULT_COLOR_MODE, type ThemeColorMode } from "@/lib/website-settings";
+
+export type ColorModeScriptProps = {
+  mode: ThemeColorMode;
+};
+
+export function ColorModeScript({ mode }: ColorModeScriptProps) {
+  const script = `(() => {
+    const root = document.documentElement;
+    const attribute = "data-color-mode";
+    const defaultMode = ${JSON.stringify(DEFAULT_COLOR_MODE)};
+    const initialMode = ${JSON.stringify(mode)};
+    const supportsMatchMedia = typeof window.matchMedia === "function";
+    const preferenceQuery = supportsMatchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : null;
+
+    const addPreferenceListener = (listener) => {
+      if (!preferenceQuery) {
+        return () => {};
+      }
+      if (typeof preferenceQuery.addEventListener === "function") {
+        preferenceQuery.addEventListener("change", listener);
+        return () => {
+          preferenceQuery.removeEventListener("change", listener);
+        };
+      }
+      preferenceQuery.addListener(listener);
+      return () => {
+        preferenceQuery.removeListener(listener);
+      };
+    };
+
+    let removePreferenceListener = null;
+
+    const apply = (modeToApply) => {
+      if (modeToApply === "system") {
+        const isDark = preferenceQuery ? preferenceQuery.matches : false;
+        root.classList.toggle("dark", isDark);
+        root.style.colorScheme = preferenceQuery ? "light dark" : (isDark ? "dark" : "light");
+        return;
+      }
+      root.classList.toggle("dark", modeToApply === "dark");
+      root.style.colorScheme = modeToApply;
+    };
+
+    const handlePreferenceChange = () => {
+      const activeMode = root.getAttribute(attribute) || defaultMode;
+      if (activeMode === "system") {
+        apply("system");
+      }
+    };
+
+    const updateFromAttribute = () => {
+      const activeMode = root.getAttribute(attribute) || defaultMode;
+      if (activeMode === "system") {
+        if (!removePreferenceListener) {
+          removePreferenceListener = addPreferenceListener(handlePreferenceChange);
+        }
+      } else if (removePreferenceListener) {
+        removePreferenceListener();
+        removePreferenceListener = null;
+      }
+      apply(activeMode);
+    };
+
+    if (!root.hasAttribute(attribute)) {
+      root.setAttribute(attribute, initialMode);
+    }
+
+    updateFromAttribute();
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === "attributes" && mutation.attributeName === attribute) {
+          updateFromAttribute();
+        }
+      }
+    });
+
+    observer.observe(root, { attributes: true, attributeFilter: [attribute] });
+  })();`;
+
+  return <script dangerouslySetInnerHTML={{ __html: script }} />;
+}

--- a/src/lib/website-settings.ts
+++ b/src/lib/website-settings.ts
@@ -9,7 +9,7 @@ export const DEFAULT_WEBSITE_SETTINGS_ID = "public" as const;
 export const DEFAULT_SITE_TITLE = "Sommertheater im Schlosspark" as const;
 export const DEFAULT_COLOR_MODE = "dark" as const;
 
-export const THEME_COLOR_MODES = ["light", "dark"] as const;
+export const THEME_COLOR_MODES = ["light", "dark", "system"] as const;
 export type ThemeColorMode = (typeof THEME_COLOR_MODES)[number];
 
 type BrandedString<Brand extends string> = string & { readonly __brand: Brand };


### PR DESCRIPTION
## Summary
- add a head script that keeps the document color mode in sync with system preferences and data attributes
- surface the color mode script and metadata updates in the root layout so system mode is available from first paint
- extend the website settings manager and API schema to include a "system" option for the color mode selector

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d31e5984c8832da1d2bc43e70b7865