### PR TITLE
Implement server analytics realtime caching and docs

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,53 @@
+# Analytics, Caching & Realtime-Dashboard
+
+Dieses Dokument beschreibt, wie die Server-Analytics aggregiert, gecacht und im Mitgliederbereich in Echtzeit aktualisiert werden.
+
+## Architekturüberblick
+- **Cronjobs (`scripts/cron/aggregate-*.ts`)** schreiben aggregierte Kennzahlen in die Postgres-Datenbank und lösen anschließend per `pg_notify('server_analytics_update', …)` einen Broadcast aus.
+- **Realtime-Server (`realtime-server/src/analytics.js`)** lauscht über `LISTEN server_analytics_update` auf diese Benachrichtigungen, erstellt einen frischen Snapshot und sendet `server_analytics_update`-Events an alle verbundenen Clients.
+- **Next.js Server-Komponente (`src/lib/server-analytics.ts`)** holt die Daten mittels `unstable_cache`, versieht sie mit Retry-/Fallback-Logik und reicht Metadaten (Quelle, Versuche, Stale-Zeitpunkt) an die UI weiter.
+- **Dashboard (`/mitglieder/server-analytics`)** zeigt Kennzahlen, SLA-Informationen und Datenqualitäts-Badges an und reagiert auf Live-Updates.
+
+## Cronjobs einrichten
+1. Stelle sicher, dass eine Postgres-Instanz erreichbar ist (`DATABASE_URL` gesetzt) und die Analyticstables vorhanden sind (`pnpm db:migrate`).
+2. Cronjobs können via `cron` oder einem Scheduler wie systemd/timer laufen. Beispiel-Crontab (alle 5 Minuten HTTP, alle 15 Minuten Seiten/Sessions):
+   ```cron
+   */5 * * * * cd /pfad/zum/repo && pnpm tsx scripts/cron/aggregate-http-metrics.ts >> logs/cron-http.log 2>&1
+   */15 * * * * cd /pfad/zum/repo && pnpm tsx scripts/cron/aggregate-page-metrics.ts >> logs/cron-page.log 2>&1
+   */15 * * * * cd /pfad/zum/repo && pnpm tsx scripts/cron/aggregate-session-metrics.ts >> logs/cron-session.log 2>&1
+   ```
+3. Jeder Job sendet nach erfolgreichem Lauf eine `server_analytics_update`-Notification. Der Realtime-Server muss deshalb parallel laufen (`pnpm start:proxy` oder `node realtime-server/src/server.js`).
+
+## Wichtige Environment-Variablen
+| Variable | Zweck |
+| --- | --- |
+| `DATABASE_URL` | Verbindung zu Postgres; notwendig für Aggregation, Caching und Notifications. |
+| `ANALYTICS_HTTP_WINDOW_MINUTES` / `ANALYTICS_HTTP_BUCKET_MINUTES` | Zeitfenster & Bucket-Größe für HTTP-Aggregationen (optional). |
+| `ANALYTICS_PAGE_WINDOW_DAYS` / `ANALYTICS_PAGE_RETENTION_DAYS` | Fenster und Aufbewahrung für Seitenkennzahlen. |
+| `ANALYTICS_SESSION_WINDOW_DAYS` / `ANALYTICS_SESSION_RETENTION_DAYS` | Fenster für Sessions & Realtime-Events. |
+| `NEXT_PUBLIC_REALTIME_URL` | Frontend-URL für Socket.io (Dev-Proxy z. B. `https://theater.local/realtime`). |
+| `REALTIME_AUTH_TOKEN` / `REALTIME_HANDSHAKE_SECRET` | Authentifizierung des Realtime-Servers. |
+
+> Ergänze neue Variablen stets in `.env.example` und dokumentiere Änderungen in den Deployment-Runbooks.
+
+## Caching & Fallback
+- `collectServerAnalytics` versucht bis zu drei Mal (`0ms`, `250ms`, `1000ms`) einen Live-Snapshot zu laden.
+- Bei Erfolg wird der Snapshot via `unstable_cache` gespeichert und als Quelle `live` markiert.
+- Schlägt die Aktualisierung fehl, liefert die Funktion die letzte erfolgreiche Messung (`source: "cached"`) inkl. `staleSince` und gesammelten Fehlergründen zurück.
+- Ist kein Cache verfügbar, werden statische Kennzahlen samt Fallback-Gründen ausgespielt (`source: "fallback"`).
+
+## Manuelle Tests & Dev-Proxy
+1. Lokale Umgebung starten: `pnpm start:proxy` (Next.js + Realtime + Proxy) oder alternativ `pnpm dev` für Turbopack.
+2. Im Browser `https://theater.local/mitglieder/server-analytics` aufrufen (Hostname via `/etc/hosts` oder Traefik konfigurieren).
+3. Zur Qualitätssicherung:
+   - Prüfen, ob das Dashboard beim Start einen Badge „Live“, „Cache“ oder „Fallback“ zeigt.
+   - Ein Cronjob/`pnpm tsx scripts/cron/...` manuell ausführen und auf ein Realtime-Update achten (`server_analytics_update` in DevTools).
+   - In Fallback-Szenarien sollten Tooltip & Badge klar auf den Grund hinweisen.
+4. Vor Commits `pnpm lint`, `pnpm test` und `pnpm build` ausführen; das Dashboard zusätzlich einmal im Proxy-Modus aufrufen.
+
+## Fehlersuche
+- **Keine Live-Daten:** Prüfen, ob Cronjobs laufen, Tabellen Daten enthalten und Notifications ankommen (`SELECT * FROM pg_listening_channels();`).
+- **Realtime-Updates kommen nicht an:** Überprüfen, ob `server_analytics_update` im Socket-Log erscheint und die Postgres-Verbindung im Realtime-Server steht (ENV & Netzwerk).
+- **Fallback ohne Reason:** Cache leeren (`pnpm next:cache:clear`) und auf Konsolenlogs achten (`[server-analytics]`).
+
+Weiterführende Informationen zu allgemeinen Proxy-/Entwicklungs-Setups siehe [`docs/dev-proxy.md`](./dev-proxy.md).

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "node-ical": "^0.21.0",
     "nodemailer": "^7.0.6",
     "pdfkit": "^0.17.2",
