### PR TITLE
Add PWA manifest and service worker

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,37 @@
+{
+  "name": "Sommertheater Scan",
+  "short_name": "Scan",
+  "description": "Offlinefähiger QR-Scanner und Synchronisationshelfer für das Sommertheater.",
+  "id": "/scan",
+  "start_url": "/scan",
+  "scope": "/",
+  "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone"],
+  "lang": "de-DE",
+  "dir": "ltr",
+  "orientation": "portrait-primary",
+  "background_color": "#f8fafc",
+  "theme_color": "#0f172a",
+  "categories": ["productivity", "business", "utilities"],
+  "prefer_related_applications": false,
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "48x48",
+      "type": "image/x-icon",
+      "purpose": "any"
+    },
+    {
+      "src": "/globe.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/window.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,89 @@
+/* global workbox */
+importScripts("https://storage.googleapis.com/workbox-cdn/releases/7.1.0/workbox-sw.js");
+
+if (workbox) {
+  const { precaching, routing, strategies, backgroundSync, core } = workbox;
+
+  const OFFLINE_QUEUE_NAME = "offline-events";
+  const OFFLINE_SYNC_TAG = `workbox-background-sync:${OFFLINE_QUEUE_NAME}`;
+
+  const broadcastMessage = async (message) => {
+    const clients = await self.clients.matchAll({
+      includeUncontrolled: true,
+      type: "window",
+    });
+
+    for (const client of clients) {
+      client.postMessage(message);
+    }
+  };
+
+  const replayQueue = async (queue) => {
+    try {
+      await queue.replayRequests();
+      await broadcastMessage({ type: "offline-events:flushed" });
+    } catch (error) {
+      const details = error instanceof Error ? error.message : String(error);
+      await broadcastMessage({ type: "offline-events:error", message: details });
+      throw error;
+    }
+  };
+
+  core.skipWaiting();
+  core.clientsClaim();
+
+  precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+
+  const syncPlugin = new backgroundSync.BackgroundSyncPlugin(OFFLINE_QUEUE_NAME, {
+    maxRetentionTime: 24 * 60,
+    onSync: async ({ queue }) => replayQueue(queue),
+  });
+
+  const offlineQueue = syncPlugin._queue;
+
+  routing.registerRoute(
+    ({ request, url }) =>
+      request.method === "GET" && url.pathname.startsWith("/api/sync"),
+    new strategies.NetworkFirst({
+      cacheName: "sync-api-cache",
+      networkTimeoutSeconds: 10,
+    }),
+    "GET",
+  );
+
+  routing.registerRoute(
+    ({ url }) => url.pathname.startsWith("/api/sync"),
+    new strategies.NetworkOnly({
+      plugins: [syncPlugin],
+    }),
+    "POST",
+  );
+
+  routing.registerRoute(
+    ({ request, url }) =>
+      url.origin === self.location.origin &&
+      ["style", "script", "font", "image"].includes(request.destination),
+    new strategies.StaleWhileRevalidate({
+      cacheName: "static-assets",
+    }),
+  );
+
+  self.addEventListener("message", (event) => {
+    const { data } = event;
+
+    if (!data || typeof data !== "object") {
+      return;
+    }
+
+    if (data.type === "SKIP_WAITING") {
+      self.skipWaiting();
+      return;
+    }
+
+    if (data.type === OFFLINE_SYNC_TAG && offlineQueue) {
+      event.waitUntil(replayQueue(offlineQueue));
+    }
+  });
+} else {
+  console.error("Workbox failed to load. Offline support is disabled.");
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,11 +17,13 @@ import { authOptions } from "@/lib/auth";
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXTAUTH_URL || "http://localhost:3000"),
+  applicationName: "Sommertheater Scan",
   title: {
     default: DEFAULT_SITE_TITLE,
     template: "%s | Sommertheater",
   },
   description: "Mystische Bühne unter freiem Himmel",
+  manifest: "/manifest.json",
   alternates: {
     canonical: "/",
   },

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -9,6 +9,7 @@ import { useWebVitals } from "@/hooks/useWebVitals";
 import { RealtimeProvider } from "@/hooks/useRealtime";
 import { OfflineSyncStatusProvider } from "@/lib/offline/hooks";
 import { OfflineSyncProvider as OfflineStorageProvider } from "@/lib/offline/storage";
+import { PwaProvider } from "@/lib/pwa/register-sw";
 
 function WebVitalsInitializer({ analyticsSessionId }: { analyticsSessionId?: string | null }) {
   useWebVitals({ analyticsSessionId });
@@ -29,18 +30,20 @@ export function Providers({
       <QueryClientProvider client={client}>
         <OfflineStorageProvider>
           <OfflineSyncStatusProvider>
-            <RealtimeProvider>
-              <FrontendEditingProvider>
-                {children}
-                <Toaster
-                  richColors
-                  position="top-right"
-                  expand={true}
-                  visibleToasts={5}
-                  gap={8}
-                />
-              </FrontendEditingProvider>
-            </RealtimeProvider>
+            <PwaProvider>
+              <RealtimeProvider>
+                <FrontendEditingProvider>
+                  {children}
+                  <Toaster
+                    richColors
+                    position="top-right"
+                    expand={true}
+                    visibleToasts={5}
+                    gap={8}
+                  />
+                </FrontendEditingProvider>
+              </RealtimeProvider>
+            </PwaProvider>
           </OfflineSyncStatusProvider>
         </OfflineStorageProvider>
       </QueryClientProvider>

--- a/src/lib/offline/sync-client.ts
+++ b/src/lib/offline/sync-client.ts
@@ -23,7 +23,7 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_FLUSH_LIMIT = 50;
 const BASE_BACKOFF_MS = 400;
 const MAX_BACKOFF_MS = 10_000;
-const BACKGROUND_SYNC_TAG = "sync:offline-events";
+const BACKGROUND_SYNC_TAG = "workbox-background-sync:offline-events";
 const CLIENT_ID_STORAGE_KEY = "offline.sync.clientId";
 
 export type SyncActivity =

--- a/src/lib/pwa/register-sw.ts
+++ b/src/lib/pwa/register-sw.ts
@@ -1,0 +1,199 @@
+"use client";
+
+import * as React from "react";
+import { Workbox } from "workbox-window";
+import { toast } from "sonner";
+
+import { useOfflineSyncClient } from "@/lib/offline/hooks";
+import type { OfflineScope } from "@/lib/offline/types";
+
+const SERVICE_WORKER_URL = "/service-worker.js";
+const OFFLINE_SYNC_TAG = "workbox-background-sync:offline-events";
+const OFFLINE_SCOPES: OfflineScope[] = ["inventory", "tickets"];
+
+type BeforeInstallPromptEvent = Event & {
+  readonly platforms?: string[];
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+  prompt: () => Promise<void>;
+};
+
+async function flushAllScopes(
+  flush: (scope: OfflineScope) => Promise<unknown>,
+  scopes: OfflineScope[],
+) {
+  await Promise.all(
+    scopes.map((scope) =>
+      flush(scope).catch((error) => {
+        console.warn(`Failed to flush offline scope ${scope}`, error);
+      }),
+    ),
+  );
+}
+
+export function PwaProvider({ children }: { children: React.ReactNode }) {
+  const { flush } = useOfflineSyncClient();
+  const deferredPrompt = React.useRef<BeforeInstallPromptEvent | null>(null);
+  const installToastId = React.useRef<string | number | null>(null);
+  const updateToastId = React.useRef<string | number | null>(null);
+
+  const requestFlush = React.useCallback(() => {
+    void flushAllScopes(flush, OFFLINE_SCOPES);
+  }, [flush]);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+      return;
+    }
+
+    let wb: Workbox | null = null;
+    let isMounted = true;
+
+    const handleServiceWorkerMessage = (event: MessageEvent) => {
+      const { data } = event;
+
+      if (!data || typeof data !== "object") {
+        return;
+      }
+
+      if (data.type === "offline-events:flushed") {
+        toast.success("Offline-Änderungen wurden synchronisiert.");
+        requestFlush();
+      } else if (data.type === "offline-events:error") {
+        const message =
+          typeof data.message === "string"
+            ? data.message
+            : "Offline-Änderungen konnten nicht synchronisiert werden.";
+        toast.error(message);
+      }
+    };
+
+    navigator.serviceWorker.addEventListener("message", handleServiceWorkerMessage);
+
+    const registerWorker = async () => {
+      try {
+        wb = new Workbox(SERVICE_WORKER_URL);
+
+        const activateUpdate = () => {
+          if (!wb) {
+            return;
+          }
+
+          void wb
+            .messageSW({ type: "SKIP_WAITING" })
+            .catch((error) =>
+              console.error("Failed to activate new service worker", error),
+            );
+        };
+
+        wb.addEventListener("waiting", () => {
+          if (updateToastId.current) {
+            toast.dismiss(updateToastId.current);
+          }
+
+          updateToastId.current = toast("Update verfügbar", {
+            description: "Eine neue Version der App steht bereit.",
+            action: {
+              label: "Aktualisieren",
+              onClick: activateUpdate,
+            },
+          });
+        });
+
+        wb.addEventListener("controlling", () => {
+          if (updateToastId.current) {
+            toast.dismiss(updateToastId.current);
+            updateToastId.current = null;
+          }
+
+          window.location.reload();
+        });
+
+        wb.addEventListener("message", (event) => {
+          handleServiceWorkerMessage(event as unknown as MessageEvent);
+        });
+
+        await wb.register();
+      } catch (error) {
+        console.error("Service Worker registration failed", error);
+        if (isMounted) {
+          toast.error("Service Worker konnte nicht registriert werden.");
+        }
+      }
+    };
+
+    void registerWorker();
+
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      const promptEvent = event as BeforeInstallPromptEvent;
+      deferredPrompt.current = promptEvent;
+
+      if (installToastId.current) {
+        toast.dismiss(installToastId.current);
+      }
+
+      installToastId.current = toast("App installieren?", {
+        description: "Lege den Scanner auf deinem Gerät ab.",
+        duration: 10000,
+        action: {
+          label: "Installieren",
+          onClick: async () => {
+            try {
+              await promptEvent.prompt();
+              const choice = await promptEvent.userChoice;
+              if (choice.outcome !== "accepted") {
+                toast.info("Installation abgebrochen.");
+              }
+            } catch (installError) {
+              console.error("Installation prompt failed", installError);
+            } finally {
+              deferredPrompt.current = null;
+              if (installToastId.current) {
+                toast.dismiss(installToastId.current);
+                installToastId.current = null;
+              }
+            }
+          },
+        },
+      });
+    };
+
+    const handleAppInstalled = () => {
+      deferredPrompt.current = null;
+      if (installToastId.current) {
+        toast.dismiss(installToastId.current);
+        installToastId.current = null;
+      }
+      toast.success("App erfolgreich installiert.");
+    };
+
+    const handleOnline = () => {
+      if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: OFFLINE_SYNC_TAG });
+      }
+      requestFlush();
+    };
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    window.addEventListener("appinstalled", handleAppInstalled);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      isMounted = false;
+      navigator.serviceWorker.removeEventListener("message", handleServiceWorkerMessage);
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+      window.removeEventListener("appinstalled", handleAppInstalled);
+      window.removeEventListener("online", handleOnline);
+      if (updateToastId.current) {
+        toast.dismiss(updateToastId.current);
+        updateToastId.current = null;
+      }
+      if (installToastId.current) {
+        toast.dismiss(installToastId.current);
+        installToastId.current = null;
+      }
+    };
+  }, [requestFlush]);
+
+  return React.createElement(React.Fragment, null, children);
+}


### PR DESCRIPTION
## Summary
- add a web manifest configured for the scanner experience, offline-friendly categories, and existing icon assets
- ship a Workbox-powered service worker that precaches assets, caches /api/sync requests, and replays the offline-events background sync queue
- register the service worker via a new client-side PwaProvider, surface install/update toasts, and expose the manifest from the root layout metadata

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d3ea01225c832db43946e1885b615d