### PR TITLE
Implement offline sync endpoints

### DIFF
--- a/prisma/migrations/20251001090000_offline_sync_events/migration.sql
+++ b/prisma/migrations/20251001090000_offline_sync_events/migration.sql
@@ -1,0 +1,51 @@
+-- CreateEnum
+CREATE TYPE "SyncScope" AS ENUM ('inventory', 'tickets');
+
+-- CreateTable
+CREATE TABLE "SyncMutation" (
+  "clientMutationId" TEXT NOT NULL,
+  "clientId" TEXT NOT NULL,
+  "scope" "SyncScope" NOT NULL,
+  "eventCount" INTEGER NOT NULL,
+  "firstServerSeq" INTEGER,
+  "lastServerSeq" INTEGER,
+  "acknowledgedSeq" INTEGER NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SyncMutation_pkey" PRIMARY KEY ("clientMutationId")
+);
+
+-- CreateTable
+CREATE TABLE "SyncEvent" (
+  "id" TEXT NOT NULL,
+  "scope" "SyncScope" NOT NULL,
+  "clientId" TEXT NOT NULL,
+  "clientMutationId" TEXT NOT NULL,
+  "dedupeKey" TEXT,
+  "type" TEXT NOT NULL,
+  "payload" JSONB NOT NULL,
+  "occurredAt" TIMESTAMP(3) NOT NULL,
+  "serverSeq" SERIAL NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "SyncEvent_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "SyncEvent_serverSeq_key" UNIQUE ("serverSeq")
+);
+
+-- CreateIndex
+CREATE INDEX "SyncEvent_scope_serverSeq_idx" ON "SyncEvent"("scope", "serverSeq");
+
+-- CreateIndex
+CREATE INDEX "SyncEvent_scope_dedupeKey_idx" ON "SyncEvent"("scope", "dedupeKey");
+
+-- CreateIndex
+CREATE INDEX "SyncEvent_scope_occurredAt_idx" ON "SyncEvent"("scope", "occurredAt");
+
+-- CreateIndex
+CREATE INDEX "SyncMutation_scope_clientId_idx" ON "SyncMutation"("scope", "clientId");
+
+-- AddForeignKey
+ALTER TABLE "SyncEvent"
+  ADD CONSTRAINT "SyncEvent_clientMutationId_fkey"
+  FOREIGN KEY ("clientMutationId") REFERENCES "SyncMutation"("clientMutationId")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,11 @@ enum Role {
   admin
 }
 
