### PR TITLE
feat: add webhook-driven auto deploy service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,17 @@ CORS_ORIGIN=https://devtheater.beegreenx.de
 #REALTIME_SERVER_URL=https://prodtheater.beegreenx.de/realtime
 #CORS_ORIGIN=https://prodtheater.beegreenx.de
 #REALTIME_CORS_ORIGIN=https://prodtheater.beegreenx.de
+
+# ------------------------------------------------------------------------------
+# Auto-deploy webhook service (docker-compose.autodeploy.yml)
+# ------------------------------------------------------------------------------
+#AUTO_DEPLOY_GIT_REMOTE_URL=git@github.com:ORG/Website.git
+#AUTO_DEPLOY_WEBHOOK_SECRET=replace-with-strong-secret
+#AUTO_DEPLOY_TARGET_BRANCH=main
+#AUTO_DEPLOY_ENV=prod
+#AUTO_DEPLOY_SERVICE_NAME=app-prod
+#AUTO_DEPLOY_COMPOSE_FILE=/opt/worktree/docker-compose.hosting.yml
+#AUTO_DEPLOY_PROJECT_NAME=theater
+#AUTO_DEPLOY_LISTEN_PORT=3000
+#AUTO_DEPLOY_WEBHOOK_PORT=9000
+#AUTO_DEPLOY_WEBHOOK_PATH=/webhook

--- a/deploy-service/Dockerfile
+++ b/deploy-service/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.6
+FROM node:22-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        lsb-release \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PNPM_HOME=/opt/pnpm
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+WORKDIR /app
+
+COPY deploy-service/entrypoint.sh /app/entrypoint.sh
+COPY deploy-service/deploy.sh /app/deploy.sh
+COPY deploy-service/server.mjs /app/server.mjs
+
+RUN chmod +x /app/entrypoint.sh /app/deploy.sh
+
+ENV LISTEN_PORT=3000
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/deploy-service/deploy.sh
+++ b/deploy-service/deploy.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
+REPO_DIR="${REPO_DIR:-/opt/worktree}"
+COMPOSE_FILE_PATH="${COMPOSE_FILE_PATH:-$REPO_DIR/docker-compose.hosting.yml}"
+DEPLOY_ENV="${DEPLOY_ENV:-prod}"
+DOCKER_COMPOSE_CMD="${DOCKER_COMPOSE_CMD:-docker compose}"
+DEPLOY_SERVICE_NAME="${DEPLOY_SERVICE_NAME:-}"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "[deploy] Repository not found in $REPO_DIR" >&2
+  exit 1
+fi
+
+if [ ! -f "$COMPOSE_FILE_PATH" ]; then
+  echo "[deploy] Compose file $COMPOSE_FILE_PATH does not exist" >&2
+  exit 1
+fi
+
+if [ -z "$DEPLOY_SERVICE_NAME" ]; then
+  if [ "$DEPLOY_ENV" = "dev" ]; then
+    DEPLOY_SERVICE_NAME="app-dev"
+  else
+    DEPLOY_SERVICE_NAME="app-prod"
+  fi
+fi
+
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-theater}"
+
+echo "[deploy] Updating repository at $REPO_DIR"
+git -C "$REPO_DIR" fetch origin --prune
+if git -C "$REPO_DIR" rev-parse "origin/$TARGET_BRANCH" >/dev/null 2>&1; then
+  git -C "$REPO_DIR" checkout "$TARGET_BRANCH"
+  git -C "$REPO_DIR" reset --hard "origin/$TARGET_BRANCH"
+else
+  echo "[deploy] Branch $TARGET_BRANCH not found on remote" >&2
+  exit 1
+fi
+
+echo "[deploy] Syncing submodules (if any)"
+git -C "$REPO_DIR" submodule update --init --recursive
+
+echo "[deploy] Building service $DEPLOY_SERVICE_NAME using $COMPOSE_FILE_PATH"
+$DOCKER_COMPOSE_CMD -f "$COMPOSE_FILE_PATH" build "$DEPLOY_SERVICE_NAME"
+
+echo "[deploy] Recreating service $DEPLOY_SERVICE_NAME"
+$DOCKER_COMPOSE_CMD -f "$COMPOSE_FILE_PATH" up -d "$DEPLOY_SERVICE_NAME"
+
+echo "[deploy] Deployment finished"

