### PR TITLE
Prevent mobile sidebar search from auto focusing

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -183,6 +183,7 @@ const Sidebar = React.forwardRef<
     ref,
   ) => {
     const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+    const sheetContentRef = React.useRef<React.ElementRef<typeof SheetContent>>(null);
 
     const touchStartPoint = React.useRef<{ x: number; y: number } | null>(null);
     const touchCurrentPoint = React.useRef<{ x: number; y: number } | null>(null);
@@ -253,6 +254,7 @@ const Sidebar = React.forwardRef<
       return (
         <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
           <SheetContent
+            ref={sheetContentRef}
             data-sidebar="sidebar"
             data-mobile="true"
             className={cn(
@@ -262,6 +264,11 @@ const Sidebar = React.forwardRef<
             )}
             style={{ "--sidebar-width": SIDEBAR_WIDTH_MOBILE } as React.CSSProperties}
             side={side}
+            tabIndex={-1}
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              sheetContentRef.current?.focus({ preventScroll: true });
+            }}
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}


### PR DESCRIPTION
## Summary
- keep the mobile members sidebar sheet from auto focusing the search field when it opens
- focus the sheet container on open instead, preventing the on-screen keyboard from appearing unintentionally

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: Next.js type check complains about invalid_type_error in src/app/api/sync/initial/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a6de60a0832d9e51f2ce4291389a