### PR TITLE
Add persistent server log pipeline with status UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.8.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/dexie": "^1.3.35",
     "@types/node": "^24",
     "@types/pdfkit": "^0.17.3",
@@ -82,6 +85,7 @@
     "@types/sanitize-html": "^2.16.0",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
+    "jsdom": "^27.0.0",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.13
+      '@testing-library/jest-dom':
+        specifier: ^6.8.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/dexie':
         specifier: ^1.3.35
         version: 1.3.35
@@ -186,6 +195,9 @@ importers:
       eslint-config-next:
         specifier: 15.5.3
         version: 15.5.3(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
+      jsdom:
+        specifier: ^27.0.0
+        version: 27.0.0(postcss@8.5.6)
       tailwindcss:
         specifier: ^4
         version: 4.1.13
@@ -200,17 +212,71 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)
+        version: 3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@asamuzakjp/css-color@4.0.5':
+    resolution: {integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==}
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    resolution: {integrity: sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14':
+    resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      postcss: ^8.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -1381,8 +1447,40 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.8.0':
+    resolution: {integrity: sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -1641,6 +1739,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -1652,12 +1754,19 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1741,6 +1850,9 @@ packages:
   bcryptjs@3.0.2:
     resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1877,11 +1989,26 @@ packages:
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@5.3.1:
+    resolution: {integrity: sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==}
+    engines: {node: '>=20'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.0:
+    resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
+    engines: {node: '>=20'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1933,6 +2060,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -1996,6 +2126,12 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
@@ -2050,6 +2186,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.24.0:
@@ -2413,6 +2553,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
@@ -2420,9 +2564,21 @@ packages:
   htmlparser2@8.0.2:
     resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   idb-keyval@6.2.2:
     resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
@@ -2445,6 +2601,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -2531,6 +2691,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2596,6 +2759,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -2729,6 +2901,10 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@11.2.2:
+    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
+    engines: {node: 20 || >=22}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -2741,6 +2917,10 @@ packages:
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
@@ -2758,6 +2938,9 @@ packages:
     resolution: {integrity: sha512-OvAXqwq57uOk+WZqFFNCMZz8yDp8BD3WazW1wAKHUrPbbdr89K9DWS6JXY09vd9xNdPNeurI8DU/X4flcfaD8A==}
     peerDependencies:
       react: ^18.0 || ^19.0
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
@@ -2777,6 +2960,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2971,6 +3158,9 @@ packages:
   parse-srcset@1.0.2:
     resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
@@ -3051,6 +3241,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
@@ -3120,6 +3314,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
 
@@ -3177,6 +3374,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3187,6 +3388,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   require-main-filename@2.0.0:
@@ -3226,6 +3431,9 @@ packages:
   rrule@2.8.1:
     resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3241,8 +3449,15 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sanitize-html@2.17.0:
     resolution: {integrity: sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -3381,6 +3596,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -3408,6 +3627,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
@@ -3466,9 +3688,24 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.16:
+    resolution: {integrity: sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==}
+
+  tldts@7.0.16:
+    resolution: {integrity: sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -3639,8 +3876,28 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
+  webidl-conversions@8.0.0:
+    resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
+    engines: {node: '>=20'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3706,6 +3963,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
@@ -3737,9 +4013,61 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@4.0.5':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/dom-selector@6.5.6':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
   '@babel/runtime@7.28.4': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.14(postcss@8.5.6)':
+    dependencies:
+      postcss: 8.5.6
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/core@1.5.0':
     dependencies:
@@ -4694,10 +5022,46 @@ snapshots:
       '@tanstack/query-core': 5.90.1
       react: 19.1.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.8.0':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -4967,6 +5331,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4980,11 +5346,17 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -5088,6 +5460,10 @@ snapshots:
   base64id@2.0.0: {}
 
   bcryptjs@3.0.2: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.12:
     dependencies:
@@ -5232,9 +5608,29 @@ snapshots:
 
   crypto-js@4.2.0: {}
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
+  cssstyle@5.3.1(postcss@8.5.6):
+    dependencies:
+      '@asamuzakjp/css-color': 4.0.5
+      '@csstools/css-syntax-patches-for-csstree': 1.0.14(postcss@8.5.6)
+      css-tree: 3.1.0
+    transitivePeerDependencies:
+      - postcss
+
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -5273,6 +5669,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -5319,6 +5717,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -5398,6 +5800,8 @@ snapshots:
       tapable: 2.2.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -5937,6 +6341,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-to-text@9.0.5:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.11.0
@@ -5952,6 +6360,13 @@ snapshots:
       domutils: 3.2.2
       entities: 4.5.0
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
@@ -5959,6 +6374,17 @@ snapshots:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb-keyval@6.2.2: {}
 
@@ -5974,6 +6400,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -6064,6 +6492,8 @@ snapshots:
 
   is-plain-object@5.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -6129,6 +6559,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0(postcss@8.5.6):
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.5.6
+      cssstyle: 5.3.1(postcss@8.5.6)
+      data-urls: 6.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - postcss
+      - supports-color
+      - utf-8-validate
 
   json-buffer@3.0.1: {}
 
@@ -6238,6 +6696,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@11.2.2: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -6247,6 +6707,8 @@ snapshots:
       react: 19.1.1
 
   luxon@3.7.2: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.19:
     dependencies:
@@ -6260,6 +6722,8 @@ snapshots:
     dependencies:
       marked: 7.0.4
       react: 19.1.1
+
+  mdn-data@2.12.2: {}
 
   memoize-one@6.0.0: {}
 
@@ -6275,6 +6739,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -6471,6 +6937,10 @@ snapshots:
 
   parse-srcset@1.0.2: {}
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseley@0.12.1:
     dependencies:
       leac: 0.6.0
@@ -6538,6 +7008,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.6.2: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@3.8.0: {}
 
@@ -6622,6 +7098,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-lifecycles-compat@3.0.4: {}
 
   react-overlays@5.2.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
@@ -6680,6 +7158,11 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -6701,6 +7184,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
 
@@ -6758,6 +7243,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6781,6 +7268,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safer-buffer@2.1.2: {}
+
   sanitize-html@2.17.0:
     dependencies:
       deepmerge: 4.3.1
@@ -6789,6 +7278,10 @@ snapshots:
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
       postcss: 8.5.6
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.26.0: {}
 
@@ -7016,6 +7509,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@3.0.0:
@@ -7032,6 +7529,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.3.1: {}
 
@@ -7077,9 +7576,23 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.16: {}
+
+  tldts@7.0.16:
+    dependencies:
+      tldts-core: 7.0.16
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.16
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
@@ -7246,7 +7759,7 @@ snapshots:
       jiti: 2.5.1
       lightningcss: 1.30.1
 
-  vitest@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1):
+  vitest@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(jsdom@27.0.0(postcss@8.5.6))(lightningcss@1.30.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -7273,6 +7786,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.5.2
+      jsdom: 27.0.0(postcss@8.5.6)
     transitivePeerDependencies:
       - jiti
       - less
@@ -7287,9 +7801,26 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
+
+  webidl-conversions@8.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7372,6 +7903,12 @@ snapshots:
       strip-ansi: 6.0.1
 
   ws@8.17.1: {}
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 

--- a/prisma/migrations/20270815120000_analytics_server_logs/migration.sql
+++ b/prisma/migrations/20270815120000_analytics_server_logs/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "AnalyticsServerLogSeverity" AS ENUM ('info', 'warning', 'error');
+
+-- CreateEnum
+CREATE TYPE "AnalyticsServerLogStatus" AS ENUM ('open', 'monitoring', 'resolved');
+
+-- CreateTable
+CREATE TABLE "analytics_server_logs" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "severity" "AnalyticsServerLogSeverity" NOT NULL,
+    "service" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "description" TEXT,
+    "metadata" JSONB,
+    "tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "status" "AnalyticsServerLogStatus" NOT NULL DEFAULT 'open',
+    "occurrences" INTEGER NOT NULL DEFAULT 1,
+    "affectedUsers" INTEGER,
+    "recommendedAction" TEXT,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "fingerprint" TEXT NOT NULL,
+
+    CONSTRAINT "analytics_server_logs_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "analytics_server_logs_fingerprint_key" UNIQUE ("fingerprint")
+);
+
+-- CreateIndex
+CREATE INDEX "analytics_server_logs_severity_lastSeenAt_idx" ON "analytics_server_logs"("severity", "lastSeenAt");
+
+-- CreateIndex
+CREATE INDEX "analytics_server_logs_status_lastSeenAt_idx" ON "analytics_server_logs"("status", "lastSeenAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1193,6 +1193,18 @@ enum AnalyticsRequestArea {
   unknown
 }
 
+enum AnalyticsServerLogSeverity {
+  info
+  warning
+  error
+}
+
+enum AnalyticsServerLogStatus {
+  open
+  monitoring
+  resolved
+}
+
 model AnalyticsHttpRequest {
   id           String                @id @default(cuid())
   timestamp    DateTime              @default(now())
@@ -1422,4 +1434,27 @@ model AnalyticsRealtimeSummary {
 
   @@map("analytics_realtime_summary")
   @@index([windowEnd])
+}
+
+model AnalyticsServerLog {
+  id                String                    @id @default(cuid())
+  createdAt         DateTime                  @default(now())
+  updatedAt         DateTime                  @updatedAt
+  severity          AnalyticsServerLogSeverity
+  service           String
+  message           String
+  description       String?
+  metadata          Json?
+  tags              String[]                  @default([])
+  status            AnalyticsServerLogStatus  @default(open)
+  occurrences       Int                       @default(1)
+  affectedUsers     Int?
+  recommendedAction String?
+  firstSeenAt       DateTime                  @default(now())
+  lastSeenAt        DateTime                  @default(now())
+  fingerprint       String                    @unique
+
+  @@map("analytics_server_logs")
+  @@index([severity, lastSeenAt])
+  @@index([status, lastSeenAt])
 }

--- a/src/app/(members)/mitglieder/server-analytics/__tests__/server-analytics-content.test.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/__tests__/server-analytics-content.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ServerAnalytics } from "@/lib/server-analytics";
+
+import { ServerAnalyticsContent } from "../server-analytics-content";
+
+const { updateStatusMock } = vi.hoisted(() => ({
+  updateStatusMock: vi.fn(),
+}));
+
+vi.mock("../actions", () => ({
+  updateServerLogStatusAction: updateStatusMock,
+}));
+
+vi.mock("@/hooks/useRealtime", () => ({
+  useRealtime: () => ({
+    socket: null,
+    isConnected: false,
+    connectionStatus: "disconnected" as const,
+  }),
+}));
+
+function createAnalytics(): ServerAnalytics {
+  const now = new Date().toISOString();
+  return {
+    generatedAt: now,
+    summary: {
+      uptimePercentage: 99.9,
+      requestsLast24h: 1_200,
+      averageResponseTimeMs: 180,
+      errorRate: 0.02,
+      peakConcurrentUsers: 42,
+      cacheHitRate: 0.7,
+      realtimeEventsLast24h: 120,
+    },
+    resourceUsage: [
+      { id: "cpu", label: "CPU", usagePercent: 56, changePercent: -0.02, capacity: "4 Kerne" },
+    ],
+    requestBreakdown: {
+      frontend: { requests: 600, avgResponseTimeMs: 160, cacheHitRate: 0.5, avgPayloadKb: 120 },
+      members: { requests: 420, avgResponseTimeMs: 210, realtimeEvents: 80, avgSessionDurationSeconds: 360 },
+      api: { requests: 180, avgResponseTimeMs: 240, backgroundJobs: 15, errorRate: 0.04 },
+    },
+    peakHours: [],
+    publicPages: [],
+    memberPages: [],
+    trafficSources: [],
+    deviceBreakdown: [],
+    sessionInsights: [],
+    optimizationInsights: [],
+    serverLogs: [
+      {
+        id: "log-1",
+        severity: "error",
+        service: "Next.js API",
+        message: "Timeout",
+        description: "Request dauerte länger als 5 Sekunden",
+        occurrences: 3,
+        firstSeen: now,
+        lastSeen: now,
+        status: "open",
+        recommendedAction: "Poolgröße prüfen",
+        affectedUsers: 4,
+        tags: ["API", "Prisma"],
+      },
+    ],
+  };
+}
+
+describe("ServerAnalyticsContent", () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { React?: typeof React }).React = React;
+    vi.clearAllMocks();
+  });
+
+  it("updates server log status via server action", async () => {
+    const analytics = createAnalytics();
+    const updatedLog = {
+      ...analytics.serverLogs[0],
+      status: "resolved" as const,
+      lastSeen: new Date("2024-01-02T00:00:00.000Z").toISOString(),
+    };
+    updateStatusMock.mockResolvedValueOnce({ success: true, log: updatedLog });
+
+    const user = userEvent.setup();
+    render(<ServerAnalyticsContent initialAnalytics={analytics} />);
+
+    const logsTab = await screen.findByRole("tab", { name: "Serverlogs" });
+    await user.click(logsTab);
+
+    const resolveButton = await screen.findByRole("button", { name: "Als gelöst markieren" });
+    await user.click(resolveButton);
+
+    await waitFor(() => {
+      expect(updateStatusMock).toHaveBeenCalledWith({ logId: "log-1", status: "resolved" });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Gelöst")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: "Als gelöst markieren" })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(members)/mitglieder/server-analytics/actions.ts
+++ b/src/app/(members)/mitglieder/server-analytics/actions.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import {
+  loadLatestCriticalServerLogs,
+  updateServerLogStatus,
+  type LoadedServerLog,
+  type ServerLogStatus,
+} from "@/lib/analytics/load-server-logs";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+const statusSchema = z.enum(["open", "monitoring", "resolved"] satisfies readonly ServerLogStatus[]);
+
+const updateStatusSchema = z.object({
+  logId: z.string().min(1, "Log-ID erforderlich"),
+  status: statusSchema,
+});
+
+export type UpdateServerLogStatusInput = z.infer<typeof updateStatusSchema>;
+
+export type UpdateServerLogStatusResult =
+  | { success: true; log: LoadedServerLog }
+  | { success: false; error: string };
+
+export async function updateServerLogStatusAction(
+  input: UpdateServerLogStatusInput,
+): Promise<UpdateServerLogStatusResult> {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.analytics");
+  if (!allowed) {
+    return { success: false, error: "not_authorized" };
+  }
+
+  const parsed = updateStatusSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "validation_failed" };
+  }
+
+  try {
+    const updated = await updateServerLogStatus(parsed.data.logId, parsed.data.status);
+    revalidatePath("/mitglieder/server-analytics");
+
+    return { success: true, log: updated };
+  } catch (error) {
+    console.error("[server-analytics] Failed to update server log status", error);
+    return { success: false, error: "update_failed" };
+  }
+}
+
+export async function reloadCriticalServerLogs(): Promise<LoadedServerLog[]> {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.analytics");
+  if (!allowed) {
+    return [];
+  }
+
+  return loadLatestCriticalServerLogs({ limit: 25 });
+}

--- a/src/lib/analytics/__tests__/server-logs.test.ts
+++ b/src/lib/analytics/__tests__/server-logs.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AnalyticsServerLog } from "@prisma/client";
+
+import { logStructuredEvent } from "@/lib/logger";
+import {
+  loadLatestCriticalServerLogs,
+  updateServerLogStatus,
+  type LoadedServerLog,
+} from "@/lib/analytics/load-server-logs";
+
+const {
+  transactionMock,
+  findUniqueMock,
+  createMock,
+  updateMock,
+  findManyMock,
+} = vi.hoisted(() => ({
+  transactionMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+  createMock: vi.fn(),
+  updateMock: vi.fn(),
+  findManyMock: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $transaction: transactionMock,
+    analyticsServerLog: {
+      findMany: findManyMock,
+      update: updateMock,
+    },
+  },
+}));
+
+function mockTransactionClient() {
+  transactionMock.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) =>
+    callback({
+      analyticsServerLog: {
+        findUnique: findUniqueMock,
+        create: createMock,
+        update: updateMock,
+      },
+    }),
+  );
+}
+
+describe("server log pipeline", () => {
+  const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DATABASE_URL = "postgres://testing";
+    mockTransactionClient();
+  });
+
+  it("persists new structured log entries when no fingerprint exists", async () => {
+    findUniqueMock.mockResolvedValueOnce(null);
+    const createdLog = {
+      id: "log-1",
+      severity: "error",
+      service: "Next.js API",
+      message: "Timeout",
+      description: "Request timeout",
+      tags: ["API"],
+      status: "open",
+      occurrences: 1,
+      metadata: null,
+      affectedUsers: null,
+      recommendedAction: null,
+      firstSeenAt: new Date("2024-01-01T00:00:00.000Z"),
+      lastSeenAt: new Date("2024-01-01T00:00:00.000Z"),
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+      fingerprint: "fingerprint",
+    } satisfies AnalyticsServerLog;
+    createMock.mockResolvedValueOnce(createdLog);
+
+    await logStructuredEvent({
+      severity: "error",
+      service: "Next.js API",
+      message: "Timeout",
+      metadata: {
+        description: "Request timeout",
+        tags: ["API"],
+        status: "open",
+        timestamp: new Date("2024-01-01T00:00:00.000Z"),
+        requestId: "req-1",
+      },
+    });
+
+    expect(transactionMock).toHaveBeenCalledTimes(1);
+    expect(findUniqueMock).toHaveBeenCalledWith({ where: { fingerprint: expect.any(String) } });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          severity: "error",
+          service: "Next.js API",
+          message: "Timeout",
+          description: "Request timeout",
+          status: "open",
+          tags: ["API"],
+          occurrences: 1,
+        }),
+      }),
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("\"service\":\"Next.js API\""));
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("updates existing aggregated logs and merges metadata", async () => {
+    const existingLog = {
+      id: "log-1",
+      severity: "warning",
+      service: "Cronjob",
+      message: "Delay",
+      description: "Existing description",
+      tags: ["queue"],
+      status: "monitoring",
+      occurrences: 3,
+      metadata: { existing: true },
+      affectedUsers: 4,
+      recommendedAction: "Existing action",
+      firstSeenAt: new Date("2024-01-01T00:00:00.000Z"),
+      lastSeenAt: new Date("2024-01-01T02:00:00.000Z"),
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+      fingerprint: "fingerprint",
+    } satisfies AnalyticsServerLog;
+    findUniqueMock.mockResolvedValueOnce(existingLog);
+
+    await logStructuredEvent({
+      severity: "error",
+      service: "Cronjob",
+      message: "Delay",
+      metadata: {
+        description: "Updated description",
+        status: "resolved",
+        occurrences: 2,
+        affectedUsers: 6,
+        recommendedAction: "New action",
+        tags: ["cron"],
+        requestId: "req-2",
+      },
+    });
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "log-1" },
+        data: expect.objectContaining({
+          severity: "error",
+          description: "Updated description",
+          status: "resolved",
+          occurrences: { increment: 2 },
+          recommendedAction: "New action",
+          affectedUsers: 6,
+          tags: expect.arrayContaining(["queue", "cron"]),
+          metadata: expect.objectContaining({ existing: true, requestId: "req-2" }),
+          lastSeenAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it("loads latest critical server logs", async () => {
+    const rows: AnalyticsServerLog[] = [
+      {
+        id: "log-1",
+        severity: "error",
+        service: "Realtime",
+        message: "Handshake failed",
+        description: "",
+        tags: ["Realtime"],
+        status: "open",
+        occurrences: 5,
+        metadata: null,
+        affectedUsers: 2,
+        recommendedAction: "Rotate token",
+        firstSeenAt: new Date("2024-01-01T00:00:00.000Z"),
+        lastSeenAt: new Date("2024-01-01T03:00:00.000Z"),
+        createdAt: new Date("2024-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2024-01-01T03:00:00.000Z"),
+        fingerprint: "abc",
+      },
+    ];
+    findManyMock.mockResolvedValueOnce(rows);
+
+    const logs = await loadLatestCriticalServerLogs({ limit: 5, withinHours: 12 });
+
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 5,
+        orderBy: [
+          { lastSeenAt: "desc" },
+          { occurrences: "desc" },
+        ],
+      }),
+    );
+    expect(logs).toEqual([
+      {
+        id: "log-1",
+        severity: "error",
+        service: "Realtime",
+        message: "Handshake failed",
+        description: "Handshake failed",
+        occurrences: 5,
+        firstSeen: rows[0].firstSeenAt.toISOString(),
+        lastSeen: rows[0].lastSeenAt.toISOString(),
+        status: "open",
+        recommendedAction: "Rotate token",
+        affectedUsers: 2,
+        tags: ["Realtime"],
+      } satisfies LoadedServerLog,
+    ]);
+  });
+
+  it("updates server log status and maps result", async () => {
+    const updatedLog: AnalyticsServerLog = {
+      id: "log-2",
+      severity: "warning",
+      service: "Cache",
+      message: "Stale content",
+      description: "",
+      tags: ["cache"],
+      status: "monitoring",
+      occurrences: 4,
+      metadata: null,
+      affectedUsers: null,
+      recommendedAction: null,
+      firstSeenAt: new Date("2024-01-01T00:00:00.000Z"),
+      lastSeenAt: new Date("2024-01-01T02:00:00.000Z"),
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2024-01-01T02:00:00.000Z"),
+      fingerprint: "def",
+    };
+    updateMock.mockResolvedValueOnce(updatedLog);
+
+    const result = await updateServerLogStatus("log-2", "monitoring");
+
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: "log-2" },
+      data: { status: "monitoring" },
+    });
+    expect(result).toEqual({
+      id: "log-2",
+      severity: "warning",
+      service: "Cache",
+      message: "Stale content",
+      description: "Stale content",
+      occurrences: 4,
+      firstSeen: updatedLog.firstSeenAt.toISOString(),
+      lastSeen: updatedLog.lastSeenAt.toISOString(),
+      status: "monitoring",
+      recommendedAction: undefined,
+      affectedUsers: undefined,
+      tags: ["cache"],
+    });
+  });
+});

