### PR TITLE
Remove footer phone number

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -55,7 +55,6 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
                   <a className="hover:underline" href="mailto:hallo@sommertheater.de">
                     hallo@sommertheater.de
                   </a>
-                  <br /> +49&nbsp;176&nbsp;1234567
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove the phone number from the Kontakt section in the site footer, leaving the email link only

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d57e5dd614832d9e12f3fb183ab1d0