### PR TITLE
Add realtime admin sync events and offline integration

### DIFF
--- a/src/lib/realtime/event-client.ts
+++ b/src/lib/realtime/event-client.ts
@@ -9,6 +9,17 @@ function resolveEventUrl() {
   return `${base}${path}`;
 }
 
+/**
+ * Emits a realtime event to the standalone Socket.io bridge.
+ *
+ * Supported admin sync events include:
+ * - `inventory_event`: broadcast inventory deltas (expects `{ scope: 'inventory', serverSeq, events, delta }`).
+ * - `ticket_scan_event`: broadcast ticket scan deltas (expects `{ scope: 'tickets', serverSeq, events, delta }`).
+ *
+ * The payload for these events should mirror the response from the sync API so
+ * connected scanner clients can immediately apply the mutation to Dexie without
+ * waiting for the next poll.
+ */
 export async function emitRealtimeEvent(eventType: string, payload: unknown): Promise<void> {
   if (!eventType) {
     console.warn('[RealtimeTriggers] Missing event type');

--- a/src/lib/realtime/service.ts
+++ b/src/lib/realtime/service.ts
@@ -6,6 +6,8 @@ import { trackPresenceEvent } from "@/lib/realtime/presence";
 import {
   ClientToServerEvents,
   InterServerEvents,
+  InventoryRealtimeEvent,
+  InventoryRealtimePayload,
   NotificationCreatedEvent,
   OnlineStatsSnapshot,
   RealtimeEvent,
@@ -13,6 +15,8 @@ import {
   RoomType,
   ServerToClientEvents,
   SocketData,
+  TicketRealtimePayload,
+  TicketScanRealtimeEvent,
   UserPresenceEvent,
   UserJoinedEvent,
   UserLeftEvent,
@@ -498,6 +502,37 @@ export class RealtimeService {
     io.to(`user_${event.targetUserId}`).emit("notification_created", fullEvent);
 
     console.log(`[Realtime] sent notification to user ${event.targetUserId}`);
+  }
+
+  public broadcastInventoryEvent(payload: InventoryRealtimePayload): void {
+    const io = this.io;
+    if (!io) return;
+
+    const event: InventoryRealtimeEvent = {
+      type: "inventory_event",
+      payload,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.broadcast(event, "global");
+  }
+
+  public broadcastTicketScanEvent(payload: TicketRealtimePayload): void {
+    const io = this.io;
+    if (!io) return;
+
+    const event: TicketScanRealtimeEvent = {
+      type: "ticket_scan_event",
+      payload,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.broadcast(event, "global");
+
+    const showId = typeof payload.showId === "string" ? payload.showId.trim() : "";
+    if (showId) {
+      this.broadcast(event, `show_${showId}` as RoomType);
+    }
   }
 
   private getOnlineStatsSnapshot(): OnlineStatsSnapshot {

--- a/src/lib/realtime/types.ts
+++ b/src/lib/realtime/types.ts
@@ -1,5 +1,7 @@
 import { AttendanceStatus } from "@prisma/client";
 
+import type { InventoryItemRecord, TicketRecord } from "@/lib/offline/types";
+import type { ServerSyncEvent } from "@/lib/offline/sync-client";
 import type { ServerAnalytics } from "@/lib/server-analytics";
 
 // Base Event Interface
@@ -56,6 +58,43 @@ export interface NotificationCreatedEvent extends BaseRealtimeEvent {
     metadata?: Record<string, unknown>;
   };
   targetUserId: string;
+}
+
+export interface InventoryRealtimePayload {
+  scope: 'inventory';
+  serverSeq?: number;
+  events?: ServerSyncEvent[];
+  mutationId?: string | null;
+  clientId?: string | null;
+  source?: string | null;
+  delta?: {
+    upserts?: InventoryItemRecord[];
+    deletes?: string[];
+  };
+}
+
+export interface TicketRealtimePayload {
+  scope: 'tickets';
+  serverSeq?: number;
+  events?: ServerSyncEvent[];
+  mutationId?: string | null;
+  clientId?: string | null;
+  source?: string | null;
+  showId?: string | null;
+  delta?: {
+    upserts?: TicketRecord[];
+    deletes?: string[];
+  };
+}
+
+export interface InventoryRealtimeEvent extends BaseRealtimeEvent {
+  type: 'inventory_event';
+  payload: InventoryRealtimePayload;
+}
+
+export interface TicketScanRealtimeEvent extends BaseRealtimeEvent {
+  type: 'ticket_scan_event';
+  payload: TicketRealtimePayload;
 }
 
 export interface UserPresenceEvent extends BaseRealtimeEvent {
@@ -118,6 +157,8 @@ export type RealtimeEvent =
   | RehearsalCreatedEvent
   | RehearsalUpdatedEvent
   | NotificationCreatedEvent
+  | InventoryRealtimeEvent
+  | TicketScanRealtimeEvent
   | UserPresenceEvent
   | OnlineStatsUpdateEvent
   | ServerAnalyticsRealtimeEvent
@@ -149,6 +190,8 @@ export interface ServerToClientEvents {
   rehearsal_created: (event: RehearsalCreatedEvent) => void;
   rehearsal_updated: (event: RehearsalUpdatedEvent) => void;
   notification_created: (event: NotificationCreatedEvent) => void;
+  inventory_event: (event: InventoryRealtimeEvent) => void;
+  ticket_scan_event: (event: TicketScanRealtimeEvent) => void;
   user_presence: (event: UserPresenceEvent) => void;
   online_stats_update: (event: OnlineStatsUpdateEvent) => void;
   server_analytics_update: (event: ServerAnalyticsRealtimeEvent) => void;


### PR DESCRIPTION
## Summary
- add inventory and ticket scan admin events to the realtime server and Next.js service so global and show rooms receive broadcasts
- extend realtime typings and hooks so admin deltas are applied to Dexie through the offline SyncClient
- let the SyncClient react to service worker background sync messages and document the new admin events in the emitRealtimeEvent helper

## Testing
- pnpm test --filter realtime *(fails: vitest CLI reports unknown option `--filter`)*
- pnpm test realtime *(fails: no test files matched the `realtime` filter)*

------
https://chatgpt.com/codex/tasks/task_e_68d40ba6ad40832da65db25db9e91a51