### PR TITLE
Handle NextAuth when database is unavailable

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,62 @@
 import NextAuth from "next-auth";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
 import { authOptions } from "@/lib/auth";
 
 const handler = NextAuth(authOptions);
-export { handler as GET, handler as POST };
+
+type NextAuthHandler = typeof handler;
+type NextAuthContext = Parameters<NextAuthHandler>[1];
+
+function isAuthTemporarilyDisabled() {
+  const explicitFlag = (process.env.AUTH_DEV_NO_DB ?? process.env.NEXT_PUBLIC_AUTH_DEV_NO_DB ?? "").trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(explicitFlag)) {
+    return true;
+  }
+
+  return !process.env.DATABASE_URL;
+}
+
+function buildDisabledResponse(request: NextRequest, reason: string) {
+  const pathname = request.nextUrl.pathname;
+  const headers = { "x-auth-disabled": "1", "x-auth-disabled-reason": reason };
+
+  if (pathname.endsWith("/session")) {
+    return NextResponse.json(null, { headers });
+  }
+
+  if (pathname.endsWith("/providers")) {
+    return NextResponse.json({}, { headers });
+  }
+
+  return NextResponse.json(
+    {
+      error: "Authentication temporarily unavailable",
+      reason,
+    },
+    { status: 503, headers },
+  );
+}
+
+async function safeHandle(request: NextRequest, context: NextAuthContext) {
+  if (isAuthTemporarilyDisabled()) {
+    return buildDisabledResponse(request, "disabled");
+  }
+
+  try {
+    return await handler(request, context);
+  } catch (error) {
+    console.error("[auth] NextAuth handler failed", error);
+    return buildDisabledResponse(request, "error");
+  }
+}
+
+export async function GET(request: NextRequest, context: NextAuthContext) {
+  return safeHandle(request, context);
+}
+
+export async function POST(request: NextRequest, context: NextAuthContext) {
+  return safeHandle(request, context);
+}
 


### PR DESCRIPTION
## Summary
- add defensive wrapper around the NextAuth app route so it responds with JSON when the database is unavailable or the dev-only auth flag is set
- send explicit 503 responses for other auth requests while returning empty JSON for session/providers to avoid NextAuth client parse errors
- log unexpected handler failures and expose the disabled reason via response headers for easier diagnostics

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d44bff6528832d9ab2b2c43b6fbe28