### PR TITLE
Show first name next to header avatar

### DIFF
--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { UserAvatar } from "@/components/user-avatar";
-import { getUserDisplayName } from "@/lib/names";
+import { getUserDisplayName, splitFullName } from "@/lib/names";
 
 export function UserNav({ className }: { className?: string }) {
   const { data: session, status } = useSession();
@@ -65,6 +65,9 @@ export function UserNav({ className }: { className?: string }) {
     },
     "",
   );
+  const { firstName: derivedFirstName } = splitFullName(name);
+  const firstNameDisplay =
+    session.user.firstName?.trim() ?? derivedFirstName ?? name;
   const role = session.user.role;
   async function onLogout() {
     try {
@@ -98,8 +101,7 @@ export function UserNav({ className }: { className?: string }) {
           loading="eager"
         />
         <span className="hidden sm:inline text-foreground/90">
-          {name}
-          {role ? ` (${role})` : ""}
+          {firstNameDisplay}
         </span>
         <svg aria-hidden className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`} viewBox="0 0 20 20" fill="currentColor">
           <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.24 4.5a.75.75 0 01-1.08 0l-4.24-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />


### PR DESCRIPTION
## Summary
- limit the header user avatar label to the member's first name instead of the full display with role
- derive a safe fallback first name from the computed display name when no explicit first name is present

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d41584299c832daaef7ff774474f29