### PR TITLE
Avoid mutating active production cookie in server components

### DIFF
--- a/src/lib/active-production.ts
+++ b/src/lib/active-production.ts
@@ -101,17 +101,8 @@ export async function getActiveProductionId(userId?: string | null) {
   const fallbackId = await resolveFallbackActiveProductionId(userId);
 
   if (!fallbackId) {
-    if (cookieValue) {
-      store.delete(ACTIVE_PRODUCTION_COOKIE);
-    }
     return null;
   }
-
-  store.set(ACTIVE_PRODUCTION_COOKIE, fallbackId, {
-    maxAge: 60 * 60 * 24 * 180,
-    sameSite: "lax",
-    path: "/",
-  });
 
   return fallbackId;
 }


### PR DESCRIPTION
## Summary
- avoid mutating the active production cookie when inferring a fallback selection so we no longer write cookies during render

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d456d7dac0832d82850ce219bfd1da