### PR TITLE
Add missing DepartmentPermission table migration

### DIFF
--- a/prisma/migrations/20270818130000_department_permissions/migration.sql
+++ b/prisma/migrations/20270818130000_department_permissions/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "public"."DepartmentPermission" (
+  "id" TEXT NOT NULL,
+  "departmentId" TEXT NOT NULL,
+  "permissionId" TEXT NOT NULL,
+  CONSTRAINT "DepartmentPermission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DepartmentPermission_departmentId_permissionId_key"
+  ON "public"."DepartmentPermission"("departmentId", "permissionId");
+
+-- AddForeignKey
+ALTER TABLE "public"."DepartmentPermission"
+  ADD CONSTRAINT "DepartmentPermission_departmentId_fkey"
+  FOREIGN KEY ("departmentId") REFERENCES "public"."Department"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "public"."DepartmentPermission"
+  ADD CONSTRAINT "DepartmentPermission_permissionId_fkey"
+  FOREIGN KEY ("permissionId") REFERENCES "public"."Permission"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- add the missing migration that creates the `DepartmentPermission` join table used by the rights matrix
- include uniqueness and cascading foreign keys so department-based grants can be persisted without 500 errors

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4612bfab4832d9e3b1f709f827294