### PR TITLE
Add analytics session tracking and aggregation pipeline

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1270,11 +1270,14 @@ model AnalyticsPageView {
   loadTimeMs Float?
   weight     Int      @default(1)
   createdAt  DateTime @default(now())
+  analyticsSessionId String?
+  analyticsSession   AnalyticsSession? @relation(fields: [analyticsSessionId], references: [id], onDelete: SetNull)
 
   @@index([path])
   @@index([scope])
   @@index([deviceHint])
   @@index([createdAt])
+  @@index([analyticsSessionId])
 }
 
 model AnalyticsDeviceSnapshot {
@@ -1328,4 +1331,95 @@ model AnalyticsDeviceMetric {
 
   @@map("analytics_device_metrics")
   @@index([device])
+}
+
+model AnalyticsSession {
+  id               String   @id
+  userId           String?
+  membershipRole   String?
+  isMember         Boolean  @default(false)
+  startedAt        DateTime @default(now())
+  lastSeenAt       DateTime @default(now())
+  endedAt          DateTime?
+  durationSeconds  Int?
+  pagePaths        String[] @default([])
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+  pageViews        AnalyticsPageView[]
+  trafficAttribution AnalyticsTrafficAttribution[]
+
+  @@index([userId])
+  @@index([lastSeenAt])
+}
+
+model AnalyticsTrafficAttribution {
+  id                 String   @id @default(cuid())
+  sessionId          String   @unique
+  analyticsSessionId String?
+  path               String
+  referrer           String?
+  referrerDomain     String?
+  utmSource          String?
+  utmMedium          String?
+  utmCampaign        String?
+  utmTerm            String?
+  utmContent         String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  analyticsSession   AnalyticsSession? @relation(fields: [analyticsSessionId], references: [id], onDelete: SetNull)
+
+  @@index([analyticsSessionId])
+  @@index([path])
+  @@index([referrerDomain])
+  @@index([utmSource])
+  @@index([utmMedium])
+}
+
+model AnalyticsRealtimeEvent {
+  id         String   @id @default(cuid())
+  eventType  String
+  occurredAt DateTime @default(now())
+  createdAt  DateTime @default(now())
+
+  @@index([occurredAt])
+  @@index([eventType, occurredAt])
+}
+
+model AnalyticsSessionInsight {
+  id                        String   @id @default(cuid())
+  segment                   String
+  avgSessionDurationSeconds Float
+  pagesPerSession           Float
+  retentionRate             Float
+  share                     Float
+  conversionRate            Float
+  generatedAt               DateTime @default(now())
+
+  @@map("analytics_session_insights")
+  @@index([segment])
+}
+
+model AnalyticsTrafficSource {
+  id                        String   @id @default(cuid())
+  channel                   String
+  sessions                  Int
+  avgSessionDurationSeconds Float
+  conversionRate            Float
+  changePercent             Float
+  generatedAt               DateTime @default(now())
+
+  @@map("analytics_traffic_sources")
+  @@index([channel])
+}
+
+model AnalyticsRealtimeSummary {
+  id          String   @id @default(cuid())
+  windowStart DateTime
+  windowEnd   DateTime
+  totalEvents Int
+  eventCounts Json?
+  generatedAt DateTime @default(now())
+
+  @@map("analytics_realtime_summary")
+  @@index([windowEnd])
 }

--- a/realtime-server/src/__tests__/session-analytics.test.js
+++ b/realtime-server/src/__tests__/session-analytics.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { setTimeout as wait } from 'node:timers/promises';
+import { test } from 'node:test';
+import { io as createClient } from 'socket.io-client';
+
+import { createRealtimeServer } from '../createRealtimeServer.js';
+
+function createHandshakeToken(userId, secret, ttlMs = 60_000) {
+  const issuedAt = Date.now();
+  const expiresAt = issuedAt + ttlMs;
+  const signature = createHmac('sha256', secret).update(`${userId}:${issuedAt}:${expiresAt}`).digest('hex');
+  return `${issuedAt}.${expiresAt}.${signature}`;
+}
+
+test('records analytics events for socket lifecycle', async () => {
+  const recordedEvents = [];
+  const analyticsRecorder = {
+    async record(eventType) {
+      recordedEvents.push(eventType);
+    },
+    async flush() {},
+  };
+
+  const server = createRealtimeServer({
+    port: 0,
+    handshakeSecret: 'test-secret',
+    analyticsRecorder,
+  });
+
+  await server.listen(0);
+  const address = server.httpServer.address();
+  assert.ok(address && typeof address.port === 'number');
+
+  const token = createHandshakeToken('user-1', 'test-secret');
+
+  const client = createClient(`http://localhost:${address.port}`, {
+    path: server.config.socketPath,
+    transports: ['websocket'],
+    auth: {
+      userId: 'user-1',
+      userName: 'Test User',
+      token,
+    },
+  });
+
+  await new Promise((resolve, reject) => {
+    client.once('connect', resolve);
+    client.once('connect_error', reject);
+  });
+
+  await new Promise((resolve) => {
+    client.once('pong', resolve);
+    client.emit('ping');
+  });
+
+  client.emit('join_room', 'global');
+  client.emit('leave_room', 'global');
+
+  await wait(50);
+
+  await new Promise((resolve) => {
+    client.once('disconnect', resolve);
+    client.close();
+  });
+
+  await server.close();
+
+  assert.ok(recordedEvents.includes('socket_connected'));
+  assert.ok(recordedEvents.includes('user_authenticated'));
+  assert.ok(recordedEvents.includes('ping'));
+  assert.ok(recordedEvents.includes('join_room'));
+  assert.ok(recordedEvents.includes('leave_room'));
+  assert.ok(recordedEvents.includes('socket_disconnected'));
+});

--- a/realtime-server/src/analytics-events.js
+++ b/realtime-server/src/analytics-events.js
@@ -1,0 +1,62 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalPrismaKey = Symbol.for('__realtime_prisma');
+
+function getGlobalPrisma() {
+  const globalObject = globalThis;
+  if (!globalObject[globalPrismaKey]) {
+    globalObject[globalPrismaKey] = new PrismaClient();
+  }
+  return globalObject[globalPrismaKey];
+}
+
+export function createRealtimeAnalyticsRecorder({ logger } = {}) {
+  const enabled = Boolean(process.env.DATABASE_URL);
+  const logError = typeof logger?.error === 'function' ? (...args) => logger.error(...args) : (...args) => console.error(...args);
+  let prisma = null;
+
+  async function ensureClient() {
+    if (!enabled) {
+      return null;
+    }
+    if (prisma) {
+      return prisma;
+    }
+    try {
+      prisma = getGlobalPrisma();
+    } catch (error) {
+      logError('[Realtime] Failed to initialize Prisma for analytics events', error);
+      prisma = null;
+    }
+    return prisma;
+  }
+
+  return {
+    async record(eventType, occurredAt = new Date()) {
+      const client = await ensureClient();
+      if (!client) {
+        return;
+      }
+      try {
+        await client.analyticsRealtimeEvent.create({
+          data: {
+            eventType,
+            occurredAt,
+          },
+        });
+      } catch (error) {
+        logError('[Realtime] Failed to persist realtime analytics event', error);
+      }
+    },
+    async flush() {
+      if (prisma && typeof prisma.$disconnect === 'function') {
+        try {
+          await prisma.$disconnect();
+        } catch (error) {
+          logError('[Realtime] Failed to disconnect Prisma for analytics recorder', error);
+        }
+        prisma = null;
+      }
+    },
+  };
+}

--- a/scripts/cron/aggregate-session-metrics.ts
+++ b/scripts/cron/aggregate-session-metrics.ts
@@ -1,0 +1,170 @@
+import { prisma } from "@/lib/prisma";
+import {
+  aggregateSessionMetrics,
+  type AnalyticsSessionLike,
+  type RealtimeEventLike,
+  type TrafficAttributionLike,
+} from "@/lib/analytics/aggregate-session-metrics";
+import type {
+  AnalyticsRealtimeEvent,
+  AnalyticsSession,
+  AnalyticsTrafficAttribution,
+} from "@prisma/client";
+
+const DEFAULT_SESSION_WINDOW_DAYS = 30;
+const DEFAULT_RETENTION_DAYS = 180;
+
+function resolvePositiveInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.round(parsed);
+}
+
+function transformSessions(sessions: AnalyticsSession[]): AnalyticsSessionLike[] {
+  return sessions.map((session) => ({
+    ...session,
+    startedAt: session.startedAt instanceof Date ? session.startedAt : new Date(session.startedAt),
+    lastSeenAt: session.lastSeenAt instanceof Date ? session.lastSeenAt : new Date(session.lastSeenAt),
+    pagePaths: Array.isArray(session.pagePaths) ? [...session.pagePaths] : [],
+  }));
+}
+
+function transformRealtimeEvents(events: AnalyticsRealtimeEvent[]): RealtimeEventLike[] {
+  return events.map((event) => ({
+    ...event,
+    occurredAt: event.occurredAt instanceof Date ? event.occurredAt : new Date(event.occurredAt),
+  }));
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.warn("[analytics] DATABASE_URL is not set. Skipping session metrics aggregation.");
+    return;
+  }
+
+  const now = new Date();
+  const windowDays = resolvePositiveInteger(
+    process.env.ANALYTICS_SESSION_WINDOW_DAYS,
+    DEFAULT_SESSION_WINDOW_DAYS,
+  );
+  const retentionDays = resolvePositiveInteger(
+    process.env.ANALYTICS_SESSION_RETENTION_DAYS,
+    DEFAULT_RETENTION_DAYS,
+  );
+  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const realtimeWindowStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+  const [sessionsRaw, trafficRaw, realtimeEventsRaw] = await Promise.all([
+    prisma.analyticsSession.findMany({
+      where: {
+        startedAt: {
+          gte: windowStart,
+          lte: now,
+        },
+      },
+    }),
+    prisma.analyticsTrafficAttribution.findMany({
+      where: {
+        createdAt: {
+          gte: windowStart,
+          lte: now,
+        },
+      },
+    }),
+    prisma.analyticsRealtimeEvent.findMany({
+      where: {
+        occurredAt: {
+          gte: realtimeWindowStart,
+          lte: now,
+        },
+      },
+    }),
+  ]);
+
+  const sessions = transformSessions(sessionsRaw);
+  const traffic = trafficRaw as AnalyticsTrafficAttribution[] as TrafficAttributionLike[];
+  const realtimeEvents = transformRealtimeEvents(realtimeEventsRaw);
+
+  const result = aggregateSessionMetrics({
+    sessions,
+    traffic,
+    realtimeEvents,
+    now,
+  });
+
+  await prisma.$transaction(async (tx) => {
+    await tx.analyticsSessionInsight.deleteMany({});
+    await tx.analyticsTrafficSource.deleteMany({});
+    await tx.analyticsRealtimeSummary.deleteMany({});
+
+    if (result.sessionInsights.length > 0) {
+      await tx.analyticsSessionInsight.createMany({
+        data: result.sessionInsights.map((insight) => ({
+          segment: insight.segment,
+          avgSessionDurationSeconds: insight.avgSessionDurationSeconds,
+          pagesPerSession: insight.pagesPerSession,
+          retentionRate: insight.retentionRate,
+          share: insight.share,
+          conversionRate: insight.conversionRate,
+        })),
+      });
+    }
+
+    if (result.trafficSources.length > 0) {
+      await tx.analyticsTrafficSource.createMany({
+        data: result.trafficSources.map((source) => ({
+          channel: source.channel,
+          sessions: source.sessions,
+          avgSessionDurationSeconds: source.avgSessionDurationSeconds,
+          conversionRate: source.conversionRate,
+          changePercent: source.changePercent,
+        })),
+      });
+    }
+
+    await tx.analyticsRealtimeSummary.create({
+      data: {
+        windowStart: result.realtimeSummary.windowStart,
+        windowEnd: result.realtimeSummary.windowEnd,
+        totalEvents: result.realtimeSummary.totalEvents,
+        eventCounts: result.realtimeSummary.eventCounts,
+      },
+    });
+
+    if (retentionDays > 0) {
+      const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+      await tx.analyticsSession.deleteMany({
+        where: {
+          startedAt: { lt: cutoff },
+        },
+      });
+      await tx.analyticsTrafficAttribution.deleteMany({
+        where: {
+          createdAt: { lt: cutoff },
+        },
+      });
+      await tx.analyticsRealtimeEvent.deleteMany({
+        where: {
+          occurredAt: { lt: cutoff },
+        },
+      });
+    }
+  });
+}
+
+void main()
+  .catch((error) => {
+    console.error("[analytics] Failed to aggregate session metrics", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    if (process.env.DATABASE_URL) {
+      try {
+        await prisma.$disconnect();
+      } catch (error) {
+        console.error("[analytics] Failed to disconnect Prisma after session aggregation", error);
+      }
+    }
+  });

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -10,6 +10,11 @@ import { RealtimeProvider } from "@/hooks/useRealtime";
 import { OfflineSyncStatusProvider } from "@/lib/offline/hooks";
 import { OfflineSyncProvider as OfflineStorageProvider } from "@/lib/offline/storage";
 
+function WebVitalsInitializer({ analyticsSessionId }: { analyticsSessionId?: string | null }) {
+  useWebVitals({ analyticsSessionId });
+  return null;
+}
+
 export function Providers({
   children,
   session,
@@ -18,9 +23,9 @@ export function Providers({
   session?: Session | null;
 }) {
   const [client] = React.useState(() => new QueryClient());
-  useWebVitals();
   return (
     <SessionProvider session={session}>
+      <WebVitalsInitializer analyticsSessionId={session?.analyticsSessionId ?? null} />
       <QueryClientProvider client={client}>
         <OfflineStorageProvider>
           <OfflineSyncStatusProvider>

--- a/src/hooks/useWebVitals.ts
+++ b/src/hooks/useWebVitals.ts
@@ -43,6 +43,7 @@ type WebVitalsContext = {
   path: string;
   scope: WebVitalsScope;
   weight: number;
+  analyticsSessionId?: string | null;
   device: DeviceHints;
   navigation: NavigationInsights;
   updatedAt: number;
@@ -57,6 +58,7 @@ declare global {
 export type UseWebVitalsOptions = {
   scope?: WebVitalsScope;
   weight?: number;
+  analyticsSessionId?: string | null;
 };
 
 function normalizePath(pathname: string | null): string {
@@ -320,6 +322,8 @@ export function useWebVitals(options?: UseWebVitalsOptions) {
     return Math.min(Math.max(rounded, 1), 10_000);
   }, [options?.weight]);
 
+  const analyticsSessionId = options?.analyticsSessionId ?? null;
+
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
@@ -329,6 +333,7 @@ export function useWebVitals(options?: UseWebVitalsOptions) {
       path: normalizedPath,
       scope,
       weight,
+      analyticsSessionId,
       device: collectDeviceHints(),
       navigation: collectNavigationInsights(),
       updatedAt: Date.now(),
@@ -349,5 +354,5 @@ export function useWebVitals(options?: UseWebVitalsOptions) {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("resize", handleVisibilityChange);
     };
-  }, [normalizedPath, scope, weight]);
+  }, [normalizedPath, scope, weight, analyticsSessionId]);
 }

--- a/src/lib/analytics/__tests__/aggregate-session-metrics.test.ts
+++ b/src/lib/analytics/__tests__/aggregate-session-metrics.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import { aggregateSessionMetrics } from "@/lib/analytics/aggregate-session-metrics";
+import type {
+  AnalyticsSessionLike,
+  TrafficAttributionLike,
+  RealtimeEventLike,
+} from "@/lib/analytics/aggregate-session-metrics";
+
+describe("aggregateSessionMetrics", () => {
+  it("builds session insights, traffic sources and realtime summary", () => {
+    const now = new Date("2024-01-02T12:00:00.000Z");
+
+    const sessions: AnalyticsSessionLike[] = [
+      {
+        id: "s1",
+        userId: "u1",
+        isMember: true,
+        membershipRole: "member",
+        startedAt: new Date("2024-01-01T10:00:00.000Z"),
+        endedAt: new Date("2024-01-01T11:00:00.000Z"),
+        lastSeenAt: new Date("2024-01-01T11:00:00.000Z"),
+        durationSeconds: null,
+        pagePaths: ["/dashboard", "/reports"],
+      },
+      {
+        id: "s2",
+        userId: "u2",
+        isMember: false,
+        membershipRole: null,
+        startedAt: new Date("2024-01-01T13:00:00.000Z"),
+        endedAt: new Date("2024-01-01T13:30:00.000Z"),
+        lastSeenAt: new Date("2024-01-01T13:30:00.000Z"),
+        durationSeconds: null,
+        pagePaths: ["/landing"],
+      },
+      {
+        id: "s3",
+        userId: "u1",
+        isMember: true,
+        membershipRole: "member",
+        startedAt: new Date("2024-01-02T08:00:00.000Z"),
+        endedAt: new Date("2024-01-02T08:45:00.000Z"),
+        lastSeenAt: new Date("2024-01-02T08:45:00.000Z"),
+        durationSeconds: null,
+        pagePaths: ["/dashboard", "/planning", "/planning"],
+      },
+    ];
+
+    const traffic: TrafficAttributionLike[] = [
+      {
+        sessionId: "pv1",
+        analyticsSessionId: "s1",
+        path: "/dashboard",
+        referrer: "https://www.google.com/search?q=theater",
+        referrerDomain: "www.google.com",
+        utmSource: null,
+        utmMedium: "cpc",
+        utmCampaign: null,
+        utmTerm: null,
+        utmContent: null,
+      },
+      {
+        sessionId: "pv2",
+        analyticsSessionId: "s2",
+        path: "/landing",
+        referrer: null,
+        referrerDomain: null,
+        utmSource: "newsletter",
+        utmMedium: "email",
+        utmCampaign: "winter-sale",
+        utmTerm: null,
+        utmContent: null,
+      },
+      {
+        sessionId: "pv3",
+        analyticsSessionId: null,
+        path: "/legacy",
+        referrer: "https://partner.example.com/article",
+        referrerDomain: "partner.example.com",
+        utmSource: null,
+        utmMedium: null,
+        utmCampaign: null,
+        utmTerm: null,
+        utmContent: null,
+      },
+      {
+        sessionId: "pv4",
+        analyticsSessionId: "s3",
+        path: "/planning",
+        referrer: null,
+        referrerDomain: null,
+        utmSource: null,
+        utmMedium: null,
+        utmCampaign: null,
+        utmTerm: null,
+        utmContent: null,
+      },
+    ];
+
+    const realtimeEvents: RealtimeEventLike[] = [
+      { eventType: "ping", occurredAt: new Date("2024-01-02T11:00:00.000Z") },
+      { eventType: "ping", occurredAt: new Date("2024-01-02T10:30:00.000Z") },
+      { eventType: "socket_connected", occurredAt: new Date("2024-01-02T09:00:00.000Z") },
+      { eventType: "join_room", occurredAt: new Date("2024-01-01T09:00:00.000Z") },
+    ];
+
+    const result = aggregateSessionMetrics({
+      sessions,
+      traffic,
+      realtimeEvents,
+      now,
+    });
+
+    expect(result.sessionInsights).toHaveLength(3);
+
+    const members = result.sessionInsights.find((entry) => entry.segment === "Mitglieder");
+    const guests = result.sessionInsights.find((entry) => entry.segment === "Gäste");
+    const returning = result.sessionInsights.find((entry) => entry.segment === "Wiederkehrend");
+
+    expect(members).toBeDefined();
+    expect(members?.avgSessionDurationSeconds).toBe(3150);
+    expect(members?.pagesPerSession).toBe(2);
+    expect(members?.retentionRate).toBeCloseTo(1, 5);
+    expect(members?.share).toBeCloseTo(2 / 3, 5);
+    expect(members?.conversionRate).toBeCloseTo(1, 5);
+
+    expect(guests).toBeDefined();
+    expect(guests?.avgSessionDurationSeconds).toBe(1800);
+    expect(guests?.pagesPerSession).toBe(1);
+    expect(guests?.retentionRate).toBe(0);
+    expect(guests?.share).toBeCloseTo(1 / 3, 5);
+    expect(guests?.conversionRate).toBe(0);
+
+    expect(returning).toBeDefined();
+    expect(returning?.avgSessionDurationSeconds).toBe(3150);
+    expect(returning?.pagesPerSession).toBe(2);
+    expect(returning?.retentionRate).toBeCloseTo(1, 5);
+    expect(returning?.conversionRate).toBeCloseTo(1, 5);
+
+    expect(result.trafficSources).toHaveLength(4);
+    expect(result.trafficSources[0].channel).toBe("Direct");
+    expect(result.trafficSources[0].sessions).toBe(1);
+    expect(result.trafficSources[0].avgSessionDurationSeconds).toBe(2700);
+    expect(result.trafficSources[0].conversionRate).toBeCloseTo(1, 5);
+
+    const paidSearch = result.trafficSources.find((entry) => entry.channel === "Paid Search");
+    expect(paidSearch).toBeDefined();
+    expect(paidSearch?.sessions).toBe(1);
+    expect(paidSearch?.avgSessionDurationSeconds).toBe(3600);
+    expect(paidSearch?.conversionRate).toBeCloseTo(1, 5);
+
+    const email = result.trafficSources.find((entry) => entry.channel === "E-Mail");
+    expect(email).toBeDefined();
+    expect(email?.sessions).toBe(1);
+    expect(email?.avgSessionDurationSeconds).toBe(1800);
+    expect(email?.conversionRate).toBeCloseTo(0, 5);
+
+    const referral = result.trafficSources.find((entry) => entry.channel === "Partner.Example.Com");
+    expect(referral).toBeDefined();
+    expect(referral?.sessions).toBe(1);
+    expect(referral?.avgSessionDurationSeconds).toBe(0);
+
+    expect(result.realtimeSummary.totalEvents).toBe(3);
+    expect(result.realtimeSummary.eventCounts).toEqual({
+      ping: 2,
+      socket_connected: 1,
+    });
+    expect(result.realtimeSummary.windowEnd.toISOString()).toBe(now.toISOString());
+    expect(result.realtimeSummary.windowStart.toISOString()).toBe(
+      new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(),
+    );
+  });
+});

--- a/src/lib/analytics/aggregate-session-metrics.ts
+++ b/src/lib/analytics/aggregate-session-metrics.ts
@@ -1,0 +1,328 @@
+import type {
+  AnalyticsRealtimeEvent,
+  AnalyticsSession,
+  AnalyticsTrafficAttribution,
+} from "@prisma/client";
+
+export type AnalyticsSessionLike = Pick<
+  AnalyticsSession,
+  | "id"
+  | "userId"
+  | "isMember"
+  | "membershipRole"
+  | "startedAt"
+  | "endedAt"
+  | "lastSeenAt"
+  | "durationSeconds"
+  | "pagePaths"
+> & { startedAt: Date; lastSeenAt: Date; pagePaths: string[] };
+
+export type TrafficAttributionLike = Pick<
+  AnalyticsTrafficAttribution,
+  | "sessionId"
+  | "analyticsSessionId"
+  | "path"
+  | "referrer"
+  | "referrerDomain"
+  | "utmSource"
+  | "utmMedium"
+  | "utmCampaign"
+  | "utmTerm"
+  | "utmContent"
+>;
+
+export type RealtimeEventLike = Pick<AnalyticsRealtimeEvent, "eventType" | "occurredAt"> & {
+  occurredAt: Date;
+};
+
+export type SessionInsight = {
+  segment: string;
+  avgSessionDurationSeconds: number;
+  pagesPerSession: number;
+  retentionRate: number;
+  share: number;
+  conversionRate: number;
+};
+
+export type TrafficSourceInsight = {
+  channel: string;
+  sessions: number;
+  avgSessionDurationSeconds: number;
+  conversionRate: number;
+  changePercent: number;
+};
+
+export type RealtimeSummary = {
+  windowStart: Date;
+  windowEnd: Date;
+  totalEvents: number;
+  eventCounts: Record<string, number>;
+};
+
+export type AggregateSessionMetricsOptions = {
+  sessions: AnalyticsSessionLike[];
+  traffic: TrafficAttributionLike[];
+  realtimeEvents: RealtimeEventLike[];
+  now?: Date;
+};
+
+export type AggregateSessionMetricsResult = {
+  sessionInsights: SessionInsight[];
+  trafficSources: TrafficSourceInsight[];
+  realtimeSummary: RealtimeSummary;
+};
+
+function toTimestamp(date: Date | string | number): number {
+  const instance = date instanceof Date ? date : new Date(date);
+  const timestamp = instance.getTime();
+  return Number.isFinite(timestamp) ? timestamp : Date.now();
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const total = values.reduce((sum, value) => sum + value, 0);
+  if (!Number.isFinite(total)) {
+    return 0;
+  }
+  return total / values.length;
+}
+
+function computeDurationSeconds(session: AnalyticsSessionLike, fallbackEnd: Date): number {
+  const start = session.startedAt instanceof Date ? session.startedAt : new Date(session.startedAt);
+  const candidateEnd = session.endedAt ?? session.lastSeenAt ?? fallbackEnd;
+  const end = candidateEnd instanceof Date ? candidateEnd : new Date(candidateEnd);
+
+  const durationMs = Math.max(0, toTimestamp(end) - toTimestamp(start));
+  const durationSeconds = Math.round(durationMs / 1000);
+  return Number.isFinite(durationSeconds) && durationSeconds >= 0 ? durationSeconds : 0;
+}
+
+function uniquePageCount(session: AnalyticsSessionLike): number {
+  const pages = Array.isArray(session.pagePaths) ? session.pagePaths : [];
+  const unique = new Set(pages.map((page) => (typeof page === "string" ? page : ""))); // duplicates removed
+  unique.delete("");
+  const count = unique.size;
+  return count > 0 ? count : 1;
+}
+
+function normalizeChannel(rawChannel: string | null | undefined): string {
+  if (!rawChannel) {
+    return "Direct";
+  }
+  const normalized = rawChannel.trim().toLowerCase();
+  if (!normalized) {
+    return "Direct";
+  }
+
+  if (["email", "newsletter"].includes(normalized)) {
+    return "E-Mail";
+  }
+  if (["social", "social_media", "social-media", "facebook", "instagram", "twitter", "linkedin"].includes(normalized)) {
+    return "Social";
+  }
+  if (["cpc", "ppc", "paidsearch", "sem"].includes(normalized)) {
+    return "Paid Search";
+  }
+  if (["display", "banner"].includes(normalized)) {
+    return "Display";
+  }
+  if (["affiliate"].includes(normalized)) {
+    return "Affiliate";
+  }
+  if (["referral"].includes(normalized)) {
+    return "Referral";
+  }
+
+  const parts = normalized.split(/[\s._-]+/).filter(Boolean);
+  if (parts.length === 0) {
+    return "Direct";
+  }
+
+  const formatted = parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1));
+  if (normalized.includes(".") && !normalized.includes(" ")) {
+    return formatted.join(".");
+  }
+
+  return formatted.join(" ");
+}
+
+function deriveChannel(attribution: TrafficAttributionLike): string {
+  if (attribution.utmMedium) {
+    return normalizeChannel(attribution.utmMedium);
+  }
+  if (attribution.utmSource) {
+    return normalizeChannel(attribution.utmSource);
+  }
+  if (attribution.referrerDomain) {
+    return normalizeChannel(attribution.referrerDomain);
+  }
+  return "Direct";
+}
+
+export function aggregateSessionMetrics({
+  sessions,
+  traffic,
+  realtimeEvents,
+  now: explicitNow,
+}: AggregateSessionMetricsOptions): AggregateSessionMetricsResult {
+  const now = explicitNow ?? new Date();
+  const fallbackEnd = now;
+
+  const totalSessions = sessions.length;
+  const sessionById = new Map<string, AnalyticsSessionLike>();
+  const returningSessionIds = new Set<string>();
+  const sessionsByUser = new Map<string, AnalyticsSessionLike[]>();
+
+  for (const session of sessions) {
+    sessionById.set(session.id, session);
+    const userId = typeof session.userId === "string" ? session.userId : null;
+    if (userId) {
+      if (!sessionsByUser.has(userId)) {
+        sessionsByUser.set(userId, []);
+      }
+      sessionsByUser.get(userId)!.push(session);
+    }
+  }
+
+  for (const [, entries] of sessionsByUser) {
+    if (entries.length > 1) {
+      for (const entry of entries) {
+        returningSessionIds.add(entry.id);
+      }
+    }
+  }
+
+  const segments: Array<{ id: string; label: string; predicate: (session: AnalyticsSessionLike) => boolean }> = [
+    { id: "members", label: "Mitglieder", predicate: (session) => Boolean(session.isMember) },
+    { id: "guests", label: "Gäste", predicate: (session) => !session.isMember },
+    { id: "returning", label: "Wiederkehrend", predicate: (session) => returningSessionIds.has(session.id) },
+  ];
+
+  const sessionInsights: SessionInsight[] = segments
+    .map((segment) => {
+      const matching = sessions.filter(segment.predicate);
+      if (matching.length === 0) {
+        return null;
+      }
+
+      const durations = matching.map((session) =>
+        computeDurationSeconds(session, fallbackEnd),
+      );
+      const avgDuration = Math.round(average(durations));
+
+      const pageCounts = matching.map((session) => uniquePageCount(session));
+      const avgPages = Number(average(pageCounts).toFixed(2));
+
+      const returningCount = matching.reduce(
+        (count, session) => count + (returningSessionIds.has(session.id) ? 1 : 0),
+        0,
+      );
+      const conversions = matching.reduce((count, session) => count + (session.isMember ? 1 : 0), 0);
+
+      const retentionRate = matching.length
+        ? clamp(returningCount / matching.length, 0, 1)
+        : 0;
+      const share = totalSessions ? clamp(matching.length / totalSessions, 0, 1) : 0;
+      const conversionRate = matching.length
+        ? clamp(conversions / matching.length, 0, 1)
+        : 0;
+
+      return {
+        segment: segment.label,
+        avgSessionDurationSeconds: avgDuration,
+        pagesPerSession: avgPages,
+        retentionRate,
+        share,
+        conversionRate,
+      } satisfies SessionInsight;
+    })
+    .filter((insight): insight is SessionInsight => insight !== null);
+
+  const channelMap = new Map<
+    string,
+    {
+      sessionKeys: Set<string>;
+      durations: number[];
+      conversions: number;
+    }
+  >();
+
+  for (const attribution of traffic) {
+    const channel = deriveChannel(attribution);
+    if (!channelMap.has(channel)) {
+      channelMap.set(channel, { sessionKeys: new Set(), durations: [], conversions: 0 });
+    }
+    const bucket = channelMap.get(channel)!;
+
+    const key = attribution.analyticsSessionId ?? `legacy:${attribution.sessionId}`;
+    if (bucket.sessionKeys.has(key)) {
+      continue;
+    }
+    bucket.sessionKeys.add(key);
+
+    const linkedSession = attribution.analyticsSessionId
+      ? sessionById.get(attribution.analyticsSessionId)
+      : null;
+
+    const duration = linkedSession ? computeDurationSeconds(linkedSession, fallbackEnd) : 0;
+    bucket.durations.push(duration);
+    if (linkedSession?.isMember) {
+      bucket.conversions += 1;
+    }
+  }
+
+  const trafficSources: TrafficSourceInsight[] = Array.from(channelMap.entries())
+    .map(([channel, data]) => {
+      const sessionsCount = data.sessionKeys.size;
+      const avgDuration = sessionsCount ? Math.round(average(data.durations)) : 0;
+      const conversionRate = sessionsCount ? clamp(data.conversions / sessionsCount, 0, 1) : 0;
+
+      return {
+        channel,
+        sessions: sessionsCount,
+        avgSessionDurationSeconds: avgDuration,
+        conversionRate,
+        changePercent: 0,
+      } satisfies TrafficSourceInsight;
+    })
+    .sort((a, b) => b.sessions - a.sessions || a.channel.localeCompare(b.channel));
+
+  const windowEnd = now;
+  const windowStart = new Date(windowEnd.getTime() - 24 * 60 * 60 * 1000);
+  const eventCounts: Record<string, number> = {};
+  let totalEvents = 0;
+
+  for (const event of realtimeEvents) {
+    const timestamp = toTimestamp(event.occurredAt);
+    if (timestamp < windowStart.getTime() || timestamp > windowEnd.getTime()) {
+      continue;
+    }
+    totalEvents += 1;
+    const type = event.eventType ?? "unknown";
+    eventCounts[type] = (eventCounts[type] ?? 0) + 1;
+  }
+
+  const realtimeSummary: RealtimeSummary = {
+    windowStart,
+    windowEnd,
+    totalEvents,
+    eventCounts,
+  };
+
+  return {
+    sessionInsights,
+    trafficSources,
+    realtimeSummary,
+  };
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,274 @@
+import { prisma } from "@/lib/prisma";
+import type { Role } from "@prisma/client";
+
+const MEMBER_ROLES = new Set<Role>([
+  "member",
+  "cast",
+  "tech",
+  "board",
+  "finance",
+  "owner",
+  "admin",
+]);
+
+function isDatabaseEnabled() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+function determineMembership(roles: Role[] | undefined) {
+  if (!roles || roles.length === 0) {
+    return { isMember: false, membershipRole: null as string | null };
+  }
+
+  const normalized = roles.filter((role): role is Role => MEMBER_ROLES.has(role));
+  if (normalized.length === 0) {
+    return { isMember: false, membershipRole: null as string | null };
+  }
+
+  const membershipRole = normalized[normalized.length - 1];
+  return { isMember: true, membershipRole };
+}
+
+function sanitizePath(path: string | null | undefined): string | null {
+  if (typeof path !== "string") {
+    return null;
+  }
+  let normalized = path.trim();
+  if (!normalized) {
+    return null;
+  }
+  if (!normalized.startsWith("/")) {
+    normalized = `/${normalized}`;
+  }
+  normalized = normalized.replace(/\\+/g, "/");
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    normalized = normalized.slice(0, -1);
+  }
+  if (normalized.length > 512) {
+    normalized = normalized.slice(0, 512);
+  }
+  return normalized;
+}
+
+type SessionIdentifier =
+  | { analyticsSessionId: string }
+  | { userId: string }
+  | { analyticsSessionId: string; userId?: string };
+
+async function resolveActiveSessionId(identifier: SessionIdentifier) {
+  if ("analyticsSessionId" in identifier && identifier.analyticsSessionId) {
+    return identifier.analyticsSessionId;
+  }
+
+  if ("userId" in identifier && identifier.userId) {
+    const session = await prisma.analyticsSession.findFirst({
+      where: {
+        userId: identifier.userId,
+        endedAt: null,
+      },
+      orderBy: { lastSeenAt: "desc" },
+    });
+    return session?.id ?? null;
+  }
+
+  return null;
+}
+
+export async function recordSessionStart({
+  analyticsSessionId,
+  userId,
+  roles,
+  startedAt,
+  initialPath,
+}: {
+  analyticsSessionId: string | null | undefined;
+  userId?: string | null;
+  roles?: Role[] | null;
+  startedAt?: Date;
+  initialPath?: string | null;
+}) {
+  if (!isDatabaseEnabled()) {
+    return;
+  }
+
+  if (typeof analyticsSessionId !== "string" || analyticsSessionId.length < 6) {
+    return;
+  }
+
+  const now = startedAt ?? new Date();
+  const { isMember, membershipRole } = determineMembership(roles ?? undefined);
+  const sanitizedPath = sanitizePath(initialPath);
+
+  try {
+    await prisma.analyticsSession.upsert({
+      where: { id: analyticsSessionId },
+      create: {
+        id: analyticsSessionId,
+        userId: userId ?? null,
+        membershipRole,
+        isMember,
+        startedAt: now,
+        lastSeenAt: now,
+        pagePaths: sanitizedPath ? [sanitizedPath] : [],
+      },
+      update: {
+        userId: userId ?? null,
+        membershipRole,
+        isMember,
+        lastSeenAt: now,
+        endedAt: null,
+        durationSeconds: null,
+        ...(sanitizedPath ? { pagePaths: { push: sanitizedPath } } : {}),
+      },
+    });
+  } catch (error) {
+    console.error("[analytics] Failed to record session start", error);
+  }
+}
+
+export async function recordSessionHeartbeat(
+  identifier: SessionIdentifier,
+  seenAt: Date = new Date(),
+) {
+  if (!isDatabaseEnabled()) {
+    return;
+  }
+
+  try {
+    const sessionId = await resolveActiveSessionId(identifier);
+    if (!sessionId) {
+      return;
+    }
+
+    await prisma.analyticsSession.update({
+      where: { id: sessionId },
+      data: {
+        lastSeenAt: seenAt,
+      },
+    });
+  } catch (error) {
+    console.error("[analytics] Failed to update session heartbeat", error);
+  }
+}
+
+export async function recordSessionPath(
+  identifier: SessionIdentifier,
+  path: string | null | undefined,
+  seenAt: Date = new Date(),
+) {
+  if (!isDatabaseEnabled()) {
+    return;
+  }
+
+  const sanitizedPath = sanitizePath(path);
+  if (!sanitizedPath) {
+    await recordSessionHeartbeat(identifier, seenAt);
+    return;
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      const sessionId = await resolveActiveSessionId(identifier);
+      if (!sessionId) {
+        return;
+      }
+
+      const existing = await tx.analyticsSession.findUnique({
+        where: { id: sessionId },
+        select: { pagePaths: true },
+      });
+      if (!existing) {
+        return;
+      }
+
+      const pages = new Set(existing.pagePaths ?? []);
+      pages.add(sanitizedPath);
+
+      await tx.analyticsSession.update({
+        where: { id: sessionId },
+        data: {
+          lastSeenAt: seenAt,
+          pagePaths: { set: Array.from(pages).slice(-50) },
+        },
+      });
+    });
+  } catch (error) {
+    console.error("[analytics] Failed to record session path", error);
+  }
+}
+
+export async function recordSessionEnd({
+  analyticsSessionId,
+  endedAt,
+}: {
+  analyticsSessionId: string | null | undefined;
+  endedAt?: Date;
+}) {
+  if (!isDatabaseEnabled()) {
+    return;
+  }
+
+  if (typeof analyticsSessionId !== "string" || analyticsSessionId.length < 6) {
+    return;
+  }
+
+  try {
+    const session = await prisma.analyticsSession.findUnique({
+      where: { id: analyticsSessionId },
+      select: { startedAt: true, lastSeenAt: true },
+    });
+
+    if (!session) {
+      return;
+    }
+
+    const endTime = endedAt ?? new Date();
+    const referenceTime = session.lastSeenAt && session.lastSeenAt > endTime ? session.lastSeenAt : endTime;
+    const durationMs = Math.max(0, referenceTime.getTime() - session.startedAt.getTime());
+    const durationSeconds = Math.round(durationMs / 1000);
+
+    await prisma.analyticsSession.update({
+      where: { id: analyticsSessionId },
+      data: {
+        endedAt: endTime,
+        lastSeenAt: referenceTime,
+        durationSeconds,
+      },
+    });
+  } catch (error) {
+    console.error("[analytics] Failed to record session end", error);
+  }
+}
+
+export async function attachUserToSession({
+  analyticsSessionId,
+  userId,
+  roles,
+}: {
+  analyticsSessionId: string | null | undefined;
+  userId?: string | null;
+  roles?: Role[] | null;
+}) {
+  if (!isDatabaseEnabled()) {
+    return;
+  }
+
+  if (typeof analyticsSessionId !== "string" || analyticsSessionId.length < 6) {
+    return;
+  }
+
+  const { isMember, membershipRole } = determineMembership(roles ?? undefined);
+
+  try {
+    await prisma.analyticsSession.update({
+      where: { id: analyticsSessionId },
+      data: {
+        userId: userId ?? null,
+        membershipRole,
+        isMember,
+      },
+    });
+  } catch {
+    // Ignore missing session errors
+  }
+}

