### PR TITLE
Fix CI pnpm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+          run_install: false
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies
@@ -29,8 +33,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+          run_install: false
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies
@@ -47,8 +55,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
+          run_install: false
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "theater-website",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "predev": "node scripts/run-prisma-migrate.mjs",
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- install pnpm 9.15.9 explicitly in the CI workflow via pnpm/action-setup
- bump the GitHub Actions Node version to 24 to match the documented runtime
- record the pnpm toolchain in package.json so corepack can activate it consistently

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d424607be0832db2d2f683515fd277