### PR TITLE
Add offline sync test coverage for scan flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run ESLint
+        run: pnpm lint
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Vitest suite
+        env:
+          NODE_ENV: test
+        run: pnpm test
+
+  playwright:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+      - name: Run Playwright tests
+        env:
+          CI: "true"
+        run: pnpm exec playwright test

--- a/e2e/sync.spec.ts
+++ b/e2e/sync.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+const isConfigured = Boolean(process.env.SCAN_E2E_BASE_URL);
+
+test.describe("offline scan sync flow", () => {
+  test.skip(!isConfigured, "SCAN_E2E_BASE_URL is not configured for Playwright tests");
+
+  test("queues ticket check-ins offline and syncs after reconnect", async ({ page }) => {
+    await page.goto("/members/scan");
+    await expect(page.getByRole("heading", { name: "Scanner" })).toBeVisible();
+
+    await test.step("switch to ticket mode", async () => {
+      await page.getByRole("tab", { name: "Tickets" }).click();
+      await expect(page.locator("text=Ticket offline vorgemerkt")).toHaveCount(0);
+    });
+
+    await test.step("simulate offline check-in", async () => {
+      await page.context().setOffline(true);
+      await page.evaluate(() => {
+        const input = document.createElement("input");
+        input.setAttribute("data-test", "scan-mock");
+        document.body.appendChild(input);
+        input.dispatchEvent(new Event("scan"));
+      });
+      await expect(page.getByText(/offline vorgemerkt/i)).toBeVisible();
+    });
+
+    await test.step("flush queue after going online", async () => {
+      await page.context().setOffline(false);
+      await page.getByRole("button", { name: "Sync senden" }).click();
+      await expect(page.getByText(/Sync gestartet/i)).toBeVisible();
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.55.1",
+    "@prisma/adapter-pg": "^6.16.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
@@ -86,7 +88,9 @@
     "@types/sanitize-html": "^2.16.0",
     "eslint": "^9",
     "eslint-config-next": "15.5.3",
+    "fake-indexeddb": "^6.2.2",
     "jsdom": "^27.0.0",
+    "pg-mem": "^3.0.5",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.3.8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,38 @@
+import { devices, defineConfig } from "@playwright/test";
+
+const baseURL = process.env.SCAN_E2E_BASE_URL ?? "http://127.0.0.1:3000";
+const startCommand = process.env.SCAN_E2E_START_COMMAND;
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 120_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: true,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  ...(startCommand
+    ? {
+        webServer: {
+          command: startCommand,
+          url: baseURL,
+          reuseExistingServer: !process.env.CI,
+          stdout: "pipe",
+          stderr: "pipe",
+          timeout: 120_000,
+        },
+      }
+    : {}),
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 5.2.1(react-hook-form@7.63.0(react@19.1.1))
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.11(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+        version: 1.0.7(@prisma/client@6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.11(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       '@prisma/client':
         specifier: 6.16.2
         version: 6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2)
@@ -70,7 +70,7 @@ importers:
         version: 2.0.4
       geist:
         specifier: ^1.5.1
-        version: 1.5.1(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
+        version: 1.5.1(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1
@@ -82,10 +82,10 @@ importers:
         version: 0.544.0(react@19.1.1)
       next:
         specifier: 15.5.3
-        version: 15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 4.24.11(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       node-ical:
         specifier: ^0.21.0
         version: 0.21.0
@@ -159,6 +159,12 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.55.1
+      '@prisma/adapter-pg':
+        specifier: ^6.16.2
+        version: 6.16.2
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.13
@@ -198,9 +204,15 @@ importers:
       eslint-config-next:
         specifier: 15.5.3
         version: 15.5.3(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)
+      fake-indexeddb:
+        specifier: ^6.2.2
+        version: 6.2.2
       jsdom:
         specifier: ^27.0.0
         version: 27.0.0(postcss@8.5.6)
+      pg-mem:
+        specifier: ^3.0.5
+        version: 3.0.5
       tailwindcss:
         specifier: ^4
         version: 4.1.13
@@ -744,8 +756,16 @@ packages:
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
+  '@playwright/test@1.55.1':
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@prisma/adapter-pg@6.16.2':
+    resolution: {integrity: sha512-C+JZmKDBm13anIRhhJYxNw0EZ3zT11n9i6JCPBf2sg7HCNlQiYAPBegqYzAYwGw8VG8xlkM0aV9xJ4AH2mQqaQ==}
 
   '@prisma/client@6.16.2':
     resolution: {integrity: sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==}
@@ -764,6 +784,9 @@ packages:
 
   '@prisma/debug@6.16.2':
     resolution: {integrity: sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==}
+
+  '@prisma/driver-adapter-utils@6.16.2':
+    resolution: {integrity: sha512-DMgfafnG0zPd+QoAQOC0Trn1xlb0fVAfQi2MpkpzSf641KiVkVPkJRXDSbcTbxGxO2HRdd0vI9U6LlesWad4XA==}
 
   '@prisma/engines-version@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43':
     resolution: {integrity: sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==}
@@ -1967,6 +1990,9 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2124,6 +2150,9 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  discontinuous-range@1.0.0:
+    resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2371,6 +2400,10 @@ packages:
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
+  fake-indexeddb@6.2.2:
+    resolution: {integrity: sha512-SGbf7fzjeHz3+12NO1dYigcYn4ivviaeULV5yY5rdGihBvvgwMds4r4UBbNIUMwkze57KTDm32rq3j1Az8mzEw==}
+    engines: {node: '>=18'}
+
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -2453,6 +2486,11 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2464,6 +2502,9 @@ packages:
   function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
+
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -2596,6 +2637,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immutable@4.3.7:
+    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -2781,9 +2825,16 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
+
+  jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -3000,6 +3051,9 @@ packages:
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
+  moo@0.5.2:
+    resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3015,6 +3069,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  nearley@2.20.1:
+    resolution: {integrity: sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==}
+    hasBin: true
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -3194,6 +3252,78 @@ packages:
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-mem@3.0.5:
+    resolution: {integrity: sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==}
+    peerDependencies:
+      '@mikro-orm/core': '>=4.5.3'
+      '@mikro-orm/postgresql': '>=4.5.3'
+      knex: '>=0.20'
+      kysely: '>=0.26'
+      mikro-orm: '*'
+      pg-promise: '>=10.8.7'
+      pg-server: ^0.1.5
+      postgres: ^3.4.4
+      slonik: '>=23.0.1'
+      typeorm: '>=0.2.29'
+    peerDependenciesMeta:
+      '@mikro-orm/core':
+        optional: true
+      '@mikro-orm/postgresql':
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mikro-orm:
+        optional: true
+      pg-promise:
+        optional: true
+      pg-server:
+        optional: true
+      postgres:
+        optional: true
+      slonik:
+        optional: true
+      typeorm:
+        optional: true
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pgsql-ast-parser@12.0.1:
+    resolution: {integrity: sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3207,6 +3337,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   png-js@1.0.0:
     resolution: {integrity: sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g==}
@@ -3226,6 +3366,26 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   preact-render-to-string@5.2.6:
     resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
@@ -3293,6 +3453,13 @@ packages:
   quill@2.0.3:
     resolution: {integrity: sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==}
     engines: {npm: '>=8.2.3'}
+
+  railroad-diagrams@1.0.0:
+    resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
+
+  randexp@0.4.6:
+    resolution: {integrity: sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==}
+    engines: {node: '>=0.12'}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -3422,6 +3589,10 @@ packages:
   restructure@3.0.2:
     resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
+  ret@0.1.15:
+    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
+    engines: {node: '>=0.12'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3550,6 +3721,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -3989,6 +4164,10 @@ packages:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -4359,10 +4538,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.11(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2))(next-auth@4.24.11(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))':
     dependencies:
       '@prisma/client': 6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2)
-      next-auth: 4.24.11(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next-auth: 4.24.11(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
 
   '@next/env@15.5.3': {}
 
@@ -4410,7 +4589,19 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
+  '@playwright/test@1.55.1':
+    dependencies:
+      playwright: 1.55.1
+
   '@popperjs/core@2.11.8': {}
+
+  '@prisma/adapter-pg@6.16.2':
+    dependencies:
+      '@prisma/driver-adapter-utils': 6.16.2
+      pg: 8.16.3
+      postgres-array: 3.0.4
+    transitivePeerDependencies:
+      - pg-native
 
   '@prisma/client@6.16.2(prisma@6.16.2(typescript@5.9.2))(typescript@5.9.2)':
     optionalDependencies:
@@ -4427,6 +4618,10 @@ snapshots:
       - magicast
 
   '@prisma/debug@6.16.2': {}
+
+  '@prisma/driver-adapter-utils@6.16.2':
+    dependencies:
+      '@prisma/debug': 6.16.2
 
   '@prisma/engines-version@6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43': {}
 
@@ -5590,6 +5785,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@2.20.3: {}
+
   concat-map@0.0.1: {}
 
   confbox@0.2.2: {}
@@ -5716,6 +5913,8 @@ snapshots:
   dfa@1.2.0: {}
 
   dijkstrajs@1.0.3: {}
+
+  discontinuous-range@1.0.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -6149,6 +6348,8 @@ snapshots:
 
   exsolve@1.0.7: {}
 
+  fake-indexeddb@6.2.2: {}
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -6238,6 +6439,9 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6252,11 +6456,13 @@ snapshots:
       hasown: 2.0.2
       is-callable: 1.2.7
 
+  functional-red-black-tree@1.0.1: {}
+
   functions-have-names@1.2.3: {}
 
-  geist@1.5.1(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
+  geist@1.5.1(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)):
     dependencies:
-      next: 15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
 
   get-caller-file@2.0.5: {}
 
@@ -6396,6 +6602,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immutable@4.3.7: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -6597,9 +6805,19 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  jsonify@0.0.1: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -6773,6 +6991,8 @@ snapshots:
 
   moment@2.30.1: {}
 
+  moo@0.5.2: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -6781,15 +7001,22 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  nearley@2.20.1:
+    dependencies:
+      commander: 2.20.3
+      moo: 0.5.2
+      railroad-diagrams: 1.0.0
+      randexp: 0.4.6
+
   negotiator@0.6.3: {}
 
-  next-auth@4.24.11(next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next-auth@4.24.11(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(nodemailer@7.0.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@babel/runtime': 7.28.4
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.27.2
@@ -6800,7 +7027,7 @@ snapshots:
     optionalDependencies:
       nodemailer: 7.0.6
 
-  next@15.5.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.5.3
       '@swc/helpers': 0.5.15
@@ -6818,6 +7045,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.3
       '@next/swc-win32-arm64-msvc': 15.5.3
       '@next/swc-win32-x64-msvc': 15.5.3
+      '@playwright/test': 1.55.1
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -6971,6 +7199,56 @@ snapshots:
 
   perfect-debounce@1.0.0: {}
 
+  pg-cloudflare@1.2.7:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-mem@3.0.5:
+    dependencies:
+      functional-red-black-tree: 1.0.1
+      immutable: 4.3.7
+      json-stable-stringify: 1.3.0
+      lru-cache: 6.0.0
+      moment: 2.30.1
+      object-hash: 2.2.0
+      pgsql-ast-parser: 12.0.1
+
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  pgsql-ast-parser@12.0.1:
+    dependencies:
+      moo: 0.5.2
+      nearley: 2.20.1
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -6982,6 +7260,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.55.1: {}
+
+  playwright@1.55.1:
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   png-js@1.0.0: {}
 
@@ -7000,6 +7286,18 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-array@3.0.4: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   preact-render-to-string@5.2.6(preact@10.27.2):
     dependencies:
@@ -7063,6 +7361,13 @@ snapshots:
       lodash-es: 4.17.21
       parchment: 3.0.0
       quill-delta: 5.1.0
+
+  railroad-diagrams@1.0.0: {}
+
+  randexp@0.4.6:
+    dependencies:
+      discontinuous-range: 1.0.0
+      ret: 0.1.15
 
   rc9@2.1.2:
     dependencies:
@@ -7211,6 +7516,8 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   restructure@3.0.2: {}
+
+  ret@0.1.15: {}
 
   reusify@1.1.0: {}
 
@@ -7438,6 +7745,8 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -7914,6 +8223,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
+
+  xtend@4.0.2: {}
 
   y18n@4.0.3: {}
 

--- a/src/app/(members)/scan/__tests__/scan-page-client.test.tsx
+++ b/src/app/(members)/scan/__tests__/scan-page-client.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  HttpError,
+  extractMessage,
+  extractTicketInfo,
+  getErrorMessage,
+  readResponseBody,
+  shouldUseOfflineFallback,
+} from "../scan-page-client";
+
+describe("scan page helpers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("derives human readable error messages", () => {
+    expect(getErrorMessage(new HttpError(503, "Service unavailable"))).toBe(
+      "Service unavailable",
+    );
+    expect(getErrorMessage(new Error("Validation failed"))).toBe("Validation failed");
+    expect(getErrorMessage(42)).toBe("42");
+  });
+
+  it("detects when offline fallback should be used", () => {
+    expect(shouldUseOfflineFallback(new HttpError(500, "Server error"))).toBe(true);
+    expect(shouldUseOfflineFallback(new HttpError(404, "Not found"))).toBe(false);
+    expect(shouldUseOfflineFallback(new TypeError("Failed to fetch"))).toBe(true);
+
+    const domException = new DOMException("Aborted", "AbortError");
+    expect(shouldUseOfflineFallback(domException)).toBe(true);
+
+    vi.stubGlobal("navigator", { onLine: false } as Partial<Navigator>);
+    expect(shouldUseOfflineFallback(new Error("Network unstable"))).toBe(true);
+  });
+
+  it("extracts useful information from ticket payloads", () => {
+    const info = extractTicketInfo({
+      ticket: {
+        id: "ticket-1",
+        holderName: "Max Mustermann",
+        eventId: "event-1",
+        status: "checked_in",
+      },
+    });
+
+    expect(info).toEqual({
+      id: "ticket-1",
+      holderName: "Max Mustermann",
+      eventId: "event-1",
+      status: "checked_in",
+    });
+
+    expect(extractTicketInfo({})).toBeNull();
+  });
+
+  it("reads response bodies regardless of payload type", async () => {
+    const jsonResponse = new Response(JSON.stringify({ message: "ok" }), {
+      headers: { "Content-Type": "application/json" },
+    });
+    await expect(readResponseBody(jsonResponse)).resolves.toEqual({ message: "ok" });
+
+    const textResponse = new Response("plain text", {
+      headers: { "Content-Type": "text/plain" },
+    });
+    await expect(readResponseBody(textResponse)).resolves.toBe("plain text");
+
+    const emptyResponse = new Response(null);
+    await expect(readResponseBody(emptyResponse)).resolves.toBeNull();
+  });
+
+  it("extracts descriptive messages from API responses", () => {
+    expect(extractMessage("All good")).toBe("All good");
+    expect(
+      extractMessage({
+        message: "Ticket gespeichert",
+      }),
+    ).toBe("Ticket gespeichert");
+    expect(extractMessage({ detail: "Conflict" })).toBe("Conflict");
+    expect(extractMessage({})).toBeNull();
+  });
+});

--- a/src/app/(members)/scan/__tests__/sync-api.test.tsx
+++ b/src/app/(members)/scan/__tests__/sync-api.test.tsx
@@ -1,0 +1,807 @@
+import type { Prisma } from "@prisma/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+type SyncScopeValue = "inventory" | "tickets";
+type TicketStatusValue = "unused" | "checked_in" | "invalid" | "pending";
+
+interface InventoryItemRow {
+  id: string;
+  name: string;
+  qty: number;
+}
+
+interface TicketRow {
+  id: string;
+  code: string;
+  eventId: string;
+  holderName: string | null;
+  status: TicketStatusValue;
+  updatedAt: Date;
+}
+
+interface SyncEventRow {
+  id: string;
+  scope: SyncScopeValue;
+  clientId: string;
+  clientMutationId: string;
+  dedupeKey: string | null;
+  type: string;
+  payload: Record<string, unknown>;
+  occurredAt: Date;
+  serverSeq: number;
+}
+
+interface SyncMutationRow {
+  clientMutationId: string;
+  clientId: string;
+  scope: SyncScopeValue;
+  eventCount: number;
+  firstServerSeq: number | null;
+  lastServerSeq: number | null;
+  acknowledgedSeq: number;
+}
+
+const fakeDb: {
+  inventoryItems: InventoryItemRow[];
+  tickets: TicketRow[];
+  syncEvents: SyncEventRow[];
+  syncMutations: SyncMutationRow[];
+} = {
+  inventoryItems: [],
+  tickets: [],
+  syncEvents: [],
+  syncMutations: [],
+};
+
+let serverSeqCounter = 0;
+
+function normalizeScope(value: unknown): SyncScopeValue {
+  if (value === "inventory") {
+    return "inventory";
+  }
+
+  if (value === "tickets") {
+    return "tickets";
+  }
+
+  throw new Error(`Unsupported sync scope: ${String(value)}`);
+}
+
+function toDate(value: Date | string | number | null | undefined): Date {
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return new Date();
+}
+
+function cloneInventoryItem(item: InventoryItemRow): InventoryItemRow {
+  return { ...item };
+}
+
+function cloneTicket(ticket: TicketRow): TicketRow {
+  return {
+    ...ticket,
+    updatedAt: new Date(ticket.updatedAt.getTime()),
+  };
+}
+
+function cloneSyncEvent(event: SyncEventRow): SyncEventRow {
+  return {
+    ...event,
+    occurredAt: new Date(event.occurredAt.getTime()),
+    payload: { ...event.payload },
+  };
+}
+
+function cloneSyncMutation(mutation: SyncMutationRow): SyncMutationRow {
+  return { ...mutation };
+}
+
+function matchesStringFilter(
+  value: string,
+  filter?: string | Prisma.StringFilter,
+): boolean {
+  if (typeof filter === "undefined") {
+    return true;
+  }
+
+  if (typeof filter === "string") {
+    return value === filter;
+  }
+
+  if (filter && typeof filter === "object") {
+    if (typeof filter.equals === "string" && value !== filter.equals) {
+      return false;
+    }
+
+    if (Array.isArray(filter.in) && !filter.in.includes(value)) {
+      return false;
+    }
+
+    if (filter.not) {
+      if (typeof filter.not === "string") {
+        return value !== filter.not;
+      }
+
+      return !matchesStringFilter(value, filter.not);
+    }
+  }
+
+  return true;
+}
+
+function matchesNullableStringFilter(
+  value: string | null,
+  filter?: string | null | Prisma.StringNullableFilter,
+): boolean {
+  if (typeof filter === "undefined") {
+    return true;
+  }
+
+  if (filter === null) {
+    return value === null;
+  }
+
+  if (typeof filter === "string") {
+    return value === filter;
+  }
+
+  if (filter && typeof filter === "object") {
+    if (filter.equals !== undefined && value !== filter.equals) {
+      return false;
+    }
+
+    if (Array.isArray(filter.in)) {
+      const allowed = filter.in.filter(
+        (item): item is string | null =>
+          typeof item === "string" || item === null,
+      );
+
+      if (!allowed.includes(value)) {
+        return false;
+      }
+    }
+
+    if (filter.not) {
+      if (filter.not === null) {
+        return value !== null;
+      }
+
+      if (typeof filter.not === "string") {
+        return value !== filter.not;
+      }
+
+      return !matchesNullableStringFilter(value, filter.not);
+    }
+  }
+
+  return true;
+}
+
+function matchesScopeFilter(value: SyncScopeValue, filter?: unknown): boolean {
+  if (typeof filter === "undefined") {
+    return true;
+  }
+
+  if (typeof filter === "string") {
+    return value === normalizeScope(filter);
+  }
+
+  if (filter && typeof filter === "object") {
+    const scoped = filter as {
+      equals?: unknown;
+      in?: unknown[];
+      not?: unknown;
+    };
+
+    if (typeof scoped.equals !== "undefined") {
+      return value === normalizeScope(scoped.equals);
+    }
+
+    if (Array.isArray(scoped.in)) {
+      const allowed = scoped.in.map(normalizeScope);
+      return allowed.includes(value);
+    }
+
+    if (typeof scoped.not !== "undefined") {
+      return !matchesScopeFilter(value, scoped.not);
+    }
+  }
+
+  return true;
+}
+
+function matchesIntFilter(
+  value: number,
+  filter?: number | Prisma.IntFilter,
+): boolean {
+  if (typeof filter === "undefined") {
+    return true;
+  }
+
+  if (typeof filter === "number") {
+    return value === filter;
+  }
+
+  if (filter && typeof filter === "object") {
+    if (typeof filter.equals === "number" && value !== filter.equals) {
+      return false;
+    }
+
+    if (typeof filter.gt === "number" && !(value > filter.gt)) {
+      return false;
+    }
+
+    if (typeof filter.gte === "number" && !(value >= filter.gte)) {
+      return false;
+    }
+
+    if (typeof filter.lt === "number" && !(value < filter.lt)) {
+      return false;
+    }
+
+    if (typeof filter.lte === "number" && !(value <= filter.lte)) {
+      return false;
+    }
+
+    if (Array.isArray(filter.in) && !filter.in.includes(value)) {
+      return false;
+    }
+
+    if (filter.not) {
+      if (typeof filter.not === "number") {
+        return value !== filter.not;
+      }
+
+      return !matchesIntFilter(value, filter.not);
+    }
+  }
+
+  return true;
+}
+
+function pickBySelect<TRecord extends Record<string, unknown>>(
+  record: TRecord,
+  select: Record<string, boolean | undefined>,
+) {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, enabled] of Object.entries(select)) {
+    if (enabled) {
+      result[key] = record[key as keyof TRecord];
+    }
+  }
+
+  return result;
+}
+
+function filterSyncEvents(where?: Prisma.SyncEventWhereInput): SyncEventRow[] {
+  if (!where) {
+    return [...fakeDb.syncEvents];
+  }
+
+  return fakeDb.syncEvents.filter((event) => {
+    if (!matchesScopeFilter(event.scope, where.scope)) {
+      return false;
+    }
+
+    if (!matchesIntFilter(event.serverSeq, where.serverSeq)) {
+      return false;
+    }
+
+    if (
+      !matchesStringFilter(
+        event.clientMutationId,
+        where.clientMutationId as string | Prisma.StringFilter | undefined,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      !matchesStringFilter(
+        event.clientId,
+        where.clientId as string | Prisma.StringFilter | undefined,
+      )
+    ) {
+      return false;
+    }
+
+    if (
+      !matchesStringFilter(
+        event.id,
+        where.id as string | Prisma.StringFilter | undefined,
+      )
+    ) {
+      return false;
+    }
+
+    if (!matchesNullableStringFilter(event.dedupeKey, where.dedupeKey)) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function resolveIntUpdate(
+  value: number | Prisma.IntFieldUpdateOperationsInput | undefined,
+  previous: number,
+): number {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    if (typeof value.set === "number") {
+      return value.set;
+    }
+
+    if (typeof value.increment === "number") {
+      return previous + value.increment;
+    }
+
+    if (typeof value.decrement === "number") {
+      return previous - value.decrement;
+    }
+  }
+
+  return previous;
+}
+
+function resolveNullableIntUpdate(
+  value: number | null | Prisma.NullableIntFieldUpdateOperationsInput | undefined,
+  previous: number | null,
+): number | null {
+  if (typeof value === "number" || value === null) {
+    return value ?? null;
+  }
+
+  if (value && typeof value === "object") {
+    if (value.set === null) {
+      return null;
+    }
+
+    if (typeof value.set === "number") {
+      return value.set;
+    }
+  }
+
+  return previous;
+}
+
+const prismaStub = {
+  inventoryItem: {
+    createMany: async ({ data }: Prisma.InventoryItemCreateManyArgs) => {
+      const records = Array.isArray(data) ? data : [data];
+      const normalized = records.map((item, index) => ({
+        id: item.id ?? `inventory-${fakeDb.inventoryItems.length + index + 1}`,
+        name: item.name ?? "",
+        qty: item.qty ?? 0,
+      }));
+
+      fakeDb.inventoryItems.push(...normalized);
+      fakeDb.inventoryItems.sort((a, b) => a.id.localeCompare(b.id));
+
+      return { count: normalized.length };
+    },
+    deleteMany: async () => {
+      const count = fakeDb.inventoryItems.length;
+      fakeDb.inventoryItems = [];
+      return { count };
+    },
+    findMany: async (options: Prisma.InventoryItemFindManyArgs = {}) => {
+      let items = fakeDb.inventoryItems.map(cloneInventoryItem);
+
+      items.sort((a, b) => a.id.localeCompare(b.id));
+
+      if (options.cursor?.id) {
+        const index = items.findIndex((item) => item.id === options.cursor?.id);
+        if (index >= 0) {
+          const skip = options.skip ?? 0;
+          items = items.slice(index + skip);
+        }
+      } else if (typeof options.skip === "number" && options.skip > 0) {
+        items = items.slice(options.skip);
+      }
+
+      if (typeof options.take === "number") {
+        items = items.slice(0, options.take);
+      }
+
+      if (options.select) {
+        const select = options.select as Record<string, boolean | undefined>;
+        const selected = items.map((item) => pickBySelect(item, select));
+        return selected as unknown;
+      }
+
+      return items as unknown;
+    },
+  },
+  ticket: {
+    create: async ({ data }: Prisma.TicketCreateArgs) => {
+      const ticket: TicketRow = {
+        id: data.data.id ?? `ticket-${fakeDb.tickets.length + 1}`,
+        code: data.data.code ?? `code-${fakeDb.tickets.length + 1}`,
+        eventId: data.data.eventId ?? "event",
+        holderName: data.data.holderName ?? null,
+        status: (data.data.status as TicketStatusValue | undefined) ?? "unused",
+        updatedAt: toDate(data.data.updatedAt ?? new Date()),
+      };
+
+      fakeDb.tickets.push(ticket);
+      fakeDb.tickets.sort((a, b) => a.id.localeCompare(b.id));
+
+      return cloneTicket(ticket) as unknown;
+    },
+    deleteMany: async () => {
+      const count = fakeDb.tickets.length;
+      fakeDb.tickets = [];
+      return { count };
+    },
+    findMany: async (options: Prisma.TicketFindManyArgs = {}) => {
+      let tickets = fakeDb.tickets.map(cloneTicket);
+
+      tickets.sort((a, b) => a.id.localeCompare(b.id));
+
+      if (options.cursor?.id) {
+        const index = tickets.findIndex((ticket) => ticket.id === options.cursor?.id);
+        if (index >= 0) {
+          const skip = options.skip ?? 0;
+          tickets = tickets.slice(index + skip);
+        }
+      } else if (typeof options.skip === "number" && options.skip > 0) {
+        tickets = tickets.slice(options.skip);
+      }
+
+      if (typeof options.take === "number") {
+        tickets = tickets.slice(0, options.take);
+      }
+
+      if (options.select) {
+        const select = options.select as Record<string, boolean | undefined>;
+        const selected = tickets.map((ticket) => pickBySelect(ticket, select));
+        return selected as unknown;
+      }
+
+      return tickets as unknown;
+    },
+  },
+  syncEvent: {
+    create: async (args: Prisma.SyncEventCreateArgs) => {
+      const input = args?.data;
+      if (!input) {
+        throw new Error("Missing sync event data");
+      }
+
+      const event: SyncEventRow = {
+        id: input.id ?? `evt-${serverSeqCounter + 1}`,
+        scope: normalizeScope(input.scope),
+        clientId: input.clientId ?? "client",
+        clientMutationId:
+          input.clientMutationId ?? `mutation-${serverSeqCounter + 1}`,
+        dedupeKey: (input.dedupeKey as string | null | undefined) ?? null,
+        type: input.type ?? "event",
+        payload: (input.payload ?? {}) as Record<string, unknown>,
+        occurredAt: toDate(input.occurredAt as Date | string | undefined),
+        serverSeq: ++serverSeqCounter,
+      };
+
+      fakeDb.syncEvents.push(event);
+
+      return cloneSyncEvent(event) as unknown;
+    },
+    findMany: async (options: Prisma.SyncEventFindManyArgs = {}) => {
+      let events = filterSyncEvents(options.where);
+
+      const order = Array.isArray(options.orderBy)
+        ? options.orderBy[0]
+        : options.orderBy;
+
+      if (order && typeof order === "object" && order.serverSeq === "desc") {
+        events = [...events].sort((a, b) => b.serverSeq - a.serverSeq);
+      } else {
+        events = [...events].sort((a, b) => a.serverSeq - b.serverSeq);
+      }
+
+      if (typeof options.skip === "number" && options.skip > 0) {
+        events = events.slice(options.skip);
+      }
+
+      if (typeof options.take === "number") {
+        events = events.slice(0, options.take);
+      }
+
+      const clones = events.map(cloneSyncEvent);
+
+      if (options.select) {
+        const select = options.select as Record<string, boolean | undefined>;
+        const selected = clones.map((event) => pickBySelect(event, select));
+        return selected as unknown;
+      }
+
+      return clones as unknown;
+    },
+    findFirst: async (options: Prisma.SyncEventFindFirstArgs = {}) => {
+      const results = (await prismaStub.syncEvent.findMany({
+        ...options,
+        take: 1,
+      })) as Array<Record<string, unknown>>;
+
+      return (results[0] ?? null) as unknown;
+    },
+    deleteMany: async () => {
+      const count = fakeDb.syncEvents.length;
+      fakeDb.syncEvents = [];
+      return { count };
+    },
+  },
+  syncMutation: {
+    create: async (args: Prisma.SyncMutationCreateArgs) => {
+      const input = args?.data;
+      if (!input) {
+        throw new Error("Missing sync mutation data");
+      }
+
+      const mutation: SyncMutationRow = {
+        clientMutationId:
+          input.clientMutationId ?? `mutation-${fakeDb.syncMutations.length + 1}`,
+        clientId: input.clientId ?? "client",
+        scope: normalizeScope(input.scope),
+        eventCount: input.eventCount ?? 0,
+        firstServerSeq: (input.firstServerSeq as number | null | undefined) ?? null,
+        lastServerSeq: (input.lastServerSeq as number | null | undefined) ?? null,
+        acknowledgedSeq: input.acknowledgedSeq as number,
+      };
+
+      fakeDb.syncMutations.push(mutation);
+
+      return cloneSyncMutation(mutation) as unknown;
+    },
+    findUnique: async ({ where }: Prisma.SyncMutationFindUniqueArgs) => {
+      if (!where?.clientMutationId) {
+        return null;
+      }
+
+      const found = fakeDb.syncMutations.find(
+        (mutation) => mutation.clientMutationId === where.clientMutationId,
+      );
+
+      return found ? (cloneSyncMutation(found) as unknown) : null;
+    },
+    update: async ({ where, data }: Prisma.SyncMutationUpdateArgs) => {
+      if (!where?.clientMutationId) {
+        throw new Error("Missing clientMutationId");
+      }
+
+      const index = fakeDb.syncMutations.findIndex(
+        (mutation) => mutation.clientMutationId === where.clientMutationId,
+      );
+
+      if (index < 0) {
+        throw new Error("Mutation not found");
+      }
+
+      const existing = fakeDb.syncMutations[index];
+
+      const updated: SyncMutationRow = {
+        ...existing,
+        eventCount: resolveIntUpdate(data.eventCount, existing.eventCount),
+        firstServerSeq: resolveNullableIntUpdate(
+          data.firstServerSeq,
+          existing.firstServerSeq,
+        ),
+        lastServerSeq: resolveNullableIntUpdate(
+          data.lastServerSeq,
+          existing.lastServerSeq,
+        ),
+        acknowledgedSeq: resolveIntUpdate(
+          data.acknowledgedSeq,
+          existing.acknowledgedSeq,
+        ),
+      };
+
+      fakeDb.syncMutations[index] = updated;
+
+      return cloneSyncMutation(updated) as unknown;
+    },
+    deleteMany: async () => {
+      const count = fakeDb.syncMutations.length;
+      fakeDb.syncMutations = [];
+      return { count };
+    },
+  },
+  $transaction: async (
+    callback: (tx: typeof prismaStub) => Promise<unknown>,
+  ): Promise<unknown> => {
+    return callback(prismaStub);
+  },
+};
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaStub }));
+
+const { GET: initialRoute } = await import("@/app/api/sync/initial/route");
+const { POST: pullRoute } = await import("@/app/api/sync/pull/route");
+const { POST: pushRoute } = await import("@/app/api/sync/push/route");
+
+function resetDatabase() {
+  fakeDb.inventoryItems = [];
+  fakeDb.tickets = [];
+  fakeDb.syncEvents = [];
+  fakeDb.syncMutations = [];
+  serverSeqCounter = 0;
+}
+
+beforeEach(() => {
+  resetDatabase();
+});
+
+describe("sync API integration", () => {
+  test("returns paginated inventory baseline with cache headers", async () => {
+    await prismaStub.inventoryItem.createMany({
+      data: [
+        { id: "item-a", name: "Akkupack", qty: 4 },
+        { id: "item-b", name: "Bühnenlicht", qty: 6 },
+        { id: "item-c", name: "Kabelsatz", qty: 12 },
+      ],
+    });
+
+    const request = new Request(
+      "http://localhost/api/sync/initial?scope=inventory&limit=2",
+    );
+
+    const response = await initialRoute(request);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("ETag")).toBeTruthy();
+
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      scope: "inventory",
+      hasMore: true,
+      nextCursor: "item-b",
+      serverSeq: 0,
+    });
+    expect(payload.records).toHaveLength(2);
+    expect(payload.records[0]).toMatchObject({ id: "item-a", quantity: 4 });
+  });
+
+  test("returns incremental ticket events when pulling after a server sequence", async () => {
+    const mutation = (await prismaStub.syncMutation.create({
+      data: {
+        clientMutationId: "seed-mutation",
+        clientId: "scanner-seed",
+        scope: "tickets",
+        eventCount: 0,
+        acknowledgedSeq: 0,
+      },
+    })) as SyncMutationRow;
+
+    const firstEvent = (await prismaStub.syncEvent.create({
+      data: {
+        id: "evt-1",
+        scope: "tickets",
+        clientId: "scanner-seed",
+        clientMutationId: mutation.clientMutationId,
+        dedupeKey: "ticket:T-1",
+        type: "ticket.checkin",
+        payload: { ticketId: "T-1", status: "checked_in" },
+        occurredAt: new Date("2025-01-10T08:00:00.000Z"),
+      },
+    })) as SyncEventRow;
+
+    await prismaStub.syncEvent.create({
+      data: {
+        id: "evt-2",
+        scope: "tickets",
+        clientId: "scanner-seed",
+        clientMutationId: mutation.clientMutationId,
+        dedupeKey: "ticket:T-2",
+        type: "ticket.checkin",
+        payload: { ticketId: "T-2", status: "checked_in" },
+        occurredAt: new Date("2025-01-10T09:15:00.000Z"),
+      },
+    });
+
+    const pullRequest = new Request("http://localhost/api/sync/pull", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ scope: "tickets", lastServerSeq: 0, limit: 10 }),
+    });
+
+    const response = await pullRoute(pullRequest);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("ETag")).toBeTruthy();
+
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      scope: "tickets",
+      serverSeq: 2,
+      hasMore: false,
+      nextCursor: 2,
+    });
+    expect(payload.events).toHaveLength(2);
+    expect(payload.events[0]).toMatchObject({ id: firstEvent.id, dedupeKey: "ticket:T-1" });
+  });
+
+  test("applies incoming ticket events and skips duplicates by dedupe key", async () => {
+    const existingMutation = (await prismaStub.syncMutation.create({
+      data: {
+        clientMutationId: "existing",
+        clientId: "scanner-1",
+        scope: "tickets",
+        eventCount: 1,
+        acknowledgedSeq: 0,
+      },
+    })) as SyncMutationRow;
+
+    const existingEvent = (await prismaStub.syncEvent.create({
+      data: {
+        id: "evt-existing",
+        scope: "tickets",
+        clientId: "scanner-1",
+        clientMutationId: existingMutation.clientMutationId,
+        dedupeKey: "ticket:T-1",
+        type: "ticket.checkin",
+        payload: { ticketId: "T-1", status: "checked_in" },
+        occurredAt: new Date("2025-01-10T07:00:00.000Z"),
+      },
+    })) as SyncEventRow;
+
+    await prismaStub.syncMutation.update({
+      where: { clientMutationId: existingMutation.clientMutationId },
+      data: {
+        eventCount: 1,
+        firstServerSeq: existingEvent.serverSeq,
+        lastServerSeq: existingEvent.serverSeq,
+        acknowledgedSeq: existingEvent.serverSeq,
+      },
+    });
+
+    const pushRequest = new Request("http://localhost/api/sync/push", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        scope: "tickets",
+        clientId: "scanner-2",
+        clientMutationId: "mutation-1",
+        lastKnownServerSeq: existingEvent.serverSeq,
+        events: [
+          {
+            id: "evt-new",
+            dedupeKey: "ticket:T-2",
+            type: "ticket.checkin",
+            payload: { ticketId: "T-2", status: "checked_in" },
+            occurredAt: "2025-01-10T10:00:00.000Z",
+          },
+          {
+            id: "evt-duplicate",
+            dedupeKey: "ticket:T-1",
+            type: "ticket.checkin",
+            payload: { ticketId: "T-1", status: "checked_in" },
+            occurredAt: "2025-01-10T10:05:00.000Z",
+          },
+        ],
+      }),
+    });
+
+    const response = await pushRoute(pushRequest);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("X-Sync-Status")).toBe("applied");
+
+    const payload = await response.json();
+    expect(payload.status).toBe("applied");
+    expect(payload.skipped).toEqual([
+      { id: "evt-duplicate", dedupeKey: "ticket:T-1", reason: "duplicate-dedupe-key" },
+    ]);
+    expect(payload.events).toHaveLength(1);
+    expect(payload.events[0]).toMatchObject({ id: "evt-new", dedupeKey: "ticket:T-2" });
+  });
+});

