### PR TITLE
Run initial deploy when auto-deploy service starts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,3 +99,4 @@ CORS_ORIGIN=https://devtheater.beegreenx.de
 #AUTO_DEPLOY_WEBHOOK_PATH=/webhook
 #AUTO_DEPLOY_CONTAINER_NAME=theater-autodeploy
 #AUTO_DEPLOY_INTERNAL_URL=http://theater-autodeploy:3000
+#AUTO_DEPLOY_RUN_ON_START=true

--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ arrives for the configured branch.
      `AUTO_DEPLOY_GIT_SSH_KNOWN_HOSTS`) – optional SSH credentials for private
      repositories.
 5. Start the service: `docker compose -f docker-compose.autodeploy.yml up -d`.
+   On first boot the container performs an initial deployment automatically
+   (equivalent to manually calling `deploy-service/deploy.sh`). Set
+   `AUTO_DEPLOY_RUN_ON_START=false` when you prefer to trigger the first build
+   yourself (for example to adjust environment variables or secrets on the
+   target host beforehand).
 6. Register a new GitHub webhook that points to the regular website hostname,
    for example `https://${DEV_HOST:-devtheater.beegreenx.de}${AUTO_DEPLOY_WEBHOOK_PATH:-/webhook}`.
    Traefik (or any other edge proxy) only needs to know about the website

--- a/deploy-service/entrypoint.sh
+++ b/deploy-service/entrypoint.sh
@@ -111,5 +111,19 @@ fi
 
 git config --global --add safe.directory "$REPO_DIR"
 
+RUN_DEPLOY_ON_START="${RUN_DEPLOY_ON_START:-${AUTO_DEPLOY_RUN_ON_START:-true}}"
+
+if [ "$RUN_DEPLOY_ON_START" = "true" ]; then
+  echo "[entrypoint] Running initial deployment before starting the webhook listener"
+  if /app/deploy.sh; then
+    echo "[entrypoint] Initial deployment finished"
+  else
+    echo "[entrypoint] Initial deployment failed" >&2
+    exit 1
+  fi
+else
+  echo "[entrypoint] Skipping initial deployment (RUN_DEPLOY_ON_START=$RUN_DEPLOY_ON_START)"
+fi
+
 echo "[entrypoint] Starting webhook listener on port ${LISTEN_PORT:-3000}"
 exec node /app/server.mjs


### PR DESCRIPTION
## Summary
- trigger the deploy script once during the auto-deploy container startup by default, with an escape hatch to skip it
- document the new AUTO_DEPLOY_RUN_ON_START toggle and mention the initial rollout in the README
- expose the toggle in .env.example for easier configuration

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build > /tmp/build.log && tail -n 20 /tmp/build.log


------
https://chatgpt.com/codex/tasks/task_e_68d5930c93e4832d9df05d1b5355adbb