### PR TITLE
Add solve button to issue detail

### DIFF
--- a/src/components/members/issues/issue-detail.tsx
+++ b/src/components/members/issues/issue-detail.tsx
@@ -171,6 +171,11 @@ export function IssueDetail({ issueId, canManage, currentUserId, onIssueUpdated 
     await handleUpdate({ visibility: nextVisibility });
   };
 
+  const handleMarkAsSolved = useCallback(async () => {
+    if (!issue) return;
+    await handleUpdate({ status: "closed" });
+  }, [handleUpdate, issue]);
+
   const handleCommentSubmit = async () => {
     if (!issue) return;
     const trimmed = commentDraft.trim();
@@ -361,6 +366,17 @@ export function IssueDetail({ issueId, canManage, currentUserId, onIssueUpdated 
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+          ) : null}
+
+          {canUpdate && issue.status === "resolved" ? (
+            <div className="space-y-2 md:col-span-2">
+              <Button type="button" onClick={handleMarkAsSolved} disabled={updating}>
+                Solve
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                Alles geklärt? Bestätige die Lösung, um das Anliegen abzuschließen.
+              </p>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- add a dedicated solve button in the issue detail view when an issue is resolved
- trigger a status update to closed when the button is pressed and explain the action to the user

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d57fdc5ff8832dbc1c3f6d8d1f0c2a