### PR TITLE
Fix Next 15 route params for production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "predev": "node scripts/run-prisma-migrate.mjs",
     "dev": "next dev --turbopack",
     "prebuild": "pnpm prisma:generate",
-    "build": "next build --turbopack",
+    "build": "next build",
     "prestart": "node scripts/run-prisma-migrate.mjs",
     "postinstall": "node -e \"if(!process.env.SKIP_PRISMA_POSTINSTALL){require('child_process').execSync('pnpm prisma:generate',{stdio:'inherit'})}\"",
     "start": "next start",

--- a/src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx
+++ b/src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx
@@ -12,9 +12,14 @@ import { GalleryMediaType } from "@prisma/client";
 import { getGalleryYearDescription, isValidGalleryYear } from "@/lib/gallery";
 import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 
-export default async function ArchiveYearPage({ params }: { params: { year: string } }) {
+export default async function ArchiveYearPage({
+  params,
+}: {
+  params: Promise<{ year: string }>;
+}) {
+  const resolvedParams = await params;
+  const yearParam = resolvedParams?.year ?? "";
   const session = await requireAuth();
-  const yearParam = params.year ?? "";
   const year = Number.parseInt(yearParam, 10);
 
   if (!isValidGalleryYear(year)) {

--- a/src/app/(members)/mitglieder/finanzen/[[...section]]/page.tsx
+++ b/src/app/(members)/mitglieder/finanzen/[[...section]]/page.tsx
@@ -19,11 +19,12 @@ const DEFAULT_STATUS_FILTER: FinanceEntryStatus[] = ["draft", "pending", "approv
 const VALID_SECTIONS = new Set(["dashboard", "buchungen", "budgets", "export"]);
 
 interface PageProps {
-  params: { section?: string[] };
+  params: Promise<{ section?: string[] }>;
 }
 
 export default async function FinancePage({ params }: PageProps) {
   const session = await requireAuth();
+  const resolvedParams = await params;
   const [canView, canManage, canApprove, canExport] = await Promise.all([
     hasPermission(session.user, "mitglieder.finanzen"),
     hasPermission(session.user, "mitglieder.finanzen.manage"),
@@ -43,7 +44,7 @@ export default async function FinancePage({ params }: PageProps) {
   }
 
   const allowedScopes = resolveAllowedVisibilityScopes(session.user, canApprove);
-  const requestedSection = params.section?.[0] ?? "dashboard";
+  const requestedSection = resolvedParams?.section?.[0] ?? "dashboard";
   const activeSection = VALID_SECTIONS.has(requestedSection)
     ? (requestedSection as "dashboard" | "buchungen" | "budgets" | "export")
     : "dashboard";

--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -24,7 +24,7 @@ import { DepartmentCard, type DepartmentMeasurementsByUser } from "../department
 
 type SummaryStat = { label: string; value: number; hint?: string; icon: LucideIcon };
 
-type PageProps = { params: { slug: string } };
+type PageProps = { params: Promise<{ slug: string }> };
 
 export default async function GewerkDetailPage({ params }: PageProps) {
   const session = await requireAuth();
@@ -48,7 +48,13 @@ export default async function GewerkDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  const slug = decodeURIComponent(params.slug);
+  const resolvedParams = await params;
+  const rawSlug = resolvedParams?.slug;
+  if (!rawSlug) {
+    notFound();
+  }
+
+  const slug = decodeURIComponent(rawSlug);
 
   const membershipRaw = await prisma.departmentMembership.findFirst({
     where: { userId, department: { slug } },

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -195,7 +195,7 @@ function formatRelativeTime(value: Date | null | undefined) {
   return formatRelativeFromNow(value);
 }
 
-type PageProps = { params: { userId: string | string[] } };
+type PageProps = { params: Promise<{ userId: string | string[] }> };
 
 type ActivityStatCardProps = {
   label: string;
@@ -279,8 +279,13 @@ export default async function MemberProfileAdminPage({ params }: PageProps) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die Mitgliederprofile.</div>;
   }
 
-  const userIdParam = params.userId;
+  const resolvedParams = await params;
+  const userIdParam = resolvedParams?.userId;
   const userId = Array.isArray(userIdParam) ? userIdParam[0] : userIdParam;
+  if (!userId) {
+    notFound();
+  }
+
   const decodedId = decodeURIComponent(userId);
 
   const member = await prisma.user.findUnique({

--- a/src/app/(members)/mitglieder/mystery/tipps/page.tsx
+++ b/src/app/(members)/mitglieder/mystery/tipps/page.tsx
@@ -7,7 +7,7 @@ import { requireAuth } from "@/lib/rbac";
 export default async function MysteryTipsAdminPage({
   searchParams,
 }: {
-  searchParams?: { clue?: string };
+  searchParams?: Promise<{ clue?: string }>;
 }) {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.mystery.tips");
@@ -42,8 +42,12 @@ export default async function MysteryTipsAdminPage({
     published: clue.published,
   }));
 
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const availableClueIds = new Set(clues.map((clue) => clue.id));
-  let selectedClueId = searchParams?.clue && availableClueIds.has(searchParams.clue) ? searchParams.clue : null;
+  let selectedClueId =
+    resolvedSearchParams?.clue && availableClueIds.has(resolvedSearchParams.clue)
+      ? resolvedSearchParams.clue
+      : null;
   if (!selectedClueId && clues.length > 0) {
     selectedClueId = clues[0].id;
   }

--- a/src/app/(members)/mitglieder/proben/[rehearsalId]/page.tsx
+++ b/src/app/(members)/mitglieder/proben/[rehearsalId]/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import sanitizeHtml from "sanitize-html";
 
 import { PageHeader } from "@/components/members/page-header";
@@ -56,7 +57,11 @@ function displayName(user?: DisplayUser | null) {
   return getUserDisplayName(user, "Unbekannt");
 }
 
-export default async function RehearsalDetailPage({ params }: { params: { rehearsalId: string } }) {
+export default async function RehearsalDetailPage({
+  params,
+}: {
+  params: Promise<{ rehearsalId: string }>;
+}) {
   const session = await requireAuth();
   const [canViewOwn, canPlan] = await Promise.all([
     hasPermission(session.user, "mitglieder.meine-proben"),
@@ -67,8 +72,14 @@ export default async function RehearsalDetailPage({ params }: { params: { rehear
     return <div className="text-sm text-red-600">Kein Zugriff auf die Probenansicht.</div>;
   }
 
+  const resolvedParams = await params;
+  const rehearsalId = resolvedParams?.rehearsalId;
+  if (!rehearsalId) {
+    notFound();
+  }
+
   const rehearsal = await prisma.rehearsal.findUnique({
-    where: { id: params.rehearsalId },
+    where: { id: rehearsalId },
     include: {
       invitees: {
         include: {

--- a/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
@@ -16,15 +16,25 @@ type MemberOption = {
   extraRoles: string[];
 };
 
-export default async function RehearsalEditorPage({ params }: { params: { rehearsalId: string } }) {
+export default async function RehearsalEditorPage({
+  params,
+}: {
+  params: Promise<{ rehearsalId: string }>;
+}) {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.probenplanung");
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die Probenplanung</div>;
   }
 
+  const resolvedParams = await params;
+  const rehearsalId = resolvedParams?.rehearsalId;
+  if (!rehearsalId) {
+    notFound();
+  }
+
   const rehearsal = await prisma.rehearsal.findUnique({
-    where: { id: params.rehearsalId },
+    where: { id: rehearsalId },
     include: {
       invitees: { select: { userId: true } },
     },

--- a/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
@@ -44,7 +44,7 @@ const selectClassName =
 const subtleSurfaceClassName =
   "rounded-2xl border border-border/60 bg-background/80 shadow-inner";
 
-type PageProps = { params: { departmentId: string } };
+type PageProps = { params: Promise<{ departmentId: string }> };
 
 type SummaryStat = { label: string; value: number; hint?: string; icon: LucideIcon };
 
@@ -86,7 +86,13 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
     );
   }
 
-  const department = (await loadDepartmentWithRelations(params.departmentId)) as DepartmentWithRelations | null;
+  const resolvedParams = await params;
+  const departmentId = resolvedParams?.departmentId;
+  if (!departmentId) {
+    notFound();
+  }
+
+  const department = (await loadDepartmentWithRelations(departmentId)) as DepartmentWithRelations | null;
   if (!department) {
     notFound();
   }

--- a/src/app/(site)/chronik/[showId]/page.tsx
+++ b/src/app/(site)/chronik/[showId]/page.tsx
@@ -12,10 +12,12 @@ import { formatChronikPlayerName } from "../formatters";
 import type { ChronikCastEntry, ChronikMeta } from "../types";
 import { ChronikPerformanceDatesCard } from "../performance-dates-card";
 
+type ChronikDetailPageParams = {
+  showId: string;
+};
+
 type ChronikDetailPageProps = {
-  params: {
-    showId: string;
-  };
+  params: Promise<ChronikDetailPageParams>;
 };
 
 function buildPrimaryDetails(meta: ChronikMeta | null) {
@@ -50,7 +52,17 @@ function sanitizeCast(meta: ChronikMeta | null) {
 }
 
 export async function generateMetadata({ params }: ChronikDetailPageProps): Promise<Metadata> {
-  const item = await getChronikItem(params.showId);
+  const resolvedParams = await params;
+  const showId = resolvedParams?.showId;
+
+  if (!showId) {
+    return {
+      title: "Chronik-Eintrag nicht gefunden",
+      description: "Der angeforderte Eintrag ist in unserer Chronik nicht verfügbar.",
+    };
+  }
+
+  const item = await getChronikItem(showId);
 
   if (!item) {
     return {
@@ -68,7 +80,13 @@ export async function generateMetadata({ params }: ChronikDetailPageProps): Prom
 }
 
 export default async function ChronikDetailPage({ params }: ChronikDetailPageProps) {
-  const item = await getChronikItem(params.showId);
+  const resolvedParams = await params;
+  const showId = resolvedParams?.showId;
+  if (!showId) {
+    notFound();
+  }
+
+  const item = await getChronikItem(showId);
 
   if (!item) {
     notFound();

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -6,8 +6,13 @@ import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
 
 export const dynamic = "force-dynamic";
 
-export default async function OnboardingInvitePage({ params }: { params: { token: string } }) {
-  const rawToken = params.token;
+export default async function OnboardingInvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const resolvedParams = await params;
+  const rawToken = resolvedParams?.token;
   if (!rawToken || typeof rawToken !== "string" || rawToken.length < 10) {
     notFound();
   }

--- a/src/app/setup/owner/[token]/page.tsx
+++ b/src/app/setup/owner/[token]/page.tsx
@@ -14,11 +14,12 @@ export const metadata: Metadata = {
 };
 
 interface OwnerSetupPageProps {
-  params: { token?: string };
+  params: Promise<{ token?: string }>;
 }
 
 export default async function OwnerSetupPage({ params }: OwnerSetupPageProps) {
-  const token = typeof params?.token === "string" ? params.token.trim() : "";
+  const resolvedParams = await params;
+  const token = typeof resolvedParams?.token === "string" ? resolvedParams.token.trim() : "";
 
   if (!token) {
     return <InvalidToken message="Dieser Link ist ungültig." />;


### PR DESCRIPTION
## Summary
- switch the production build script back to `next build` so the webpack manifest includes data routes and `next start` works again
- update dynamic route pages to accept `Promise`-typed `params`/`searchParams`, await them before use, and guard against missing values
- ensure optional route parameters are decoded safely before database access

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build
- pnpm start
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68d3f53dfa08832d8b18849aa763db10