### PR TITLE
Fix hydration-safe media query hook

### DIFF
--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -7,10 +7,7 @@ import { useEffect, useState } from "react";
  * Returns whether the provided media query currently matches.
  */
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia(query).matches;
-  });
+  const [matches, setMatches] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return undefined;


### PR DESCRIPTION
## Summary
- prevent the media query hook from reading `matchMedia` during the first render so SSR and hydration markup stay in sync

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4495c3f98832dbfeba832fd628865