--- a/src/app/(members)/scan/scan-page-client.tsx
+++ b/src/app/(members)/scan/scan-page-client.tsx
@@ -43,18 +43,18 @@ const STATUS_LABELS: Record<SyncScopeState["status"], string> = {
   error: "Fehler",
 };
 
-class HttpError extends Error {
+export class HttpError extends Error {
   constructor(public readonly status: number, message: string) {
     super(message);
     this.name = "HttpError";
   }
 }
 
-function isNonEmptyString(value: unknown): value is string {
+export function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function getErrorMessage(error: unknown): string {
+export function getErrorMessage(error: unknown): string {
   if (error instanceof HttpError) {
     return error.message;
   }
@@ -64,7 +64,7 @@ function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
-function shouldUseOfflineFallback(error: unknown): boolean {
+export function shouldUseOfflineFallback(error: unknown): boolean {
   if (error instanceof HttpError) {
     return error.status === 0 || error.status >= 500;
   }
@@ -84,7 +84,7 @@ function shouldUseOfflineFallback(error: unknown): boolean {
   return false;
 }
 
-async function readResponseBody(response: Response): Promise<unknown> {
+export async function readResponseBody(response: Response): Promise<unknown> {
   try {
     return await response.clone().json();
   } catch {
@@ -97,7 +97,7 @@ async function readResponseBody(response: Response): Promise<unknown> {
   }
 }
 
-function extractTicketInfo(data: unknown): {
+export function extractTicketInfo(data: unknown): {
   id?: string;
   holderName?: string;
   eventId?: string;
@@ -130,7 +130,7 @@ function extractTicketInfo(data: unknown): {
   return { id, holderName, eventId, status };
 }
 
-function extractMessage(data: unknown): string | null {
+export function extractMessage(data: unknown): string | null {
   if (!data) {
     return null;
   }

--- a/src/lib/offline/__tests__/storage.test.ts
+++ b/src/lib/offline/__tests__/storage.test.ts
@@ -1,0 +1,270 @@
+import "fake-indexeddb/auto";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import type { OfflineDatabase } from "../db";
+import type { OfflineDelta, OfflineSnapshot } from "../types";
+
+describe("offline storage", () => {
+  let db: OfflineDatabase;
+  let storageModule: typeof import("../storage");
+
+  beforeAll(async () => {
+    const globalWithWindow = globalThis as typeof globalThis & { window?: typeof globalThis };
+    if (!globalWithWindow.window) {
+      globalWithWindow.window = globalWithWindow;
+    }
+
+    const dbModule = await import("../db");
+    storageModule = await import("../storage");
+
+    if (!dbModule.offlineDb) {
+      throw new Error("Expected offlineDb to be available for tests");
+    }
+
+    db = dbModule.offlineDb;
+    await db.delete().catch(() => undefined);
+    await db.open();
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await db.transaction(
+      "rw",
+      db.items,
+      db.tickets,
+      db.eventQueue,
+      db.syncState,
+      db.audits,
+      async () => {
+        await db.items.clear();
+        await db.tickets.clear();
+        await db.eventQueue.clear();
+        await db.syncState.clear();
+        await db.audits.clear();
+      },
+    );
+  });
+
+  it("initialises the offline database with expected stores", () => {
+    const tableNames = db.tables.map((table) => table.name).sort();
+    expect(tableNames).toEqual([
+      "audits",
+      "eventQueue",
+      "items",
+      "syncState",
+      "tickets",
+    ]);
+
+    const eventQueue = db.tables.find((table) => table.name === "eventQueue");
+    expect(eventQueue?.schema.primKey.keyPath).toBe("id");
+    expect(eventQueue?.schema.indexes.map((index) => index.name).sort()).toEqual([
+      "createdAt",
+      "dedupeKey",
+      "type",
+    ]);
+  });
+
+  it("merges events with matching dedupe keys and records an audit", async () => {
+    const { enqueueEvent } = storageModule;
+
+    const first = await enqueueEvent({
+      id: "event-1",
+      type: "ticket.checkin",
+      payload: { ticketId: "ticket-42" },
+      dedupeKey: "ticket:ticket-42",
+      createdAt: new Date("2025-01-10T12:00:00.000Z").toISOString(),
+    });
+
+    const merged = await enqueueEvent({
+      type: "ticket.checkin",
+      payload: { ticketId: "ticket-42", status: "checked_in" },
+      dedupeKey: "ticket:ticket-42",
+      createdAt: new Date("2025-01-10T12:05:00.000Z").toISOString(),
+    });
+
+    expect(merged.id).toBe(first.id);
+
+    const stored = await db.eventQueue.get(first.id);
+    expect(stored?.payload).toEqual({ ticketId: "ticket-42", status: "checked_in" });
+    expect(stored?.retryCount).toBe(0);
+
+    const audits = await db.audits.orderBy("createdAt").toArray();
+    expect(audits).toHaveLength(2);
+    expect(audits[0]).toMatchObject({ action: "queue" });
+    expect(audits[1]).toMatchObject({
+      action: "queue",
+      summary: "Merged event with dedupe key ticket:ticket-42",
+    });
+  });
+
+  it("consumes queued events oldest-first and emits dequeue audits", async () => {
+    const { enqueueEvent, consumeEvents } = storageModule;
+
+    await enqueueEvent({
+      id: "inventory-1",
+      type: "inventory.adjustment",
+      payload: { itemId: "item-1", delta: 1 },
+      dedupeKey: "inventory:item-1",
+      createdAt: new Date("2025-01-10T09:00:00.000Z").toISOString(),
+    });
+
+    await enqueueEvent({
+      id: "ticket-1",
+      type: "ticket.checkin",
+      payload: { ticketId: "ticket-1" },
+      dedupeKey: "ticket:ticket-1",
+      createdAt: new Date("2025-01-10T09:05:00.000Z").toISOString(),
+    });
+
+    const events = await consumeEvents(10);
+
+    expect(events.map((event) => event.id)).toEqual(["inventory-1", "ticket-1"]);
+    expect(await db.eventQueue.count()).toBe(0);
+
+    const auditSummaries = await db.audits
+      .filter((audit) => audit.action === "dequeue")
+      .toArray()
+      .then((records) => records.map((record) => record.summary).sort());
+    expect(auditSummaries).toEqual([
+      "Dequeued offline event inventory-1",
+      "Dequeued offline event ticket-1",
+    ]);
+  });
+
+  it("applies inventory snapshots by replacing local state", async () => {
+    const { applySnapshot } = storageModule;
+
+    const snapshot: OfflineSnapshot = {
+      scope: "inventory",
+      serverSeq: 42,
+      capturedAt: "2025-01-10T11:30:00.000Z",
+      records: [
+        {
+          id: "item-1",
+          sku: "SKU-1",
+          name: "Scheinwerfer",
+          quantity: 5,
+          updatedAt: "2025-01-10T11:30:00.000Z",
+        },
+        {
+          id: "item-2",
+          sku: "SKU-2",
+          name: "Funkmikrofon",
+          quantity: 3,
+          updatedAt: "2025-01-10T11:30:00.000Z",
+        },
+      ],
+    };
+
+    await applySnapshot(snapshot);
+
+    const items = await db.items.orderBy("id").toArray();
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({ id: "item-1", quantity: 5 });
+
+    const state = await db.syncState.get("inventory");
+    expect(state).toMatchObject({
+      scope: "inventory",
+      lastServerSeq: 42,
+      lastSnapshotAt: "2025-01-10T11:30:00.000Z",
+    });
+
+    const audit = await db.audits.where("action").equals("snapshot").first();
+    expect(audit).toMatchObject({
+      scope: "inventory",
+      summary: "Applied snapshot for inventory",
+    });
+  });
+
+  it("applies ticket deltas with upserts and deletes", async () => {
+    const { applySnapshot, applyDeltas } = storageModule;
+
+    await applySnapshot({
+      scope: "tickets",
+      serverSeq: 5,
+      capturedAt: "2025-01-09T10:00:00.000Z",
+      records: [
+        {
+          id: "ticket-1",
+          code: "T-1",
+          status: "unused",
+          holderName: "Erika Muster",
+          eventId: "event-1",
+          updatedAt: "2025-01-09T10:00:00.000Z",
+        },
+        {
+          id: "ticket-2",
+          code: "T-2",
+          status: "unused",
+          holderName: null,
+          eventId: "event-1",
+          updatedAt: "2025-01-09T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const delta: OfflineDelta = {
+      scope: "tickets",
+      serverSeq: 6,
+      upserts: [
+        {
+          id: "ticket-2",
+          code: "T-2",
+          status: "checked_in",
+          holderName: "Alex Beispiel",
+          eventId: "event-1",
+          updatedAt: "2025-01-10T12:00:00.000Z",
+        },
+        {
+          id: "ticket-3",
+          code: "T-3",
+          status: "pending",
+          holderName: null,
+          eventId: "event-2",
+          updatedAt: "2025-01-10T12:00:00.000Z",
+        },
+      ],
+      deletes: ["ticket-1"],
+    };
+
+    await applyDeltas(delta);
+
+    const tickets = await db.tickets.orderBy("id").toArray();
+    expect(tickets).toEqual([
+      {
+        id: "ticket-2",
+        code: "T-2",
+        status: "checked_in",
+        holderName: "Alex Beispiel",
+        eventId: "event-1",
+        updatedAt: "2025-01-10T12:00:00.000Z",
+      },
+      {
+        id: "ticket-3",
+        code: "T-3",
+        status: "pending",
+        holderName: null,
+        eventId: "event-2",
+        updatedAt: "2025-01-10T12:00:00.000Z",
+      },
+    ]);
+
+    const state = await db.syncState.get("tickets");
+    expect(state).toMatchObject({
+      scope: "tickets",
+      lastServerSeq: 6,
+      lastSnapshotAt: "2025-01-09T10:00:00.000Z",
+    });
+
+    const audit = await db.audits.where("action").equals("delta").first();
+    expect(audit).toMatchObject({
+      scope: "tickets",
+      summary: "Applied delta for tickets",
+      metadata: expect.objectContaining({ upserts: 2, deletes: 1 }),
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    exclude: [...configDefaults.exclude, "realtime-server/**"],
+    exclude: [...configDefaults.exclude, "realtime-server/**", "e2e/**"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add an in-memory Prisma stub to exercise the sync API routes in integration tests
- cover baseline, pull, and push scenarios for the scanner sync workflow with regression-focused assertions
- tidy the offline storage unit tests so the new lint job stays green

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d41404ff7c832db4770d856794efa1