### PR TITLE
Remove gender-inclusive phrasing from German UI copy

### DIFF
--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/meal-plan-context.ts
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/meal-plan-context.ts
@@ -26,8 +26,8 @@ export const STYLE_BADGE_VARIANTS: Record<DietaryStyleOption, string> = {
 };
 
 export const STYLE_LABELS: Record<DietaryStyleOption, string> = {
-  none: "Allesesser:in",
-  omnivore: "Allesesser:in",
+  none: "Allesesser",
+  omnivore: "Allesesser",
   vegetarian: "Vegetarisch",
   vegan: "Vegan",
   pescetarian: "Pescetarisch",

--- a/src/app/(members)/mitglieder/meine-gewerke/actions.ts
+++ b/src/app/(members)/mitglieder/meine-gewerke/actions.ts
@@ -39,7 +39,7 @@ export async function joinDepartmentAction(formData: FormData) {
   const session = await requireAuth();
   const userId = session.user?.id;
   if (!userId) {
-    throw new Error("Benutzer:in konnte nicht ermittelt werden.");
+    throw new Error("Benutzer konnte nicht ermittelt werden.");
   }
 
   const departmentIdValue = formData.get("departmentId");

--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -247,7 +247,7 @@ export default async function MeineGewerkePage() {
 
   const heroDescription = memberships.length
     ? "Behalte deine Zuständigkeiten im Blick, choreografiere Aufgaben und sichere kollisionsfreie Zeitfenster für dein Team."
-    : "Sobald du einem Gewerk zugeordnet bist, findest du hier Aufgaben, Ansprechpartner:innen und Terminvorschläge.";
+    : "Sobald du einem Gewerk zugeordnet bist, findest du hier Aufgaben, Ansprechpartner und Terminvorschläge.";
 
   const hero = (
     <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-background/70 p-6 shadow-[0_28px_90px_-50px_rgba(99,102,241,0.8)] sm:p-10">
@@ -320,7 +320,7 @@ export default async function MeineGewerkePage() {
         <div className="space-y-2">
           <h2 className="text-lg font-semibold text-foreground sm:text-xl">Weitere Gewerke beitreten</h2>
           <p className="text-sm text-muted-foreground">
-            Verstärke zusätzliche Teams, um deren Aufgabenlisten, Ansprechpartner:innen und Terminvorschläge freizuschalten.
+            Verstärke zusätzliche Teams, um deren Aufgabenlisten, Ansprechpartner und Terminvorschläge freizuschalten.
           </p>
         </div>
       </div>

--- a/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
@@ -137,7 +137,7 @@ export default async function DepartmentTodosPage() {
 
   const heroDescription = memberships.length
     ? "Alle Aufgaben, Zuständigkeiten und Leitungen deiner Gewerke gebündelt an einem Ort."
-    : "Sobald du einem Gewerk beitrittst, erscheinen hier deine Todos und Ansprechpartner:innen.";
+    : "Sobald du einem Gewerk beitrittst, erscheinen hier deine Todos und Ansprechpartner.";
 
   const headerActions = (
     <>
@@ -220,7 +220,7 @@ export default async function DepartmentTodosPage() {
           <div className="space-y-4 text-sm text-muted-foreground sm:text-base">
             <h2 className="text-lg font-semibold text-foreground sm:text-xl">Noch keine Gewerke-Aufgaben</h2>
             <p>
-              Tritt einem Gewerk bei, um hier Aufgaben, Zuständigkeiten und Ansprechpartner:innen zu sehen.
+              Tritt einem Gewerk bei, um hier Aufgaben, Zuständigkeiten und Ansprechpartner zu sehen.
             </p>
             <div>
               <Button asChild>
@@ -421,7 +421,7 @@ export default async function DepartmentTodosPage() {
               <div className="grid gap-6 lg:grid-cols-2">
                 <section className="rounded-2xl border border-border/60 bg-background/70 p-4 shadow-inner">
                   <div className="flex items-center justify-between">
-                    <h3 className="text-sm font-semibold text-foreground">Leitung &amp; Ansprechpartner:innen</h3>
+                    <h3 className="text-sm font-semibold text-foreground">Leitung &amp; Ansprechpartner</h3>
                     <Badge variant="muted" size="sm">
                       {leadership.length} {leadership.length === 1 ? "Person" : "Personen"}
                     </Badge>

--- a/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
+++ b/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
@@ -72,7 +72,7 @@ export default async function OnboardingAnalyticsPage() {
       <Card className="border border-border/70">
         <CardHeader>
           <CardTitle>Mystery Scoreboard</CardTitle>
-          <p className="text-sm text-muted-foreground">Top-Spieler:innen mit Punkten für richtige Rätsel-Ideen.</p>
+          <p className="text-sm text-muted-foreground">Top-Spieler mit Punkten für richtige Rätsel-Ideen.</p>
         </CardHeader>
         <CardContent>
           {scoreboard.length === 0 ? (
@@ -232,7 +232,7 @@ export default async function OnboardingAnalyticsPage() {
                 const gender =
                   profile.gender && profile.gender.toLowerCase() !== "keine angabe" ? profile.gender : null;
                 const showDietaryPreference =
-                  profile.dietaryPreference && profile.dietaryPreference !== "Allesesser:in";
+                  profile.dietaryPreference && profile.dietaryPreference !== "Allesesser";
                 const dietaryStrictness =
                   profile.dietaryPreferenceStrictness && profile.dietaryPreferenceStrictness !== "Nicht relevant"
                     ? profile.dietaryPreferenceStrictness

--- a/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
@@ -984,7 +984,7 @@ export function ServerAnalyticsContent({ initialAnalytics }: ServerAnalyticsCont
                           <div className="flex flex-wrap justify-end gap-3 text-xs text-muted-foreground">
                             <span>Vorkommen: {numberFormat.format(log.occurrences)}</span>
                             {typeof log.affectedUsers === "number" ? (
-                              <span>Betroffene Nutzer:innen: {numberFormat.format(log.affectedUsers)}</span>
+                              <span>Betroffene Nutzer: {numberFormat.format(log.affectedUsers)}</span>
                             ) : null}
                           </div>
                         </div>

--- a/src/app/(site)/ueber-uns/page.tsx
+++ b/src/app/(site)/ueber-uns/page.tsx
@@ -58,7 +58,7 @@ const baseHighlights: Highlight[] = [
   {
     label: "Ensemble",
     value: "45+",
-    detail: "Darstellende, Musiker:innen und helfende Hände",
+    detail: "Darsteller, Musiker und helfende Hände",
   },
   {
     label: "Publikum",
@@ -89,7 +89,7 @@ const signature = [
     icon: Trees,
     title: "Schulgelände voller Gewerke",
     description:
-      "Schüler:innen des BSZ Altroßthal bringen Floristik, Holz- und Metallbau ein – so wachsen Bühne, Kostüm und Szenografie Hand in Hand.",
+      "Schüler des BSZ Altroßthal bringen Floristik, Holz- und Metallbau ein – so wachsen Bühne, Kostüm und Szenografie Hand in Hand.",
   },
 ];
 
@@ -119,19 +119,19 @@ const milestones = [
     year: "2009",
     title: "Die erste Inszenierung",
     description:
-      "Toni Burghard Friedrich initiiert das Sommertheater mit \"Die lustigen Weiber von Windsor\" und schafft einen neuen Ort für Schüler:innen des BSZ.",
+      "Toni Burghard Friedrich initiiert das Sommertheater mit \"Die lustigen Weiber von Windsor\" und schafft einen neuen Ort für Schüler des BSZ.",
   },
   {
     year: "2012",
     title: "Floristik trifft Bühne",
     description:
-      "Florist:innen gestalten erstmals lebendige Bühnenbilder aus regionalen Pflanzen und geben dem Park seine ikonischen Duftinseln.",
+      "Floristen gestalten erstmals lebendige Bühnenbilder aus regionalen Pflanzen und geben dem Park seine ikonischen Duftinseln.",
   },
   {
     year: "2017",
     title: "Werkstatt-Ateliers",
     description:
-      "Neue Workshops ermöglichen Schüler:innen, sich in Lichttechnik, Metallbau und Kostümhandwerk auszuprobieren und Verantwortung zu übernehmen.",
+      "Neue Workshops ermöglichen Schülern, sich in Lichttechnik, Metallbau und Kostümhandwerk auszuprobieren und Verantwortung zu übernehmen.",
   },
   {
     year: "2023",
@@ -154,7 +154,7 @@ const engagement = [
   {
     title: "Fördern",
     description:
-      "Als Partner:in oder Sponsor:in stärkst du kulturelle Angebote in der Region und ermöglichst faire Gagen für unser Kreativteam.",
+      "Als Partner oder Sponsor stärkst du kulturelle Angebote in der Region und ermöglichst faire Gagen für unser Kreativteam.",
     action: {
       label: "Kontakt aufnehmen",
       href: "mailto:foerderkreis@sommertheater-altrossthal.de",
@@ -224,7 +224,7 @@ const trades: Trade[] = [
     title: "Soufflage",
     focus: "Bei Hängern einspringen",
     description:
-      "Mit Textbuch und Ruhe bewahren die Souffleur:innen den Überblick – und geben im richtigen Moment leise Stichworte.",
+      "Mit Textbuch und Ruhe bewahren die Souffleure den Überblick – und geben im richtigen Moment leise Stichworte.",
   },
   {
     icon: Music3,
@@ -260,7 +260,7 @@ export default async function AboutPage() {
     return {
       ...item,
       value: NUMBER_FORMATTER.format(ensembleStats.memberCount),
-      detail: "Mitglieder in der aktuellen Produktion – Darstellende, Musiker:innen und helfende Hände",
+      detail: "Mitglieder in der aktuellen Produktion – Darsteller, Musiker und helfende Hände",
     };
   });
   const jsonLd = {
@@ -311,15 +311,15 @@ export default async function AboutPage() {
             Schlosspark Altrossthal.
           </Text>
           <Text tone="muted" className="mt-4">
-            Gegründet wurde das Sommertheater 2009 vom damaligen Schüler Toni Burghard Friedrich. Seitdem treffen sich Lernende, Alumni und Freund:innen des
+            Gegründet wurde das Sommertheater 2009 vom damaligen Schüler Toni Burghard Friedrich. Seitdem treffen sich Lernende, Alumni und Freunde des
             BSZ Altroßthal, um eine Bühne zu schaffen, die weit über klassischen Unterricht hinausgeht.
           </Text>
           <Text tone="muted" className="mt-4">
-            Das Ensemble besteht aus Schüler:innen des Beruflichen Gymnasiums und der Fachoberschule, Auszubildenden aus Landwirtschaft, Floristik, Konditorei
-            und vielen weiteren Gewerken sowie Freund:innen des Beruflichen Schulzentrums für Agrarwirtschaft und Ernährung Dresden.
+            Das Ensemble besteht aus Schülern des Beruflichen Gymnasiums und der Fachoberschule, Auszubildenden aus Landwirtschaft, Floristik, Konditorei
+            und vielen weiteren Gewerken sowie Freunden des Beruflichen Schulzentrums für Agrarwirtschaft und Ernährung Dresden.
           </Text>
           <Text tone="muted" className="mt-4">
-            Die Regie übernehmen meist professionelle Schauspieler:innen oder Regisseur:innen, die ihre Erfahrung teilen und gemeinsam mit uns neue Sommerstücke
+            Die Regie übernehmen meist professionelle Schauspieler oder Regisseure, die ihre Erfahrung teilen und gemeinsam mit uns neue Sommerstücke
             entwickeln.
           </Text>
         </div>
@@ -437,7 +437,7 @@ export default async function AboutPage() {
                 das Publikum mitnimmt in eine andere Welt.
               </Heading>
               <Text variant="small" tone="muted">
-                Jedes Szenenbild wird speziell für den Schlosspark entwickelt. Lichtinstallationen und räumlicher Klang lassen die Besucher:innen mitten in der
+                Jedes Szenenbild wird speziell für den Schlosspark entwickelt. Lichtinstallationen und räumlicher Klang lassen die Besucher mitten in der
                 Geschichte stehen.
               </Text>
             </div>

--- a/src/app/(site)/unsere-schulkatze/encounters-section.tsx
+++ b/src/app/(site)/unsere-schulkatze/encounters-section.tsx
@@ -535,7 +535,7 @@ export function DieterEncountersSection() {
                     <div>
                       <Text weight="semibold">Ausgeblendete Begegnungen</Text>
                       <Text variant="small" tone="muted">
-                        Nur für Moderator:innen sichtbar. Blenden Sie Beiträge bei Bedarf wieder ein.
+                        Nur für Moderatoren sichtbar. Blenden Sie Beiträge bei Bedarf wieder ein.
                       </Text>
                     </div>
                     <Button

--- a/src/app/(site)/unsere-schulkatze/page.tsx
+++ b/src/app/(site)/unsere-schulkatze/page.tsx
@@ -117,7 +117,7 @@ const careCircle: Supporter[] = [
     icon: Users,
     title: "Pflege-AG & Schülerschaft",
     description:
-      "In festen Diensten sorgten engagierte Schüler:innen für Futter, frisches Wasser und liebevolle Aufmerksamkeit.",
+      "In festen Diensten sorgten engagierte Schüler für Futter, frisches Wasser und liebevolle Aufmerksamkeit.",
   },
   {
     icon: ShieldCheck,
@@ -306,7 +306,7 @@ export default function SchulkatzePage() {
             In Erinnerung an Dieter
           </Heading>
           <Text variant="bodyLg" tone="muted" align="center">
-            Dieter hat Generationen von Schüler:innen begleitet und unserer Schule ein unverwechselbares Gefühl von Heimat gegeben.
+            Dieter hat Generationen von Schülern begleitet und unserer Schule ein unverwechselbares Gefühl von Heimat gegeben.
             Seine Geschichte erinnert uns daran, wie wertvoll Fürsorge und Gemeinschaft sind.
           </Text>
           <Text tone="muted" align="center">

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -30,8 +30,8 @@ const genderOptionLabels = {
 type GenderOption = keyof typeof genderOptionLabels;
 
 const dietaryStyleLabels = {
-  none: "Allesesser:in",
-  omnivore: "Allesesser:in",
+  none: "Allesesser",
+  omnivore: "Allesesser",
   vegetarian: "Vegetarisch",
   vegan: "Vegan",
   pescetarian: "Pescetarisch",

--- a/src/components/members/profile-dietary-preferences.tsx
+++ b/src/components/members/profile-dietary-preferences.tsx
@@ -220,7 +220,7 @@ export function ProfileDietaryPreferences({
               Ernährungsstil
             </h3>
             <p className="text-xs text-muted-foreground">
-              Wir planen dich standardmäßig als Allesesser:in ein. Besondere Wünsche oder Einschränkungen teilst du am besten direkt über die Allergieverwaltung oder im persönlichen Gespräch mit dem Team.
+              Wir planen dich standardmäßig als Allesesser ein. Besondere Wünsche oder Einschränkungen teilst du am besten direkt über die Allergieverwaltung oder im persönlichen Gespräch mit dem Team.
             </p>
           </div>
           <div className="space-y-2 rounded-lg border border-border/60 bg-background p-3">

--- a/src/components/members/profile-page-client.tsx
+++ b/src/components/members/profile-page-client.tsx
@@ -486,7 +486,7 @@ export function ProfilePageClient({
           <PageHeader
             variant="section"
             title="Mein Profil"
-            description="Halte deine Angaben aktuell, damit Teams und Kolleg:innen optimal planen können."
+            description="Halte deine Angaben aktuell, damit Teams und Kollegen optimal planen können."
           />
           <div className="mt-6">
             <ProfilePhotoConsentNotice

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1795,7 +1795,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                     />
                   )}
                   <p className="text-xs text-muted-foreground">
-                    Allesesser:in ist vorausgewählt. Wähle eine andere Option, wenn du besondere Ernährungsweisen hast.
+                    Allesesser ist vorausgewählt. Wähle eine andere Option, wenn du besondere Ernährungsweisen hast.
                   </p>
                 </div>
                 <div className="space-y-2 text-sm">
@@ -1804,7 +1804,7 @@ export function OnboardingWizard({ sessionToken, invite }: OnboardingWizardProps
                     <div className="space-y-1 rounded-lg border border-border/50 bg-background px-3 py-2">
                       <p className="text-sm font-medium text-foreground">Nicht relevant</p>
                       <p className="text-xs text-muted-foreground">
-                        Für Allesesser:innen planen wir flexibel. Melde dich einfach beim Team, falls es besondere Wünsche gibt.
+                        Für Allesesser planen wir flexibel. Melde dich einfach beim Team, falls es besondere Wünsche gibt.
                       </p>
                     </div>
                   ) : (

--- a/src/data/dietary-preferences.ts
+++ b/src/data/dietary-preferences.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 export const DIETARY_STYLE_OPTIONS = [
-  { value: "none", label: "Allesesser:in" },
-  { value: "omnivore", label: "Allesesser:in" },
+  { value: "none", label: "Allesesser" },
+  { value: "omnivore", label: "Allesesser" },
   { value: "vegetarian", label: "Vegetarisch" },
   { value: "vegan", label: "Vegan" },
   { value: "pescetarian", label: "Pescetarisch" },


### PR DESCRIPTION
## Summary
- replace gender-neutral colon wording on the public "Über uns" and "Unsere Schulkatze" pages with the requested masculine phrasing
- adjust member area labels, error text, and analytics copy to drop gender-neutral forms
- align dietary preference options and onboarding guidance to use "Allesesser" consistently

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d555fa9d4c832d8e34fc2701efa48a