### PR TITLE
Add Instagram link to site footer

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -115,6 +115,14 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
             <a className="transition-colors hover:text-primary" href="mailto:hallo@sommertheater.de">
               Kontakt
             </a>
+            <a
+              className="transition-colors hover:text-primary"
+              href="https://www.instagram.com/schlossparktheater"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              Instagram
+            </a>
           </div>
           <p className="text-xs text-muted-foreground/80 sm:text-sm">
             {isDevBuild ? (


### PR DESCRIPTION
## Summary
- add an external link to the theater's Instagram profile in the footer so it appears on every page

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5ad243d54832d9c31c8ca94acb3ed