### PR TITLE
Fix Über uns layout alignment

### DIFF
--- a/src/app/(site)/ueber-uns/page.tsx
+++ b/src/app/(site)/ueber-uns/page.tsx
@@ -298,241 +298,271 @@ export default async function AboutPage() {
         />
       </div>
 
-      <section className="layout-container pb-12 pt-16 sm:pt-24">
-        <div className="max-w-3xl">
-          <Text variant="eyebrow" uppercase tone="primary">
-            Sommertheater Altrossthal
-          </Text>
-          <Heading level="h1" className="mt-4">
-            Über uns
-          </Heading>
-          <Text variant="bodyLg" tone="muted" className="mt-6">
-            Wir erzählen Geschichten für laue Sommernächte. Unser Ensemble verbindet professionelle Theaterarbeit mit ehrenamtlichem Herzblut – mitten im
-            Schlosspark Altrossthal.
-          </Text>
-          <Text tone="muted" className="mt-4">
-            Gegründet wurde das Sommertheater 2009 vom damaligen Schüler Toni Burghard Friedrich. Seitdem treffen sich Lernende, Alumni und Freund:innen des
-            BSZ Altroßthal, um eine Bühne zu schaffen, die weit über klassischen Unterricht hinausgeht.
-          </Text>
-          <Text tone="muted" className="mt-4">
-            Das Ensemble besteht aus Schüler:innen des Beruflichen Gymnasiums und der Fachoberschule, Auszubildenden aus Landwirtschaft, Floristik, Konditorei
-            und vielen weiteren Gewerken sowie Freund:innen des Beruflichen Schulzentrums für Agrarwirtschaft und Ernährung Dresden.
-          </Text>
-          <Text tone="muted" className="mt-4">
-            Die Regie übernehmen meist professionelle Schauspieler:innen oder Regisseur:innen, die ihre Erfahrung teilen und gemeinsam mit uns neue Sommerstücke
-            entwickeln.
-          </Text>
-        </div>
+      <section
+        className="mx-auto w-full px-[var(--layout-gutter)] pb-12 pt-16 sm:pt-24"
+        style={{ maxWidth: "min(100vw, calc(var(--layout-max-width) + 2 * var(--layout-gutter)))" }}
+      >
+        <div className="mx-auto w-full max-w-[var(--layout-max-width)]">
+          <div className="mx-auto max-w-3xl">
+            <Text variant="eyebrow" uppercase tone="primary">
+              Sommertheater Altrossthal
+            </Text>
+            <Heading level="h1" className="mt-4">
+              Über uns
+            </Heading>
+            <Text variant="bodyLg" tone="muted" className="mt-6">
+              Wir erzählen Geschichten für laue Sommernächte. Unser Ensemble verbindet professionelle Theaterarbeit mit ehrenamtlichem Herzblut – mitten im
+              Schlosspark Altrossthal.
+            </Text>
+            <Text tone="muted" className="mt-4">
+              Gegründet wurde das Sommertheater 2009 vom damaligen Schüler Toni Burghard Friedrich. Seitdem treffen sich Lernende, Alumni und Freund:innen des
+              BSZ Altroßthal, um eine Bühne zu schaffen, die weit über klassischen Unterricht hinausgeht.
+            </Text>
+            <Text tone="muted" className="mt-4">
+              Das Ensemble besteht aus Schüler:innen des Beruflichen Gymnasiums und der Fachoberschule, Auszubildenden aus Landwirtschaft, Floristik, Konditorei
+              und vielen weiteren Gewerken sowie Freund:innen des Beruflichen Schulzentrums für Agrarwirtschaft und Ernährung Dresden.
+            </Text>
+            <Text tone="muted" className="mt-4">
+              Die Regie übernehmen meist professionelle Schauspieler:innen oder Regisseur:innen, die ihre Erfahrung teilen und gemeinsam mit uns neue Sommerstücke
+              entwickeln.
+            </Text>
+          </div>
 
-        <div className="mt-10 grid gap-4 sm:grid-cols-3">
-          {highlights.map((item) => (
-            <Card key={item.label} className="bg-card/70">
-              <CardHeader>
-                <p className="text-sm uppercase tracking-wide text-muted-foreground/80">{item.label}</p>
-              </CardHeader>
-              <CardContent>
-                <p className="text-3xl font-semibold text-primary">{item.value}</p>
-                <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-      </section>
-
-      <section className="layout-container pb-16 sm:pb-24">
-        <div className="max-w-3xl">
-          <Heading level="h2">Gewerke, die eine Produktion tragen</Heading>
-          <Text variant="bodyLg" tone="muted" className="mt-4">
-            Jeder Sommer entsteht aus vielen Händen und Talenten. Unser Ensemble arbeitet bereichsübergreifend – von der ersten Textprobe bis zur letzten
-            Vorstellungsnacht.
-          </Text>
-          <Text tone="muted" className="mt-2">
-            Scroll durch die Werkstätten und entdecke, wie vielfältig Theaterarbeit am BSZ Altroßthal ist.
-          </Text>
-        </div>
-        <div className="relative mt-8">
-          <div
-            className="pointer-events-none absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-background via-background/80 to-transparent"
-            aria-hidden
-          />
-          <div
-            className="flex gap-6 overflow-x-auto pb-6 pr-6 [scrollbar-color:theme(colors.primary/40)_transparent] [scrollbar-width:thin]"
-            role="list"
-            aria-label="Gewerke des Ensembles"
-          >
-            {trades.map(({ icon: Icon, title, focus, description }) => (
-              <Card
-                key={title}
-                role="listitem"
-                className="flex w-[min(22rem,80vw)] shrink-0 snap-start flex-col justify-between gap-4 rounded-2xl border-border/40 bg-card/70 p-6 shadow-lg"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/15 text-primary">
-                    <Icon className="h-6 w-6" aria-hidden />
-                  </div>
-                  <Heading level="h3" className="text-xl" weight="bold">
-                    {title}
-                  </Heading>
-                </div>
-                <div className="space-y-3">
-                  <Text variant="small" className="font-medium text-primary">
-                    {focus}
-                  </Text>
-                  <Text variant="small" tone="muted">
-                    {description}
-                  </Text>
-                </div>
+          <div className="mt-10 grid gap-4 sm:grid-cols-3">
+            {highlights.map((item) => (
+              <Card key={item.label} className="bg-card/70">
+                <CardHeader>
+                  <p className="text-sm uppercase tracking-wide text-muted-foreground/80">{item.label}</p>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-3xl font-semibold text-primary">{item.value}</p>
+                  <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                </CardContent>
               </Card>
             ))}
           </div>
-          <div
-            className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-background via-background/80 to-transparent"
-            aria-hidden
-          />
         </div>
-        <Text variant="small" tone="muted" className="mt-4">
-          Tipp: Mit dem horizontalen Scrollbalken oder per Wischgeste kannst du alle Gewerke entdecken.
-        </Text>
       </section>
 
-      <section className="layout-container pb-16 sm:pb-24">
-        <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
-          <div className="space-y-6">
-            <Heading level="h2">Unsere Handschrift</Heading>
-            <Text variant="bodyLg" tone="muted">
-              Die Sommerproduktionen entstehen über Monate hinweg – von der ersten Idee bis zur letzten Generalprobe. Dabei verbinden wir poetische Stoffe mit
-              immersiven Erlebnissen, die nur unter freiem Himmel möglich sind. Werkstätten für Floristik, Holz- und Metallgestaltung sowie Maskenbild des
-              Berufsschulzentrums fließen direkt in Bühnenwelten ein.
+      <section
+        className="mx-auto w-full px-[var(--layout-gutter)] pb-16 sm:pb-24"
+        style={{ maxWidth: "min(100vw, calc(var(--layout-max-width) + 2 * var(--layout-gutter)))" }}
+      >
+        <div className="mx-auto w-full max-w-[var(--layout-max-width)]">
+          <div className="mx-auto max-w-3xl">
+            <Heading level="h2">Gewerke, die eine Produktion tragen</Heading>
+            <Text variant="bodyLg" tone="muted" className="mt-4">
+              Jeder Sommer entsteht aus vielen Händen und Talenten. Unser Ensemble arbeitet bereichsübergreifend – von der ersten Textprobe bis zur letzten
+              Vorstellungsnacht.
             </Text>
-            <div className="space-y-5">
-              {signature.map(({ icon: Icon, title, description }) => (
-                <div
+            <Text tone="muted" className="mt-2">
+              Scroll durch die Werkstätten und entdecke, wie vielfältig Theaterarbeit am BSZ Altroßthal ist.
+            </Text>
+          </div>
+          <div className="relative mt-8">
+            <div
+              className="pointer-events-none absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-background via-background/80 to-transparent"
+              aria-hidden
+            />
+            <div
+              className="flex gap-6 overflow-x-auto pb-6 pr-6 [scrollbar-color:theme(colors.primary/40)_transparent] [scrollbar-width:thin]"
+              role="list"
+              aria-label="Gewerke des Ensembles"
+            >
+              {trades.map(({ icon: Icon, title, focus, description }) => (
+                <Card
                   key={title}
-                  className="group flex gap-4 rounded-xl border border-border/40 bg-card/60 p-4 transition hover:border-primary/50 hover:bg-card/80"
+                  role="listitem"
+                  className="flex w-[min(22rem,80vw)] shrink-0 snap-start flex-col justify-between gap-4 rounded-2xl border-border/40 bg-card/70 p-6 shadow-lg"
                 >
-                  <div className="mt-1 flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
-                    <Icon className="h-6 w-6" aria-hidden />
-                  </div>
-                  <div>
-                    <Heading level="h4" className="text-lg" weight="bold">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/15 text-primary">
+                      <Icon className="h-6 w-6" aria-hidden />
+                    </div>
+                    <Heading level="h3" className="text-xl" weight="bold">
                       {title}
                     </Heading>
-                    <Text variant="small" tone="muted" className="mt-1">
+                  </div>
+                  <div className="space-y-3">
+                    <Text variant="small" className="font-medium text-primary">
+                      {focus}
+                    </Text>
+                    <Text variant="small" tone="muted">
                       {description}
                     </Text>
                   </div>
-                </div>
+                </Card>
               ))}
             </div>
+            <div
+              className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-background via-background/80 to-transparent"
+              aria-hidden
+            />
           </div>
-
-          <div className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/10 via-background to-background p-8 shadow-lg">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(248,223,150,0.18),_transparent_60%)]" aria-hidden />
-            <div className="relative space-y-4">
-              <Text variant="eyebrow" uppercase tone="primary">
-                Atmosphäre
-              </Text>
-              <Heading level="h3" className="text-2xl">
-                Wenn die Sonne hinter den Baumwipfeln verschwindet, beginnt unser Bühnenraum zu leben: leuchtende Pfade, flüsternde Bäume und ein Ensemble, das
-                das Publikum mitnimmt in eine andere Welt.
-              </Heading>
-              <Text variant="small" tone="muted">
-                Jedes Szenenbild wird speziell für den Schlosspark entwickelt. Lichtinstallationen und räumlicher Klang lassen die Besucher:innen mitten in der
-                Geschichte stehen.
-              </Text>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="layout-container pb-16 sm:pb-24">
-        <div className="max-w-2xl">
-          <Heading level="h2">Werte, die wir leben</Heading>
-          <Text variant="bodyLg" tone="muted" className="mt-4">
-            Ensemblearbeit bedeutet Vertrauen. Unsere Werte spiegeln sich in jeder Probe, jedem Ehrenamt und jedem Gast wider, der den Weg nach Altrossthal findet.
+          <Text variant="small" tone="muted" className="mt-4">
+            Tipp: Mit dem horizontalen Scrollbalken oder per Wischgeste kannst du alle Gewerke entdecken.
           </Text>
         </div>
-        <div className="mt-10 grid gap-6 md:grid-cols-3">
-          {values.map(({ icon: Icon, title, description }) => (
-            <Card key={title} className="relative overflow-hidden bg-card/70">
-              <div className="absolute right-4 top-4 h-16 w-16 rounded-full bg-primary/10 blur-2xl" aria-hidden />
-              <CardHeader>
-                <Icon className="h-8 w-8 text-primary" aria-hidden />
-              </CardHeader>
-              <CardContent>
-                <CardTitle className="text-xl">{title}</CardTitle>
-                <Text variant="small" tone="muted" className="mt-2">
-                  {description}
-                </Text>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
       </section>
 
-      <section className="layout-container pb-16 sm:pb-24">
-        <div className="grid gap-10 lg:grid-cols-2">
-          <div>
-            <Heading level="h2">Meilensteine</Heading>
-            <Text variant="bodyLg" tone="muted" className="mt-4">
-              Wir wachsen organisch und mit viel Leidenschaft. Ein paar Stationen auf unserem Weg:
-            </Text>
-          </div>
-          <div className="relative">
-            <div className="absolute left-3 top-1 bottom-1 w-px bg-gradient-to-b from-primary/60 via-primary/20 to-transparent" aria-hidden />
-            <ul className="space-y-8">
-              {milestones.map((milestone) => (
-                <li key={milestone.year} className="relative pl-12">
-                  <div className="absolute left-0 top-1.5 flex h-6 w-6 items-center justify-center rounded-full border border-primary/50 bg-primary/20 text-primary">
-                    <span className="text-xs font-semibold">{milestone.year}</span>
-                  </div>
-                  <Heading level="h4" className="text-lg" weight="bold">
-                    {milestone.title}
-                  </Heading>
-                  <Text variant="small" tone="muted" className="mt-2">
-                    {milestone.description}
-                  </Text>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </section>
-
-      <section className="layout-container pb-20 sm:pb-28">
-        <div className="rounded-3xl border border-border/40 bg-card/60 p-8 sm:p-12">
-          <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
-            <div className="space-y-5">
-              <Heading level="h2">Engagement rund um das Ensemble</Heading>
+      <section
+        className="mx-auto w-full px-[var(--layout-gutter)] pb-16 sm:pb-24"
+        style={{ maxWidth: "min(100vw, calc(var(--layout-max-width) + 2 * var(--layout-gutter)))" }}
+      >
+        <div className="mx-auto w-full max-w-[var(--layout-max-width)]">
+          <div className="grid gap-10 lg:grid-cols-[1.1fr_0.9fr] lg:items-center">
+            <div className="space-y-6">
+              <Heading level="h2">Unsere Handschrift</Heading>
               <Text variant="bodyLg" tone="muted">
-                Unser Sommertheater lebt von Menschen, die ihre Zeit und ihr Können einbringen. Wir begleiten neue Mitglieder mit Mentoring-Formaten, öffnen die
-                Werkstätten des BSZ Altroßthal für Floristik, Holz und Metall und bieten Fortbildungen für Licht, Ton und Bühnenbild an.
+                Die Sommerproduktionen entstehen über Monate hinweg – von der ersten Idee bis zur letzten Generalprobe. Dabei verbinden wir poetische Stoffe mit
+                immersiven Erlebnissen, die nur unter freiem Himmel möglich sind. Werkstätten für Floristik, Holz- und Metallgestaltung sowie Maskenbild des
+                Berufsschulzentrums fließen direkt in Bühnenwelten ein.
               </Text>
-              <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                <MapPin className="h-5 w-5 text-primary" aria-hidden />
-                <span>Schlosspark Altrossthal · Probenscheune im Alten Forsthaus</span>
+              <div className="space-y-5">
+                {signature.map(({ icon: Icon, title, description }) => (
+                  <div
+                    key={title}
+                    className="group flex gap-4 rounded-xl border border-border/40 bg-card/60 p-4 transition hover:border-primary/50 hover:bg-card/80"
+                  >
+                    <div className="mt-1 flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
+                      <Icon className="h-6 w-6" aria-hidden />
+                    </div>
+                    <div>
+                      <Heading level="h4" className="text-lg" weight="bold">
+                        {title}
+                      </Heading>
+                      <Text variant="small" tone="muted" className="mt-1">
+                        {description}
+                      </Text>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
-            <div className="grid gap-4 sm:grid-cols-2">
-              {engagement.map((item) => (
-                <div key={item.title} className="rounded-2xl border border-border/40 bg-background/70 p-5">
-                  <Heading level="h4" className="text-lg" weight="bold">
-                    {item.title}
-                  </Heading>
+
+            <div className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/10 via-background to-background p-8 shadow-lg">
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(248,223,150,0.18),_transparent_60%)]" aria-hidden />
+              <div className="relative space-y-4">
+                <Text variant="eyebrow" uppercase tone="primary">
+                  Atmosphäre
+                </Text>
+                <Heading level="h3" className="text-2xl">
+                  Wenn die Sonne hinter den Baumwipfeln verschwindet, beginnt unser Bühnenraum zu leben: leuchtende Pfade, flüsternde Bäume und ein Ensemble, das
+                  das Publikum mitnimmt in eine andere Welt.
+                </Heading>
+                <Text variant="small" tone="muted">
+                  Jedes Szenenbild wird speziell für den Schlosspark entwickelt. Lichtinstallationen und räumlicher Klang lassen die Besucher:innen mitten in der
+                  Geschichte stehen.
+                </Text>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="mx-auto w-full px-[var(--layout-gutter)] pb-16 sm:pb-24"
+        style={{ maxWidth: "min(100vw, calc(var(--layout-max-width) + 2 * var(--layout-gutter)))" }}
+      >
+        <div className="mx-auto w-full max-w-[var(--layout-max-width)]">
+          <div className="mx-auto max-w-2xl">
+            <Heading level="h2">Werte, die wir leben</Heading>
+            <Text variant="bodyLg" tone="muted" className="mt-4">
+              Ensemblearbeit bedeutet Vertrauen. Unsere Werte spiegeln sich in jeder Probe, jedem Ehrenamt und jedem Gast wider, der den Weg nach Altrossthal findet.
+            </Text>
+          </div>
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {values.map(({ icon: Icon, title, description }) => (
+              <Card key={title} className="relative overflow-hidden bg-card/70">
+                <div className="absolute right-4 top-4 h-16 w-16 rounded-full bg-primary/10 blur-2xl" aria-hidden />
+                <CardHeader>
+                  <Icon className="h-8 w-8 text-primary" aria-hidden />
+                </CardHeader>
+                <CardContent>
+                  <CardTitle className="text-xl">{title}</CardTitle>
                   <Text variant="small" tone="muted" className="mt-2">
-                    {item.description}
+                    {description}
                   </Text>
-                  <Link
-                    href={item.action.href}
-                    className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:text-primary/80"
-                  >
-                    {item.action.label}
-                    <span className="ml-2 text-lg" aria-hidden>
-                      →
-                    </span>
-                  </Link>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="mx-auto w-full px-[var(--layout-gutter)] pb-16 sm:pb-24"
+        style={{ maxWidth: "min(100vw, calc(var(--layout-max-width) + 2 * var(--layout-gutter)))" }}
+      >
+        <div className="mx-auto w-full max-w-[var(--layout-max-width)]">
+          <div className="grid gap-10 lg:grid-cols-2">
+            <div>
+              <Heading level="h2">Meilensteine</Heading>
+              <Text variant="bodyLg" tone="muted" className="mt-4">
+                Wir wachsen organisch und mit viel Leidenschaft. Ein paar Stationen auf unserem Weg:
+              </Text>
+            </div>
+            <div className="relative">
+              <div className="absolute left-3 top-1 bottom-1 w-px bg-gradient-to-b from-primary/60 via-primary/20 to-transparent" aria-hidden />
+              <ul className="space-y-8">
+                {milestones.map((milestone) => (
+                  <li key={milestone.year} className="relative pl-12">
+                    <div className="absolute left-0 top-1.5 flex h-6 w-6 items-center justify-center rounded-full border border-primary/50 bg-primary/20 text-primary">
+                      <span className="text-xs font-semibold">{milestone.year}</span>
+                    </div>
+                    <Heading level="h4" className="text-lg" weight="bold">
+                      {milestone.title}
+                    </Heading>
+                    <Text variant="small" tone="muted" className="mt-2">
+                      {milestone.description}
+                    </Text>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        className="mx-auto w-full px-[var(--layout-gutter)] pb-20 sm:pb-28"
+        style={{ maxWidth: "min(100vw, calc(var(--layout-max-width) + 2 * var(--layout-gutter)))" }}
+      >
+        <div className="mx-auto w-full max-w-[var(--layout-max-width)]">
+          <div className="rounded-3xl border border-border/40 bg-card/60 p-8 sm:p-12">
+            <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
+              <div className="space-y-5">
+                <Heading level="h2">Engagement rund um das Ensemble</Heading>
+                <Text variant="bodyLg" tone="muted">
+                  Unser Sommertheater lebt von Menschen, die ihre Zeit und ihr Können einbringen. Wir begleiten neue Mitglieder mit Mentoring-Formaten, öffnen die
+                  Werkstätten des BSZ Altroßthal für Floristik, Holz und Metall und bieten Fortbildungen für Licht, Ton und Bühnenbild an.
+                </Text>
+                <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                  <MapPin className="h-5 w-5 text-primary" aria-hidden />
+                  <span>Schlosspark Altrossthal · Probenscheune im Alten Forsthaus</span>
                 </div>
-              ))}
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {engagement.map((item) => (
+                  <div key={item.title} className="rounded-2xl border border-border/40 bg-background/70 p-5">
+                    <Heading level="h4" className="text-lg" weight="bold">
+                      {item.title}
+                    </Heading>
+                    <Text variant="small" tone="muted" className="mt-2">
+                      {item.description}
+                    </Text>
+                    <Link
+                      href={item.action.href}
+                      className="mt-4 inline-flex items-center text-sm font-medium text-primary hover:text-primary/80"
+                    >
+                      {item.action.label}
+                      <span className="ml-2 text-lg" aria-hidden>
+                        →
+                      </span>
+                    </Link>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- wrap each section on the public Über uns page in responsive containers that respect the global layout max width
- keep existing content structure but ensure the page centers and no longer requires horizontal scrolling on smaller screens

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d542d81f60832dbb03ef9f5314b404