### PR TITLE
Rename Schulkatze content to Dennis Dieter

### DIFF
--- a/src/app/(site)/unsere-schulkatze/encounters-section.tsx
+++ b/src/app/(site)/unsere-schulkatze/encounters-section.tsx
@@ -14,8 +14,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Heading, Text } from "@/components/ui/typography";
 
-const STORAGE_KEY = "dieter-dennis-encounters";
-const MODERATION_STORAGE_KEY = "dieter-dennis-hidden-encounters";
+const STORAGE_KEY = "dennis-dieter-encounters";
+const MODERATION_STORAGE_KEY = "dennis-dieter-hidden-encounters";
 
 const MODERATOR_ROLES = new Set<Role>(["board", "admin", "owner"]);
 
@@ -34,32 +34,32 @@ type StoredEncounter = Omit<Encounter, "source">;
 const curatedEncounters: Encounter[] = [
   {
     id: "curated-1",
-    since: "Sommer 2019",
-    nickname: "Direktor Dennis",
+    since: "Sommer 2024",
+    nickname: "Dennis Dieter vom Werkhof",
     story:
-      "Bei der Generalprobe durfte Dieter auf der leeren Zuschauertribüne thronen. Sein zufriedenes Schnurren war das entspannteste Zeichen für eine gelungene Premiere.",
+      "Bei der Generalprobe huschte Dennis Dieter zwischen den Kulissen hindurch, kletterte auf die letzte Reihe und beobachtete uns mit großen Augen. Sein zufriedenes Schnurren nahm allen die Nervosität.",
     author: "Lara aus der Kostümwerkstatt",
-    createdAt: "Juni 2023",
+    createdAt: "Juni 2024",
     source: "curated",
   },
   {
     id: "curated-2",
-    since: "Frühjahr 2016",
-    nickname: "Professor Dieter",
+    since: "Frühjahr 2024",
+    nickname: "Bibliotheks-Dennis",
     story:
-      "In der Prüfungswoche spazierte er durch die Aula, legte sich mitten zwischen die Skripte und erinnerte uns daran, Pausen einzuplanen. Seitdem gehört ein Streicheln von Dieter zu jeder Lernrunde.",
+      "Im Selbstlernzentrum legte er sich mitten zwischen Karteikästen und erinnerte uns daran, Pausen zu machen. Seitdem gehört ein kurzer Streichler für Dennis Dieter zu jeder Lernrunde.",
     author: "Herr Schubert, Mathekollegium",
-    createdAt: "März 2022",
+    createdAt: "März 2024",
     source: "curated",
   },
   {
     id: "curated-3",
-    since: "Herbst 2021",
+    since: "Herbst 2024",
     nickname: "Captain Dennis",
     story:
-      "Beim Kulissenbau für das Hafenstück bewachte er mit ernster Miene die Werkzeugkisten. Niemand vergaß dank ihm den Helm – Dieter passte einfach auf uns auf.",
+      "Beim Kulissenbau bewachte er mit wachem Blick die Werkzeugkisten. Niemand vergaß dank ihm den Helm – Dennis Dieter passte einfach auf uns auf.",
     author: "Werkstatt-AG",
-    createdAt: "Oktober 2023",
+    createdAt: "Oktober 2024",
     source: "curated",
   },
 ];
