### PR TITLE
Adjust docker publish workflow for branch-specific tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - main
     paths:
       - '.github/workflows/docker-publish.yml'
       - 'Dockerfile.dev'
@@ -32,6 +33,7 @@ env:
 
 jobs:
   build-and-push-website:
+    if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,3 +85,43 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ matrix.build_args }}
+
+  build-and-push-website-latest:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: Build and Push Theater Website Image (latest)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Extract Docker metadata (latest)
+        id: meta-latest
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.WEBSITE_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+
+      - name: Build and push latest Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prod
+          push: true
+          tags: ${{ steps.meta-latest.outputs.tags }}
+          labels: ${{ steps.meta-latest.outputs.labels }}
+          build-args: |
+            NODE_ENV=production
+            GIT_COMMIT_SHA=${{ github.sha }}


### PR DESCRIPTION
## Summary
- trigger docker publish workflow on both dev and main branches
- keep dev branch building dev and prod images while main builds a latest production image

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d541dcad88832d8b61aedc2a7d6268