### PR TITLE
Handle member invite load failures without throwing

### DIFF
--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -331,6 +331,7 @@ export function MemberInviteManager() {
 
   const loadInvites = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const response = await fetch("/api/member-invites", { cache: "no-store" });
       const data = await response.json().catch(() => null);
@@ -340,7 +341,8 @@ export function MemberInviteManager() {
           extractErrorMessage(data) ??
           response.statusText ??
           "Einladungen konnten nicht geladen werden";
-        throw new Error(message);
+        setError(message);
+        return;
       }
       const invitesPayload = Array.isArray(data?.invites)
         ? (data.invites as (InviteSummaryPayload & { show?: ProductionSummary | null })[])


### PR DESCRIPTION
## Summary
- reset previous errors before refreshing member invite data and stop processing if the fetch fails
- keep load failures in component state instead of rethrowing so the UI handles them without console stack traces

## Testing
- pnpm lint
- pnpm test
- TERM=dumb CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d45ce32598832dad1a8fe13ee9ca56