### PR TITLE
Add migration for department join approval flag

### DIFF
--- a/prisma/migrations/20270819120000_department_requires_join_approval/migration.sql
+++ b/prisma/migrations/20270819120000_department_requires_join_approval/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."Department"
+ADD COLUMN "requiresJoinApproval" BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- add prisma migration that adds the missing requiresJoinApproval column on Department so Prisma queries match the database schema

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build > build.log

------
https://chatgpt.com/codex/tasks/task_e_68d506445f74832da221d6f3743f757e