+    "pg": "^8.16.3",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
     "prisma": "6.16.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       pdfkit:
         specifier: ^0.17.2
         version: 0.17.2
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -3191,6 +3194,40 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3223,6 +3260,22 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   preact-render-to-string@5.2.6:
     resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
@@ -3547,6 +3600,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -3985,6 +4042,10 @@ packages:
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -6968,6 +7029,41 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  pg-cloudflare@1.2.7:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -6997,6 +7093,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   preact-render-to-string@5.2.6(preact@10.27.2):
     dependencies:
@@ -7435,6 +7541,8 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -7911,6 +8019,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
+
+  xtend@4.0.2: {}
 
   y18n@4.0.3: {}
 

--- a/realtime-server/src/__tests__/analytics-realtime.test.js
+++ b/realtime-server/src/__tests__/analytics-realtime.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { setTimeout as wait } from 'node:timers/promises';
+import { test } from 'node:test';
+
+import { createAnalyticsManager } from '../analytics.js';
+
+test('analytics manager handles bursts of external notifications', async () => {
+  const staticData = {
+    resourceUsage: [
+      {
+        id: 'cpu',
+        label: 'CPU',
+        usagePercent: 25,
+        changePercent: 0,
+        capacity: '2 cores',
+      },
+    ],
+    deviceBreakdown: [{ device: 'Desktop', sessions: 10, avgPageLoadMs: 500, share: 0.5 }],
+    publicPages: [{ path: '/home', title: 'Home', loadTimeMs: 1000 }],
+    memberPages: [{ path: '/members', title: 'Members', loadTimeMs: 900 }],
+  };
+
+  const emitter = new EventEmitter();
+  let refreshCalls = 0;
+
+  const manager = createAnalyticsManager({
+    logger: { warn: () => {}, error: () => {} },
+    intervalMs: 10_000,
+    maxAgeMs: 20_000,
+    loadStaticData: () => JSON.parse(JSON.stringify(staticData)),
+    collectResourceUsage: async () => {
+      refreshCalls += 1;
+      await wait(5);
+      return staticData.resourceUsage;
+    },
+    subscribeToExternalUpdates: (handler) => {
+      emitter.on('trigger', handler);
+      return {
+        async close() {
+          emitter.off('trigger', handler);
+        },
+      };
+    },
+  });
+
+  const emittedEvents = [];
+  const io = {
+    emit(event, payload) {
+      emittedEvents.push({ event, payload });
+    },
+  };
+
+  manager.start(io);
+  await wait(20);
+
+  const bursts = 50;
+  for (let index = 0; index < bursts; index += 1) {
+    emitter.emit('trigger', { job: 'test', index });
+  }
+
+  await wait(100);
+  manager.stop();
+
+  assert.ok(emittedEvents.length >= bursts);
+  assert.ok(emittedEvents.length <= bursts + 2);
+  assert.ok(refreshCalls <= bursts + 2);
+  assert.equal(manager.state.refreshPromise, null);
+
+  const lastEvent = emittedEvents.at(-1);
+  assert.ok(lastEvent);
+  assert.equal(lastEvent.event, 'server_analytics_update');
+  assert.equal(lastEvent.payload.type, 'server_analytics_update');
+  assert.equal(lastEvent.payload.analytics.metadata.source, 'fallback');
+  assert.equal(lastEvent.payload.analytics.metadata.attempts, 1);
+  assert.ok(Array.isArray(lastEvent.payload.analytics.metadata.fallbackReasons));
+  assert.ok(
+    lastEvent.payload.analytics.metadata.fallbackReasons.includes(
+      'DATABASE_URL ist nicht gesetzt – verwende statische Kennzahlen',
+    ),
+  );
+  assert.equal(typeof lastEvent.payload.analytics.summary.requestsLast24h, 'number');
+});

