### PR TITLE
Implement offline sync client and context

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -6,7 +6,8 @@ import { SessionProvider } from "next-auth/react";
 import type { Session } from "next-auth";
 import { FrontendEditingProvider } from "@/components/frontend-editing/frontend-editing-provider";
 import { RealtimeProvider } from "@/hooks/useRealtime";
-import { OfflineSyncProvider } from "@/lib/offline/storage";
+import { OfflineSyncStatusProvider } from "@/lib/offline/hooks";
+import { OfflineSyncProvider as OfflineStorageProvider } from "@/lib/offline/storage";
 
 export function Providers({
   children,
@@ -19,20 +20,22 @@ export function Providers({
   return (
     <SessionProvider session={session}>
       <QueryClientProvider client={client}>
-        <OfflineSyncProvider>
-          <RealtimeProvider>
-            <FrontendEditingProvider>
-              {children}
-              <Toaster
-                richColors
-                position="top-right"
-                expand={true}
-                visibleToasts={5}
-                gap={8}
-              />
-            </FrontendEditingProvider>
-          </RealtimeProvider>
-        </OfflineSyncProvider>
+        <OfflineStorageProvider>
+          <OfflineSyncStatusProvider>
+            <RealtimeProvider>
+              <FrontendEditingProvider>
+                {children}
+                <Toaster
+                  richColors
+                  position="top-right"
+                  expand={true}
+                  visibleToasts={5}
+                  gap={8}
+                />
+              </FrontendEditingProvider>
+            </RealtimeProvider>
+          </OfflineSyncStatusProvider>
+        </OfflineStorageProvider>
       </QueryClientProvider>
     </SessionProvider>
   );

--- a/src/lib/offline/hooks.tsx
+++ b/src/lib/offline/hooks.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import * as React from "react";
+
+import { offlineDb } from "./db";
+import { useOfflineSync as useOfflineStorage } from "./storage";
+import type { OfflineScope, PendingEvent, PendingEventInput } from "./types";
+import {
+  OfflineSyncContext,
+  SyncClient,
+  SyncError,
+  type BootstrapResult,
+  type FlushResult,
+  type OfflineSyncContextValue,
+  type PullResult,
+  type SyncScopeState,
+} from "./sync-client";
+
+function createInitialScopeState(): Record<OfflineScope, SyncScopeState> {
+  return {
+    inventory: {
+      status: "idle",
+      lastSyncedAt: null,
+      lastError: null,
+      lastServerSeq: 0,
+    },
+    tickets: {
+      status: "idle",
+      lastSyncedAt: null,
+      lastError: null,
+      lastServerSeq: 0,
+    },
+  };
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof SyncError) {
+    return error.message;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+async function refreshScopeFromDb(scope: OfflineScope) {
+  if (!offlineDb) {
+    return null;
+  }
+
+  const state = await offlineDb.syncState.get(scope);
+  return state ?? null;
+}
+
+export function OfflineSyncStatusProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const storage = useOfflineStorage();
+  const isReady = storage.isSupported && storage.isReady;
+  const [client] = React.useState(() => new SyncClient());
+  const [scopes, setScopes] = React.useState(createInitialScopeState);
+
+  const updateScope = React.useCallback(
+    (scope: OfflineScope, updater: (state: SyncScopeState) => SyncScopeState) => {
+      setScopes((previous) => ({
+        ...previous,
+        [scope]: updater(previous[scope]),
+      }));
+    },
+    [],
+  );
+
+  const ensureReady = React.useCallback(
+    (scope: OfflineScope) => {
+      if (!isReady) {
+        throw new SyncError(
+          "Offline persistence is not ready yet.",
+          "unsupported",
+          scope,
+        );
+      }
+    },
+    [isReady],
+  );
+
+  const syncScopeStateFromDb = React.useCallback(
+    async (scope: OfflineScope) => {
+      if (!isReady) {
+        return;
+      }
+
+      const record = await refreshScopeFromDb(scope);
+
+      if (!record) {
+        return;
+      }
+
+      updateScope(scope, (previous) => ({
+        ...previous,
+        lastServerSeq: record.lastServerSeq,
+        lastSyncedAt: record.updatedAt ?? previous.lastSyncedAt,
+      }));
+    },
+    [isReady, updateScope],
+  );
+
+  React.useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadInitialState = async () => {
+      const scopesToLoad: OfflineScope[] = ["inventory", "tickets"];
+
+      for (const scope of scopesToLoad) {
+        const record = await refreshScopeFromDb(scope);
+
+        if (cancelled || !record) {
+          continue;
+        }
+
+        updateScope(scope, (previous) => ({
+          ...previous,
+          lastServerSeq: record.lastServerSeq,
+          lastSyncedAt: record.updatedAt ?? previous.lastSyncedAt,
+          lastError: null,
+        }));
+      }
+    };
+
+    void loadInitialState();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isReady, updateScope]);
+
+  const markStatus = React.useCallback(
+    (scope: OfflineScope, status: SyncScopeState["status"], error?: string | null) => {
+      updateScope(scope, (previous) => ({
+        ...previous,
+        status,
+        ...(typeof error !== "undefined" ? { lastError: error } : {}),
+      }));
+    },
+    [updateScope],
+  );
+
+  const bootstrap = React.useCallback(
+    async (scope: OfflineScope): Promise<BootstrapResult> => {
+      ensureReady(scope);
+      markStatus(scope, "bootstrapping", null);
+
+      try {
+        const result = await client.bootstrap(scope);
+
+        updateScope(scope, (previous) => ({
+          ...previous,
+          status: "idle",
+          lastError: null,
+          lastSyncedAt: result.capturedAt,
+          lastServerSeq: result.serverSeq,
+        }));
+
+        return result;
+      } catch (error) {
+        const message = toErrorMessage(error);
+        markStatus(scope, "error", message);
+        throw error;
+      }
+    },
+    [client, ensureReady, markStatus, updateScope],
+  );
+
+  const flush = React.useCallback(
+    async (scope: OfflineScope): Promise<FlushResult> => {
+      ensureReady(scope);
+      markStatus(scope, "flushing", null);
+
+      try {
+        const result = await client.flush(scope);
+        updateScope(scope, (previous) => ({
+          ...previous,
+          status: "idle",
+          lastError: null,
+          lastSyncedAt: result.completedAt,
+          lastServerSeq: result.serverSeq,
+        }));
+        await syncScopeStateFromDb(scope);
+        return result;
+      } catch (error) {
+        const message = toErrorMessage(error);
+        markStatus(scope, "error", message);
+        throw error;
+      }
+    },
+    [client, ensureReady, markStatus, syncScopeStateFromDb, updateScope],
+  );
+
+  const pull = React.useCallback(
+    async (scope: OfflineScope): Promise<PullResult> => {
+      ensureReady(scope);
+      markStatus(scope, "pulling", null);
+
+      try {
+        const result = await client.pull(scope);
+        updateScope(scope, (previous) => ({
+          ...previous,
+          status: "idle",
+          lastError: null,
+          lastSyncedAt: result.completedAt,
+          lastServerSeq: result.serverSeq,
+        }));
+        await syncScopeStateFromDb(scope);
+        return result;
+      } catch (error) {
+        const message = toErrorMessage(error);
+        markStatus(scope, "error", message);
+        throw error;
+      }
+    },
+    [client, ensureReady, markStatus, syncScopeStateFromDb, updateScope],
+  );
+
+  const enqueue = React.useCallback(
+    async (event: PendingEventInput): Promise<PendingEvent> => {
+      const scope = client.determineScopeFromEvent(event);
+      ensureReady(scope);
+
+      try {
+        const pending = await client.enqueue(event);
+        updateScope(scope, (previous) => ({
+          ...previous,
+          lastError: null,
+        }));
+        return pending;
+      } catch (error) {
+        const message = toErrorMessage(error);
+        markStatus(scope, "error", message);
+        throw error;
+      }
+    },
+    [client, ensureReady, markStatus, updateScope],
+  );
+
+  React.useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleOnline = () => {
+      void Promise.all([flush("inventory"), flush("tickets")]).catch((error) => {
+        console.warn("Failed to flush offline events after going online", error);
+      });
+    };
+
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+    };
+  }, [flush, isReady]);
+
+  const isSyncing = React.useMemo(
+    () =>
+      Object.values(scopes).some((scopeState) =>
+        ["bootstrapping", "flushing", "pulling"].includes(scopeState.status),
+      ),
+    [scopes],
+  );
+
+  const value = React.useMemo<OfflineSyncContextValue>(
+    () => ({
+      client,
+      scopes,
+      bootstrap,
+      flush,
+      pull,
+      enqueue,
+      isSyncing,
+    }),
+    [bootstrap, client, enqueue, flush, isSyncing, pull, scopes],
+  );
+
+  return (
+    <OfflineSyncContext.Provider value={value}>
+      {children}
+    </OfflineSyncContext.Provider>
+  );
+}
+
+export function useOfflineSyncClient() {
+  const context = React.useContext(OfflineSyncContext);
+
+  if (!context) {
+    throw new Error(
+      "useOfflineSyncClient must be used within an OfflineSyncStatusProvider.",
+    );
+  }
+
+  return context;
+}

