### PR TITLE
Add transactional ticket check-in API

### DIFF
--- a/prisma/migrations/20270816120000_ticket_checkins/migration.sql
+++ b/prisma/migrations/20270816120000_ticket_checkins/migration.sql
@@ -1,0 +1,50 @@
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('unused', 'checked_in', 'invalid');
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "holderName" TEXT,
+    "status" "TicketStatus" NOT NULL DEFAULT 'unused',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Ticket_code_key" UNIQUE ("code")
+);
+
+-- CreateTable
+CREATE TABLE "TicketScanEvent" (
+    "id" TEXT NOT NULL,
+    "ticketId" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "statusBefore" "TicketStatus" NOT NULL,
+    "statusAfter" "TicketStatus" NOT NULL,
+    "source" TEXT,
+    "occurredAt" TIMESTAMP(3) NOT NULL,
+    "dedupeKey" TEXT,
+    "serverSeq" INTEGER,
+    "processedAt" TIMESTAMP(3),
+    "provisional" BOOLEAN NOT NULL DEFAULT FALSE,
+    "clientId" TEXT,
+    "clientMutationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TicketScanEvent_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "TicketScanEvent_dedupeKey_key" UNIQUE ("dedupeKey")
+);
+
+-- CreateIndex
+CREATE INDEX "Ticket_eventId_idx" ON "Ticket"("eventId");
+
+-- CreateIndex
+CREATE INDEX "TicketScanEvent_ticketId_occurredAt_idx" ON "TicketScanEvent"("ticketId", "occurredAt");
+
+-- AddForeignKey
+ALTER TABLE "TicketScanEvent"
+  ADD CONSTRAINT "TicketScanEvent_ticketId_fkey"
+  FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,12 @@ enum SyncScope {
   tickets
 }
 
