### PR TITLE
Refactor member profile page layout with tabbed summaries

### DIFF
--- a/src/components/members/measurements/member-measurements-manager.tsx
+++ b/src/components/members/measurements/member-measurements-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -28,6 +28,7 @@ interface MeasurementEntry {
 
 interface MemberMeasurementsManagerProps {
   initialMeasurements: MeasurementEntry[];
+  onMeasurementsChange?: (measurements: MeasurementEntry[]) => void;
 }
 
 type DialogState =
@@ -36,6 +37,7 @@ type DialogState =
 
 export function MemberMeasurementsManager({
   initialMeasurements,
+  onMeasurementsChange,
 }: MemberMeasurementsManagerProps) {
   const [measurements, setMeasurements] = useState(() =>
     sortMeasurements(initialMeasurements),
@@ -43,6 +45,13 @@ export function MemberMeasurementsManager({
   const [dialogState, setDialogState] = useState<DialogState | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const profileCompletion = useOptionalProfileCompletion();
+
+  const notifyMeasurementsChange = useCallback(
+    (next: MeasurementEntry[]) => {
+      onMeasurementsChange?.(next);
+    },
+    [onMeasurementsChange],
+  );
 
   const openCreateDialog = () => {
     setDialogState({ mode: "create" });
@@ -95,6 +104,7 @@ export function MemberMeasurementsManager({
         const withoutType = prev.filter((entry) => entry.type !== saved.type);
         const next = sortMeasurements([...withoutType, saved]);
         profileCompletion?.setItemComplete("measurements", next.length > 0);
+        notifyMeasurementsChange(next);
         return next;
       });
       setDialogState(null);

--- a/src/components/members/profile-dietary-preferences.tsx
+++ b/src/components/members/profile-dietary-preferences.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { AllergyLevel } from "@prisma/client";
 import { Loader2, Plus, Trash2, Pencil } from "lucide-react";
 import { toast } from "sonner";
@@ -67,11 +67,16 @@ type DialogState =
 interface ProfileDietaryPreferencesProps {
   initialPreference: DietaryPreferenceState;
   initialAllergies: AllergyEntry[];
+  onDietaryChange?: (data: {
+    preference: DietaryPreferenceState;
+    allergies: AllergyEntry[];
+  }) => void;
 }
 
 export function ProfileDietaryPreferences({
   initialPreference,
   initialAllergies,
+  onDietaryChange,
 }: ProfileDietaryPreferencesProps) {
   const { setItemComplete } = useProfileCompletion();
   const [preference, setPreference] = useState<DietaryPreferenceState>(
@@ -93,6 +98,13 @@ export function ProfileDietaryPreferences({
   );
   const [dialogState, setDialogState] = useState<DialogState | null>(null);
   const [deletingAllergen, setDeletingAllergen] = useState<string | null>(null);
+
+  const emitDietaryChange = useCallback(
+    (nextPreference: DietaryPreferenceState, nextAllergies: AllergyEntry[]) => {
+      onDietaryChange?.({ preference: nextPreference, allergies: nextAllergies });
+    },
+    [onDietaryChange],
+  );
 
   const styleRequiresCustom = draftStyle === "custom";
   const strictnessDisabled = draftStyle === "none";
@@ -157,6 +169,7 @@ export function ProfileDietaryPreferences({
       setDraftCustomStyle(nextPreference.customLabel ?? "");
       setItemComplete("dietary", true);
       toast.success("Ernährungsinformationen aktualisiert.");
+      emitDietaryChange(nextPreference, allergies);
     } catch (error) {
       const message =
         error instanceof Error
@@ -205,14 +218,16 @@ export function ProfileDietaryPreferences({
       note: saved?.note ?? data.note,
       updatedAt: saved?.updatedAt ?? new Date().toISOString(),
     };
-    setAllergies((prev) =>
-      sortAllergies([
+    setAllergies((prev) => {
+      const next = sortAllergies([
         ...prev.filter(
           (item) => item.allergen.toLowerCase() !== entry.allergen.toLowerCase(),
         ),
         entry,
-      ]),
-    );
+      ]);
+      emitDietaryChange(preference, next);
+      return next;
+    });
     setDialogState(null);
   };
 
@@ -231,11 +246,13 @@ export function ProfileDietaryPreferences({
             : "Allergie konnte nicht entfernt werden.";
         throw new Error(message);
       }
-      setAllergies((prev) =>
-        prev.filter(
+      setAllergies((prev) => {
+        const next = prev.filter(
           (entry) => entry.allergen.toLowerCase() !== allergen.toLowerCase(),
-        ),
-      );
+        );
+        emitDietaryChange(preference, next);
+        return next;
+      });
       toast.success("Allergie entfernt.");
     } catch (error) {
       const message =

--- a/src/components/members/profile-form.tsx
+++ b/src/components/members/profile-form.tsx
@@ -22,6 +22,15 @@ interface ProfileFormProps {
   initialAvatarSource?: AvatarSource | null;
   initialAvatarUpdatedAt?: string | null;
   initialDateOfBirth?: string | null;
+  onProfileChange?: (data: {
+    firstName: string | null;
+    lastName: string | null;
+    name: string | null;
+    email: string | null;
+    avatarSource: AvatarSource | null;
+    avatarUpdatedAt: string | null;
+    dateOfBirth: string | null;
+  }) => void;
 }
 
 const AVATAR_CHOICES = ["GRAVATAR", "UPLOAD", "INITIALS"] as const;
@@ -59,6 +68,7 @@ export function ProfileForm({
   initialAvatarSource,
   initialAvatarUpdatedAt,
   initialDateOfBirth,
+  onProfileChange,
 }: ProfileFormProps) {
   const { update } = useSession();
   const derivedNames = initialName ? splitFullName(initialName) : { firstName: null, lastName: null };
@@ -270,6 +280,16 @@ export function ProfileForm({
       setRemoveAvatar(false);
       setSuccess("Profil wurde erfolgreich aktualisiert");
       toast.success("Profil wurde aktualisiert");
+
+      onProfileChange?.({
+        firstName: updatedFirstName ?? null,
+        lastName: updatedLastName ?? null,
+        name: updatedName ?? null,
+        email: updatedEmail ?? null,
+        avatarSource: (updatedAvatarSource ?? null) as AvatarSource | null,
+        avatarUpdatedAt: updatedAvatarTimestamp,
+        dateOfBirth: updatedDateOfBirthIso ?? null,
+      });
 
       completion.setItemComplete(
         "basics",


### PR DESCRIPTION
## Summary
- add change notification callbacks to the profile form, dietary preferences and measurement manager components so parents can react to updates
- redesign the member profile client to present compact tabbed summaries with click-to-edit panels instead of collapsible sections
- keep local state for profile data, diet info, measurements and photo consent to immediately reflect edits in the UI

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d45dfb9620832d932245375162cebc