--- a/realtime-server/src/__tests__/analytics.test.js
+++ b/realtime-server/src/__tests__/analytics.test.js
@@ -40,6 +40,7 @@ test('analytics manager refreshes snapshots with fallback data', async () => {
       throw error;
     },
     getDatabaseUrl: () => null,
+    subscribeToExternalUpdates: () => null,
   });
 
   const firstSnapshot = await manager.refresh();
@@ -122,6 +123,7 @@ test('analytics manager merges database overrides when module is available', asy
       ],
     }),
     getDatabaseUrl: () => 'postgres://example',
+    subscribeToExternalUpdates: () => null,
   });
 
   const snapshot = await manager.refresh();

--- a/src/data/server-analytics-static.json
+++ b/src/data/server-analytics-static.json
@@ -3,10 +3,13 @@
     "uptimePercentage": 99.982,
     "requestsLast24h": 19284,
     "averageResponseTimeMs": 184,
+    "p95ResponseTimeMs": 412,
     "errorRate": 0.0035,
     "peakConcurrentUsers": 312,
     "cacheHitRate": 0.78,
-    "realtimeEventsLast24h": 4860
+    "realtimeEventsLast24h": 4860,
+    "slaTargetPercentage": 99.95,
+    "slaViolationMinutes": 6.3
   },
   "resourceUsage": [
     {

--- a/src/lib/__tests__/server-analytics.test.ts
+++ b/src/lib/__tests__/server-analytics.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const analyticsScenario = vi.hoisted(() => ({
+  useDatabase: true,
+  httpSummary: () => ({
+    windowStart: new Date("2024-01-01T00:00:00.000Z"),
+    windowEnd: new Date("2024-01-01T01:00:00.000Z"),
+    totalRequests: 2400,
+    successfulRequests: 2350,
+    clientErrorRequests: 30,
+    serverErrorRequests: 20,
+    averageDurationMs: 180,
+    p95DurationMs: 420,
+    averagePayloadBytes: 8192,
+    uptimePercentage: 99.96,
+    frontendRequests: 1200,
+    frontendAvgResponseMs: 150,
+    frontendAvgPayloadBytes: 4096,
+    membersRequests: 800,
+    membersAvgResponseMs: 190,
+    apiRequests: 400,
+    apiAvgResponseMs: 210,
+    apiErrorRate: 0.03,
+  }),
+  peakHours: () => [
+    {
+      bucketStart: new Date("2024-01-01T10:00:00.000Z"),
+      bucketEnd: new Date("2024-01-01T11:00:00.000Z"),
+      requests: 320,
+      share: 0.12,
+    },
+  ],
+  deviceOverrides: () => [
+    { device: "Desktop", sessions: 180, avgPageLoadMs: 540, share: 0.6 },
+    { device: "Mobile", sessions: 120, avgPageLoadMs: 680, share: 0.4 },
+  ],
+  pageMetrics: () => [
+    { path: "/", avgPageLoadMs: 980, lcpMs: 1300, scope: "public", weight: 200 },
+    {
+      path: "/mitglieder/dashboard",
+      avgPageLoadMs: 760,
+      lcpMs: 980,
+      scope: "members",
+      weight: 120,
+    },
+  ],
+  sessionInsights: () => [
+    {
+      segment: "Neu",
+      avgSessionDurationSeconds: 420,
+      pagesPerSession: 4.2,
+      retentionRate: 0.58,
+      share: 0.4,
+      conversionRate: 0.18,
+    },
+  ],
+  trafficSources: () => [
+    {
+      channel: "Direkt",
+      sessions: 420,
+      avgSessionDurationSeconds: 380,
+      conversionRate: 0.12,
+      changePercent: 0.05,
+    },
+  ],
+  realtimeSummary: () => ({
+    windowStart: new Date("2024-01-01T00:00:00.000Z"),
+    windowEnd: new Date("2024-01-02T00:00:00.000Z"),
+    totalEvents: 640,
+    eventCounts: { connect: 120, update: 520 },
+  }),
+  logs: () => [
+    {
+      id: "log-1",
+      severity: "warning" as const,
+      service: "Prisma",
+      message: "Pool exhausted",
+      description: "Connections at limit",
+      occurrences: 3,
+      firstSeen: new Date("2024-01-01T00:00:00.000Z"),
+      lastSeen: new Date("2024-01-01T01:30:00.000Z"),
+      status: "open" as const,
+      recommendedAction: "Scale pool",
+      affectedUsers: 4,
+      tags: ["DB", "Pool"],
+    },
+  ],
+}));
+
+const cacheState = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  failNext: false,
+}));
+
+vi.mock("next/cache", async () => {
+  const actual = await vi.importActual<typeof import("next/cache")>("next/cache");
+  return {
+    ...actual,
+    unstable_cache: <T extends (...args: never[]) => unknown>(fn: T, key: unknown) => {
+      const cacheKey = JSON.stringify(key);
+      return async (...args: Parameters<T>) => {
+        if (cacheState.failNext) {
+          cacheState.failNext = false;
+          throw new Error("cache unavailable");
+        }
+        if (cacheState.store.has(cacheKey)) {
+          return cacheState.store.get(cacheKey);
+        }
+        const result = await fn(...args);
+        cacheState.store.set(cacheKey, result);
+        return result;
+      };
+    },
+  };
+});
+
+vi.mock("node:timers/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:timers/promises")>("node:timers/promises");
+  return {
+    ...actual,
+    setTimeout: () => Promise.resolve(),
+  };
+});
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    cpus: () => [
+      { times: { user: 10, nice: 0, sys: 5, idle: 20, irq: 0 } },
+      { times: { user: 8, nice: 0, sys: 4, idle: 18, irq: 0 } },
+    ],
+    loadavg: () => [0.5, 0.4, 0.3],
+    totalmem: () => 16 * 1024 * 1024 * 1024,
+    freemem: () => 6 * 1024 * 1024 * 1024,
+  };
+});
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    statfs: vi.fn(async () => ({
+      bsize: 4096,
+      blocks: 500_000,
+      bavail: 200_000,
+      bfree: 200_000,
+      frsize: 4096,
+    })),
+  };
+});
+
+vi.mock("@/lib/analytics/load-server-logs", () => ({
+  loadLatestCriticalServerLogs: vi.fn(async () => {
+    if (!analyticsScenario.useDatabase) {
+      return [];
+    }
+    return analyticsScenario
+      .logs()
+      .map((log) => ({
+        ...log,
+        firstSeen: new Date(log.firstSeen),
+        lastSeen: new Date(log.lastSeen),
+        tags: Array.isArray(log.tags) ? [...log.tags] : [],
+      }));
+  }),
+}));
+
+vi.mock("@/lib/server-analytics-data", () => ({
+  loadDeviceBreakdownFromDatabase: vi.fn(async () => {
+    if (!analyticsScenario.useDatabase) {
+      return null;
+    }
+    return analyticsScenario.deviceOverrides().map((device) => ({ ...device }));
+  }),
+  loadPagePerformanceMetrics: vi.fn(async () => {
+    if (!analyticsScenario.useDatabase) {
+      return [];
+    }
+    return analyticsScenario.pageMetrics().map((metric) => ({ ...metric }));
+  }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    analyticsHttpSummary: {
+      findFirst: vi.fn(async () => (analyticsScenario.useDatabase ? { ...analyticsScenario.httpSummary() } : null)),
+    },
+    analyticsHttpPeakHour: {
+      findMany: vi.fn(async () => (analyticsScenario.useDatabase ? analyticsScenario.peakHours().map((hour) => ({ ...hour })) : [])),
+    },
+    analyticsSessionInsight: {
+      findMany: vi.fn(async () => (analyticsScenario.useDatabase ? analyticsScenario.sessionInsights().map((row) => ({ ...row })) : [])),
+    },
+    analyticsTrafficSource: {
+      findMany: vi.fn(async () => (analyticsScenario.useDatabase ? analyticsScenario.trafficSources().map((row) => ({ ...row })) : [])),
+    },
+    analyticsRealtimeSummary: {
+      findFirst: vi.fn(async () => (analyticsScenario.useDatabase ? { ...analyticsScenario.realtimeSummary() } : null)),
+    },
+  },
+}));
+
+describe("collectServerAnalytics", () => {
+  const originalDatabaseUrl = process.env.DATABASE_URL;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cacheState.store.clear();
+    cacheState.failNext = false;
+    analyticsScenario.useDatabase = true;
+    process.env.DATABASE_URL = "postgres://example.test";
+    vi.resetModules();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env.DATABASE_URL = originalDatabaseUrl;
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("returns live analytics when database data is available", async () => {
+    const { collectServerAnalytics } = await import("@/lib/server-analytics");
+
+    const snapshot = await collectServerAnalytics();
+
+    expect(snapshot.metadata.source).toBe("live");
+    expect(snapshot.metadata.attempts).toBe(1);
+    expect(snapshot.summary.requestsLast24h).toBe(analyticsScenario.httpSummary().totalRequests);
+    expect(snapshot.metadata.fallbackReasons).toBeUndefined();
+  });
+
+  it("serves cached analytics when the database falls back after a successful run", async () => {
+    const { collectServerAnalytics } = await import("@/lib/server-analytics");
+
+    const liveSnapshot = await collectServerAnalytics();
+    expect(liveSnapshot.metadata.source).toBe("live");
+
+    cacheState.store.clear();
+    analyticsScenario.useDatabase = false;
+
+    const cachedSnapshot = await collectServerAnalytics();
+
+    expect(cachedSnapshot.metadata.source).toBe("cached");
+    expect(cachedSnapshot.metadata.attempts).toBeGreaterThan(1);
+    expect(cachedSnapshot.metadata.staleSince).toBeDefined();
+    expect(cachedSnapshot.summary.requestsLast24h).toBe(liveSnapshot.summary.requestsLast24h);
+    expect(cachedSnapshot.metadata.fallbackReasons).toEqual(
+      expect.arrayContaining([
+        "Datenbank lieferte keine Live-Kennzahlen – verwende letzten bekannten Stand",
+      ]),
+    );
+  });
+
+  it("falls back to static analytics when no cached snapshot is available", async () => {
+    analyticsScenario.useDatabase = false;
+    cacheState.store.clear();
+
+    const { collectServerAnalytics } = await import("@/lib/server-analytics");
+
+    const snapshot = await collectServerAnalytics();
+
+    expect(snapshot.metadata.source).toBe("fallback");
+    expect(snapshot.metadata.attempts).toBeGreaterThan(1);
+    expect(snapshot.metadata.fallbackReasons?.length ?? 0).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/tickets/__tests__/service.test.ts
+++ b/src/lib/tickets/__tests__/service.test.ts
@@ -7,7 +7,11 @@ import {
   serializeTicketForPayload,
   TicketCheckInError,
 } from "@/lib/tickets/service";
-import { TicketStatus } from "@prisma/client";
+
+const TICKET_STATUS = {
+  checked_in: "checked_in",
+  unused: "unused",
+} as const;
 
 describe("ticket service helpers", () => {
   it("normalizes missing occurredAt to a current timestamp", () => {
@@ -36,7 +40,7 @@ describe("ticket service helpers", () => {
     const ticket = {
       id: "ticket-1",
       code: "CODE-1",
-      status: TicketStatus.checked_in,
+      status: TICKET_STATUS.checked_in,
       eventId: "event-1",
       holderName: null,
       createdAt: new Date("2024-12-31T12:00:00.000Z"),
@@ -46,7 +50,7 @@ describe("ticket service helpers", () => {
     expect(serializeTicketForPayload(ticket)).toEqual({
       id: "ticket-1",
       code: "CODE-1",
-      status: TicketStatus.checked_in,
+      status: TICKET_STATUS.checked_in,
       eventId: "event-1",
       updatedAt: updatedAt.toISOString(),
     });
@@ -58,8 +62,8 @@ describe("ticket service helpers", () => {
       id: "scan-1",
       ticketId: "ticket-1",
       code: "CODE-1",
-      statusBefore: TicketStatus.unused,
-      statusAfter: TicketStatus.checked_in,
+      statusBefore: TICKET_STATUS.unused,
+      statusAfter: TICKET_STATUS.checked_in,
       source: null,
       occurredAt,
       dedupeKey: null,
@@ -76,8 +80,8 @@ describe("ticket service helpers", () => {
       id: "scan-1",
       ticketId: "ticket-1",
       code: "CODE-1",
-      statusBefore: TicketStatus.unused,
-      statusAfter: TicketStatus.checked_in,
+      statusBefore: TICKET_STATUS.unused,
+      statusAfter: TICKET_STATUS.checked_in,
       occurredAt: occurredAt.toISOString(),
       provisional: false,
     });
@@ -90,8 +94,8 @@ describe("ticket service helpers", () => {
       id: "scan-2",
       ticketId: "ticket-2",
       code: "CODE-2",
-      statusBefore: TicketStatus.unused,
-      statusAfter: TicketStatus.checked_in,
+      statusBefore: TICKET_STATUS.unused,
+      statusAfter: TICKET_STATUS.checked_in,
       source: "scanner",
       occurredAt,
       dedupeKey: "ticket:ticket-2",
@@ -108,8 +112,8 @@ describe("ticket service helpers", () => {
       id: "scan-2",
       ticketId: "ticket-2",
       code: "CODE-2",
-      statusBefore: TicketStatus.unused,
-      statusAfter: TicketStatus.checked_in,
+      statusBefore: TICKET_STATUS.unused,
+      statusAfter: TICKET_STATUS.checked_in,
       occurredAt: occurredAt.toISOString(),
       provisional: false,
       processedAt: processedAt.toISOString(),


### PR DESCRIPTION
## Summary
- add caching, retry metadata and SLA metrics to `collectServerAnalytics`
- broadcast analytics updates from cron jobs via Postgres NOTIFY and enhance realtime listener
- surface new UI badges/trends, add docs, and cover new flows with tests

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3c820f378832d9fba5bbca8f680dc