--- a/deploy-service/entrypoint.sh
+++ b/deploy-service/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GIT_REMOTE_URL:?GIT_REMOTE_URL must be set}"
+: "${GITHUB_WEBHOOK_SECRET:?GITHUB_WEBHOOK_SECRET must be set}"
+
+TARGET_BRANCH="${TARGET_BRANCH:-main}"
+REPO_DIR="${REPO_DIR:-/opt/worktree}"
+GIT_CLONE_DEPTH="${GIT_CLONE_DEPTH:-0}"
+
+mkdir -p "$REPO_DIR"
+
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "[entrypoint] Cloning $GIT_REMOTE_URL into $REPO_DIR (branch: $TARGET_BRANCH)"
+  clone_args=("$GIT_REMOTE_URL" "$REPO_DIR")
+  if [ "$GIT_CLONE_DEPTH" != "0" ]; then
+    clone_args=("--depth" "$GIT_CLONE_DEPTH" "--branch" "$TARGET_BRANCH" "--single-branch" "$GIT_REMOTE_URL" "$REPO_DIR")
+  else
+    clone_args=("--branch" "$TARGET_BRANCH" "--single-branch" "$GIT_REMOTE_URL" "$REPO_DIR")
+  fi
+  git clone "${clone_args[@]}"
+else
+  echo "[entrypoint] Existing repository detected at $REPO_DIR"
+  git -C "$REPO_DIR" remote set-url origin "$GIT_REMOTE_URL"
+  git -C "$REPO_DIR" fetch --all --prune
+  git -C "$REPO_DIR" checkout "$TARGET_BRANCH"
+  git -C "$REPO_DIR" reset --hard "origin/$TARGET_BRANCH"
+fi
+
+echo "[entrypoint] Starting webhook listener on port ${LISTEN_PORT:-3000}"
+exec node /app/server.mjs

