### PR TITLE
Enable build cache for Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,3 +83,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ matrix.build_args }}
+          cache-from: type=gha,scope=${{ matrix.environment }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.environment }}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 # Development Dockerfile bundling the Next.js app and realtime server
 FROM node:24-alpine
 
@@ -25,7 +27,8 @@ WORKDIR /app
 
 # Install deps first (better caching)
 COPY package.json pnpm-lock.yaml ./
-RUN SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --no-frozen-lockfile
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3 \
+    SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --no-frozen-lockfile
 
 # Copy the rest
 COPY . .


### PR DESCRIPTION
## Summary
- enable BuildKit cache reuse in the Docker publish workflow
- reuse the pnpm store between Dockerfile.dev builds with a cache mount

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d41e8928d8832d851babc239ff4612