### PR TITLE
Add onboarding WhatsApp link configuration

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -10,7 +10,15 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 
-import { setActiveProductionAction, updateProductionTimelineAction } from "../actions";
+import { X } from "lucide-react";
+
+import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
+
+import {
+  setActiveProductionAction,
+  updateOnboardingSettingsAction,
+  updateProductionTimelineAction,
+} from "../actions";
 
 function formatShowTitle(show: { title: string | null; year: number }) {
   if (show.title && show.title.trim()) return show.title;
@@ -59,6 +67,8 @@ export default async function ProduktionDetailPage({
   const finalRehearsalWeekStartLabel = show.finalRehearsalWeekStart
     ? new Intl.DateTimeFormat("de-DE", { dateStyle: "long" }).format(show.finalRehearsalWeekStart)
     : null;
+  const whatsappLink = getOnboardingWhatsAppLink(show.meta);
+  const onboardingRedirect = `/mitglieder/produktionen/${show.id}`;
 
   return (
     <div className="space-y-10">
@@ -162,6 +172,55 @@ export default async function ProduktionDetailPage({
             <Button type="submit" className="sm:w-auto">
               Zeitplan aktualisieren
             </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="space-y-2">
+          <CardTitle className="text-lg font-semibold">Onboarding-Einstellungen</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Hinterlege optional den WhatsApp-Beitrittslink für neue Mitglieder. Der Link erscheint in der
+            Onboarding-Zusammenfassung und auf dem Mitglieder-Dashboard.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form action={updateOnboardingSettingsAction} className="space-y-4">
+            <input type="hidden" name="showId" value={show.id} />
+            <input type="hidden" name="redirectPath" value={onboardingRedirect} />
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="whatsappLink">
+                WhatsApp-Beitrittslink
+              </label>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <Input
+                  id="whatsappLink"
+                  name="whatsappLink"
+                  defaultValue={whatsappLink ?? ""}
+                  placeholder="https://chat.whatsapp.com/..."
+                  className="sm:max-w-lg"
+                />
+                <div className="flex items-center gap-2">
+                  <Button type="submit">Speichern</Button>
+                  {whatsappLink ? (
+                    <Button
+                      type="submit"
+                      name="clear"
+                      value="1"
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-destructive"
+                      aria-label="Link entfernen"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Nur offizielle WhatsApp-Beitrittslinks werden akzeptiert. Lass das Feld leer, um den Link zu entfernen.
+              </p>
+            </div>
           </form>
         </CardContent>
       </Card>

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -8,6 +8,7 @@ import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProductionId } from "@/lib/active-production";
 import { buildProfileChecklist } from "@/lib/profile-completion";
+import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 
 const onboardingProfileSelect = Prisma.validator<Prisma.MemberOnboardingProfileSelect>()({
   focus: true,
@@ -18,6 +19,7 @@ const onboardingProfileSelect = Prisma.validator<Prisma.MemberOnboardingProfileS
   updatedAt: true,
   dietaryPreference: true,
   dietaryPreferenceStrictness: true,
+  show: { select: { meta: true } },
 });
 
 export async function GET() {
@@ -213,6 +215,8 @@ export async function GET() {
       level: entry.level,
     }));
 
+    const whatsappLink = getOnboardingWhatsAppLink(onboardingProfile?.show?.meta ?? null);
+
     const onboarding = {
       completed: Boolean(onboardingProfile),
       completedAt: onboardingProfile?.createdAt?.toISOString() ?? null,
@@ -220,6 +224,7 @@ export async function GET() {
       background: onboardingProfile?.background ?? null,
       backgroundClass: onboardingProfile?.backgroundClass ?? null,
       notes: onboardingProfile?.notes ?? null,
+      whatsappLink,
       stats: {
         acting: { count: actingPreferences.length, averageWeight: averageWeight(actingPreferences) },
         crew: { count: crewPreferences.length, averageWeight: averageWeight(crewPreferences) },

--- a/src/app/onboarding/[token]/page.tsx
+++ b/src/app/onboarding/[token]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { prisma } from "@/lib/prisma";
 import { calculateInviteStatus, generateInviteToken, hashInviteToken } from "@/lib/member-invites";
+import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard";
 
 export const dynamic = "force-dynamic";
@@ -28,7 +29,7 @@ export default async function OnboardingInvitePage({
     where: { tokenHash },
     include: {
       createdBy: { select: { name: true, email: true } },
-      show: { select: { id: true, title: true, year: true } },
+      show: { select: { id: true, title: true, year: true, meta: true } },
     },
   });
 
@@ -65,6 +66,8 @@ export default async function OnboardingInvitePage({
     },
   });
 
+  const whatsappLink = getOnboardingWhatsAppLink(invite.show?.meta);
+
   return (
     <main id="main" className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 sm:py-12 lg:px-8">
       <OnboardingWizard
@@ -78,7 +81,10 @@ export default async function OnboardingInvitePage({
           expiresAt: invite.expiresAt ? invite.expiresAt.toISOString() : null,
           usageCount: invite.usageCount,
           remainingUses: status.remainingUses,
-          production: invite.show,
+          production: invite.show
+            ? { id: invite.show.id, title: invite.show.title, year: invite.show.year }
+            : null,
+          whatsappLink,
         }}
       />
     </main>

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -45,6 +45,8 @@ import {
   PiggyBank,
   CalendarRange,
   UtensilsCrossed,
+  MessageCircle,
+  X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -77,6 +79,7 @@ interface OnboardingOverview {
   background: string | null;
   backgroundClass: string | null;
   notes: string | null;
+  whatsappLink: string | null;
   stats: {
     acting: OnboardingDomainStats;
     crew: OnboardingDomainStats;
@@ -361,6 +364,10 @@ function parseOnboardingOverview(value: unknown): OnboardingOverview | null {
   const updatedAt = parseIsoDate(photoRecord.updatedAt);
 
   const passwordSet = Boolean(value.passwordSet);
+  const whatsappLink =
+    typeof value.whatsappLink === "string" && value.whatsappLink.trim()
+      ? value.whatsappLink.trim()
+      : null;
 
   return {
     completed,
@@ -369,6 +376,7 @@ function parseOnboardingOverview(value: unknown): OnboardingOverview | null {
     background,
     backgroundClass,
     notes,
+    whatsappLink,
     stats: {
       acting: actingStats,
       crew: crewStats,
@@ -438,6 +446,7 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
   const [isLoading, setIsLoading] = useState(true);
   const [onboarding, setOnboarding] = useState<OnboardingOverview | null>(null);
   const [onboardingLoaded, setOnboardingLoaded] = useState(false);
+  const [whatsappDismissed, setWhatsappDismissed] = useState(false);
   const [finalRehearsalWeek, setFinalRehearsalWeek] = useState<FinalRehearsalWeekInfo | null>(null);
   const [profileCompletion, setProfileCompletion] = useState<
     { complete: boolean; completed: number; total: number } | null
@@ -446,6 +455,10 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
   useEffect(() => {
     setStats((prev) => ({ ...prev, totalOnline: liveOnline }));
   }, [liveOnline]);
+
+  useEffect(() => {
+    setWhatsappDismissed(false);
+  }, [onboarding?.whatsappLink]);
 
   useEffect(() => {
     let cancelled = false;
@@ -845,6 +858,33 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
             </div>
           </div>
 
+          {onboarding.whatsappLink && !whatsappDismissed ? (
+            <div className="space-y-2 rounded-xl border border-emerald-300/60 bg-emerald-50 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 text-sm font-semibold text-emerald-900">
+                  <MessageCircle className="h-4 w-4" />
+                  WhatsApp-Gruppe
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setWhatsappDismissed(true)}
+                  className="rounded-full border border-transparent p-1 text-emerald-900/70 transition hover:border-emerald-300 hover:text-emerald-900"
+                  aria-label="Hinweis ausblenden"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+              <p className="text-xs text-emerald-900/80">
+                Tritt der Ensemble-Gruppe bei, um Ansprechpersonen und aktuelle Infos zu erhalten.
+              </p>
+              <Button asChild size="sm" variant="outline" className="border-emerald-400/60 text-emerald-900">
+                <a href={onboarding.whatsappLink} target="_blank" rel="noopener noreferrer">
+                  WhatsApp öffnen
+                </a>
+              </Button>
+            </div>
+          ) : null}
+
           <div className="space-y-2 rounded-xl border border-border/60 bg-background/85 p-3">
             <div className="flex items-center justify-between">
               <span className="text-xs font-semibold uppercase text-muted-foreground">Fotoerlaubnis</span>
@@ -866,7 +906,7 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         </CardContent>
       </Card>
     );
-  }, [onboarding, onboardingLoaded]);
+  }, [onboarding, onboardingLoaded, whatsappDismissed]);
 
   if (!session?.user) {
     return (

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { AllergyLevel, type Role } from "@prisma/client";
-import { Sparkles, ShieldCheck, Lock, Target } from "lucide-react";
+import { Sparkles, ShieldCheck, Lock, Target, MessageCircle } from "lucide-react";
 import { toast } from "sonner";
 
 import { SignaturePad } from "@/components/onboarding/signature-pad";
@@ -252,6 +252,7 @@ type InviteMeta = {
   usageCount: number;
   remainingUses: number | null;
   production: { id: string; title: string | null; year: number } | null;
+  whatsappLink: string | null;
 };
 
 type OnboardingWizardProps = {
@@ -1075,6 +1076,16 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
       return null;
     }
   }, [invite.expiresAt]);
+
+  const whatsappHost = useMemo(() => {
+    if (!invite.whatsappLink) return null;
+    try {
+      const url = new URL(invite.whatsappLink);
+      return url.hostname.replace(/^www\./, "");
+    } catch {
+      return null;
+    }
+  }, [invite.whatsappLink]);
 
   return (
     <div className="space-y-6 sm:space-y-8">
@@ -2189,6 +2200,26 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                 </div>
               </div>
             </section>
+
+            {invite.whatsappLink ? (
+              <section className="space-y-3 rounded-2xl border border-emerald-300/60 bg-emerald-50 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-emerald-900">
+                    <MessageCircle className="h-4 w-4" />
+                    WhatsApp-Gruppe
+                  </div>
+                  <Button asChild size="sm" variant="outline" className="border-emerald-400/60 text-emerald-900">
+                    <a href={invite.whatsappLink} target="_blank" rel="noopener noreferrer">
+                      WhatsApp öffnen
+                    </a>
+                  </Button>
+                </div>
+                <p className="text-xs text-emerald-900/80">
+                  Tritt unserer WhatsApp-Gruppe bei, um alle Updates und Ansprechpartner kennenzulernen.
+                  {whatsappHost ? ` (${whatsappHost})` : null}
+                </p>
+              </section>
+            ) : null}
 
             {success ? (
               <div className="rounded-lg border border-emerald-300 bg-emerald-50/80 p-4 text-sm text-emerald-900">

--- a/src/lib/onboarding-settings.ts
+++ b/src/lib/onboarding-settings.ts
@@ -1,0 +1,56 @@
+import { Prisma } from "@prisma/client";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneRecord(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  return { ...value };
+}
+
+export function getOnboardingWhatsAppLink(
+  meta: Prisma.JsonValue | null | undefined,
+): string | null {
+  if (!isRecord(meta)) {
+    return null;
+  }
+  const onboarding = (meta as Record<string, unknown>).onboarding;
+  if (!isRecord(onboarding)) {
+    return null;
+  }
+  const rawLink = onboarding.whatsappLink;
+  if (typeof rawLink !== "string") {
+    return null;
+  }
+  const trimmed = rawLink.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function setOnboardingWhatsAppLink(
+  meta: Prisma.JsonValue | null | undefined,
+  link: string | null,
+): Prisma.JsonObject | Prisma.JsonNullValueInput {
+  const base = cloneRecord(meta);
+  const onboarding = cloneRecord(base.onboarding);
+
+  if (link) {
+    onboarding.whatsappLink = link;
+    base.onboarding = onboarding;
+  } else {
+    delete onboarding.whatsappLink;
+    if (Object.keys(onboarding).length > 0) {
+      base.onboarding = onboarding;
+    } else {
+      delete base.onboarding;
+    }
+  }
+
+  if (Object.keys(base).length === 0) {
+    return Prisma.JsonNull;
+  }
+
+  return base as Prisma.JsonObject;
+}


### PR DESCRIPTION
## Summary
- add onboarding settings helpers to extract and persist WhatsApp links in show metadata
- extend production settings with a WhatsApp link form and server action to manage the onboarding link
- surface the optional onboarding WhatsApp link in the invite flow, dashboard overview API, dashboard card, and onboarding summary

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d448eaacec832d82d2db351d58aa39