### PR TITLE
Fix MemberInvite show migration backfill

### DIFF
--- a/prisma/migrations/20270925094732_add_show_id_to_member_invite/migration.sql
+++ b/prisma/migrations/20270925094732_add_show_id_to_member_invite/migration.sql
@@ -1,25 +1,45 @@
--- Add showId column to MemberInvite and backfill existing rows if possible
+-- Add showId column to MemberInvite and backfill existing rows when possible
 ALTER TABLE "public"."MemberInvite"
 ADD COLUMN IF NOT EXISTS "showId" TEXT;
 
--- Attempt to backfill showId with the latest active show when available.
--- This assumes there is at least one show and that invites should default to the latest show.
--- If the application requires a specific mapping, this step should be replaced accordingly.
-WITH latest_show AS (
-  SELECT "id"
-  FROM "public"."Show"
-  ORDER BY "premiere" DESC NULLS LAST, "createdAt" DESC
-  LIMIT 1
+-- Prefer using onboarding profiles because they already store the historical show relation
+WITH invite_profile AS (
+  SELECT DISTINCT ON (mop."inviteId")
+    mop."inviteId",
+    mop."showId"
+  FROM "public"."MemberOnboardingProfile" AS mop
+  WHERE mop."inviteId" IS NOT NULL AND mop."showId" IS NOT NULL
+  ORDER BY mop."inviteId", mop."updatedAt" DESC
 )
 UPDATE "public"."MemberInvite" AS mi
-SET "showId" = ls."id"
-FROM latest_show AS ls
-WHERE mi."showId" IS NULL;
+SET "showId" = ip."showId"
+FROM invite_profile AS ip
+WHERE mi."id" = ip."inviteId" AND mi."showId" IS NULL;
 
+-- Fallback to the most recent show for invites that are not linked to onboarding data
+DO $$
+DECLARE
+  fallback_show_id TEXT;
+BEGIN
+  SELECT "id"
+  INTO fallback_show_id
+  FROM "public"."Show"
+  ORDER BY "revealedAt" DESC NULLS LAST, "year" DESC, "id" DESC
+  LIMIT 1;
+
+  IF fallback_show_id IS NOT NULL THEN
+    UPDATE "public"."MemberInvite"
+    SET "showId" = fallback_show_id
+    WHERE "showId" IS NULL;
+  END IF;
+END;
+$$;
+
+-- Ensure no dangling NULLs remain before adding the constraint
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM "public"."MemberInvite" WHERE "showId" IS NULL) THEN
-    RAISE EXCEPTION 'MemberInvite.showId contains NULL values. Please backfill before running this migration.';
+    RAISE EXCEPTION 'MemberInvite.showId contains NULL values after backfill. Please resolve them manually before running this migration.';
   END IF;
 END;
 $$;


### PR DESCRIPTION
## Summary
- backfill `MemberInvite.showId` using related onboarding profiles before falling back to the latest show
- update the fallback ordering to rely on existing `Show` columns and keep the null guard message informative

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5140c4d60832d9004d878b908e5f3