### PR TITLE
Handle branch filtering in docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,16 +63,36 @@ jobs:
               GIT_COMMIT_SHA=${{ github.sha }}
             metadata_tags: |
               type=raw,value=latest
-    if: github.ref == format('refs/heads/{0}', matrix.branch)
     name: Build and Push Theater Website Image (${{ matrix.environment }})
     steps:
+      - name: Check branch compatibility
+        id: branch-filter
+        env:
+          CURRENT_BRANCH: ${{ github.ref_name }}
+          MATRIX_BRANCH: ${{ matrix.branch }}
+        run: |
+          if [ "$CURRENT_BRANCH" != "$MATRIX_BRANCH" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Skip build for non-matching branch
+        if: steps.branch-filter.outputs.should_run != 'true'
+        run: |
+          echo "Skipping build for branch '${{ github.ref_name }}' (target: ${{ matrix.branch }})"
+
       - name: Checkout repository
+        if: steps.branch-filter.outputs.should_run == 'true'
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
+        if: steps.branch-filter.outputs.should_run == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        if: steps.branch-filter.outputs.should_run == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -80,6 +100,7 @@ jobs:
           password: ${{ secrets.DOCKER_PAT }}
 
       - name: Extract Docker metadata (${{ matrix.environment }})
+        if: steps.branch-filter.outputs.should_run == 'true'
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -87,6 +108,7 @@ jobs:
           tags: ${{ matrix.metadata_tags }}
 
       - name: Build and push ${{ matrix.environment }} Docker image
+        if: steps.branch-filter.outputs.should_run == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Summary
- add a branch compatibility check to the Docker publish workflow so that matrix jobs skip when the Git ref does not match
- guard all build steps behind the branch check to avoid running Docker builds for unrelated branches

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d54457d054832d820383e877101eab