### PR TITLE
Skip docker publish workflow on PRs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,7 @@ env:
 
 jobs:
   build-and-push-website:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- add a job-level guard so the docker publish workflow is skipped when the event is a pull request

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d551d7c600832d9583dae47ca0c5a3