--- a/src/lib/analytics/load-server-logs.ts
+++ b/src/lib/analytics/load-server-logs.ts
@@ -1,0 +1,102 @@
+import type {
+  AnalyticsServerLog,
+  AnalyticsServerLogSeverity,
+  AnalyticsServerLogStatus,
+} from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+export type ServerLogSeverity = AnalyticsServerLogSeverity;
+export type ServerLogStatus = AnalyticsServerLogStatus;
+
+export type LoadedServerLog = {
+  id: string;
+  severity: ServerLogSeverity;
+  service: string;
+  message: string;
+  description: string;
+  occurrences: number;
+  firstSeen: string;
+  lastSeen: string;
+  status: ServerLogStatus;
+  recommendedAction?: string;
+  affectedUsers?: number;
+  tags: string[];
+};
+
+const CRITICAL_SEVERITIES: ServerLogSeverity[] = ["warning", "error"];
+
+function normalizeTags(tags: AnalyticsServerLog["tags"]): string[] {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+  const normalized = tags
+    .filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+    .map((tag) => tag.trim());
+
+  return Array.from(new Set(normalized)).slice(0, 16);
+}
+
+function mapRowToLoadedLog(row: AnalyticsServerLog): LoadedServerLog {
+  const description = typeof row.description === "string" && row.description.trim().length > 0
+    ? row.description
+    : row.message;
+  return {
+    id: row.id,
+    severity: row.severity,
+    service: row.service,
+    message: row.message,
+    description,
+    occurrences: Math.max(1, row.occurrences ?? 1),
+    firstSeen: row.firstSeenAt.toISOString(),
+    lastSeen: row.lastSeenAt.toISOString(),
+    status: row.status,
+    recommendedAction: row.recommendedAction ?? undefined,
+    affectedUsers: typeof row.affectedUsers === "number" ? row.affectedUsers : undefined,
+    tags: normalizeTags(row.tags),
+  };
+}
+
+export async function loadLatestCriticalServerLogs({
+  limit = 20,
+  withinHours = 48,
+}: {
+  limit?: number;
+  withinHours?: number;
+} = {}): Promise<LoadedServerLog[]> {
+  if (!process.env.DATABASE_URL) {
+    return [];
+  }
+
+  const since = withinHours > 0 ? new Date(Date.now() - withinHours * 60 * 60 * 1000) : undefined;
+
+  const rows = await prisma.analyticsServerLog.findMany({
+    where: {
+      severity: { in: CRITICAL_SEVERITIES },
+      ...(since ? { lastSeenAt: { gte: since } } : {}),
+    },
+    orderBy: [
+      { lastSeenAt: "desc" },
+      { occurrences: "desc" },
+    ],
+    take: Math.max(1, limit),
+  });
+
+  return rows.map(mapRowToLoadedLog);
+}
+
+export async function updateServerLogStatus(
+  logId: string,
+  status: ServerLogStatus,
+): Promise<LoadedServerLog> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("Log store is not configured");
+  }
+
+  const updated = await prisma.analyticsServerLog.update({
+    where: { id: logId },
+    data: { status },
+  });
+
+  return mapRowToLoadedLog(updated);
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,367 @@
+import crypto from "node:crypto";
+
+import { Prisma } from "@prisma/client";
+import type { AnalyticsServerLog, AnalyticsServerLogSeverity, AnalyticsServerLogStatus } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+export type StructuredLogSeverity = AnalyticsServerLogSeverity;
+export type StructuredLogStatus = AnalyticsServerLogStatus;
+
+export type StructuredLogMetadata = Record<string, unknown> & {
+  fingerprint?: unknown;
+  timestamp?: unknown;
+  description?: unknown;
+  tags?: unknown;
+  status?: unknown;
+  recommendedAction?: unknown;
+  affectedUsers?: unknown;
+  occurrences?: unknown;
+};
+
+export type StructuredLogEvent = {
+  severity: StructuredLogSeverity;
+  service: string;
+  message: string;
+  metadata?: StructuredLogMetadata;
+};
+
+type NormalizedLogEvent = {
+  severity: StructuredLogSeverity;
+  service: string;
+  message: string;
+  description?: string;
+  tags: string[];
+  status?: StructuredLogStatus;
+  recommendedAction?: string;
+  affectedUsers?: number;
+  occurrences: number;
+  metadata: Record<string, unknown> | null;
+  fingerprint: string;
+  timestamp: Date;
+};
+
+const SEVERITY_WEIGHT: Record<StructuredLogSeverity, number> = {
+  info: 1,
+  warning: 2,
+  error: 3,
+};
+
+function isValidStatus(value: unknown): value is StructuredLogStatus {
+  return value === "open" || value === "monitoring" || value === "resolved";
+}
+
+function sanitizeTimestamp(value: unknown): Date {
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const parsed = new Date(value);
+    if (Number.isFinite(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = new Date(value);
+    if (Number.isFinite(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return new Date();
+}
+
+function sanitizeTags(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const tags = value
+    .filter((tag): tag is string => typeof tag === "string" && tag.trim().length > 0)
+    .map((tag) => tag.trim());
+
+  return Array.from(new Set(tags)).slice(0, 12);
+}
+
+function sanitizeNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+function sanitizeOccurrences(value: unknown): number {
+  const parsed = sanitizeNumber(value);
+  if (!parsed || parsed < 1) {
+    return 1;
+  }
+
+  return parsed;
+}
+
+function sanitizeDescription(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  return undefined;
+}
+
+function sanitizeMetadataContext(value: Record<string, unknown>): Record<string, unknown> | null {
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const [key, rawValue] of entries) {
+    if (rawValue === undefined) {
+      continue;
+    }
+
+    if (rawValue === null || typeof rawValue === "string" || typeof rawValue === "boolean") {
+      result[key] = rawValue;
+      continue;
+    }
+
+    if (typeof rawValue === "number") {
+      result[key] = Number.isFinite(rawValue) ? rawValue : null;
+      continue;
+    }
+
+    if (rawValue instanceof Date) {
+      result[key] = rawValue.toISOString();
+      continue;
+    }
+
+    if (Array.isArray(rawValue)) {
+      const sanitizedArray = rawValue
+        .map((item) => {
+          if (item === undefined) return undefined;
+          if (item === null || typeof item === "string" || typeof item === "boolean") return item;
+          if (typeof item === "number") return Number.isFinite(item) ? item : null;
+          if (item instanceof Date) return item.toISOString();
+          if (typeof item === "object") {
+            return sanitizeMetadataContext(item as Record<string, unknown>);
+          }
+          return String(item);
+        })
+        .filter((item) => item !== undefined);
+
+      result[key] = sanitizedArray;
+      continue;
+    }
+
+    if (typeof rawValue === "object") {
+      result[key] = sanitizeMetadataContext(rawValue as Record<string, unknown>);
+      continue;
+    }
+
+    result[key] = String(rawValue);
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function normalizeEvent(event: StructuredLogEvent): NormalizedLogEvent {
+  const service = event.service.trim() || "application";
+  const message = event.message.trim() || "(empty message)";
+  const metadata = event.metadata ?? {};
+
+  const {
+    fingerprint: fingerprintValue,
+    timestamp: timestampValue,
+    description: descriptionValue,
+    tags: tagsValue,
+    status: statusValue,
+    recommendedAction: recommendedActionValue,
+    affectedUsers: affectedUsersValue,
+    occurrences: occurrencesValue,
+    ...context
+  } = metadata;
+
+  const description = sanitizeDescription(descriptionValue);
+  const timestamp = sanitizeTimestamp(timestampValue);
+  const tags = sanitizeTags(tagsValue);
+  const status = isValidStatus(statusValue) ? statusValue : undefined;
+  const recommendedAction = sanitizeDescription(recommendedActionValue);
+  const affectedUsers = sanitizeNumber(affectedUsersValue);
+  const occurrences = sanitizeOccurrences(occurrencesValue);
+
+  const sanitizedContext = sanitizeMetadataContext(context);
+  const fingerprintSource =
+    typeof fingerprintValue === "string" && fingerprintValue.trim().length > 0
+      ? fingerprintValue.trim()
+      : `${service}|${message}|${description ?? ""}|${JSON.stringify(sanitizedContext ?? {})}|${tags.join(",")}`;
+
+  const fingerprint = crypto.createHash("sha256").update(fingerprintSource).digest("hex");
+
+  return {
+    severity: event.severity,
+    service,
+    message,
+    description,
+    tags,
+    status,
+    recommendedAction,
+    affectedUsers,
+    occurrences,
+    metadata: sanitizedContext,
+    fingerprint,
+    timestamp,
+  };
+}
+
+function mergeMetadata(
+  existing: Prisma.JsonValue | null | undefined,
+  nextMetadata: Record<string, unknown> | null,
+): Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue {
+  if (!nextMetadata || Object.keys(nextMetadata).length === 0) {
+    if (existing === null || existing === undefined) {
+      return Prisma.JsonNull;
+    }
+    return existing as Prisma.InputJsonValue;
+  }
+
+  if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+    return nextMetadata as Prisma.InputJsonValue;
+  }
+
+  const merged: Record<string, unknown> = { ...(existing as Record<string, unknown>) };
+  for (const [key, value] of Object.entries(nextMetadata)) {
+    merged[key] = value;
+  }
+  return merged as Prisma.InputJsonValue;
+}
+
+function mergeTags(existing: string[] | null | undefined, next: string[]): string[] {
+  const tagSet = new Set<string>();
+  for (const tag of existing ?? []) {
+    if (typeof tag === "string" && tag.trim().length > 0) {
+      tagSet.add(tag.trim());
+    }
+  }
+  for (const tag of next) {
+    tagSet.add(tag);
+  }
+  return Array.from(tagSet).slice(0, 16);
+}
+
+async function persistLogEvent(event: NormalizedLogEvent) {
+  if (!process.env.DATABASE_URL) {
+    return;
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      const existing = await tx.analyticsServerLog.findUnique({
+        where: { fingerprint: event.fingerprint },
+      });
+
+      if (existing) {
+        const severityWeightExisting = SEVERITY_WEIGHT[existing.severity as StructuredLogSeverity] ?? 0;
+        const severityWeightNext = SEVERITY_WEIGHT[event.severity];
+        const severity: StructuredLogSeverity =
+          severityWeightNext >= severityWeightExisting ? event.severity : (existing.severity as StructuredLogSeverity);
+
+        const nextLastSeenAt = event.timestamp > existing.lastSeenAt ? event.timestamp : existing.lastSeenAt;
+
+        const nextStatus = event.status ?? (existing.status as StructuredLogStatus);
+        const nextDescription = event.description ?? existing.description ?? undefined;
+        const nextRecommendedAction = event.recommendedAction ?? existing.recommendedAction ?? undefined;
+        const nextAffectedUsers =
+          event.affectedUsers ?? (typeof existing.affectedUsers === "number" ? existing.affectedUsers : undefined);
+
+        await tx.analyticsServerLog.update({
+          where: { id: existing.id },
+          data: {
+            severity,
+            service: event.service,
+            message: event.message,
+            description: nextDescription ?? null,
+            recommendedAction: nextRecommendedAction ?? null,
+            affectedUsers: typeof nextAffectedUsers === "number" ? nextAffectedUsers : null,
+            status: nextStatus,
+            tags: mergeTags(existing.tags, event.tags),
+            metadata: mergeMetadata(existing.metadata, event.metadata),
+            occurrences: { increment: event.occurrences },
+            lastSeenAt: nextLastSeenAt,
+          },
+        });
+      } else {
+        await tx.analyticsServerLog.create({
+          data: {
+            severity: event.severity,
+            service: event.service,
+            message: event.message,
+            description: event.description ?? null,
+            recommendedAction: event.recommendedAction ?? null,
+            affectedUsers: typeof event.affectedUsers === "number" ? event.affectedUsers : null,
+            status: event.status ?? "open",
+            tags: event.tags,
+            metadata: event.metadata ? (event.metadata as Prisma.InputJsonValue) : Prisma.JsonNull,
+            occurrences: event.occurrences,
+            firstSeenAt: event.timestamp,
+            lastSeenAt: event.timestamp,
+            fingerprint: event.fingerprint,
+          },
+        });
+      }
+    });
+  } catch (error) {
+    console.error("[logger] Failed to persist structured log event", error);
+  }
+}
+
+export async function logStructuredEvent(event: StructuredLogEvent): Promise<void> {
+  const normalized = normalizeEvent(event);
+
+  const consolePayload = {
+    timestamp: normalized.timestamp.toISOString(),
+    severity: normalized.severity,
+    service: normalized.service,
+    message: normalized.message,
+    metadata: {
+      description: normalized.description,
+      tags: normalized.tags,
+      status: normalized.status,
+      recommendedAction: normalized.recommendedAction,
+      affectedUsers: normalized.affectedUsers,
+      occurrences: normalized.occurrences,
+      context: normalized.metadata,
+    },
+  };
+
+  console.log(JSON.stringify(consolePayload));
+
+  await persistLogEvent(normalized);
+}
+
+export function createLogger(service: string) {
+  const normalizedService = service.trim() || "application";
+  return {
+    info(message: string, metadata?: StructuredLogMetadata) {
+      return logStructuredEvent({ severity: "info", service: normalizedService, message, metadata });
+    },
+    warn(message: string, metadata?: StructuredLogMetadata) {
+      return logStructuredEvent({ severity: "warning", service: normalizedService, message, metadata });
+    },
+    error(message: string, metadata?: StructuredLogMetadata) {
+      return logStructuredEvent({ severity: "error", service: normalizedService, message, metadata });
+    },
+  };
+}
+
+export type PersistedServerLog = AnalyticsServerLog;


### PR DESCRIPTION
## Summary
- add Prisma enums, table, and migration to persist analytics server logs
- implement structured logger that writes to stdout and the log store and expose queries/actions for critical logs
- update server analytics aggregation and UI to surface database-backed logs with status controls and tests

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3bc46697c832d97dc0105c022c507