+enum SyncScope {
+  inventory
+  tickets
+}
+
 enum DepartmentMembershipRole {
   lead
   member
@@ -857,6 +862,40 @@ model InventoryItem {
   location  String?
   owner     String?
   condition String?
+}
+
+model SyncEvent {
+  id               String    @id @default(cuid())
+  scope            SyncScope
+  clientId         String
+  clientMutationId String
+  dedupeKey        String?
+  type             String
+  payload          Json
+  occurredAt       DateTime
+  serverSeq        Int       @unique @default(autoincrement())
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+  mutation         SyncMutation? @relation(fields: [clientMutationId], references: [clientMutationId], onDelete: Cascade)
+
+  @@index([scope, serverSeq])
+  @@index([scope, dedupeKey])
+  @@index([scope, occurredAt])
+}
+
+model SyncMutation {
+  clientMutationId String   @id
+  clientId         String
+  scope            SyncScope
+  eventCount       Int
+  firstServerSeq   Int?
+  lastServerSeq    Int?
+  acknowledgedSeq  Int
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+  events           SyncEvent[]
+
+  @@index([scope, clientId])
 }
 
 model FinanceEntry {

--- a/src/app/api/sync/initial/route.ts
+++ b/src/app/api/sync/initial/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { buildSyncEtag, selectBaseline } from "@/lib/sync/server";
+
+const querySchema = z.object({
+  scope: z.enum(["inventory", "tickets"]),
+  cursor: z.string().optional(),
+  limit: z
+    .coerce.number({ invalid_type_error: "limit must be a number" })
+    .int()
+    .min(1)
+    .max(500)
+    .optional(),
+});
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const parsed = querySchema.parse({
+      scope: url.searchParams.get("scope"),
+      cursor: url.searchParams.get("cursor") ?? undefined,
+      limit: url.searchParams.get("limit") ?? undefined,
+    });
+
+    const baseline = await selectBaseline(parsed.scope, {
+      cursor: parsed.cursor ?? null,
+      limit: parsed.limit ?? null,
+    });
+
+    const etag = buildSyncEtag(
+      "baseline",
+      baseline.scope,
+      baseline.serverSeq,
+      baseline.nextCursor ?? "",
+      baseline.records.length,
+    );
+
+    const headers = new Headers({
+      "Cache-Control": "private, max-age=0, must-revalidate",
+      ETag: `"${etag}"`,
+      "Last-Modified": new Date(baseline.capturedAt).toUTCString(),
+    });
+
+    return NextResponse.json(baseline, { headers });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: "Invalid sync baseline request",
+          issues: error.issues,
+        },
+        { status: 400 },
+      );
+    }
+
+    console.error("Failed to select sync baseline", error);
+    return NextResponse.json(
+      { error: "Failed to create sync baseline" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/sync/pull/route.ts
+++ b/src/app/api/sync/pull/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { buildSyncEtag, selectDeltas } from "@/lib/sync/server";
+
+const payloadSchema = z.object({
+  scope: z.enum(["inventory", "tickets"]),
+  lastServerSeq: z.number().int().nonnegative(),
+  limit: z.number().int().min(1).max(500).optional(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const json = await request.json();
+    const payload = payloadSchema.parse(json);
+
+    const deltas = await selectDeltas(payload.scope, payload.lastServerSeq, {
+      limit: payload.limit ?? null,
+    });
+
+    const latestEvent = deltas.events.at(-1);
+    const etag = buildSyncEtag(
+      "deltas",
+      deltas.scope,
+      deltas.serverSeq,
+      deltas.nextCursor ?? "",
+      deltas.events.length,
+    );
+
+    const headers = new Headers({
+      "Cache-Control": "private, max-age=0, must-revalidate",
+      ETag: `"${etag}"`,
+      "Last-Modified": latestEvent
+        ? new Date(latestEvent.occurredAt).toUTCString()
+        : new Date().toUTCString(),
+    });
+
+    return NextResponse.json(deltas, { headers });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid sync pull payload", issues: error.issues },
+        { status: 400 },
+      );
+    }
+
+    console.error("Failed to select sync deltas", error);
+    return NextResponse.json(
+      { error: "Failed to load sync events" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/sync/push/route.ts
+++ b/src/app/api/sync/push/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  applyIncomingEvents,
+  buildSyncEtag,
+  type ApplyIncomingEventsResult,
+} from "@/lib/sync/server";
+
+const payloadSchema = z.object({
+  scope: z.enum(["inventory", "tickets"]),
+  clientId: z.string().min(1),
+  clientMutationId: z.string().min(1),
+  events: z
+    .array(
+      z.object({
+        id: z.string().min(1).optional(),
+        dedupeKey: z.string().min(1).optional(),
+        type: z.string().min(1),
+        payload: z.record(z.any()),
+        occurredAt: z.string(),
+      }),
+    )
+    .max(1000),
+  lastKnownServerSeq: z.number().int().nonnegative(),
+});
+
+function normalizeMutationResult(result: ApplyIncomingEventsResult) {
+  if (result.status === "applied") {
+    return {
+      status: result.status,
+      serverSeq: result.serverSeq,
+      events: result.events,
+      skipped: result.skipped,
+      mutation: {
+        clientMutationId: result.mutation.clientMutationId,
+        scope: result.mutation.scope,
+        eventCount: result.mutation.eventCount,
+        firstServerSeq: result.mutation.firstServerSeq,
+        lastServerSeq: result.mutation.lastServerSeq,
+      },
+    } as const;
+  }
+
+  if (result.status === "duplicate") {
+    return {
+      status: result.status,
+      serverSeq: result.serverSeq,
+      events: result.events,
+      mutation: {
+        clientMutationId: result.mutation.clientMutationId,
+        scope: result.mutation.scope,
+        eventCount: result.mutation.eventCount,
+        firstServerSeq: result.mutation.firstServerSeq,
+        lastServerSeq: result.mutation.lastServerSeq,
+      },
+    } as const;
+  }
+
+  return {
+    status: result.status,
+    serverSeq: result.serverSeq,
+    events: result.events,
+  } as const;
+}
+
+export async function POST(request: Request) {
+  try {
+    const json = await request.json();
+    const payload = payloadSchema.parse(json);
+
+    const result = await applyIncomingEvents(payload);
+    const responseBody = normalizeMutationResult(result);
+
+    const etag = buildSyncEtag(
+      "push",
+      payload.scope,
+      responseBody.serverSeq,
+      payload.clientMutationId,
+    );
+
+    const headers = new Headers({
+      "Cache-Control": "no-store",
+      ETag: `"${etag}"`,
+      "Last-Modified": new Date().toUTCString(),
+      "X-Sync-Status": responseBody.status,
+    });
+
+    const status = result.status === "stale" ? 409 : 200;
+
+    return NextResponse.json(responseBody, { status, headers });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid sync push payload", issues: error.issues },
+        { status: 400 },
+      );
+    }
+
+    console.error("Failed to apply incoming events", error);
+    return NextResponse.json(
+      { error: "Failed to apply sync events" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/sync/server.ts
+++ b/src/lib/sync/server.ts
@@ -1,0 +1,430 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import type {
+  InventoryItemRecord,
+  OfflineScope,
+  TicketRecord,
+} from "@/lib/offline/types";
+import { prisma } from "@/lib/prisma";
+import {
+  Prisma,
+  type PrismaClient,
+  SyncScope,
+  type SyncEvent as SyncEventModel,
+  type SyncMutation,
+} from "@prisma/client";
+
+const MAX_BASELINE_LIMIT = 500;
+const MAX_DELTA_LIMIT = 500;
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+export interface BaselineOptions {
+  cursor?: string | null;
+  limit?: number | null;
+}
+
+interface BaseBaselineResult<TRecord> {
+  scope: OfflineScope;
+  records: TRecord[];
+  serverSeq: number;
+  capturedAt: string;
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+export type InventoryBaselineResult = BaseBaselineResult<InventoryItemRecord>;
+export type TicketBaselineResult = BaseBaselineResult<TicketRecord>;
+export type BaselineResult = InventoryBaselineResult | TicketBaselineResult;
+
+export interface ServerSyncEvent {
+  id: string;
+  scope: OfflineScope;
+  type: string;
+  payload: Record<string, unknown>;
+  occurredAt: string;
+  serverSeq: number;
+  clientId: string;
+  dedupeKey?: string | null;
+}
+
+export interface DeltaOptions {
+  limit?: number | null;
+}
+
+export interface DeltaResult {
+  scope: OfflineScope;
+  events: ServerSyncEvent[];
+  serverSeq: number;
+  hasMore: boolean;
+  nextCursor?: number;
+}
+
+export interface IncomingEventInput {
+  id?: string;
+  dedupeKey?: string | null;
+  type: string;
+  payload: Record<string, unknown>;
+  occurredAt: string;
+}
+
+export interface ApplyIncomingEventsInput {
+  scope: OfflineScope;
+  clientId: string;
+  clientMutationId: string;
+  events: IncomingEventInput[];
+  lastKnownServerSeq: number;
+}
+
+export interface SkippedIncomingEvent {
+  id: string;
+  dedupeKey?: string | null;
+  reason: "duplicate-id" | "duplicate-dedupe-key";
+}
+
+export type ApplyIncomingEventsResult =
+  | {
+      status: "applied";
+      serverSeq: number;
+      events: ServerSyncEvent[];
+      skipped: SkippedIncomingEvent[];
+      mutation: SyncMutation;
+    }
+  | {
+      status: "duplicate";
+      serverSeq: number;
+      events: ServerSyncEvent[];
+      mutation: SyncMutation;
+    }
+  | {
+      status: "stale";
+      serverSeq: number;
+      events: ServerSyncEvent[];
+      mutation?: SyncMutation;
+    };
+
+function getDb(client?: Prisma.TransactionClient): DbClient {
+  return client ?? prisma;
+}
+
+function toSyncScope(scope: OfflineScope): SyncScope {
+  switch (scope) {
+    case "inventory":
+      return SyncScope.inventory;
+    case "tickets":
+      return SyncScope.tickets;
+    default:
+      const exhaustiveCheck: never = scope;
+      throw new Error(`Unsupported scope: ${exhaustiveCheck}`);
+  }
+}
+
+function fromSyncScope(scope: SyncScope): OfflineScope {
+  switch (scope) {
+    case SyncScope.inventory:
+      return "inventory";
+    case SyncScope.tickets:
+      return "tickets";
+    default:
+      const exhaustiveCheck: never = scope;
+      throw new Error(`Unsupported scope enum: ${exhaustiveCheck}`);
+  }
+}
+
+function mapSyncEvent(event: SyncEventModel): ServerSyncEvent {
+  return {
+    id: event.id,
+    scope: fromSyncScope(event.scope),
+    type: event.type,
+    payload: (event.payload ?? {}) as Record<string, unknown>,
+    occurredAt: event.occurredAt.toISOString(),
+    serverSeq: event.serverSeq,
+    clientId: event.clientId,
+    dedupeKey: event.dedupeKey,
+  };
+}
+
+async function getLatestServerSeq(
+  scope: SyncScope,
+  client?: Prisma.TransactionClient,
+): Promise<number> {
+  const db = getDb(client);
+  const latest = await db.syncEvent.findFirst({
+    where: { scope },
+    orderBy: { serverSeq: "desc" },
+    select: { serverSeq: true },
+  });
+
+  return latest?.serverSeq ?? 0;
+}
+
+function clampLimit(value: number | null | undefined, max: number): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return max;
+  }
+
+  const normalized = Math.max(1, Math.floor(value));
+  return Math.min(normalized, max);
+}
+
+export function buildSyncEtag(
+  ...parts: Array<string | number | boolean | null | undefined>
+): string {
+  const hash = createHash("sha256");
+
+  for (const part of parts) {
+    if (part === null || typeof part === "undefined") {
+      hash.update("-");
+    } else {
+      hash.update(String(part));
+    }
+
+    hash.update("|");
+  }
+
+  return hash.digest("base64url");
+}
+
+export async function selectBaseline(
+  scope: OfflineScope,
+  options: BaselineOptions = {},
+): Promise<BaselineResult> {
+  const normalizedScope = toSyncScope(scope);
+  const limit = clampLimit(options.limit, MAX_BASELINE_LIMIT);
+  const capturedAt = new Date().toISOString();
+  const serverSeq = await getLatestServerSeq(normalizedScope);
+
+  if (scope === "inventory") {
+    const items = await prisma.inventoryItem.findMany({
+      orderBy: { id: "asc" },
+      take: limit + 1,
+      ...(options.cursor
+        ? {
+            skip: 1,
+            cursor: { id: options.cursor },
+          }
+        : {}),
+    });
+
+    const hasMore = items.length > limit;
+    const records = hasMore ? items.slice(0, limit) : items;
+
+    const mapped: InventoryItemRecord[] = records.map((item) => ({
+      id: item.id,
+      sku: item.id,
+      name: item.name,
+      quantity: item.qty,
+      updatedAt: capturedAt,
+    }));
+
+    return {
+      scope,
+      records: mapped,
+      serverSeq,
+      capturedAt,
+      hasMore,
+      nextCursor: hasMore ? records[records.length - 1]?.id : undefined,
+    } satisfies InventoryBaselineResult;
+  }
+
+  const hasMore = false;
+  return {
+    scope,
+    records: [],
+    serverSeq,
+    capturedAt,
+    hasMore,
+  } satisfies TicketBaselineResult;
+}
+
+export async function selectDeltas(
+  scope: OfflineScope,
+  lastServerSeq: number,
+  options: DeltaOptions = {},
+): Promise<DeltaResult> {
+  const normalizedScope = toSyncScope(scope);
+  const limit = clampLimit(options.limit, MAX_DELTA_LIMIT);
+  const serverSeq = await getLatestServerSeq(normalizedScope);
+
+  if (lastServerSeq >= serverSeq) {
+    return {
+      scope,
+      events: [],
+      serverSeq,
+      hasMore: false,
+    };
+  }
+
+  const events = await prisma.syncEvent.findMany({
+    where: {
+      scope: normalizedScope,
+      serverSeq: { gt: lastServerSeq },
+    },
+    orderBy: { serverSeq: "asc" },
+    take: limit + 1,
+  });
+
+  const hasMore = events.length > limit;
+  const trimmed = hasMore ? events.slice(0, limit) : events;
+
+  return {
+    scope,
+    events: trimmed.map(mapSyncEvent),
+    serverSeq,
+    hasMore,
+    nextCursor: trimmed.at(-1)?.serverSeq,
+  };
+}
+
+function normalizeIncomingEvent(event: IncomingEventInput): Required<IncomingEventInput> {
+  const occurredAt = new Date(event.occurredAt);
+
+  if (Number.isNaN(occurredAt.getTime())) {
+    throw new Error(`Invalid occurredAt timestamp for event ${event.id ?? "<unknown>"}`);
+  }
+
+  return {
+    id: event.id ?? randomUUID(),
+    dedupeKey: event.dedupeKey ?? null,
+    type: event.type,
+    payload: event.payload,
+    occurredAt: occurredAt.toISOString(),
+  } satisfies Required<IncomingEventInput>;
+}
+
+export async function applyIncomingEvents(
+  payload: ApplyIncomingEventsInput,
+): Promise<ApplyIncomingEventsResult> {
+  const normalizedScope = toSyncScope(payload.scope);
+  const normalizedEvents = payload.events.map(normalizeIncomingEvent);
+
+  return prisma.$transaction(async (tx) => {
+    const currentSeq = await getLatestServerSeq(normalizedScope, tx);
+
+    if (currentSeq !== payload.lastKnownServerSeq) {
+      return {
+        status: "stale",
+        serverSeq: currentSeq,
+        events: [],
+      } satisfies ApplyIncomingEventsResult;
+    }
+
+    const existingMutation = await tx.syncMutation.findUnique({
+      where: { clientMutationId: payload.clientMutationId },
+    });
+
+    if (existingMutation) {
+      const previousEvents = await tx.syncEvent.findMany({
+        where: { clientMutationId: payload.clientMutationId },
+        orderBy: { serverSeq: "asc" },
+      });
+
+      return {
+        status: "duplicate",
+        serverSeq: existingMutation.lastServerSeq ?? existingMutation.acknowledgedSeq,
+        events: previousEvents.map(mapSyncEvent),
+        mutation: existingMutation,
+      } satisfies ApplyIncomingEventsResult;
+    }
+
+    const eventIds = normalizedEvents.map((event) => event.id);
+    const dedupeKeys = normalizedEvents
+      .map((event) => event.dedupeKey)
+      .filter((key): key is string => typeof key === "string" && key.length > 0);
+
+    const [existingEvents, existingDedupe] = await Promise.all([
+      eventIds.length
+        ? tx.syncEvent.findMany({
+            where: { id: { in: eventIds } },
+            select: { id: true },
+          })
+        : Promise.resolve([]),
+      dedupeKeys.length
+        ? tx.syncEvent.findMany({
+            where: {
+              scope: normalizedScope,
+              dedupeKey: { in: dedupeKeys },
+            },
+            select: { dedupeKey: true },
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const existingIdSet = new Set(existingEvents.map((event) => event.id));
+    const existingDedupeSet = new Set(existingDedupe.map((event) => event.dedupeKey).filter(Boolean));
+
+    const skipped: SkippedIncomingEvent[] = [];
+    const filtered: Required<IncomingEventInput>[] = [];
+
+    for (const event of normalizedEvents) {
+      if (existingIdSet.has(event.id)) {
+        skipped.push({ id: event.id, dedupeKey: event.dedupeKey, reason: "duplicate-id" });
+        continue;
+      }
+
+      if (event.dedupeKey) {
+        if (existingDedupeSet.has(event.dedupeKey)) {
+          skipped.push({ id: event.id, dedupeKey: event.dedupeKey, reason: "duplicate-dedupe-key" });
+          continue;
+        }
+
+        existingDedupeSet.add(event.dedupeKey);
+      }
+
+      filtered.push(event);
+    }
+
+    const mutation = await tx.syncMutation.create({
+      data: {
+        clientMutationId: payload.clientMutationId,
+        clientId: payload.clientId,
+        scope: normalizedScope,
+        eventCount: filtered.length,
+        acknowledgedSeq: currentSeq,
+      },
+    });
+
+    const insertedEvents: SyncEventModel[] = [];
+
+    for (const event of filtered) {
+      const created = await tx.syncEvent.create({
+        data: {
+          id: event.id,
+          scope: normalizedScope,
+          clientId: payload.clientId,
+          clientMutationId: mutation.clientMutationId,
+          dedupeKey: event.dedupeKey,
+          type: event.type,
+          payload: event.payload,
+          occurredAt: new Date(event.occurredAt),
+        },
+      });
+
+      insertedEvents.push(created);
+    }
+
+    const newSeq = insertedEvents.at(-1)?.serverSeq ?? currentSeq;
+
+    const updatedMutation = await tx.syncMutation.update({
+      where: { clientMutationId: mutation.clientMutationId },
+      data: {
+        eventCount: insertedEvents.length,
+        firstServerSeq: insertedEvents.at(0)?.serverSeq ?? null,
+        lastServerSeq: insertedEvents.at(-1)?.serverSeq ?? null,
+        acknowledgedSeq: newSeq,
+      },
+    });
+
+    return {
+      status: "applied",
+      serverSeq: newSeq,
+      events: insertedEvents.map(mapSyncEvent),
+      skipped,
+      mutation: updatedMutation,
+    } satisfies ApplyIncomingEventsResult;
+  });
+}
+
+export async function getScopeWatermark(scope: OfflineScope): Promise<number> {
+  return getLatestServerSeq(toSyncScope(scope));
+}


### PR DESCRIPTION
## Summary
- add SyncScope enum and SyncEvent/SyncMutation models plus migration for the offline sync log
- implement server-side sync helpers for baselines, deltas and applying incoming events with dedupe handling
- expose /api/sync/initial, /api/sync/pull and /api/sync/push route handlers including validation and HTTP caching headers

## Testing
- pnpm lint
- pnpm test
- pnpm test --filter sync *(fails: Vitest CLI in this repo does not support --filter)*

------
https://chatgpt.com/codex/tasks/task_e_68d3866eb3cc832dbe684ef50d6bd23b