--- a/src/lib/offline/sync-client.ts
+++ b/src/lib/offline/sync-client.ts
@@ -1,0 +1,890 @@
+"use client";
+
+import { createContext } from "react";
+
+import { offlineDb, type OfflineDatabase } from "./db";
+import {
+  applyDeltas,
+  applySnapshot,
+  enqueueEvent as persistEvent,
+} from "./storage";
+import type {
+  InventoryItemRecord,
+  OfflineDelta,
+  OfflineScope,
+  OfflineSnapshot,
+  PendingEvent,
+  PendingEventInput,
+  TicketRecord,
+} from "./types";
+
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_FLUSH_LIMIT = 50;
+const BASE_BACKOFF_MS = 400;
+const MAX_BACKOFF_MS = 10_000;
+const BACKGROUND_SYNC_TAG = "sync:offline-events";
+const CLIENT_ID_STORAGE_KEY = "offline.sync.clientId";
+
+export type SyncActivity =
+  | "idle"
+  | "bootstrapping"
+  | "flushing"
+  | "pulling"
+  | "error";
+
+export interface SyncScopeState {
+  status: SyncActivity;
+  lastSyncedAt: string | null;
+  lastError: string | null;
+  lastServerSeq: number;
+}
+
+export interface BootstrapResult {
+  scope: OfflineScope;
+  serverSeq: number;
+  recordCount: number;
+  capturedAt: string;
+}
+
+export interface FlushResult {
+  scope: OfflineScope;
+  status: "applied" | "duplicate" | "noop";
+  pushed: number;
+  skipped: number;
+  serverSeq: number;
+  completedAt: string;
+}
+
+export interface PullResult {
+  scope: OfflineScope;
+  events: number;
+  applied: number;
+  serverSeq: number;
+  completedAt: string;
+  hasMore: boolean;
+}
+
+export interface OfflineSyncContextValue {
+  client: SyncClient;
+  scopes: Record<OfflineScope, SyncScopeState>;
+  bootstrap: (scope: OfflineScope) => Promise<BootstrapResult>;
+  flush: (scope: OfflineScope) => Promise<FlushResult>;
+  pull: (scope: OfflineScope) => Promise<PullResult>;
+  enqueue: (event: PendingEventInput) => Promise<PendingEvent>;
+  isSyncing: boolean;
+}
+
+export const OfflineSyncContext =
+  createContext<OfflineSyncContextValue | null>(null);
+
+interface RequestOptions {
+  retries?: number;
+  timeoutMs?: number;
+  acceptStatuses?: number[];
+}
+
+interface BaselineResponse<TRecord extends InventoryItemRecord | TicketRecord> {
+  scope: OfflineScope;
+  records: TRecord[];
+  serverSeq: number;
+  capturedAt: string;
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+interface PullResponse {
+  scope: OfflineScope;
+  events: ServerSyncEvent[];
+  serverSeq: number;
+  hasMore: boolean;
+  nextCursor?: number;
+}
+
+interface PushResponseBase {
+  status: "applied" | "duplicate" | "stale";
+  serverSeq: number;
+  events: ServerSyncEvent[];
+}
+
+interface PushResponseApplied extends PushResponseBase {
+  status: "applied";
+  skipped: { id: string; dedupeKey?: string | null; reason: string }[];
+  mutation: {
+    clientMutationId: string;
+    scope: OfflineScope;
+    eventCount: number;
+    firstServerSeq: number | null;
+    lastServerSeq: number | null;
+  };
+}
+
+interface PushResponseDuplicate extends PushResponseBase {
+  status: "duplicate";
+  mutation: {
+    clientMutationId: string;
+    scope: OfflineScope;
+    eventCount: number;
+    firstServerSeq: number | null;
+    lastServerSeq: number | null;
+  };
+}
+
+interface PushResponseStale extends PushResponseBase {
+  status: "stale";
+}
+
+type PushResponse =
+  | PushResponseApplied
+  | PushResponseDuplicate
+  | PushResponseStale;
+
+export interface ServerSyncEvent {
+  id: string;
+  scope: OfflineScope;
+  type: string;
+  payload: Record<string, unknown> | null;
+  occurredAt: string;
+  serverSeq: number;
+  clientId: string;
+  dedupeKey?: string | null;
+}
+
+export class SyncError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "http"
+      | "network"
+      | "timeout"
+      | "stale"
+      | "unsupported",
+    public readonly scope?: OfflineScope,
+    options?: { cause?: unknown },
+  ) {
+    super(message, { cause: options?.cause });
+    this.name = "SyncError";
+  }
+}
+
+export class SyncClient {
+  private readonly fetcher: typeof fetch;
+  private mutationCounter = 0;
+  private fallbackClientId: string | null = null;
+
+  constructor(fetcher: typeof fetch = fetch) {
+    this.fetcher = fetcher;
+  }
+
+  async bootstrap(scope: OfflineScope): Promise<BootstrapResult> {
+    if (scope === "inventory") {
+      const baseline = await this.loadBaseline<InventoryItemRecord>(scope);
+      const snapshot: OfflineSnapshot = {
+        scope: "inventory",
+        records: baseline.records,
+        serverSeq: baseline.serverSeq,
+        capturedAt: baseline.capturedAt,
+      };
+
+      await applySnapshot(snapshot);
+
+      return {
+        scope,
+        serverSeq: baseline.serverSeq,
+        recordCount: baseline.records.length,
+        capturedAt: baseline.capturedAt,
+      } satisfies BootstrapResult;
+    }
+
+    const baseline = await this.loadBaseline<TicketRecord>(scope);
+    const snapshot: OfflineSnapshot = {
+      scope: "tickets",
+      records: baseline.records,
+      serverSeq: baseline.serverSeq,
+      capturedAt: baseline.capturedAt,
+    };
+
+    await applySnapshot(snapshot);
+
+    return {
+      scope,
+      serverSeq: baseline.serverSeq,
+      recordCount: baseline.records.length,
+      capturedAt: baseline.capturedAt,
+    } satisfies BootstrapResult;
+  }
+
+  private async loadBaseline<TRecord extends InventoryItemRecord | TicketRecord>(
+    scope: OfflineScope,
+  ): Promise<{ records: TRecord[]; serverSeq: number; capturedAt: string }> {
+    const records: TRecord[] = [];
+    let cursor: string | undefined;
+    let serverSeq = 0;
+    let capturedAt = new Date().toISOString();
+
+    while (true) {
+      const searchParams = new URLSearchParams({ scope });
+
+      if (cursor) {
+        searchParams.set("cursor", cursor);
+      }
+
+      const { data } = await this.requestJson<BaselineResponse<TRecord>>(
+        `/api/sync/initial?${searchParams.toString()}`,
+      );
+
+      records.push(...data.records);
+      serverSeq = data.serverSeq;
+      capturedAt = data.capturedAt ?? capturedAt;
+
+      if (!data.hasMore || !data.nextCursor) {
+        break;
+      }
+
+      cursor = data.nextCursor;
+    }
+
+    return { records, serverSeq, capturedAt };
+  }
+
+  async enqueue(input: PendingEventInput): Promise<PendingEvent> {
+    const event = await persistEvent(input);
+    void this.scheduleBackgroundSync();
+    return event;
+  }
+
+  async flush(scope: OfflineScope): Promise<FlushResult> {
+    const db = this.ensureDb();
+    const events = await this.takeEvents(db, scope, DEFAULT_FLUSH_LIMIT);
+
+    if (events.length === 0) {
+      return {
+        scope,
+        status: "noop",
+        pushed: 0,
+        skipped: 0,
+        serverSeq: await this.getServerSeq(db, scope),
+        completedAt: new Date().toISOString(),
+      } satisfies FlushResult;
+    }
+
+    const lastServerSeq = await this.getServerSeq(db, scope);
+    const payload = {
+      scope,
+      clientId: this.ensureClientId(),
+      clientMutationId: this.createMutationId(),
+      events: events.map((event) => ({
+        id: event.id,
+        dedupeKey: event.dedupeKey || undefined,
+        type: event.type,
+        payload: event.payload,
+        occurredAt: event.createdAt,
+      })),
+      lastKnownServerSeq: lastServerSeq,
+    };
+
+    try {
+      const { data, response } = await this.requestJson<PushResponse>(
+        "/api/sync/push",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+        { acceptStatuses: [409] },
+      );
+
+      if (data.status === "stale" || response.status === 409) {
+        await this.requeueEvents(events);
+        void this.scheduleBackgroundSync();
+        throw new SyncError(
+          "Server rejected offline events because local snapshot is stale.",
+          "stale",
+          scope,
+        );
+      }
+
+      const skipped = data.status === "applied" ? data.skipped.length : 0;
+      const completedAt = new Date().toISOString();
+      await this.touchSyncState(db, scope, data.serverSeq);
+
+      return {
+        scope,
+        status: data.status,
+        pushed: events.length,
+        skipped,
+        serverSeq: data.serverSeq,
+        completedAt,
+      } satisfies FlushResult;
+    } catch (error) {
+      await this.requeueEvents(events);
+      void this.scheduleBackgroundSync();
+
+      if (error instanceof SyncError) {
+        throw error;
+      }
+
+      if (this.isAbortError(error)) {
+        throw new SyncError(
+          "Sync request timed out while pushing pending events.",
+          "timeout",
+          scope,
+          { cause: error },
+        );
+      }
+
+      throw new SyncError(
+        "Failed to deliver offline events to the server.",
+        "network",
+        scope,
+        { cause: error },
+      );
+    }
+  }
+
+  async pull(scope: OfflineScope): Promise<PullResult> {
+    const db = this.ensureDb();
+    const lastServerSeq = await this.getServerSeq(db, scope);
+
+    const { data } = await this.requestJson<PullResponse>(
+      "/api/sync/pull",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope,
+          lastServerSeq,
+        }),
+      },
+    );
+
+    if (!data.events.length) {
+      await this.touchSyncState(db, scope, data.serverSeq);
+      return {
+        scope,
+        events: 0,
+        applied: 0,
+        serverSeq: data.serverSeq,
+        completedAt: new Date().toISOString(),
+        hasMore: data.hasMore,
+      } satisfies PullResult;
+    }
+
+    const delta = this.buildDeltaFromEvents(scope, data.events);
+
+    if (delta.upserts?.length || delta.deletes?.length) {
+      const offlineDelta: OfflineDelta = {
+        scope,
+        serverSeq: data.serverSeq,
+        upserts: delta.upserts,
+        deletes: delta.deletes,
+      };
+
+      await applyDeltas(offlineDelta);
+    } else {
+      await this.touchSyncState(db, scope, data.serverSeq);
+    }
+
+    return {
+      scope,
+      events: data.events.length,
+      applied:
+        (delta.upserts?.length ?? 0) + (delta.deletes?.length ?? 0),
+      serverSeq: data.serverSeq,
+      completedAt: new Date().toISOString(),
+      hasMore: data.hasMore,
+    } satisfies PullResult;
+  }
+
+  determineScopeFromEvent(event: PendingEvent | PendingEventInput): OfflineScope {
+    return this.inferScope(event.type);
+  }
+
+  private ensureDb(): OfflineDatabase {
+    if (!offlineDb) {
+      throw new SyncError(
+        "IndexedDB is not available; offline sync cannot be used.",
+        "unsupported",
+      );
+    }
+
+    return offlineDb;
+  }
+
+  private async getServerSeq(db: OfflineDatabase, scope: OfflineScope) {
+    const state = await db.syncState.get(scope);
+    return state?.lastServerSeq ?? 0;
+  }
+
+  private async takeEvents(
+    db: OfflineDatabase,
+    scope: OfflineScope,
+    limit: number,
+  ): Promise<PendingEvent[]> {
+    if (limit <= 0) {
+      return [];
+    }
+
+    const result: PendingEvent[] = [];
+
+    await db.transaction("rw", db.eventQueue, async () => {
+      const ordered = await db.eventQueue.orderBy("createdAt").toArray();
+
+      for (const event of ordered) {
+        if (result.length >= limit) {
+          break;
+        }
+
+        if (this.inferScope(event.type) !== scope) {
+          continue;
+        }
+
+        result.push(event);
+      }
+
+      if (result.length > 0) {
+        await db.eventQueue.bulkDelete(result.map((event) => event.id));
+      }
+    });
+
+    return result;
+  }
+
+  private async requeueEvents(events: PendingEvent[]) {
+    if (!events.length) {
+      return;
+    }
+
+    for (const event of events) {
+      await persistEvent({
+        ...event,
+        id: event.id,
+        createdAt: event.createdAt,
+        retryCount: event.retryCount + 1,
+      });
+    }
+  }
+
+  private inferScope(type: string): OfflineScope {
+    return type.startsWith("inventory") ? "inventory" : "tickets";
+  }
+
+  private createMutationId(): string {
+    this.mutationCounter += 1;
+
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}-${this.mutationCounter}`;
+  }
+
+  private ensureClientId(): string {
+    if (typeof window === "undefined") {
+      this.fallbackClientId ??=
+        `offline-client-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      return this.fallbackClientId;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(CLIENT_ID_STORAGE_KEY);
+
+      if (stored) {
+        return stored;
+      }
+
+      const newId =
+        typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+          ? crypto.randomUUID()
+          : `offline-client-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+      window.localStorage.setItem(CLIENT_ID_STORAGE_KEY, newId);
+      return newId;
+    } catch {
+      this.fallbackClientId ??=
+        `offline-client-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      return this.fallbackClientId;
+    }
+  }
+
+  private async touchSyncState(
+    db: OfflineDatabase,
+    scope: OfflineScope,
+    serverSeq: number,
+  ) {
+    await db.transaction("rw", db.syncState, async () => {
+      const existing = await db.syncState.get(scope);
+      const updatedAt = new Date().toISOString();
+
+      await db.syncState.put({
+        scope,
+        lastServerSeq: Math.max(serverSeq, existing?.lastServerSeq ?? 0),
+        updatedAt,
+        lastSnapshotAt: existing?.lastSnapshotAt,
+      });
+    });
+  }
+
+  private async scheduleBackgroundSync() {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (!("serviceWorker" in navigator)) {
+      return;
+    }
+
+    try {
+      const registration = await navigator.serviceWorker.ready;
+
+      if (
+        "sync" in registration &&
+        registration.sync &&
+        typeof registration.sync.register === "function"
+      ) {
+        await registration.sync.register(BACKGROUND_SYNC_TAG);
+        return;
+      }
+
+      registration.active?.postMessage({ type: BACKGROUND_SYNC_TAG });
+    } catch (error) {
+      console.warn("Failed to register background sync", error);
+    }
+  }
+
+  private async requestJson<T>(
+    input: RequestInfo | URL,
+    init: RequestInit = {},
+    options: RequestOptions = {},
+  ): Promise<{ data: T; response: Response }> {
+    const response = await this.fetchWithRetry(input, init, options);
+    const data = await this.parseJson<T>(response);
+    return { data, response };
+  }
+
+  private async fetchWithRetry(
+    input: RequestInfo | URL,
+    init: RequestInit = {},
+    options: RequestOptions = {},
+  ): Promise<Response> {
+    const {
+      retries = DEFAULT_RETRY_ATTEMPTS,
+      timeoutMs = DEFAULT_TIMEOUT_MS,
+      acceptStatuses = [],
+    } = options;
+    const accepted = new Set(acceptStatuses);
+
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (attempt <= retries) {
+      const controller = new AbortController();
+      const timeoutId =
+        timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+
+      try {
+        const response = await this.fetcher(input, {
+          ...init,
+          signal: controller.signal,
+        });
+
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        if (!response.ok && !accepted.has(response.status)) {
+          if (this.shouldRetryStatus(response.status) && attempt < retries) {
+            await this.delay(this.getBackoffDelay(attempt));
+            attempt += 1;
+            continue;
+          }
+
+          throw new SyncError(
+            `Request failed with status ${response.status}`,
+            "http",
+          );
+        }
+
+        return response;
+      } catch (error) {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
+        if (error instanceof SyncError) {
+          throw error;
+        }
+
+        lastError = error;
+
+        if (this.isAbortError(error)) {
+          if (attempt >= retries) {
+            throw new SyncError("Request aborted", "timeout", undefined, {
+              cause: error,
+            });
+          }
+
+          await this.delay(this.getBackoffDelay(attempt));
+          attempt += 1;
+          continue;
+        }
+
+        if (attempt >= retries) {
+          throw error;
+        }
+
+        await this.delay(this.getBackoffDelay(attempt));
+        attempt += 1;
+      }
+    }
+
+    throw lastError ?? new Error("Unknown sync request failure");
+  }
+
+  private getBackoffDelay(attempt: number) {
+    const exponential = BASE_BACKOFF_MS * 2 ** attempt;
+    const jitter = Math.random() * BASE_BACKOFF_MS;
+    return Math.min(exponential + jitter, MAX_BACKOFF_MS);
+  }
+
+  private delay(durationMs: number) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, durationMs);
+    });
+  }
+
+  private shouldRetryStatus(status: number) {
+    return status >= 500 || status === 408 || status === 429;
+  }
+
+  private isAbortError(error: unknown): boolean {
+    return (
+      (typeof DOMException !== "undefined" && error instanceof DOMException
+        ? error.name === "AbortError"
+        : false) ||
+      (error instanceof Error && error.name === "AbortError")
+    );
+  }
+
+  private async parseJson<T>(response: Response): Promise<T> {
+    try {
+      const clone = response.clone();
+      return (await clone.json()) as T;
+    } catch {
+      return {} as T;
+    }
+  }
+
+  private buildDeltaFromEvents(
+    scope: "inventory",
+    events: ServerSyncEvent[],
+  ): { upserts?: InventoryItemRecord[]; deletes?: string[] };
+  private buildDeltaFromEvents(
+    scope: "tickets",
+    events: ServerSyncEvent[],
+  ): { upserts?: TicketRecord[]; deletes?: string[] };
+  private buildDeltaFromEvents(
+    scope: OfflineScope,
+    events: ServerSyncEvent[],
+  ) {
+    if (scope === "inventory") {
+      return this.buildInventoryDelta(events);
+    }
+
+    return this.buildTicketDelta(events);
+  }
+
+  private buildInventoryDelta(events: ServerSyncEvent[]) {
+    const upserts: InventoryItemRecord[] = [];
+    const deletes: string[] = [];
+
+    for (const event of events) {
+      const payload = event.payload ?? {};
+      const normalizedType = event.type.toLowerCase();
+      const recordCandidate =
+        this.extractInventoryRecord(payload.record, event.occurredAt) ??
+        this.extractInventoryRecord(payload.item, event.occurredAt) ??
+        this.extractInventoryRecord(payload, event.occurredAt);
+
+      if (recordCandidate) {
+        upserts.push(recordCandidate);
+        continue;
+      }
+
+      const shouldDelete =
+        normalizedType.includes("delete") ||
+        normalizedType.includes("remove") ||
+        payload.deleted === true;
+
+      if (!shouldDelete) {
+        continue;
+      }
+
+      const deleteId = this.extractIdentifier(payload);
+
+      if (deleteId) {
+        deletes.push(deleteId);
+      }
+    }
+
+    return {
+      upserts: upserts.length ? upserts : undefined,
+      deletes: deletes.length ? deletes : undefined,
+    } satisfies { upserts?: InventoryItemRecord[]; deletes?: string[] };
+  }
+
+  private buildTicketDelta(events: ServerSyncEvent[]) {
+    const upserts: TicketRecord[] = [];
+    const deletes: string[] = [];
+
+    for (const event of events) {
+      const payload = event.payload ?? {};
+      const normalizedType = event.type.toLowerCase();
+      const recordCandidate =
+        this.extractTicketRecord(payload.record, event.occurredAt) ??
+        this.extractTicketRecord(payload.ticket, event.occurredAt) ??
+        this.extractTicketRecord(payload, event.occurredAt);
+
+      if (recordCandidate) {
+        upserts.push(recordCandidate);
+        continue;
+      }
+
+      const shouldDelete =
+        normalizedType.includes("delete") ||
+        normalizedType.includes("remove") ||
+        payload.deleted === true;
+
+      if (!shouldDelete) {
+        continue;
+      }
+
+      const deleteId = this.extractIdentifier(payload);
+
+      if (deleteId) {
+        deletes.push(deleteId);
+      }
+    }
+
+    return {
+      upserts: upserts.length ? upserts : undefined,
+      deletes: deletes.length ? deletes : undefined,
+    } satisfies { upserts?: TicketRecord[]; deletes?: string[] };
+  }
+
+  private extractInventoryRecord(
+    value: unknown,
+    occurredAt: string,
+  ): InventoryItemRecord | null {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    const id = this.pickString(record, [
+      "id",
+      "itemId",
+      "inventoryItemId",
+    ]);
+
+    if (!id) {
+      return null;
+    }
+
+    const quantity = this.pickNumber(record, ["quantity", "qty", "count"]);
+
+    if (typeof quantity !== "number") {
+      return null;
+    }
+
+    const name =
+      this.pickString(record, ["name", "label", "title"]) ?? "Unbekannt";
+    const sku = this.pickString(record, ["sku", "code"]) ?? id;
+
+    const updatedAt =
+      this.pickString(record, ["updatedAt", "occurredAt"]) ?? occurredAt;
+
+    return {
+      id,
+      sku,
+      name,
+      quantity,
+      updatedAt,
+    } satisfies InventoryItemRecord;
+  }
+
+  private extractTicketRecord(
+    value: unknown,
+    occurredAt: string,
+  ): TicketRecord | null {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    const id = this.pickString(record, ["id", "ticketId"]);
+    const code = this.pickString(record, ["code", "qr", "ticketCode"]);
+    const status = this.pickString(record, ["status"]);
+    const eventId = this.pickString(record, ["eventId", "showId"]);
+
+    if (!id || !code || !status || !eventId) {
+      return null;
+    }
+
+    const updatedAt =
+      this.pickString(record, ["updatedAt", "occurredAt"]) ?? occurredAt;
+
+    const holderName = this.pickString(record, ["holderName", "name"]);
+
+    return {
+      id,
+      code,
+      status: status as TicketRecord["status"],
+      eventId,
+      holderName: holderName ?? undefined,
+      updatedAt,
+    } satisfies TicketRecord;
+  }
+
+  private pickString(
+    source: Record<string, unknown>,
+    keys: string[],
+  ): string | null {
+    for (const key of keys) {
+      const value = source[key];
+
+      if (typeof value === "string" && value.length > 0) {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+  private pickNumber(
+    source: Record<string, unknown>,
+    keys: string[],
+  ): number | null {
+    for (const key of keys) {
+      const value = source[key];
+
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+  private extractIdentifier(payload: Record<string, unknown>): string | null {
+    return (
+      this.pickString(payload, [
+        "id",
+        "itemId",
+        "ticketId",
+        "deletedId",
+        "deleteId",
+      ]) ?? null
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a SyncClient with bootstrap/flush/pull helpers, retry & background sync integration, plus a context describing per-scope status
- provide an OfflineSyncStatusProvider and hook that orchestrate the client, persist state updates, and expose enqueue/bootstrap/flush/pull helpers to the UI
- wrap the application providers with the storage and sync status providers so consumers can access offline sync state

## Testing
- pnpm lint
- pnpm test --filter offline-sync *(fails: vitest CLI in repo does not recognise --filter)*
- CI=1 pnpm build *(fails: existing type error in src/app/api/sync/initial/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a111a404832d90ae03a32c0a14f5