### PR TITLE
Avoid toast spam when offline queue is empty

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -19,6 +19,13 @@ if (workbox) {
   };
 
   const replayQueue = async (queue) => {
+    const pendingEntries = typeof queue.getAll === "function" ? await queue.getAll() : null;
+    const hasPending = Array.isArray(pendingEntries) ? pendingEntries.length > 0 : true;
+
+    if (!hasPending) {
+      return;
+    }
+
     try {
       await queue.replayRequests();
       await broadcastMessage({ type: "offline-events:flushed" });


### PR DESCRIPTION
## Summary
- skip the offline sync success toast when the Workbox queue is empty so we do not notify users unnecessarily

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d513243e54832d998b696a50bdbc24