### PR TITLE
Improve member invite migration resilience

### DIFF
--- a/prisma/migrations/20270925094732_add_show_id_to_member_invite/migration.sql
+++ b/prisma/migrations/20270925094732_add_show_id_to_member_invite/migration.sql
@@ -16,25 +16,67 @@ SET "showId" = ip."showId"
 FROM invite_profile AS ip
 WHERE mi."id" = ip."inviteId" AND mi."showId" IS NULL;
 
--- Fallback to the most recent show for invites that are not linked to onboarding data
--- If no show exists yet, create a placeholder record so we always have
--- something to reference. The migration only inserts this when the table
--- is currently empty, which is the case for fresh production databases
--- that only relied on invites so far.
+-- If an invite resulted in a membership, use that production membership as the source of truth
+WITH redemption_membership AS (
+  SELECT DISTINCT ON (mir."inviteId")
+    mir."inviteId",
+    pm."showId"
+  FROM "public"."MemberInviteRedemption" AS mir
+  JOIN "public"."ProductionMembership" AS pm
+    ON pm."userId" = mir."userId"
+  WHERE mir."userId" IS NOT NULL
+    AND pm."showId" IS NOT NULL
+  ORDER BY mir."inviteId", pm."joinedAt" DESC NULLS LAST, pm."showId" DESC
+)
+UPDATE "public"."MemberInvite" AS mi
+SET "showId" = rm."showId"
+FROM redemption_membership AS rm
+WHERE mi."id" = rm."inviteId" AND mi."showId" IS NULL;
+
+-- Fallback to the most recent show for invites that are not linked to onboarding or memberships
+WITH fallback AS (
+  SELECT "id"
+  FROM "public"."Show"
+  ORDER BY "revealedAt" DESC NULLS LAST, "year" DESC, "id" DESC
+  LIMIT 1
+)
+UPDATE "public"."MemberInvite" AS mi
+SET "showId" = fallback."id"
+FROM fallback
+WHERE mi."showId" IS NULL AND fallback."id" IS NOT NULL;
+
+-- Ensure legacy invites without a matching show always receive a deterministic placeholder show
 DO $$
 DECLARE
   placeholder_show_id CONSTANT TEXT := 'legacy-member-invite-show';
   placeholder_year    INTEGER;
   earliest_invite     TIMESTAMP;
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM "public"."Show") AND EXISTS (SELECT 1 FROM "public"."MemberInvite") THEN
+  IF EXISTS (
+    SELECT 1
+    FROM "public"."MemberInvite" AS mi
+    WHERE mi."showId" IS NULL
+       OR NOT EXISTS (
+         SELECT 1 FROM "public"."Show" AS s WHERE s."id" = mi."showId"
+       )
+  ) THEN
     SELECT MIN("createdAt") INTO earliest_invite FROM "public"."MemberInvite";
     placeholder_year := COALESCE(
       CAST(EXTRACT(YEAR FROM earliest_invite) AS INTEGER),
       CAST(EXTRACT(YEAR FROM CURRENT_DATE) AS INTEGER)
     );
 
-    INSERT INTO "public"."Show" ("id", "year", "title", "synopsis", "dates", "posterUrl", "revealedAt", "finalRehearsalWeekStart", "meta")
+    INSERT INTO "public"."Show" (
+      "id",
+      "year",
+      "title",
+      "synopsis",
+      "dates",
+      "posterUrl",
+      "revealedAt",
+      "finalRehearsalWeekStart",
+      "meta"
+    )
     VALUES (
       placeholder_show_id,
       placeholder_year,
@@ -47,62 +89,13 @@ BEGIN
       jsonb_build_object('generatedByMigration', '20270925094732_add_show_id_to_member_invite')
     )
     ON CONFLICT ("id") DO NOTHING;
-  END IF;
-END;
-$$;
 
-DO $$
-DECLARE
-  fallback_show_id TEXT;
-BEGIN
-  SELECT "id"
-  INTO fallback_show_id
-  FROM "public"."Show"
-  ORDER BY "revealedAt" DESC NULLS LAST, "year" DESC, "id" DESC
-  LIMIT 1;
-
-  IF fallback_show_id IS NOT NULL THEN
-    UPDATE "public"."MemberInvite"
-    SET "showId" = fallback_show_id
-    WHERE "showId" IS NULL;
-  END IF;
-END;
-$$;
-
--- Ensure legacy invites without a matching show always receive
--- a deterministic placeholder show.
-DO $$
-DECLARE
-  placeholder_show_id CONSTANT TEXT := 'legacy-member-invite-show';
-  placeholder_year    INTEGER;
-  earliest_invite     TIMESTAMP;
-BEGIN
-  IF EXISTS (SELECT 1 FROM "public"."MemberInvite" WHERE "showId" IS NULL) THEN
-    IF NOT EXISTS (SELECT 1 FROM "public"."Show" WHERE "id" = placeholder_show_id) THEN
-      SELECT MIN("createdAt") INTO earliest_invite FROM "public"."MemberInvite";
-      placeholder_year := COALESCE(
-        CAST(EXTRACT(YEAR FROM earliest_invite) AS INTEGER),
-        CAST(EXTRACT(YEAR FROM CURRENT_DATE) AS INTEGER)
-      );
-
-      INSERT INTO "public"."Show" ("id", "year", "title", "synopsis", "dates", "posterUrl", "revealedAt", "finalRehearsalWeekStart", "meta")
-      VALUES (
-        placeholder_show_id,
-        placeholder_year,
-        'Legacy-Mitgliedschaften',
-        'Automatisch erstellte Produktion für bestehende Einladungen ohne Show-Verknüpfung.',
-        '[]'::jsonb,
-        NULL,
-        NULL,
-        NULL,
-        jsonb_build_object('generatedByMigration', '20270925094732_add_show_id_to_member_invite')
-      )
-      ON CONFLICT ("id") DO NOTHING;
-    END IF;
-
-    UPDATE "public"."MemberInvite"
+    UPDATE "public"."MemberInvite" AS mi
     SET "showId" = placeholder_show_id
-    WHERE "showId" IS NULL;
+    WHERE mi."showId" IS NULL
+       OR NOT EXISTS (
+         SELECT 1 FROM "public"."Show" AS s WHERE s."id" = mi."showId"
+       );
   END IF;
 END;
 $$;


### PR DESCRIPTION
## Summary
- expand the `20270925094732_add_show_id_to_member_invite` migration to backfill invite `showId` values via onboarding data, redeemed memberships, and fallbacks
- create a deterministic placeholder production for invites with missing or invalid show references before enforcing constraints

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d522934eb4832da80f359241ebbe33