### PR TITLE
Refactor Sperrliste settings into modal

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/page-client.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page-client.tsx
@@ -7,7 +7,7 @@ import type { HolidayRange } from "@/types/holidays";
 
 import type { BlockedDay } from "./block-calendar";
 import type { OverviewMember } from "./block-overview";
-import { SperrlisteSettingsManager } from "./settings-manager";
+import { SperrlisteSettingsDialog } from "./settings-dialog";
 import { SperrlisteTabs } from "./sperrliste-tabs";
 
 interface SperrlistePageClientProps {
@@ -34,19 +34,21 @@ export function SperrlistePageClient({
   return (
     <div className="space-y-6">
       {canManageSettings ? (
-        <SperrlisteSettingsManager
-          settings={settings}
-          defaultHolidaySourceUrl={defaultHolidayUrl}
-          onSettingsChange={(payload) => {
-            setSettings(payload.settings);
-            if (payload.holidays) {
-              setHolidays(payload.holidays);
-            }
-            if (payload.defaults?.holidaySourceUrl) {
-              setDefaultHolidayUrl(payload.defaults.holidaySourceUrl);
-            }
-          }}
-        />
+        <div className="flex justify-end">
+          <SperrlisteSettingsDialog
+            settings={settings}
+            defaultHolidaySourceUrl={defaultHolidayUrl}
+            onSettingsChange={(payload) => {
+              setSettings(payload.settings);
+              if (payload.holidays) {
+                setHolidays(payload.holidays);
+              }
+              if (payload.defaults?.holidaySourceUrl) {
+                setDefaultHolidayUrl(payload.defaults.holidaySourceUrl);
+              }
+            }}
+          />
+        </div>
       ) : null}
 
       <SperrlisteTabs

--- a/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { Settings2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import type { SperrlisteSettingsChangePayload } from "./settings-manager";
+import { SperrlisteSettingsManager } from "./settings-manager";
+import type { ClientSperrlisteSettings } from "@/lib/sperrliste-settings";
+
+interface SperrlisteSettingsDialogProps {
+  settings: ClientSperrlisteSettings;
+  defaultHolidaySourceUrl: string;
+  onSettingsChange?: (payload: SperrlisteSettingsChangePayload) => void;
+}
+
+export function SperrlisteSettingsDialog({
+  settings,
+  defaultHolidaySourceUrl,
+  onSettingsChange,
+}: SperrlisteSettingsDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="gap-2">
+          <Settings2 className="h-4 w-4" aria-hidden />
+          <span>Sperrlisten-Einstellungen</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] overflow-hidden border-0 bg-transparent p-0 sm:max-w-5xl">
+        <div className="max-h-[90vh] overflow-y-auto">
+          <SperrlisteSettingsManager
+            settings={settings}
+            defaultHolidaySourceUrl={defaultHolidaySourceUrl}
+            onSettingsChange={(payload) => {
+              onSettingsChange?.(payload);
+            }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
@@ -22,16 +22,16 @@ const CHECKED_AT_FORMATTER = new Intl.DateTimeFormat("de-DE", {
 
 const FREEZE_DAY_PRESETS = [0, 3, 5, 7, 10, 14, 21, 28, 30] as const;
 
+export type SperrlisteSettingsChangePayload = {
+  settings: ClientSperrlisteSettings;
+  holidays?: HolidayRange[];
+  defaults?: { holidaySourceUrl: string };
+};
+
 interface SperrlisteSettingsManagerProps {
   settings: ClientSperrlisteSettings;
   defaultHolidaySourceUrl: string;
-  onSettingsChange?: (
-    payload: {
-      settings: ClientSperrlisteSettings;
-      holidays?: HolidayRange[];
-      defaults?: { holidaySourceUrl: string };
-    },
-  ) => void;
+  onSettingsChange?: (payload: SperrlisteSettingsChangePayload) => void;
 }
 
 type ErrorState = {


### PR DESCRIPTION
## Summary
- add a dedicated dialog that wraps the existing Sperrliste settings manager in a modal
- replace the inline settings manager with a button that opens the modal from the Sperrliste page
- export a shared change payload type to simplify passing settings updates through the dialog

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d55413cee4832dbc5a91ba182e16b7