### PR TITLE
Enhance mystery timer highlight and spacing

### DIFF
--- a/src/app/(site)/mystery/_components/mystery-countdown-card.tsx
+++ b/src/app/(site)/mystery/_components/mystery-countdown-card.tsx
@@ -127,12 +127,13 @@ export function MysteryCountdownCard({
 
   return (
     <Card className="relative">
-      <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <CardHeader className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <CardTitle>Nächstes Rätsel in</CardTitle>
         {canEdit ? (
           <Button
             size="sm"
             variant={editorOpen ? "secondary" : "outline"}
+            className="sm:self-start"
             onClick={() => toggleFeature("mystery.timer")}
             aria-pressed={editorOpen}
             aria-controls={EDITOR_SECTION_ID}
@@ -144,7 +145,11 @@ export function MysteryCountdownCard({
       <CardContent className="space-y-4">
         {showCountdown ? (
           <>
-            <Countdown targetDate={state.effectiveCountdownTarget} initialNow={initialNow} />
+            <Countdown
+              targetDate={state.effectiveCountdownTarget}
+              initialNow={initialNow}
+              variant="highlight"
+            />
             {countdownLabel ? (
               <Text variant="small" tone="muted">
                 Start am {countdownLabel}

--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -5,10 +5,13 @@ import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Text } from "@/components/ui/typography";
 
+type CountdownVariant = "default" | "highlight";
+
 type CountdownProps = {
   targetDate: string;
   initialNow: number;
   className?: string;
+  variant?: CountdownVariant;
 };
 
 type CountdownState = {
@@ -57,7 +60,7 @@ function formatNumber(value: number) {
   return value.toString().padStart(2, "0");
 }
 
-export function Countdown({ targetDate, initialNow, className }: CountdownProps) {
+export function Countdown({ targetDate, initialNow, className, variant = "default" }: CountdownProps) {
   const targetTimestamp = useMemo(() => new Date(targetDate).getTime(), [targetDate]);
   const [state, setState] = useState<CountdownState>(() => {
     if (Number.isNaN(targetTimestamp) || !Number.isFinite(initialNow)) {
@@ -102,12 +105,27 @@ export function Countdown({ targetDate, initialNow, className }: CountdownProps)
     { label: "Sekunden", value: state.seconds },
   ];
 
+  const containerClassName = cn("grid w-full grid-cols-2 gap-3 sm:grid-cols-4", className);
+  const cellClassName =
+    variant === "highlight"
+      ? "rounded-lg border border-primary/50 bg-primary/10 px-4 py-3 text-center shadow-sm text-primary"
+      : "rounded-lg border border-border bg-card px-4 py-3 text-center shadow-sm";
+  const numberClassName = cn(
+    "text-3xl font-semibold tabular-nums sm:text-4xl",
+    variant === "highlight" ? "text-primary" : undefined,
+  );
+  const labelTone = variant === "highlight" ? "primary" : "muted";
+
   return (
-    <div className={cn("grid w-full grid-cols-2 gap-3 sm:grid-cols-4", className)} aria-live="polite">
+    <div className={containerClassName} aria-live="polite">
       {timeParts.map((part) => (
-        <div key={part.label} className="rounded-lg border border-border bg-card px-4 py-3 text-center shadow-sm">
-          <div className="text-3xl font-semibold tabular-nums sm:text-4xl">{formatNumber(part.value)}</div>
-          <Text variant="small" tone="muted" className="mt-1 uppercase tracking-[0.2em]">
+        <div key={part.label} className={cellClassName}>
+          <div className={numberClassName}>{formatNumber(part.value)}</div>
+          <Text
+            variant="small"
+            tone={labelTone}
+            className={cn("mt-1 uppercase tracking-[0.2em]", variant === "highlight" ? "text-primary/80" : undefined)}
+          >
             {part.label}
           </Text>
         </div>


### PR DESCRIPTION
## Summary
- add a highlight variant to the countdown component to support accent styling
- space the mystery timer editor button away from the timer and apply the highlight variant

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d44ed1dc00832da6ff08ed70fb549e