@@ -72,7 +72,7 @@ function generateId() {
   return `encounter-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-export function DieterEncountersSection() {
+export function DennisDieterEncountersSection() {
   const { data: session } = useSession();
   const [userEncounters, setUserEncounters] = useState<Encounter[]>([]);
   const [hiddenEncounterIds, setHiddenEncounterIds] = useState<string[]>([]);
@@ -279,7 +279,7 @@ export function DieterEncountersSection() {
     setUserEncounters((previous) => [newEncounter, ...previous]);
     form.reset();
 
-    const sinceInput = form.querySelector<HTMLInputElement>("#dieter-since");
+    const sinceInput = form.querySelector<HTMLInputElement>("#dennis-dieter-since");
     sinceInput?.focus();
   }, []);
 
@@ -300,11 +300,11 @@ export function DieterEncountersSection() {
         <div className="mx-auto max-w-6xl space-y-10">
           <div className="space-y-4 text-center">
             <Heading level="h2" align="center">
-              Begegnungen mit Dieter Dennis von Altroßthal
+              Begegnungen mit Dennis Dieter von Altroßthal
             </Heading>
             <Text variant="body" tone="muted" align="center">
-              Seit wann kennen Sie schon Dieter Dennis von Altroßthal? Wie hieß sie bei Ihnen? Teilen Sie uns Ihre Begegnung mit
-              Dieter mit. Wir freuen uns mehr über sie zu erfahren.
+              Seit wann kennen Sie schon Dennis Dieter von Altroßthal? Welchen Spitznamen hat er bei Ihnen? Teilen Sie uns Ihre Begegnung
+              mit Dennis Dieter mit. Wir freuen uns, mehr darüber zu erfahren.
             </Text>
           </div>
 
@@ -347,7 +347,7 @@ export function DieterEncountersSection() {
                   className="rounded-full px-4"
                   onClick={toggleFormVisibility}
                   aria-expanded={isFormOpen}
-                  aria-controls="dieter-encounter-form"
+                  aria-controls="dennis-dieter-encounter-form"
                 >
                   <Sparkles className="h-4 w-4" aria-hidden />
                   {isFormOpen ? "Formular schließen" : "Begegnung eintragen"}
@@ -356,21 +356,21 @@ export function DieterEncountersSection() {
 
               {isFormOpen ? (
                 <form
-                  id="dieter-encounter-form"
-                  className="mt-5 space-y-5 rounded-2xl border border-border/40 bg-background/70 p-4 shadow-inner sm:p-5"
+                  id="dennis-dieter-encounter-form"
+                  className="mt-6 space-y-4"
                   onSubmit={handleSubmit}
                 >
                   <div className="grid gap-3 sm:grid-cols-2">
                     <div className="space-y-1.5">
-                      <Label htmlFor="dieter-since">Seit wann kennen Sie Dieter?</Label>
-                      <Input id="dieter-since" name="since" placeholder="z. B. Frühjahr 2020" required autoComplete="off" />
+                      <Label htmlFor="dennis-dieter-since">Seit wann kennen Sie Dennis Dieter?</Label>
+                      <Input id="dennis-dieter-since" name="since" placeholder="z. B. Frühjahr 2024" required autoComplete="off" />
                     </div>
                     <div className="space-y-1.5">
-                      <Label htmlFor="dieter-nickname">Wie hieß sie bei Ihnen?</Label>
+                      <Label htmlFor="dennis-dieter-nickname">Wie hieß er bei Ihnen?</Label>
                       <Input
-                        id="dieter-nickname"
+                        id="dennis-dieter-nickname"
                         name="nickname"
-                        placeholder="Unser Spitzname für Dieter"
+                        placeholder="Unser Spitzname für Dennis Dieter"
                         required
                         autoComplete="off"
                       />
@@ -378,9 +378,9 @@ export function DieterEncountersSection() {
                   </div>
 
                   <div className="space-y-1.5">
-                    <Label htmlFor="dieter-author">Wer teilt diese Begegnung? (optional)</Label>
+                    <Label htmlFor="dennis-dieter-author">Wer teilt diese Begegnung? (optional)</Label>
                     <Input
-                      id="dieter-author"
+                      id="dennis-dieter-author"
                       name="author"
                       placeholder="Ihr Name, Ihre Klasse oder Gruppe"
                       autoComplete="off"
@@ -388,11 +388,11 @@ export function DieterEncountersSection() {
                   </div>
 
                   <div className="space-y-1.5">
-                    <Label htmlFor="dieter-story">Ihre Begegnung mit Dieter</Label>
+                    <Label htmlFor="dennis-dieter-story">Ihre Begegnung mit Dennis Dieter</Label>
                     <Textarea
-                      id="dieter-story"
+                      id="dennis-dieter-story"
                       name="story"
-                      placeholder="Was haben Sie mit Dieter erlebt?"
+                      placeholder="Was haben Sie mit Dennis Dieter erlebt?"
                       rows={5}
                       required
                     />
@@ -521,7 +521,7 @@ export function DieterEncountersSection() {
                           Noch keine Begegnungen
                         </Text>
                         <Text variant="small" tone="muted">
-                          Seien Sie die erste Person, die Dieter Dennis hier vorstellt.
+                          Seien Sie die erste Person, die Dennis Dieter hier vorstellt.
                         </Text>
                       </Card>
                     </li>

--- a/src/app/(site)/unsere-schulkatze/page.tsx
+++ b/src/app/(site)/unsere-schulkatze/page.tsx
@@ -9,7 +9,7 @@ import { Card } from "@/components/ui/card";
 import { TextLink } from "@/components/ui/text-link";
 import { Heading, Text } from "@/components/ui/typography";
 
-import { DieterEncountersSection } from "./encounters-section";
+import { DennisDieterEncountersSection } from "./encounters-section";
 import { SchulkatzeImageRotator } from "./image-rotator";
 
 const SUPPORTED_IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".gif", ".avif"]);
@@ -39,14 +39,14 @@ const schulkatzeImages = resolveSchulkatzeImages();
 export const metadata: Metadata = {
   title: "Unsere Schulkatze",
   description:
-    "Wir erinnern uns an Dieter Dennis von Altroßthal, die grau getigerte Schulkatze des BSZ Altrossthal, und erzählen seine Geschichte.",
+    "Wir stellen Dennis Dieter von Altroßthal, die neugierige Schulkatze des BSZ Altroßthal, vor und sammeln seine Geschichten.",
   alternates: {
     canonical: "/unsere-schulkatze",
   },
   openGraph: {
-    title: "Unsere Schulkatze | Sommertheater Altrossthal",
+    title: "Unsere Schulkatze | Sommertheater Altroßthal",
     description:
-      "Porträt und Erinnerungen an Dieter, unsere grau getigerte Schulkatze, die uns über viele Jahre begleitet hat.",
+      "Porträt und Begegnungen mit Dennis Dieter, unserer grau getigerten Schulkatze, der seit 2024 Teil des BSZ Altroßthal ist.",
     url: "/unsere-schulkatze",
     type: "website",
   },
@@ -75,19 +75,19 @@ const highlights: Highlight[] = [
     icon: Cat,
     title: "Porträt",
     description:
-      "Dieter Dennis von Altroßthal war unsere grau getigerte Schulkatze – verlässlich, gelassen und immer bereit für eine stille Beobachtung.",
+      "Dennis Dieter von Altroßthal ist unsere grau getigerte Schulkatze – aufmerksam, verspielt und immer auf der Suche nach einem sonnigen Platz.",
   },
   {
     icon: MoonStar,
-    title: "Uralter Bekannter",
+    title: "Neu auf dem Campus",
     description:
-      "Niemand konnte genau sagen, wann er eingezogen ist. Gefühlt streifte er schon seit über fünfzehn, zwanzig Jahren über das Schulgelände.",
+      "Seit dem Frühjahr 2024 erkundet er jeden Winkel des Schulgeländes und begrüßt Frühaufsteher auf dem Weg zur ersten Stunde.",
   },
   {
     icon: Heart,
     title: "Teil der Gemeinschaft",
     description:
-      "Ob Unterricht oder Premiere: Dieter gehörte einfach dazu und brachte eine Ruhe mit, die uns alle miteinander verband.",
+      "Ob Unterricht, Probentage oder Premiere: Dennis Dieter sucht die Nähe der Menschen und schenkt uns Momente der Ruhe.",
   },
 ];
 
@@ -96,19 +96,19 @@ const memories: Memory[] = [
     icon: Sun,
     title: "Frühe Streifzüge",
     detail:
-      "Geschichten erzählen davon, dass Dieter morgens schon vor dem ersten Klingeln seine Runden drehte und uns mit prüfendem Blick begrüßte.",
+      "Dennis Dieter startet seinen Tag in der Bibliothek, schnuppert an Büchern und beobachtet den Sonnenaufgang durch die großen Fenster.",
   },
   {
     icon: PawPrint,
     title: "Lieblingsorte",
     detail:
-      "Fensterbänke, Probebühnen und Parkbänke wurden zu seinen Ruhepolen – überall dort wirkte er wie ein grauer Wächter des Geländes.",
+      "Fensterbänke, Proberaumteppiche und der Innenhof sind seine Rückzugsorte – von dort aus behält er alles neugierig im Blick.",
   },
   {
     icon: MoonStar,
     title: "Abende im Park",
     detail:
-      "Wenn der Tag endete, blieb er oft noch eine Weile, als wolle er sicherstellen, dass alles seinen Platz hat, bevor er in die Nacht verschwand.",
+      "Nach Proben oder Aufführungen begleitet er uns noch bis zur Straßenbahnhaltestelle und verabschiedet die letzten Gäste mit einem sanften Miauen.",
   },
 ];
 
@@ -117,27 +117,27 @@ const careCircle: Supporter[] = [
     icon: Users,
     title: "Pflege-AG & Schülerschaft",
     description:
-      "In festen Diensten sorgten engagierte Schüler für Futter, frisches Wasser und liebevolle Aufmerksamkeit.",
+      "In festen Diensten sorgen engagierte Schüler für Futter, frisches Wasser und spielerische Abwechslung.",
   },
   {
     icon: ShieldCheck,
     title: "Hausmeisterteam & Tierärztin",
     description:
-      "Sie behielten Gesundheit und Sicherheit im Blick, koordinierten Checks und boten Dieter auch in seinen älteren Jahren Halt.",
+      "Sie behalten Dennis Dieters Gesundheit im Blick, koordinieren Checks und sorgen für sichere Rückzugsorte auf dem Campus.",
   },
   {
     icon: Fish,
     title: "Patenschaften & Spenden",
     description:
-      "Klassen und Kollegium legten zusammen, damit Futter, Medikamente und letzte Wege gemeinschaftlich getragen wurden.",
+      "Klassen und Kollegium legen zusammen, damit Futter, Spielzeug und Tierarztbesuche verlässlich finanziert sind.",
   },
 ];
 
 const lessons: string[] = [
-  "Tiere, die unsere Schule begleiten, brauchen feste Bezugspersonen und klare Absprachen – Dieter hat uns das gelehrt.",
-  "Gemeinsame Rituale schaffen Vertrauen, besonders wenn ein Vierbeiner über so viele Jahre Teil der Gemeinschaft ist.",
-  "In Abschiedsmomenten hilft es, Erinnerungen zu teilen und Orte des Gedenkens zu schaffen.",
-  "Wer künftig eine Schulkatze willkommen heißt, sollte an Dieters Bedürfnisse denken: Ruhe, Respekt und Zeit.",
+  "Tiere, die unsere Schule begleiten, brauchen feste Bezugspersonen und klare Absprachen – Dennis Dieter zeigt uns das jeden Tag.",
+  "Gemeinsame Rituale schaffen Vertrauen, besonders wenn ein Vierbeiner neu in eine gewachsene Gemeinschaft kommt.",
+  "In lebhaften Schulmomenten helfen ruhige Ecken, damit Dennis Dieter sich zurückziehen und Kraft sammeln kann.",
+  "Wer künftig eine Schulkatze willkommen heißt, sollte an Dennis Dieters Bedürfnisse denken: Ruhe, Respekt und Zeit.",
 ];
 
 export default function SchulkatzePage() {
@@ -168,25 +168,25 @@ export default function SchulkatzePage() {
               Unsere Schulkatze
             </Heading>
             <Text variant="bodyLg" tone="muted" className="mt-4">
-              Dieter Dennis von Altroßthal – von allen nur Dieter genannt – war unsere grau getigerte Schulkatze. Über Generationen hinweg
-              streifte er über das Schulgelände und wurde zum vertrauten Gesicht des BSZ Altrossthal.
+              Dennis Dieter von Altroßthal – von allen nur Dennis Dieter genannt – ist unsere neue grau getigerte Schulkatze. Seit dem Frühjahr
+              2024 streift er über das Schulgelände und begrüßt Besucher mit neugierigen Blicken.
             </Text>
             <Text tone="muted">
-              Niemand wusste genau, seit wann er da war; gefühlt waren es weit über fünfzehn Jahre. Seine stille Präsenz begleitete Unterricht,
-              Proben und Festspiele gleichermaßen.
+              Mit seiner offenen Art begleitet er Unterricht, Proben und Premieren gleichermaßen. Mal liegt er mitten im
+              Kostümfundus, mal sitzt er aufmerksam im Zuschauerraum und beobachtet jede Szene.
             </Text>
             <Text tone="muted">
-              In diesem Jahr mussten wir uns von Dieter verabschieden. Die Erinnerungen an ihn, seine Gelassenheit und die Fürsorge der
-              Schulgemeinschaft bleiben und prägen, wie wir auch künftig füreinander da sind.
+              Gemeinsam mit der Pflege-AG achten wir darauf, dass Dennis Dieter seinen eigenen Rhythmus behalten kann. Er zeigt uns, wie
+              Fürsorge und Rücksicht eine Gemeinschaft stärken.
             </Text>
           </div>
           <figure className="relative mx-auto max-w-sm overflow-hidden rounded-3xl border border-border bg-background shadow-lg">
             <SchulkatzeImageRotator
               images={schulkatzeImages}
-              alt="Schulkatze Dieter Dennis von Altroßthal, grau getigert, sitzt aufmerksam im Schulhof."
+              alt="Schulkatze Dennis Dieter von Altroßthal, grau getigert, sitzt aufmerksam im Schulhof."
             />
             <figcaption className="border-t border-border bg-background px-4 py-3 text-sm text-muted-foreground">
-              Dieter Dennis von Altroßthal war über viele Jahre Teil unserer Schulgemeinschaft.
+              Dennis Dieter von Altroßthal ist seit 2024 Teil unserer Schulgemeinschaft.
             </figcaption>
           </figure>
         </div>
@@ -222,7 +222,7 @@ export default function SchulkatzePage() {
                 <PawPrint className="h-5 w-5" aria-hidden />
               </div>
               <Text weight="semibold" className="text-base sm:text-lg">
-                Erinnerungen an Dieter
+                Erinnerungen an Dennis Dieter
               </Text>
             </div>
             <div className="space-y-4">
@@ -248,7 +248,7 @@ export default function SchulkatzePage() {
                 <Heart className="h-5 w-5" aria-hidden />
               </div>
               <Text weight="semibold" className="text-base sm:text-lg">
-                Wer sich gekümmert hat
+                Wer sich kümmert
               </Text>
             </div>
             <div className="space-y-3">
@@ -277,12 +277,12 @@ export default function SchulkatzePage() {
               <ShieldCheck className="h-5 w-5" aria-hidden />
             </div>
             <Text weight="semibold" className="text-base sm:text-lg">
-              Was wir aus Dieters Zeit mitnehmen
+              Was wir aus Dennis Dieters Zeit mitnehmen
             </Text>
           </div>
           <div className="space-y-3">
             <Text variant="small" tone="muted">
-              Dieter hat uns gezeigt, wie wichtig Achtsamkeit ist. Diese Gedanken begleiten uns auch in Zukunft:
+              Dennis Dieter zeigt uns, wie wichtig Achtsamkeit und klare Strukturen im Schulalltag sind. Diese Gedanken begleiten uns:
             </Text>
             <ul className="space-y-2">
               {lessons.map((lesson) => (
@@ -298,19 +298,19 @@ export default function SchulkatzePage() {
         </Card>
       </section>
 
-      <DieterEncountersSection />
+      <DennisDieterEncountersSection />
 
       <section className="layout-container pb-24">
         <div className="mx-auto max-w-3xl space-y-4 text-center">
           <Heading level="h2" align="center">
-            In Erinnerung an Dieter
+            Gemeinsam für Dennis Dieter
           </Heading>
           <Text variant="bodyLg" tone="muted" align="center">
-            Dieter hat Generationen von Schülern begleitet und unserer Schule ein unverwechselbares Gefühl von Heimat gegeben.
-            Seine Geschichte erinnert uns daran, wie wertvoll Fürsorge und Gemeinschaft sind.
+            Dennis Dieter bringt frischen Wind in unsere Schulgemeinschaft und erinnert uns daran, wie schön geteilte Verantwortung sein
+            kann. Jede Begegnung mit ihm erzählt eine neue Geschichte.
           </Text>
           <Text tone="muted" align="center">
-            Wer Erinnerungen teilen oder die Arbeit der Pflege-AG weiterführen möchte, erreicht uns unter{' '}
+            Wer Tipps zur Eingewöhnung hat oder die Arbeit der Pflege-AG unterstützen möchte, erreicht uns unter{' '}
             <TextLink href="mailto:schulkatze@sommertheater-altrossthal.de">schulkatze@sommertheater-altrossthal.de</TextLink>.
           </Text>
         </div>


### PR DESCRIPTION
## Summary
- rename the Schulkatze landing page copy to present Dennis Dieter, including metadata, highlights, memories, and calls to action
- adjust the encounters module strings, curated stories, storage keys, and form markup to reference Dennis Dieter consistently

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d579981304832d8d1540a251a1ccca