--- a/src/lib/realtime/presence.ts
+++ b/src/lib/realtime/presence.ts
@@ -1,0 +1,68 @@
+import { recordSessionHeartbeat, recordSessionPath } from "@/lib/auth/session";
+
+type PresenceAction = "join" | "leave";
+
+type PresencePayload = {
+  userId?: string | null;
+  room?: string | null;
+  action: PresenceAction;
+  occurredAt?: Date;
+};
+
+function mapRoomToPath(room: string | null | undefined): string | null {
+  if (!room) {
+    return null;
+  }
+
+  const normalized = room.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized === "global") {
+    return "/mitglieder";
+  }
+
+  if (normalized.startsWith("rehearsal_")) {
+    const rehearsalId = normalized.slice("rehearsal_".length);
+    if (rehearsalId) {
+      return `/mitglieder/proben/${rehearsalId}`;
+    }
+  }
+
+  if (normalized.startsWith("show_")) {
+    const showId = normalized.slice("show_".length);
+    if (showId) {
+      return `/mitglieder/produktionen/${showId}`;
+    }
+  }
+
+  if (normalized.startsWith("user_")) {
+    return "/mitglieder";
+  }
+
+  return null;
+}
+
+export async function trackPresenceEvent({
+  userId,
+  room,
+  action,
+  occurredAt,
+}: PresencePayload) {
+  if (!userId) {
+    return;
+  }
+
+  const timestamp = occurredAt ?? new Date();
+
+  if (action === "join") {
+    const path = mapRoomToPath(room);
+    if (path) {
+      await recordSessionPath({ userId }, path, timestamp);
+      return;
+    }
+  }
+
+  await recordSessionHeartbeat({ userId }, timestamp);
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -17,6 +17,7 @@ declare module "next-auth" {
       isDeactivated?: boolean;
       deactivatedAt?: string | null;
     };
+    analyticsSessionId?: string | null;
   }
   interface User {
     firstName?: string | null;


### PR DESCRIPTION
## Summary
- add Prisma tables and session utilities to capture auth lifecycle, traffic attribution, and realtime events
- pipe analytics identifiers through NextAuth/web vitals clients and add cron aggregation to publish insights + traffic sources
- instrument realtime server analytics recorder, extend server analytics reader, and cover the new flows with unit/E2E tests

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3ae3af0c0832da575a1b2e3726de3