### PR TITLE
Add department permission grants and join approval controls

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -383,11 +383,13 @@ model Department {
   description String?
   color       String?
   isCore      Boolean  @default(true)
+  requiresJoinApproval Boolean @default(false)
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   memberships DepartmentMembership[]
   breakdownItems SceneBreakdownItem[]
   tasks        DepartmentTask[]
+  permissions  DepartmentPermission[]
 }
 
 model DepartmentMembership {
@@ -423,6 +425,16 @@ model DepartmentTask {
   @@index([departmentId, status])
   @@index([assigneeId])
   @@index([createdAt])
+}
+
+model DepartmentPermission {
+  id           String     @id @default(cuid())
+  departmentId String
+  permissionId String
+  department   Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  permission   Permission @relation(fields: [permissionId], references: [id], onDelete: Cascade)
+
+  @@unique([departmentId, permissionId])
 }
 
 model Character {
@@ -733,6 +745,7 @@ model Permission {
   label       String?
   description String?
   grants      AppRolePermission[]
+  departmentGrants DepartmentPermission[]
 }
 
 model AppRole {

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -641,6 +641,7 @@ async function main() {
         description: dept.description ?? null,
         color: dept.color ?? null,
         isCore: true,
+        requiresJoinApproval: dept.requiresJoinApproval ?? false,
       },
       create: {
         slug: dept.slug,
@@ -648,6 +649,7 @@ async function main() {
         description: dept.description ?? null,
         color: dept.color ?? null,
         isCore: true,
+        requiresJoinApproval: dept.requiresJoinApproval ?? false,
       },
     });
   }

--- a/src/app/(members)/mitglieder/meine-gewerke/actions.ts
+++ b/src/app/(members)/mitglieder/meine-gewerke/actions.ts
@@ -49,11 +49,15 @@ export async function joinDepartmentAction(formData: FormData) {
 
   const department = await prisma.department.findUnique({
     where: { id: departmentIdValue },
-    select: { id: true },
+    select: { id: true, requiresJoinApproval: true },
   });
 
   if (!department) {
     throw new Error("Das ausgewählte Gewerk existiert nicht mehr.");
+  }
+
+  if (department.requiresJoinApproval) {
+    throw new Error("Dieses Gewerk benötigt eine Zustimmung durch die Leitung.");
   }
 
   await prisma.departmentMembership.upsert({

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -394,6 +394,7 @@ export async function createDepartmentAction(formData: FormData): Promise<void> 
     }
     const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 2000 });
     const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
+    const requiresApproval = parseCheckbox(formData.get("requiresApproval"));
     const baseSlug = slugify(slugInput ?? name);
     const slug = await ensureUniqueDepartmentSlug(baseSlug);
 
@@ -403,6 +404,7 @@ export async function createDepartmentAction(formData: FormData): Promise<void> 
         slug,
         description: description ?? null,
         color: color ?? null,
+        requiresJoinApproval: requiresApproval,
       },
     });
 
@@ -431,6 +433,7 @@ export async function updateDepartmentAction(formData: FormData): Promise<void> 
     }
     const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 2000 });
     const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
+    const requiresApproval = parseCheckbox(formData.get("requiresApproval"));
 
     let slug = department.slug;
     if (slugInput) {
@@ -445,6 +448,7 @@ export async function updateDepartmentAction(formData: FormData): Promise<void> 
         slug,
         description: description ?? null,
         color: color ?? null,
+        requiresJoinApproval: requiresApproval,
       },
     });
 

--- a/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
@@ -142,6 +142,17 @@ export default async function ProduktionsGewerkePage() {
                   className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
                 />
               </div>
+              <div className="space-y-1 sm:col-span-2">
+                <span className="text-sm font-medium">Beitritt</span>
+                <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    name="requiresApproval"
+                    className="h-4 w-4 rounded border border-border"
+                  />
+                  Leitung muss neue Mitglieder bestätigen, bevor sie beitreten.
+                </label>
+              </div>
             </fieldset>
             <div className="space-y-1">
               <label className="text-sm font-medium">Beschreibung</label>
@@ -177,6 +188,11 @@ export default async function ProduktionsGewerkePage() {
                       ) : null}
                       {department.slug ? (
                         <p className="text-xs uppercase tracking-wide text-muted-foreground">Slug: {department.slug}</p>
+                      ) : null}
+                      {department.requiresJoinApproval ? (
+                        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                          Beitritt benötigt Zustimmung der Leitung
+                        </p>
                       ) : null}
                     </div>
                   </div>
@@ -219,6 +235,20 @@ export default async function ProduktionsGewerkePage() {
                         defaultValue={department.color ?? "#94a3b8"}
                         className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
                       />
+                    </div>
+                    <div className="space-y-1 md:col-span-2">
+                      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Beitritt
+                      </span>
+                      <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <input
+                          type="checkbox"
+                          name="requiresApproval"
+                          defaultChecked={department.requiresJoinApproval}
+                          className="h-4 w-4 rounded border border-border"
+                        />
+                        Leitung muss neue Mitglieder bestätigen, bevor sie beitreten.
+                      </label>
                     </div>
                     <div className="space-y-1 md:col-span-2">
                       <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
## Summary
- add department-level permission grants and ensure Prisma schema, seed data and RBAC helpers include trade memberships
- extend the permissions API and matrix UI with a Gewerke view for assigning rights alongside roles
- allow productions to require approval for Gewerke joins and surface the toggle in creation, editing and member flows

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d44413d97c832dabbde6289e601fe3