### PR TITLE
Fix rehearsal timezone handling and add end time support

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/page.tsx
@@ -18,6 +18,7 @@ import {
 import { RehearsalList, type RehearsalLite } from "./rehearsal-list";
 import { combineNameParts } from "@/lib/names";
 import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import { DEFAULT_TIME_ZONE, formatIsoDateInTimeZone } from "@/lib/date-time";
 export default async function ProbenplanungPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.probenplanung");
@@ -71,10 +72,11 @@ export default async function ProbenplanungPage() {
 
   const calendarBlockedDays: CalendarBlockedDay[] = blockedDays.map((entry) => {
     const iso = entry.date.toISOString();
+    const dateKey = formatIsoDateInTimeZone(iso, DEFAULT_TIME_ZONE);
     return {
       id: entry.id,
       date: iso,
-      dateKey: iso.slice(0, 10),
+      dateKey,
       reason: entry.reason,
       kind: "BLOCKED",
       user: {
@@ -90,12 +92,13 @@ export default async function ProbenplanungPage() {
   const calendarRehearsals: CalendarRehearsal[] = publishedRehearsals.map((r) => {
     const startIso = r.start.toISOString();
     const endIso = r.end ? r.end.toISOString() : null;
+    const dateKey = formatIsoDateInTimeZone(startIso, DEFAULT_TIME_ZONE);
     return {
       id: r.id,
       title: r.title,
       start: startIso,
       end: endIso,
-      dateKey: startIso.slice(0, 10),
+      dateKey,
       location: r.location,
     };
   });
@@ -103,6 +106,7 @@ export default async function ProbenplanungPage() {
   const draftDateFormatter = new Intl.DateTimeFormat("de-DE", {
     dateStyle: "full",
     timeStyle: "short",
+    timeZone: DEFAULT_TIME_ZONE,
   });
   const now = new Date();
   const total = publishedRehearsals.length;

--- a/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/proben/[rehearsalId]/page.tsx
@@ -7,6 +7,11 @@ import { requireAuth } from "@/lib/rbac";
 
 import { RehearsalEditor } from "../../rehearsal-editor";
 import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import {
+  DEFAULT_TIME_ZONE,
+  formatIsoDateInTimeZone,
+  parseDateTimeInTimeZone,
+} from "@/lib/date-time";
 
 type MemberOption = {
   id: string;
@@ -58,8 +63,11 @@ export default async function RehearsalEditorPage({
     },
   });
 
-  const dateKey = rehearsal.start.toISOString().slice(0, 10);
-  const dayStart = new Date(`${dateKey}T00:00:00`);
+  const dateKey = formatIsoDateInTimeZone(
+    rehearsal.start.toISOString(),
+    DEFAULT_TIME_ZONE,
+  );
+  const dayStart = parseDateTimeInTimeZone(dateKey, "00:00", DEFAULT_TIME_ZONE);
   const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
 
   const blocked = await prisma.blockedDay.findMany({
@@ -104,6 +112,7 @@ export default async function RehearsalEditorPage({
           status: rehearsal.status,
           title: rehearsal.title,
           start: rehearsal.start.toISOString(),
+          end: rehearsal.end ? rehearsal.end.toISOString() : null,
           location: rehearsal.location,
           description: rehearsal.description,
           inviteeIds: rehearsal.invitees.map((entry) => entry.userId),

--- a/src/lib/date-time.ts
+++ b/src/lib/date-time.ts
@@ -1,0 +1,87 @@
+export const DEFAULT_TIME_ZONE = "Europe/Berlin" as const;
+
+function ensureValidDate(date: Date) {
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Invalid date");
+  }
+}
+
+export function parseDateTimeInTimeZone(
+  date: string,
+  time: string,
+  timeZone: string = DEFAULT_TIME_ZONE,
+): Date {
+  const [yearStr, monthStr, dayStr] = date.split("-");
+  const [hourStr, minuteStr] = time.split(":");
+  const year = Number.parseInt(yearStr ?? "", 10);
+  const month = Number.parseInt(monthStr ?? "", 10);
+  const day = Number.parseInt(dayStr ?? "", 10);
+  const hour = Number.parseInt(hourStr ?? "", 10);
+  const minute = Number.parseInt(minuteStr ?? "", 10);
+
+  if (
+    Number.isNaN(year) ||
+    Number.isNaN(month) ||
+    Number.isNaN(day) ||
+    Number.isNaN(hour) ||
+    Number.isNaN(minute)
+  ) {
+    throw new Error("Invalid date parts");
+  }
+
+  const initial = new Date(Date.UTC(year, month - 1, day, hour, minute));
+  ensureValidDate(initial);
+
+  const zoned = new Date(initial.toLocaleString("en-US", { timeZone }));
+  ensureValidDate(zoned);
+
+  const diff = initial.getTime() - zoned.getTime();
+  const result = new Date(initial.getTime() + diff);
+  ensureValidDate(result);
+  return result;
+}
+
+function formatParts(
+  iso: string,
+  timeZone: string,
+  options: Intl.DateTimeFormatOptions,
+): Map<string, string> {
+  const date = new Date(iso);
+  ensureValidDate(date);
+  const formatter = new Intl.DateTimeFormat("en-CA", { timeZone, ...options });
+  const parts = formatter.formatToParts(date);
+  const map = new Map<string, string>();
+  for (const part of parts) {
+    map.set(part.type, part.value);
+  }
+  return map;
+}
+
+export function formatIsoDateInTimeZone(
+  iso: string,
+  timeZone: string = DEFAULT_TIME_ZONE,
+): string {
+  const parts = formatParts(iso, timeZone, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const year = parts.get("year") ?? "0000";
+  const month = parts.get("month") ?? "01";
+  const day = parts.get("day") ?? "01";
+  return `${year}-${month}-${day}`;
+}
+
+export function formatIsoTimeInTimeZone(
+  iso: string,
+  timeZone: string = DEFAULT_TIME_ZONE,
+): string {
+  const parts = formatParts(iso, timeZone, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const hour = parts.get("hour") ?? "00";
+  const minute = parts.get("minute") ?? "00";
+  return `${hour}:${minute}`;
+}


### PR DESCRIPTION
## Summary
- add shared date-time utilities for Europe/Berlin conversions
- ensure rehearsal actions parse start/end times in the local timezone
- expose an end time field in the rehearsal editor and propagate to calendar data

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d57b82ab54832d8e8d0c8b217a3f7a