+enum TicketStatus {
+  unused
+  checked_in
+  invalid
+}
+
 enum DepartmentMembershipRole {
   lead
   member
@@ -1422,6 +1428,42 @@ model AnalyticsTrafficSource {
 
   @@map("analytics_traffic_sources")
   @@index([channel])
+}
+
+model Ticket {
+  id         String        @id @default(cuid())
+  code       String        @unique
+  eventId    String
+  holderName String?
+  status     TicketStatus  @default(unused)
+  createdAt  DateTime      @default(now())
+  updatedAt  DateTime      @updatedAt
+
+  scanEvents TicketScanEvent[]
+
+  @@index([eventId])
+}
+
+model TicketScanEvent {
+  id               String        @id @default(cuid())
+  ticketId         String
+  code             String
+  statusBefore     TicketStatus
+  statusAfter      TicketStatus
+  source           String?
+  occurredAt       DateTime
+  dedupeKey        String?       @unique
+  serverSeq        Int?
+  processedAt      DateTime?
+  provisional      Boolean       @default(false)
+  clientId         String?
+  clientMutationId String?
+  createdAt        DateTime      @default(now())
+  updatedAt        DateTime      @updatedAt
+
+  ticket Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+
+  @@index([ticketId, occurredAt])
 }
 
 model AnalyticsRealtimeSummary {

--- a/src/app/api/ticket/checkin/route.ts
+++ b/src/app/api/ticket/checkin/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+import {
+  checkInTicket,
+  TicketCheckInError,
+  type TicketCheckInResult,
+} from "@/lib/tickets/service";
+
+const payloadSchema = z
+  .object({
+    ticketId: z.string().trim().min(1).optional(),
+    code: z.string().trim().min(1).optional(),
+    dedupeKey: z.string().trim().min(1).optional(),
+    occurredAt: z.string().datetime().optional(),
+    source: z.string().trim().min(1).optional(),
+    clientId: z.string().trim().min(1).optional(),
+    clientMutationId: z.string().trim().min(1).optional(),
+  })
+  .refine((value) => Boolean(value.ticketId || value.code), {
+    message: "ticketId oder code erforderlich",
+    path: ["code"],
+  });
+
+function formatTicket(response: TicketCheckInResult["ticket"]) {
+  return {
+    id: response.id,
+    code: response.code,
+    status: response.status,
+    holderName: response.holderName ?? null,
+    eventId: response.eventId,
+    updatedAt: response.updatedAt.toISOString(),
+  };
+}
+
+function formatScanEvent(event: TicketCheckInResult["scanEvent"]) {
+  if (!event) {
+    return null;
+  }
+
+  return {
+    id: event.id,
+    ticketId: event.ticketId,
+    occurredAt: event.occurredAt.toISOString(),
+    processedAt: event.processedAt ? event.processedAt.toISOString() : null,
+    statusBefore: event.statusBefore,
+    statusAfter: event.statusAfter,
+    source: event.source ?? null,
+    dedupeKey: event.dedupeKey ?? null,
+    serverSeq: event.serverSeq ?? null,
+    provisional: event.provisional,
+  };
+}
+
+export async function POST(request: Request) {
+  try {
+    const json = await request.json();
+    const payload = payloadSchema.parse(json);
+
+    const result = await prisma.$transaction((tx) =>
+      checkInTicket(tx, {
+        ticketId: payload.ticketId ?? null,
+        code: payload.code ?? null,
+        dedupeKey: payload.dedupeKey ?? null,
+        occurredAt: payload.occurredAt ?? null,
+        source: payload.source ?? "scanner",
+        clientId: payload.clientId ?? null,
+        clientMutationId: payload.clientMutationId ?? null,
+      }),
+    );
+
+    const message = result.alreadyCheckedIn
+      ? "Ticket wurde bereits eingecheckt."
+      : "Ticket erfolgreich eingecheckt.";
+
+    return NextResponse.json({
+      status: result.status,
+      provisional: result.provisional,
+      serverSeq: result.serverSeq,
+      alreadyCheckedIn: result.alreadyCheckedIn,
+      message,
+      ticket: formatTicket(result.ticket),
+      event: formatScanEvent(result.scanEvent),
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Ungültiger Ticket-Scan", issues: error.issues },
+        { status: 400 },
+      );
+    }
+
+    if (error instanceof TicketCheckInError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code },
+        { status: error.status },
+      );
+    }
+
+    console.error("Ticket check-in failed", error);
+    return NextResponse.json(
+      { error: "Ticket-Check-in fehlgeschlagen" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/offline/sync-client.ts
+++ b/src/lib/offline/sync-client.ts
@@ -454,7 +454,7 @@ export class SyncClient {
 
     const result: PendingEvent[] = [];
     // Dexie transaction scope ensures atomic dequeue of events
-    await (db as any).transaction("rw", db.eventQueue, async () => {
+    await db.transaction("rw", db.eventQueue, async () => {
       const ordered = await db.eventQueue.orderBy("createdAt").toArray();
 
       for (const event of ordered) {
@@ -539,7 +539,7 @@ export class SyncClient {
     scope: OfflineScope,
     serverSeq: number,
   ) {
-    await (db as any).transaction("rw", db.syncState, async () => {
+    await db.transaction("rw", db.syncState, async () => {
       const existing = await db.syncState.get(scope);
       const updatedAt = new Date().toISOString();
 

--- a/src/lib/tickets/__tests__/service.test.ts
+++ b/src/lib/tickets/__tests__/service.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeDedupeKey,
+  normalizeOccurredAt,
+  serializeScanEventForPayload,
+  serializeTicketForPayload,
+  TicketCheckInError,
+} from "@/lib/tickets/service";
+import { TicketStatus } from "@prisma/client";
+
+describe("ticket service helpers", () => {
+  it("normalizes missing occurredAt to a current timestamp", () => {
+    const before = Date.now();
+    const result = normalizeOccurredAt();
+    const after = Date.now();
+
+    expect(result.getTime()).toBeGreaterThanOrEqual(before);
+    expect(result.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it("throws a TicketCheckInError for invalid occurredAt values", () => {
+    expect(() => normalizeOccurredAt("not-a-date")).toThrow(TicketCheckInError);
+  });
+
+  it("keeps provided dedupe keys and trims whitespace", () => {
+    expect(computeDedupeKey("abc", "  ticket:abc   ")).toBe("ticket:abc");
+  });
+
+  it("falls back to ticket-based dedupe keys when missing", () => {
+    expect(computeDedupeKey("xyz")).toBe("ticket:xyz");
+  });
+
+  it("serializes tickets into payload-friendly records", () => {
+    const updatedAt = new Date("2025-01-01T12:00:00.000Z");
+    const ticket = {
+      id: "ticket-1",
+      code: "CODE-1",
+      status: TicketStatus.checked_in,
+      eventId: "event-1",
+      holderName: null,
+      createdAt: new Date("2024-12-31T12:00:00.000Z"),
+      updatedAt,
+    };
+
+    expect(serializeTicketForPayload(ticket)).toEqual({
+      id: "ticket-1",
+      code: "CODE-1",
+      status: TicketStatus.checked_in,
+      eventId: "event-1",
+      updatedAt: updatedAt.toISOString(),
+    });
+  });
+
+  it("serializes scan events and omits optional fields when absent", () => {
+    const occurredAt = new Date("2025-01-02T12:00:00.000Z");
+    const scanEvent = {
+      id: "scan-1",
+      ticketId: "ticket-1",
+      code: "CODE-1",
+      statusBefore: TicketStatus.unused,
+      statusAfter: TicketStatus.checked_in,
+      source: null,
+      occurredAt,
+      dedupeKey: null,
+      serverSeq: 10,
+      processedAt: null,
+      provisional: false,
+      clientId: null,
+      clientMutationId: null,
+      createdAt: occurredAt,
+      updatedAt: occurredAt,
+    };
+
+    expect(serializeScanEventForPayload(scanEvent)).toEqual({
+      id: "scan-1",
+      ticketId: "ticket-1",
+      code: "CODE-1",
+      statusBefore: TicketStatus.unused,
+      statusAfter: TicketStatus.checked_in,
+      occurredAt: occurredAt.toISOString(),
+      provisional: false,
+    });
+  });
+
+  it("includes optional metadata in scan event payloads when present", () => {
+    const occurredAt = new Date("2025-01-03T12:00:00.000Z");
+    const processedAt = new Date("2025-01-03T12:05:00.000Z");
+    const scanEvent = {
+      id: "scan-2",
+      ticketId: "ticket-2",
+      code: "CODE-2",
+      statusBefore: TicketStatus.unused,
+      statusAfter: TicketStatus.checked_in,
+      source: "scanner",
+      occurredAt,
+      dedupeKey: "ticket:ticket-2",
+      serverSeq: 11,
+      processedAt,
+      provisional: false,
+      clientId: "scanner",
+      clientMutationId: "mutation-1",
+      createdAt: occurredAt,
+      updatedAt: occurredAt,
+    };
+
+    expect(serializeScanEventForPayload(scanEvent)).toEqual({
+      id: "scan-2",
+      ticketId: "ticket-2",
+      code: "CODE-2",
+      statusBefore: TicketStatus.unused,
+      statusAfter: TicketStatus.checked_in,
+      occurredAt: occurredAt.toISOString(),
+      provisional: false,
+      processedAt: processedAt.toISOString(),
+      source: "scanner",
+      dedupeKey: "ticket:ticket-2",
+    });
+  });
+});

--- a/src/lib/tickets/service.ts
+++ b/src/lib/tickets/service.ts
@@ -1,0 +1,392 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  Prisma,
+  SyncScope,
+  TicketStatus,
+  type Ticket,
+  type TicketScanEvent,
+} from "@prisma/client";
+
+export type TransactionClient = Prisma.TransactionClient;
+
+type TicketIdentifier = {
+  ticketId?: string | null;
+  code?: string | null;
+};
+
+export interface TicketCheckInInput extends TicketIdentifier {
+  dedupeKey?: string | null;
+  occurredAt?: Date | string | null;
+  source?: string | null;
+  clientId?: string | null;
+  clientMutationId?: string | null;
+}
+
+export interface TicketCheckInResult {
+  ticket: Ticket;
+  scanEvent: TicketScanEvent | null;
+  status: TicketStatus;
+  provisional: boolean;
+  serverSeq: number | null;
+  alreadyCheckedIn: boolean;
+}
+
+export class TicketCheckInError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly code: "NOT_FOUND" | "INVALID_STATE" | "INVALID_INPUT",
+  ) {
+    super(message);
+    this.name = "TicketCheckInError";
+  }
+}
+
+export function normalizeOccurredAt(value?: Date | string | null): Date {
+  if (!value) {
+    return new Date();
+  }
+
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      throw new TicketCheckInError(
+        "Zeitstempel für Scan ungültig.",
+        400,
+        "INVALID_INPUT",
+      );
+    }
+
+    return value;
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    throw new TicketCheckInError(
+      "Zeitstempel für Scan ungültig.",
+      400,
+      "INVALID_INPUT",
+    );
+  }
+
+  return parsed;
+}
+
+export function computeDedupeKey(ticketId: string, provided?: string | null): string {
+  if (provided && provided.trim().length > 0) {
+    return provided.trim();
+  }
+
+  if (!ticketId || ticketId.trim().length === 0) {
+    throw new TicketCheckInError(
+      "Ticket-Identifikator fehlt.",
+      400,
+      "INVALID_INPUT",
+    );
+  }
+
+  return `ticket:${ticketId}`;
+}
+
+export function serializeTicketForPayload(ticket: Ticket): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    id: ticket.id,
+    code: ticket.code,
+    status: ticket.status,
+    eventId: ticket.eventId,
+    updatedAt: ticket.updatedAt.toISOString(),
+  };
+
+  if (ticket.holderName) {
+    payload.holderName = ticket.holderName;
+  }
+
+  return payload;
+}
+
+export function serializeScanEventForPayload(
+  scanEvent: TicketScanEvent,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    id: scanEvent.id,
+    ticketId: scanEvent.ticketId,
+    code: scanEvent.code,
+    statusBefore: scanEvent.statusBefore,
+    statusAfter: scanEvent.statusAfter,
+    occurredAt: scanEvent.occurredAt.toISOString(),
+    provisional: scanEvent.provisional,
+  };
+
+  if (scanEvent.processedAt) {
+    payload.processedAt = scanEvent.processedAt.toISOString();
+  }
+
+  if (scanEvent.source) {
+    payload.source = scanEvent.source;
+  }
+
+  if (scanEvent.dedupeKey) {
+    payload.dedupeKey = scanEvent.dedupeKey;
+  }
+
+  return payload;
+}
+
+function isUniqueConstraintError(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2002"
+  );
+}
+
+async function lockTicket(
+  db: TransactionClient,
+  identifier: TicketIdentifier,
+): Promise<Ticket | null> {
+  const { ticketId, code } = identifier;
+
+  if (ticketId && ticketId.trim().length > 0) {
+    const rows = await db.$queryRaw<Ticket[]>`
+      SELECT * FROM "Ticket"
+      WHERE id = ${ticketId}
+      FOR UPDATE
+    `;
+
+    const ticket = rows[0] ?? null;
+
+    if (ticket && code) {
+      const normalizedCode = code.trim();
+
+      if (normalizedCode.length > 0 && normalizedCode !== ticket.code) {
+        throw new TicketCheckInError(
+          "Ticket-Code stimmt nicht mit Ticket-ID überein.",
+          400,
+          "INVALID_INPUT",
+        );
+      }
+    }
+
+    return ticket;
+  }
+
+  if (code && code.trim().length > 0) {
+    const normalizedCode = code.trim();
+    const rows = await db.$queryRaw<Ticket[]>`
+      SELECT * FROM "Ticket"
+      WHERE code = ${normalizedCode}
+      FOR UPDATE
+    `;
+
+    return rows[0] ?? null;
+  }
+
+  return null;
+}
+
+async function createSyncEnvelope(
+  db: TransactionClient,
+  ticket: Ticket,
+  scanEvent: TicketScanEvent,
+  dedupeKey: string,
+  occurredAt: Date,
+  clientId?: string | null,
+  clientMutationId?: string | null,
+): Promise<{ serverSeq: number; mutationId: string }> {
+  const normalizedClientId = clientId?.trim() && clientId.trim().length > 0 ? clientId.trim() : "server";
+  const mutationId =
+    clientMutationId && clientMutationId.trim().length > 0
+      ? clientMutationId.trim()
+      : `ticket-checkin:${scanEvent.id}`;
+
+  const latest = await db.syncEvent.findFirst({
+    where: { scope: SyncScope.tickets },
+    orderBy: { serverSeq: "desc" },
+    select: { serverSeq: true },
+  });
+
+  await db.syncMutation.create({
+    data: {
+      clientMutationId: mutationId,
+      clientId: normalizedClientId,
+      scope: SyncScope.tickets,
+      eventCount: 0,
+      acknowledgedSeq: latest?.serverSeq ?? 0,
+    },
+  });
+
+  const payload = {
+    ticket: serializeTicketForPayload(ticket),
+    scanEvent: serializeScanEventForPayload(scanEvent),
+  } satisfies Record<string, unknown>;
+
+  const created = await db.syncEvent.create({
+    data: {
+      id: randomUUID(),
+      scope: SyncScope.tickets,
+      clientId: normalizedClientId,
+      clientMutationId: mutationId,
+      dedupeKey,
+      type: "ticket.checkin",
+      payload: payload as Prisma.InputJsonValue,
+      occurredAt,
+    },
+  });
+
+  await db.syncMutation.update({
+    where: { clientMutationId: mutationId },
+    data: {
+      eventCount: 1,
+      firstServerSeq: created.serverSeq,
+      lastServerSeq: created.serverSeq,
+      acknowledgedSeq: created.serverSeq,
+    },
+  });
+
+  return { serverSeq: created.serverSeq, mutationId };
+}
+
+export async function checkInTicket(
+  db: TransactionClient,
+  input: TicketCheckInInput,
+): Promise<TicketCheckInResult> {
+  const occurredAt = normalizeOccurredAt(input.occurredAt);
+  const dedupeFromPayload = input.dedupeKey?.trim() && input.dedupeKey.trim().length > 0 ? input.dedupeKey.trim() : null;
+
+  if (dedupeFromPayload) {
+    const existing = await db.ticketScanEvent.findUnique({
+      where: { dedupeKey: dedupeFromPayload },
+      include: { ticket: true },
+    });
+
+    if (existing?.ticket) {
+      return {
+        ticket: existing.ticket,
+        scanEvent: existing,
+        status: existing.statusAfter,
+        provisional: existing.provisional,
+        serverSeq: existing.serverSeq ?? null,
+        alreadyCheckedIn: existing.statusAfter === TicketStatus.checked_in,
+      } satisfies TicketCheckInResult;
+    }
+  }
+
+  const ticket = await lockTicket(db, {
+    ticketId: input.ticketId,
+    code: input.code,
+  });
+
+  if (!ticket) {
+    throw new TicketCheckInError("Ticket wurde nicht gefunden.", 404, "NOT_FOUND");
+  }
+
+  if (ticket.status === TicketStatus.invalid) {
+    throw new TicketCheckInError(
+      "Ticket ist ungültig und kann nicht eingecheckt werden.",
+      409,
+      "INVALID_STATE",
+    );
+  }
+
+  if (ticket.status === TicketStatus.checked_in) {
+    const latestEvent = await db.ticketScanEvent.findFirst({
+      where: { ticketId: ticket.id },
+      orderBy: { occurredAt: "desc" },
+    });
+
+    return {
+      ticket,
+      scanEvent: latestEvent ?? null,
+      status: ticket.status,
+      provisional: latestEvent?.provisional ?? false,
+      serverSeq: latestEvent?.serverSeq ?? null,
+      alreadyCheckedIn: true,
+    } satisfies TicketCheckInResult;
+  }
+
+  if (ticket.status !== TicketStatus.unused) {
+    throw new TicketCheckInError(
+      "Ticket befindet sich in einem unbekannten Status.",
+      409,
+      "INVALID_STATE",
+    );
+  }
+
+  const updatedTicket = await db.ticket.update({
+    where: { id: ticket.id },
+    data: { status: TicketStatus.checked_in },
+  });
+
+  const dedupeKey = computeDedupeKey(updatedTicket.id, dedupeFromPayload);
+  const processedAt = new Date();
+  const normalizedSource = input.source?.trim() && input.source.trim().length > 0 ? input.source.trim() : null;
+  const normalizedClientId = input.clientId?.trim() && input.clientId.trim().length > 0 ? input.clientId.trim() : null;
+  const normalizedClientMutationId =
+    input.clientMutationId?.trim() && input.clientMutationId.trim().length > 0
+      ? input.clientMutationId.trim()
+      : null;
+
+  let scanEvent: TicketScanEvent;
+
+  try {
+    scanEvent = await db.ticketScanEvent.create({
+      data: {
+        ticketId: updatedTicket.id,
+        code: updatedTicket.code,
+        statusBefore: ticket.status,
+        statusAfter: TicketStatus.checked_in,
+        source: normalizedSource,
+        occurredAt,
+        dedupeKey,
+        processedAt,
+        provisional: false,
+        clientId: normalizedClientId,
+        clientMutationId: normalizedClientMutationId,
+      },
+    });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      const existing = await db.ticketScanEvent.findUnique({
+        where: { dedupeKey },
+        include: { ticket: true },
+      });
+
+      if (existing?.ticket) {
+        return {
+          ticket: existing.ticket,
+          scanEvent: existing,
+          status: existing.statusAfter,
+          provisional: existing.provisional,
+          serverSeq: existing.serverSeq ?? null,
+          alreadyCheckedIn: existing.statusAfter === TicketStatus.checked_in,
+        } satisfies TicketCheckInResult;
+      }
+    }
+
+    throw error;
+  }
+
+  const syncEvent = await createSyncEnvelope(
+    db,
+    updatedTicket,
+    scanEvent,
+    dedupeKey,
+    occurredAt,
+    normalizedClientId,
+    normalizedClientMutationId,
+  );
+
+  const finalizedEvent = await db.ticketScanEvent.update({
+    where: { id: scanEvent.id },
+    data: { serverSeq: syncEvent.serverSeq },
+  });
+
+  return {
+    ticket: updatedTicket,
+    scanEvent: finalizedEvent,
+    status: updatedTicket.status,
+    provisional: finalizedEvent.provisional,
+    serverSeq: finalizedEvent.serverSeq ?? null,
+    alreadyCheckedIn: false,
+  } satisfies TicketCheckInResult;
+}


### PR DESCRIPTION
## Summary
- add Ticket and TicketScanEvent models plus migration to persist scan history
- implement a ticket check-in service and API route that lock rows, emit sync events and surface dedupe status
- update sync baseline handling, Dexie transactions and add unit tests for ticket helpers

## Testing
- pnpm lint
- pnpm test --filter ticket *(fails: Unknown option `--filter`)*
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3c82e1d74832d9a8b133c74ded48b