### PR TITLE
Improve members navigation layout

### DIFF
--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -225,6 +225,7 @@ export function MembersNav({
                     const isPrimitiveBadge =
                       typeof badgeContent === "string" ||
                       typeof badgeContent === "number";
+                    const reserveBadgeSpace = showBadge && isPrimitiveBadge;
 
                     return (
                       <SidebarMenuItem key={item.href}>
@@ -246,16 +247,28 @@ export function MembersNav({
                               className={cn(
                                 "h-4 w-4 shrink-0 transition-opacity",
                                 active ? "opacity-100" : "opacity-70",
+                                !isCollapsed && "mt-0.5",
                               )}
                             />
-                            <span className={cn("truncate", isCollapsed && "sr-only")}>{item.label}</span>
+                            {!isCollapsed ? (
+                              <div
+                                className={cn(
+                                  "flex min-w-0 flex-1 flex-col",
+                                  reserveBadgeSpace && "pr-8",
+                                )}
+                              >
+                                <span className="break-words text-sidebar-foreground leading-5">
+                                  {item.label}
+                                </span>
+                              </div>
+                            ) : null}
                             {showBadge ? (
                               isPrimitiveBadge ? (
                                 <SidebarMenuBadge className="border border-sidebar-border/60 bg-sidebar/50 text-eyebrow text-sidebar-foreground/70">
                                   {badgeContent}
                                 </SidebarMenuBadge>
                               ) : (
-                                <span className="ml-auto flex items-center">{badgeContent}</span>
+                                <span className="ml-auto flex shrink-0 items-center">{badgeContent}</span>
                               )
                             ) : null}
                           </Link>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -764,7 +764,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = "SidebarMenuItem";
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-semibold data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-start gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-semibold data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 group-data-[collapsible=icon]:items-center group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -773,9 +773,9 @@ const sidebarMenuButtonVariants = cva(
           "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
-        default: "h-8 text-sm",
-        sm: "h-7 text-xs",
-        lg: "h-12 text-sm group-data-[collapsible=icon]:!p-0",
+        default: "min-h-[2rem] text-sm",
+        sm: "min-h-[1.75rem] text-xs",
+        lg: "min-h-[3rem] text-sm group-data-[collapsible=icon]:!p-0",
       },
     },
     defaultVariants: {

--- a/src/lib/offline/sync-client.ts
+++ b/src/lib/offline/sync-client.ts
@@ -454,7 +454,7 @@ export class SyncClient {
 
     const result: PendingEvent[] = [];
     // Dexie transaction scope ensures atomic dequeue of events
-    await (db as any).transaction("rw", db.eventQueue, async () => {
+    await db.transaction("rw", db.eventQueue, async () => {
       const ordered = await db.eventQueue.orderBy("createdAt").toArray();
 
       for (const event of ordered) {
@@ -539,7 +539,7 @@ export class SyncClient {
     scope: OfflineScope,
     serverSeq: number,
   ) {
-    await (db as any).transaction("rw", db.syncState, async () => {
+    await db.transaction("rw", db.syncState, async () => {
       const existing = await db.syncState.get(scope);
       const updatedAt = new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- let members navigation labels wrap, reserve space for badges, and avoid collapsed horizontal scrolling
- update sidebar menu button variants to align icons at the top and allow dynamic heights for multi-line content
- replace the remaining Dexie transaction casts with typed calls in the offline sync client

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3ce582f5c832daef4e0c8e562ad29