### PR TITLE
Guard against missing notifications in dashboard overview API

### DIFF
--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -176,13 +176,24 @@ export async function GET() {
 
     const activeProduction = activeProductionPromise ? await activeProductionPromise : null;
 
+    const notificationActivities = recentNotifications.flatMap((entry) => {
+      const notification = entry.notification;
+      if (!notification) {
+        console.warn("[Dashboard API] Skipping notification without payload", entry.notificationId);
+        return [] as const;
+      }
+      return [
+        {
+          id: entry.notificationId,
+          type: "notification" as const,
+          message: notification.title,
+          timestamp: notification.createdAt.toISOString(),
+        },
+      ];
+    });
+
     const activities = [
-      ...recentNotifications.map((entry) => ({
-        id: entry.notificationId,
-        type: "notification" as const,
-        message: entry.notification.title,
-        timestamp: entry.notification.createdAt.toISOString(),
-      })),
+      ...notificationActivities,
       ...recentRehearsals.map((rehearsal) => ({
         id: `rehearsal_${rehearsal.id}_${rehearsal.createdAt.getTime()}`,
         type: "rehearsal" as const,


### PR DESCRIPTION
## Summary
- skip notification recipients without an associated notification when building the dashboard activity feed
- log a warning for skipped recipients so missing data can be diagnosed without failing the request

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d45342c6b0832db862b4df1d6fa7f2