### PR TITLE
Prevent horizontal scrolling when tables overflow

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -105,7 +105,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <ColorModeScript mode={resolvedSettings.colorMode} />
         <ThemeStyleRegistry tokens={themeTokens} />
       </head>
-      <body className="antialiased bg-background text-foreground">
+      <body
+        className={cn(
+          "antialiased bg-background text-foreground",
+          "overflow-x-hidden",
+        )}
+      >
         <Providers session={session}>
           <a
             href="#main"


### PR DESCRIPTION
## Summary
- prevent the document body from creating a global horizontal scrollbar by hiding overflow on the x-axis

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4452bb6cc832da4a1d8d404f1066d