### PR TITLE
Remove caching from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.9
@@ -34,7 +33,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.9
@@ -56,7 +54,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
       - uses: pnpm/action-setup@v4
         with:
           version: 9.15.9

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,5 +83,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ matrix.build_args }}
-          cache-from: type=gha,scope=${{ matrix.environment }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.environment }}


### PR DESCRIPTION
## Summary
- remove pnpm dependency caching from the CI workflow
- disable Buildx cache usage in the Docker publish workflow

## Testing
- pnpm lint
- pnpm test *(fails: Cannot find package 'fake-indexeddb/auto' required by src/lib/offline/__tests__/storage.test.ts)*
- CI=1 pnpm build *(fails: Missing dev dependency '@playwright/test' referenced in playwright.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d42e78775c832dbc9d01e495bc7cad