### PR TITLE
Fix Show table creation order

### DIFF
--- a/prisma/migrations/20250220120000_production_membership_table/migration.sql
+++ b/prisma/migrations/20250220120000_production_membership_table/migration.sql
@@ -1,4 +1,18 @@
 -- CreateTable
+CREATE TABLE "public"."Show" (
+    "id" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "title" TEXT,
+    "synopsis" TEXT,
+    "dates" JSONB NOT NULL,
+    "posterUrl" TEXT,
+    "revealedAt" TIMESTAMP(3),
+    "meta" JSONB,
+
+    CONSTRAINT "Show_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "public"."ProductionMembership" (
     "id" TEXT NOT NULL,
     "showId" TEXT NOT NULL,

--- a/prisma/migrations/20250916174056_attendance_log/migration.sql
+++ b/prisma/migrations/20250916174056_attendance_log/migration.sql
@@ -113,21 +113,6 @@ CREATE TABLE "public"."VerificationToken" (
     "expires" TIMESTAMP(3) NOT NULL
 );
 
--- CreateTable
-CREATE TABLE "public"."Show" (
-    "id" TEXT NOT NULL,
-    "year" INTEGER NOT NULL,
-    "title" TEXT,
-    "synopsis" TEXT,
-    "dates" JSONB NOT NULL,
-    "posterUrl" TEXT,
-    "revealedAt" TIMESTAMP(3),
-    "meta" JSONB,
-
-    CONSTRAINT "Show_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
 CREATE TABLE "public"."Clue" (
     "id" TEXT NOT NULL,
     "showId" TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- create the Show table in the production membership migration so its foreign keys resolve from scratch
- remove the duplicate Show table creation from the later attendance log migration to avoid conflicts during deploys

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d530b4a314832da5eedb36998c5362