### PR TITLE
Fix permissions lookup when user lacks roles

### DIFF
--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -641,6 +641,10 @@ export async function hasPermission(user: UserLike, permissionKey: string): Prom
     roleFilters.push({ roleId: { in: customRoleIds } });
   }
 
+  if (!roleFilters.length) {
+    return false;
+  }
+
   const rolePermissions = await prisma.appRolePermission.count({
     where: {
       permissionId: perm.id,


### PR DESCRIPTION
## Summary
- guard the role-based permission lookup to avoid Prisma queries with empty OR filters

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d45a81ecd0832d881957b264733d64