### PR TITLE
Set project to ESM module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "theater-website",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "packageManager": "pnpm@9.15.9",
   "scripts": {
     "predev": "node scripts/run-prisma-migrate.mjs",


### PR DESCRIPTION
## Summary
- add a "type": "module" declaration to package.json so Node treats the app as an ES module project and avoids runtime warnings

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d50dacd630832d8813a683cd03b942