### PR TITLE
Fix onboarding invite PDF generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "date-fns": "^4.1.0",
     "dexie": "4.0.4",
     "dexie-observable": "4.0.1-beta.13",
+    "fontkit": "^2.0.4",
     "geist": "^1.5.1",
     "http-proxy": "^1.18.1",
     "idb-keyval": "^6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       dexie-observable:
         specifier: 4.0.1-beta.13
         version: 4.0.1-beta.13(dexie@4.0.4)
+      fontkit:
+        specifier: ^2.0.4
+        version: 2.0.4
       geist:
         specifier: ^1.5.1
         version: 1.5.1(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))

--- a/src/lib/pdf/fonts.ts
+++ b/src/lib/pdf/fonts.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 const FONT_DEFINITIONS: ReadonlyArray<{ id: string; file: string }> = [
@@ -8,13 +8,75 @@ const FONT_DEFINITIONS: ReadonlyArray<{ id: string; file: string }> = [
 
 const FONT_DIRECTORY = path.join(process.cwd(), "public", "fonts", "pdf");
 
+const FONT_SIGNATURES = new Set<number>([
+  0x00010000, // TrueType
+  0x4f54544f, // OpenType ("OTTO")
+  0x74746366, // TrueType Collection ("ttcf")
+  0x74727565, // legacy Apple TrueType ("true")
+  0x74797031, // Type 1 in sfnt wrapper ("typ1")
+]);
+
+const fontSupportCache = new Map<string, boolean>();
+const missingFontWarnings = new Set<string>();
+const unsupportedFontWarnings = new Set<string>();
+const registrationFailureWarnings = new Set<string>();
+
+function hasSupportedSignature(absolutePath: string): boolean {
+  const cached = fontSupportCache.get(absolutePath);
+  if (typeof cached === "boolean") {
+    return cached;
+  }
+
+  let supported = false;
+  try {
+    const buffer = readFileSync(absolutePath);
+    if (buffer.length >= 4) {
+      const signature = buffer.readUInt32BE(0);
+      supported = FONT_SIGNATURES.has(signature);
+    }
+  } catch {
+    supported = false;
+  }
+
+  fontSupportCache.set(absolutePath, supported);
+  return supported;
+}
+
 export function registerDefaultPdfFonts(doc: PDFKit.PDFDocument) {
   for (const { id, file } of FONT_DEFINITIONS) {
     const absolutePath = path.join(FONT_DIRECTORY, file);
+
     if (!existsSync(absolutePath)) {
-      throw new Error(`PDF font asset missing: ${absolutePath}`);
+      if (!missingFontWarnings.has(absolutePath)) {
+        missingFontWarnings.add(absolutePath);
+        console.warn(
+          `[pdf] Schriftart ${file} (${absolutePath}) wurde nicht gefunden. Verwende Standard-PDFKit-Schriften.`,
+        );
+      }
+      continue;
     }
 
-    doc.registerFont(id, absolutePath);
+    if (!hasSupportedSignature(absolutePath)) {
+      if (!unsupportedFontWarnings.has(absolutePath)) {
+        unsupportedFontWarnings.add(absolutePath);
+        console.warn(
+          `[pdf] Schriftart ${file} (${absolutePath}) hat ein nicht unterstütztes Format. Verwende Standard-PDFKit-Schriften.`,
+        );
+      }
+      continue;
+    }
+
+    try {
+      doc.registerFont(id, absolutePath);
+    } catch (error) {
+      const key = `${id}:${absolutePath}`;
+      if (!registrationFailureWarnings.has(key)) {
+        registrationFailureWarnings.add(key);
+        console.warn(
+          `[pdf] Schriftart ${file} (${absolutePath}) konnte nicht registriert werden. Verwende Standard-PDFKit-Schriften.`,
+          error,
+        );
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- install `fontkit` so PDFKit can load custom fonts when available
- harden the PDF font registration helper to validate assets, warn once on issues, and fall back to built-in fonts

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3eaa9a4e4832da35cab8835f8cc09