--- a/deploy-service/server.mjs
+++ b/deploy-service/server.mjs
@@ -1,0 +1,170 @@
+import { createServer } from 'node:http';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { URL } from 'node:url';
+
+const secret = process.env.GITHUB_WEBHOOK_SECRET;
+if (!secret) {
+  throw new Error('GITHUB_WEBHOOK_SECRET must be defined');
+}
+
+const targetBranch = process.env.TARGET_BRANCH ?? 'main';
+const webhookPath = process.env.WEBHOOK_PATH ?? '/webhook';
+const listenPort = Number.parseInt(process.env.LISTEN_PORT ?? process.env.PORT ?? '3000', 10);
+
+let deploymentQueue = Promise.resolve();
+let lastStatus = {
+  ok: true,
+  message: 'ready',
+  finishedAt: null,
+};
+
+function headerToString(header) {
+  if (!header) {
+    return undefined;
+  }
+  return Array.isArray(header) ? header[0] : header;
+}
+
+function verifySignature(signatureHeader, payloadBuffer) {
+  if (!signatureHeader) {
+    return false;
+  }
+  const expected = createHmac('sha256', secret).update(payloadBuffer).digest('hex');
+  const expectedHeader = Buffer.from(`sha256=${expected}`);
+  const actualHeader = Buffer.from(signatureHeader);
+  if (expectedHeader.length !== actualHeader.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedHeader, actualHeader);
+}
+
+function runDeployment(reason) {
+  return new Promise((resolve, reject) => {
+    console.log(`[webhook] Triggered deployment: ${reason}`);
+    lastStatus = {
+      ok: true,
+      message: 'in_progress',
+      finishedAt: null,
+    };
+    const child = spawn('/app/deploy.sh', {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    child.stdout.on('data', (chunk) => {
+      process.stdout.write(chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      process.stderr.write(chunk);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        console.log('[webhook] Deployment finished successfully');
+        lastStatus = {
+          ok: true,
+          message: 'success',
+          finishedAt: new Date().toISOString(),
+        };
+        resolve();
+      } else {
+        const error = new Error(`Deployment exited with status ${code}`);
+        lastStatus = {
+          ok: false,
+          message: error.message,
+          finishedAt: new Date().toISOString(),
+        };
+        reject(error);
+      }
+    });
+  });
+}
+
+function enqueueDeployment(reason) {
+  deploymentQueue = deploymentQueue
+    .catch(() => undefined)
+    .then(() => runDeployment(reason));
+  return deploymentQueue;
+}
+
+function respondJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+const server = createServer((req, res) => {
+  const { method } = req;
+  const url = new URL(req.url ?? '/', 'http://localhost');
+
+  if (method === 'GET' && url.pathname === '/healthz') {
+    respondJson(res, 200, { status: 'ok', lastStatus });
+    return;
+  }
+
+  if (method !== 'POST' || url.pathname !== webhookPath) {
+    respondJson(res, 404, { error: 'not_found' });
+    return;
+  }
+
+  const signatureHeader = headerToString(req.headers['x-hub-signature-256']);
+  const eventType = req.headers['x-github-event'];
+
+  const chunks = [];
+  req.on('data', (chunk) => {
+    chunks.push(chunk);
+  });
+  req.on('error', (error) => {
+    console.error('[webhook] Failed to read request body', error);
+    respondJson(res, 500, { error: 'read_error' });
+  });
+  req.on('end', () => {
+    if (res.writableEnded) {
+      return;
+    }
+    const buffer = Buffer.concat(chunks);
+
+    if (!verifySignature(signatureHeader, buffer)) {
+      respondJson(res, 401, { error: 'invalid_signature' });
+      return;
+    }
+
+    if (eventType === 'ping') {
+      respondJson(res, 200, { status: 'pong' });
+      return;
+    }
+
+    if (eventType !== 'push') {
+      respondJson(res, 202, { status: 'ignored', reason: `event ${eventType} unsupported` });
+      return;
+    }
+
+    let payload;
+    try {
+      payload = JSON.parse(buffer.toString('utf8'));
+    } catch (error) {
+      console.warn('[webhook] Unable to parse webhook payload', error);
+      respondJson(res, 400, { error: 'invalid_json' });
+      return;
+    }
+
+    if (payload.ref !== `refs/heads/${targetBranch}`) {
+      respondJson(res, 202, { status: 'ignored', reason: `branch ${payload.ref} does not match target ${targetBranch}` });
+      return;
+    }
+
+    enqueueDeployment(`push to ${targetBranch}`).catch((error) => {
+      console.error('[webhook] Deployment failed', error);
+    });
+
+    respondJson(res, 202, { status: 'queued' });
+  });
+});
+
+server.listen(listenPort, () => {
+  console.log(`[webhook] Listening on 0.0.0.0:${listenPort}, path ${webhookPath}`);
+});

--- a/docker-compose.autodeploy.yml
+++ b/docker-compose.autodeploy.yml
@@ -1,0 +1,25 @@
+services:
+  auto-deploy:
+    build:
+      context: .
+      dockerfile: deploy-service/Dockerfile
+    image: ${AUTO_DEPLOY_IMAGE:-limitlessgreen/theater_autodeploy:latest}
+    restart: unless-stopped
+    environment:
+      GIT_REMOTE_URL: ${AUTO_DEPLOY_GIT_REMOTE_URL:?set AUTO_DEPLOY_GIT_REMOTE_URL}
+      GITHUB_WEBHOOK_SECRET: ${AUTO_DEPLOY_WEBHOOK_SECRET:?set AUTO_DEPLOY_WEBHOOK_SECRET}
+      TARGET_BRANCH: ${AUTO_DEPLOY_TARGET_BRANCH:-main}
+      DEPLOY_ENV: ${AUTO_DEPLOY_ENV:-prod}
+      COMPOSE_FILE_PATH: ${AUTO_DEPLOY_COMPOSE_FILE:-/opt/worktree/docker-compose.hosting.yml}
+      DEPLOY_SERVICE_NAME: ${AUTO_DEPLOY_SERVICE_NAME:-}
+      COMPOSE_PROJECT_NAME: ${AUTO_DEPLOY_PROJECT_NAME:-theater}
+      LISTEN_PORT: ${AUTO_DEPLOY_LISTEN_PORT:-3000}
+      WEBHOOK_PATH: ${AUTO_DEPLOY_WEBHOOK_PATH:-/webhook}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - auto-deploy-repo:/opt/worktree
+    ports:
+      - "${AUTO_DEPLOY_WEBHOOK_PORT:-9000}:${AUTO_DEPLOY_LISTEN_PORT:-3000}"
+
+volumes:
+  auto-deploy-repo:


### PR DESCRIPTION
## Summary
- add a Dockerized webhook listener that verifies GitHub signatures and rebuilds the target compose service on matching pushes
- document the auto-deploy workflow and surface configuration variables for the new service

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d546e13e28832d9817be4b146446a3