### PR TITLE
Add production-aware onboarding and invites

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -275,6 +275,7 @@ model User {
   onboardingProfile      MemberOnboardingProfile?
   interests              UserInterest[]
   rolePreferences        MemberRolePreference[]
+  productionMemberships  ProductionMembership[]
   interestsAuthored      Interest[]             @relation("InterestCreatedBy")
   issuesCreated          Issue[]                @relation("IssueCreatedBy")
   issuesUpdated          Issue[]                @relation("IssueUpdatedBy")
@@ -349,6 +350,9 @@ model Show {
   characters Character[]
   scenes     Scene[]
   finalRehearsalDuties FinalRehearsalDuty[]
+  memberships ProductionMembership[]
+  onboardingProfiles MemberOnboardingProfile[]
+  invites    MemberInvite[]
 }
 
 model FinalRehearsalDuty {
@@ -1102,10 +1106,12 @@ model MemberInvite {
   roles       Role[]
   isDisabled  Boolean  @default(false)
   createdById String
+  showId      String
 
   createdBy   User     @relation("MemberInvitesCreated", fields: [createdById], references: [id], onDelete: Cascade)
   redemptions MemberInviteRedemption[]
   onboardings MemberOnboardingProfile[]
+  show        Show     @relation(fields: [showId], references: [id], onDelete: Cascade)
 }
 
 model MemberInviteRedemption {
@@ -1166,6 +1172,7 @@ model MemberOnboardingProfile {
   userId       String           @unique
   inviteId     String?
   redemptionId String?         @unique
+  showId       String?
   focus        OnboardingFocus
   background   String?
   backgroundClass String?
@@ -1180,8 +1187,24 @@ model MemberOnboardingProfile {
   user       User                     @relation(fields: [userId], references: [id], onDelete: Cascade)
   invite     MemberInvite?            @relation(fields: [inviteId], references: [id], onDelete: SetNull)
   redemption MemberInviteRedemption?  @relation("OnboardingProfileRedemption", fields: [redemptionId], references: [id], onDelete: SetNull)
+  show       Show?                    @relation(fields: [showId], references: [id], onDelete: SetNull)
 
   @@index([inviteId])
+}
+
+model ProductionMembership {
+  id        String   @id @default(cuid())
+  showId    String
+  userId    String
+  joinedAt  DateTime @default(now())
+  leftAt    DateTime?
+
+  show      Show     @relation(fields: [showId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([showId, userId])
+  @@index([userId, leftAt])
+  @@index([showId, leftAt])
 }
 
 model Announcement {

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -200,6 +200,23 @@ async function main() {
   const latestShow = await prisma.show.findFirst({ orderBy: { year: "desc" } });
   const referenceYear = latestShow?.year ?? new Date().getUTCFullYear();
 
+  if (latestShow) {
+    const seededUsers = await prisma.user.findMany({
+      where: { email: { in: emails } },
+      select: { id: true },
+    });
+
+    if (seededUsers.length) {
+      await prisma.productionMembership.createMany({
+        data: seededUsers.map((user) => ({
+          userId: user.id,
+          showId: latestShow.id,
+        })),
+        skipDuplicates: true,
+      });
+    }
+  }
+
   const financeBudgetSeeds = [
     {
       id: "seed-budget-costumes",

--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -84,7 +84,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
 
   const session = await requireAuth();
   const permissions = await getUserPermissionKeys(session.user);
-  const activeProduction = await getActiveProduction();
+  const activeProduction = await getActiveProduction(session.user?.id);
 
   let resolvedSettings = resolveWebsiteSettings(null);
 

--- a/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
@@ -233,7 +233,7 @@ export default async function FinalRehearsalDutyPlanPage() {
     );
   }
   const canManage = await hasPermission(session.user, FINAL_WEEK_MANAGE_PERMISSION_KEY);
-  const activeProductionId = await getActiveProductionId();
+  const activeProductionId = await getActiveProductionId(session.user?.id);
 
   const baseSelection = await Promise.all([
     activeProductionId
@@ -270,7 +270,19 @@ export default async function FinalRehearsalDutyPlanPage() {
       : Promise.resolve([]),
     canManage
       ? prisma.user.findMany({
-          where: { deactivatedAt: null },
+          where: {
+            deactivatedAt: null,
+            ...(show
+              ? {
+                  productionMemberships: {
+                    some: {
+                      showId: show.id,
+                      OR: [{ leftAt: null }, { leftAt: { gt: new Date() } }],
+                    },
+                  },
+                }
+              : {}),
+          },
           orderBy: [
             { firstName: "asc" },
             { lastName: "asc" },

--- a/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
@@ -30,7 +30,9 @@ export default async function EinkaufslistePage() {
     );
   }
 
-  const { plannerDays, defaultParticipantCount, totalParticipants } = await loadMealPlanningContext();
+  const { plannerDays, defaultParticipantCount, totalParticipants } = await loadMealPlanningContext(
+    session.user?.id,
+  );
   const assignments: PlannerAssignments = {};
   for (const day of plannerDays) {
     const dayAssignments: Record<string, string | null | undefined> = {};

--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
@@ -75,7 +75,7 @@ export default async function EssensplanungPage() {
     plannerDays,
     defaultParticipantCount,
     priorityProfiles,
-  } = await loadMealPlanningContext();
+  } = await loadMealPlanningContext(session.user?.id);
 
   const finalWeekStart = show?.finalRehearsalWeekStart ?? null;
   const numberFormatter = new Intl.NumberFormat("de-DE");

--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -50,7 +50,7 @@ export default async function ProduktionDetailPage({
     notFound();
   }
 
-  const activeProductionId = await getActiveProductionId();
+  const activeProductionId = await getActiveProductionId(session.user?.id);
   const isActive = activeProductionId === show.id;
   const title = formatShowTitle(show);
   const finalRehearsalWeekStartValue = show.finalRehearsalWeekStart

--- a/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
@@ -62,7 +62,7 @@ export default async function ProduktionsBesetzungPage() {
     );
   }
 
-  const activeProduction = await getActiveProduction();
+  const activeProduction = await getActiveProduction(session.user?.id);
   const headerActions = (
     <Button asChild variant="outline" size="sm">
       <Link href="/mitglieder/produktionen">Zur Übersicht</Link>
@@ -89,6 +89,15 @@ export default async function ProduktionsBesetzungPage() {
 
   const [users, show] = await Promise.all([
     prisma.user.findMany({
+      where: {
+        deactivatedAt: null,
+        productionMemberships: {
+          some: {
+            showId: activeProduction.id,
+            OR: [{ leftAt: null }, { leftAt: { gt: new Date() } }],
+          },
+        },
+      },
       orderBy: [
         { name: "asc" },
         { email: "asc" },

--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -41,7 +41,7 @@ export default async function ProduktionenPage() {
       orderBy: { year: "desc" },
       select: { id: true, year: true, title: true, synopsis: true },
     }),
-    getActiveProduction(),
+    getActiveProduction(session.user?.id),
   ]);
 
   const activeShowId = activeProduction?.id ?? null;

--- a/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
@@ -60,7 +60,7 @@ export default async function ProduktionsSzenenPage() {
     );
   }
 
-  const activeProduction = await getActiveProduction();
+  const activeProduction = await getActiveProduction(session.user?.id);
   const headerActions = (
     <Button asChild variant="outline" size="sm">
       <Link href="/mitglieder/produktionen">Zur Übersicht</Link>
@@ -87,6 +87,15 @@ export default async function ProduktionsSzenenPage() {
 
   const [users, departments, show] = await Promise.all([
     prisma.user.findMany({
+      where: {
+        deactivatedAt: null,
+        productionMemberships: {
+          some: {
+            showId: activeProduction.id,
+            OR: [{ leftAt: null }, { leftAt: { gt: new Date() } }],
+          },
+        },
+      },
       orderBy: [
         { name: "asc" },
         { email: "asc" },

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -49,7 +49,7 @@ export async function GET() {
     const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
     endOfMonth.setHours(23, 59, 59, 999);
 
-    const activeProductionId = await getActiveProductionId();
+    const activeProductionId = await getActiveProductionId(userId);
     const activeProductionPromise = activeProductionId
       ? prisma.show.findUnique({
           where: { id: activeProductionId },

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -26,7 +26,10 @@ export default async function OnboardingInvitePage({
   const tokenHash = isHashedToken ? token.toLowerCase() : hashInviteToken(token);
   const invite = await prisma.memberInvite.findUnique({
     where: { tokenHash },
-    include: { createdBy: { select: { name: true, email: true } } },
+    include: {
+      createdBy: { select: { name: true, email: true } },
+      show: { select: { id: true, title: true, year: true } },
+    },
   });
 
   if (!invite) {
@@ -75,6 +78,7 @@ export default async function OnboardingInvitePage({
           expiresAt: invite.expiresAt ? invite.expiresAt.toISOString() : null,
           usageCount: invite.usageCount,
           remainingUses: status.remainingUses,
+          production: invite.show,
         }}
       />
     </main>

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -251,6 +251,7 @@ type InviteMeta = {
   expiresAt: string | null;
   usageCount: number;
   remainingUses: number | null;
+  production: { id: string; title: string | null; year: number } | null;
 };
 
 type OnboardingWizardProps = {
@@ -312,6 +313,15 @@ function requiresBszClass(value: string) {
   const normalized = normalizeForMatch(value);
   if (!normalized.includes("bsz")) return false;
   return ["altrossthal", "altrothal", "canaletto"].some((keyword) => normalized.includes(keyword));
+}
+
+function formatProductionLabel(production: InviteMeta["production"]) {
+  if (!production) return "deine Produktion";
+  const trimmed = production.title?.trim() ?? "";
+  if (trimmed) {
+    return `${trimmed} (${production.year})`;
+  }
+  return `Produktion ${production.year}`;
 }
 
 export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps) {
@@ -1077,6 +1087,11 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
               {invite.createdBy ? ` von ${invite.createdBy}` : ""}.
               {inviteExpiresAt ? ` Gültig bis ${inviteExpiresAt}.` : ""}
             </p>
+            {invite.production ? (
+              <Badge variant="outline" className="mt-2 border-primary/60 text-primary">
+                Einladung für {formatProductionLabel(invite.production)}
+              </Badge>
+            ) : null}
           </div>
           <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground sm:flex-nowrap">
             <Badge variant="outline">Link-ID gesichert</Badge>

--- a/src/lib/active-production.ts
+++ b/src/lib/active-production.ts
@@ -5,20 +5,137 @@ import { prisma } from "@/lib/prisma";
 
 export const ACTIVE_PRODUCTION_COOKIE = "active-production";
 
-export async function getActiveProductionId() {
-  const store = await cookies();
-  const value = store.get(ACTIVE_PRODUCTION_COOKIE)?.value;
-  return value ?? null;
+type ActiveMembership = {
+  showId: string;
+  leftAt: Date | null;
+  show: {
+    id: string;
+    title: string | null;
+    year: number;
+    finalRehearsalWeekStart: Date | null;
+  };
+};
+
+function isMembershipActive<T extends { leftAt: Date | null }>(entry: T): entry is T {
+  if (!entry.leftAt) return true;
+  return entry.leftAt.getTime() > Date.now();
 }
 
-export const getActiveProduction = cache(async () => {
-  const activeProductionId = await getActiveProductionId();
+function selectPreferredMembership(memberships: ActiveMembership[]) {
+  if (memberships.length === 0) return null;
+  if (memberships.length === 1) return memberships[0];
+
+  return memberships
+    .slice()
+    .sort((a, b) => {
+      const aDate = a.show.finalRehearsalWeekStart?.getTime() ?? 0;
+      const bDate = b.show.finalRehearsalWeekStart?.getTime() ?? 0;
+      if (aDate !== bDate) {
+        return bDate - aDate;
+      }
+      return b.show.year - a.show.year;
+    })[0];
+}
+
+async function resolveFallbackActiveProductionId(userId: string | null | undefined) {
+  if (!userId) {
+    return null;
+  }
+
+  const memberships = await prisma.productionMembership.findMany({
+    where: { userId },
+    include: {
+      show: {
+        select: {
+          id: true,
+          title: true,
+          year: true,
+          finalRehearsalWeekStart: true,
+        },
+      },
+    },
+  });
+
+  if (memberships.length === 0) {
+    return null;
+  }
+
+  const normalizedMemberships: ActiveMembership[] = memberships.map((membership) => ({
+    showId: membership.showId,
+    leftAt: membership.leftAt,
+    show: membership.show,
+  }));
+
+  const activeMemberships = normalizedMemberships.filter(isMembershipActive);
+  if (activeMemberships.length === 0) {
+    return null;
+  }
+
+  const preferred = selectPreferredMembership(activeMemberships);
+  return preferred?.showId ?? null;
+}
+
+export async function getActiveProductionId(userId?: string | null) {
+  const store = await cookies();
+  const cookieValue = store.get(ACTIVE_PRODUCTION_COOKIE)?.value ?? null;
+
+  if (!userId) {
+    return cookieValue;
+  }
+
+  if (cookieValue) {
+    const membership = await prisma.productionMembership.findFirst({
+      where: {
+        userId,
+        showId: cookieValue,
+        OR: [{ leftAt: null }, { leftAt: { gt: new Date() } }],
+      },
+      select: { id: true },
+    });
+
+    if (membership) {
+      return cookieValue;
+    }
+  }
+
+  const fallbackId = await resolveFallbackActiveProductionId(userId);
+
+  if (!fallbackId) {
+    if (cookieValue) {
+      store.delete(ACTIVE_PRODUCTION_COOKIE);
+    }
+    return null;
+  }
+
+  store.set(ACTIVE_PRODUCTION_COOKIE, fallbackId, {
+    maxAge: 60 * 60 * 24 * 180,
+    sameSite: "lax",
+    path: "/",
+  });
+
+  return fallbackId;
+}
+
+export const getActiveProduction = cache(async (userId?: string | null) => {
+  const activeProductionId = await getActiveProductionId(userId);
   if (!activeProductionId) {
     return null;
   }
 
-  const show = await prisma.show.findUnique({
-    where: { id: activeProductionId },
+  const where = userId
+    ? {
+        id: activeProductionId,
+        memberships: {
+          some: {
+            userId,
+            OR: [{ leftAt: null }, { leftAt: { gt: new Date() } }],
+          },
+        },
+      }
+    : { id: activeProductionId };
+
+  const show = await prisma.show.findFirst({
+    where,
     select: {
       id: true,
       title: true,

--- a/src/lib/member-invites.ts
+++ b/src/lib/member-invites.ts
@@ -46,6 +46,7 @@ export function describeInvite(invite: MemberInvite, now: Date = new Date()) {
     maxUses: invite.maxUses,
     usageCount: invite.usageCount,
     roles: invite.roles,
+    showId: invite.showId,
     ...status,
   };
 }

--- a/src/lib/realtime/service.ts
+++ b/src/lib/realtime/service.ts
@@ -324,19 +324,16 @@ export class RealtimeService {
 
   private async isUserAuthorizedForShow(userId: string, showId: string): Promise<boolean> {
     try {
-      const show = await prisma.show.findFirst({
+      const membership = await prisma.productionMembership.findFirst({
         where: {
-          id: showId,
-          OR: [
-            { characters: { some: { castings: { some: { userId } } } } },
-            { rehearsals: { some: { attendance: { some: { userId } } } } },
-            { rehearsals: { some: { invitees: { some: { userId } } } } },
-          ],
+          userId,
+          showId,
+          OR: [{ leftAt: null }, { leftAt: { gt: new Date() } }],
         },
         select: { id: true },
       });
 
-      return Boolean(show);
+      return Boolean(membership);
     } catch (error) {
       console.error(`[Realtime] Failed to verify show access for user ${userId} and show ${showId}`, error);
       return false;


### PR DESCRIPTION
## Summary
- add a ProductionMembership model, enforce show relations on invites, and seed memberships for demo users
- update onboarding completion to require a production invite and create the related membership record
- surface production context in member invite APIs and UI while wiring active-production state through the members area

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4389196d8832d9a77aca47d35fd3a