### PR TITLE
Publish deploy service image and support private deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,12 @@ CORS_ORIGIN=https://devtheater.beegreenx.de
 # Auto-deploy webhook service (docker-compose.autodeploy.yml)
 # ------------------------------------------------------------------------------
 #AUTO_DEPLOY_GIT_REMOTE_URL=git@github.com:ORG/Website.git
+#AUTO_DEPLOY_GIT_HTTP_USERNAME=git
+#AUTO_DEPLOY_GIT_HTTP_PASSWORD=ghp_your-token
+#AUTO_DEPLOY_GIT_HTTP_TOKEN=ghp_your-token
+#AUTO_DEPLOY_GIT_CREDENTIAL_STORE_PATH=/tmp/git-credentials
+#AUTO_DEPLOY_GIT_SSH_PRIVATE_KEY="-----BEGIN OPENSSH PRIVATE KEY-----\n...\n-----END OPENSSH PRIVATE KEY-----"
+#AUTO_DEPLOY_GIT_SSH_KNOWN_HOSTS=github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
 #AUTO_DEPLOY_WEBHOOK_SECRET=replace-with-strong-secret
 #AUTO_DEPLOY_TARGET_BRANCH=main
 #AUTO_DEPLOY_ENV=prod

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,7 @@ on:
       - 'prisma/**'
       - 'realtime-server/**'
       - 'scripts/**'
+      - 'deploy-service/**'
   workflow_dispatch:
 
 env:
@@ -118,3 +119,40 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ matrix.build_args }}
+
+  build-and-push-deploy-service:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: Build and Push Deploy Service Image
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Extract Docker metadata (deploy-service)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.WEBSITE_IMAGE_NAME }}
+          tags: |
+            type=raw,value=deploy-service
+
+      - name: Build and push deploy-service Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy-service/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ arrives for the configured branch.
      service name instead of the dev/prod default.
    - `AUTO_DEPLOY_WEBHOOK_SECRET` – shared secret for the GitHub webhook
      signature.
+   - `AUTO_DEPLOY_GIT_HTTP_TOKEN` or the combination of
+     `AUTO_DEPLOY_GIT_HTTP_USERNAME`/`AUTO_DEPLOY_GIT_HTTP_PASSWORD` – optional
+     HTTPS credentials for private repositories.
+   - `AUTO_DEPLOY_GIT_SSH_PRIVATE_KEY` (plus
+     `AUTO_DEPLOY_GIT_SSH_KNOWN_HOSTS`) – optional SSH credentials for private
+     repositories.
 5. Start the service: `docker compose -f docker-compose.autodeploy.yml up -d`.
 6. Register a new GitHub webhook that points to
    `https://<host>:${AUTO_DEPLOY_WEBHOOK_PORT}${AUTO_DEPLOY_WEBHOOK_PATH}` and

--- a/deploy-service/Dockerfile
+++ b/deploy-service/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
         git \
         gnupg \
         lsb-release \
+        openssh-client \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \

--- a/deploy-service/entrypoint.sh
+++ b/deploy-service/entrypoint.sh
@@ -8,6 +8,88 @@ TARGET_BRANCH="${TARGET_BRANCH:-main}"
 REPO_DIR="${REPO_DIR:-/opt/worktree}"
 GIT_CLONE_DEPTH="${GIT_CLONE_DEPTH:-0}"
 
+configure_git_http_credentials() {
+  local remote_url="$1"
+  local username="${GIT_HTTP_USERNAME:-}"
+  local password="${GIT_HTTP_PASSWORD:-}"
+  local token="${GIT_HTTP_TOKEN:-}"
+
+  if [ -n "$token" ]; then
+    username="${GIT_HTTP_USERNAME:-git}"
+    password="$token"
+  fi
+
+  if [ -z "$username" ] || [ -z "$password" ]; then
+    return 0
+  fi
+
+  case "$remote_url" in
+    http://*|https://*)
+      local host
+      host="$(printf '%s\n' "$remote_url" | sed -E 's#^[a-z]+://([^/]+).*#\1#')"
+      local scheme
+      scheme="$(printf '%s\n' "$remote_url" | sed -E 's#^([a-z]+)://.*#\1#')"
+      if [ -z "$host" ]; then
+        echo "[entrypoint] Unable to extract host from $remote_url for HTTP credentials" >&2
+        return 1
+      fi
+
+      local cred_file="${GIT_CREDENTIAL_STORE_PATH:-/tmp/git-credentials}"
+      printf '%s://%s:%s@%s\n' "$scheme" "$username" "$password" "$host" >"$cred_file"
+      chmod 600 "$cred_file"
+      git config --global credential.helper "store --file=$cred_file"
+      echo "[entrypoint] Configured HTTP credentials for $host"
+      ;;
+    *)
+      echo "[entrypoint] HTTP credentials provided but remote URL is not HTTP(S); skipping" >&2
+      ;;
+  esac
+}
+
+configure_git_ssh() {
+  local key="${GIT_SSH_PRIVATE_KEY:-}"
+  if [ -z "$key" ]; then
+    return 0
+  fi
+
+  local ssh_dir="${HOME}/.ssh"
+  mkdir -p "$ssh_dir"
+  chmod 700 "$ssh_dir"
+
+  local key_path="${GIT_SSH_PRIVATE_KEY_PATH:-$ssh_dir/id_ed25519}"
+  printf '%s\n' "$key" >"$key_path"
+  chmod 600 "$key_path"
+  echo "[entrypoint] Installed SSH private key at $key_path"
+
+  if [ -n "${GIT_SSH_KNOWN_HOSTS:-}" ]; then
+    printf '%s\n' "$GIT_SSH_KNOWN_HOSTS" >"$ssh_dir/known_hosts"
+    chmod 600 "$ssh_dir/known_hosts"
+    echo "[entrypoint] Added provided SSH known_hosts entries"
+  else
+    local host=""
+    case "$GIT_REMOTE_URL" in
+      git@*:* )
+        host="$(printf '%s\n' "$GIT_REMOTE_URL" | sed -E 's#^[^@]+@([^:]+):.*#\1#')"
+        ;;
+      ssh://*)
+        host="$(printf '%s\n' "$GIT_REMOTE_URL" | sed -E 's#^ssh://([^/]+)/.*#\1#')"
+        ;;
+    esac
+
+    if [ -n "$host" ]; then
+      if ssh-keyscan -H "$host" >>"$ssh_dir/known_hosts" 2>/dev/null; then
+        chmod 600 "$ssh_dir/known_hosts"
+        echo "[entrypoint] Added $host to SSH known_hosts"
+      else
+        echo "[entrypoint] Warning: failed to automatically add $host to known_hosts" >&2
+      fi
+    fi
+  fi
+}
+
+configure_git_http_credentials "$GIT_REMOTE_URL"
+configure_git_ssh
+
 mkdir -p "$REPO_DIR"
 
 if [ ! -d "$REPO_DIR/.git" ]; then
@@ -26,6 +108,8 @@ else
   git -C "$REPO_DIR" checkout "$TARGET_BRANCH"
   git -C "$REPO_DIR" reset --hard "origin/$TARGET_BRANCH"
 fi
+
+git config --global --add safe.directory "$REPO_DIR"
 
 echo "[entrypoint] Starting webhook listener on port ${LISTEN_PORT:-3000}"
 exec node /app/server.mjs


### PR DESCRIPTION
## Summary
- publish the deploy-service Docker image with a dedicated tag whenever main is updated
- extend the deploy container to support HTTPS tokens or SSH keys for cloning private repositories
- document the new auto-deploy credentials in the env template and README

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d570a83cb4832d927bc05dcb269e04