### PR TITLE
Add guideline to avoid gendered language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@
 - Tickets oder PR-Beschreibungen sollten Kontext, Entscheidungspunkte und QA-Schritte enthalten. Verweise auf Monitoring/Analytics ergänzen, falls betroffen.
 - Beachte die "Dev only Screenshot"-Sektion in den systemweiten Vorgaben: Bei wahrnehmbaren UI-Änderungen und vorhandener Dev-Server-Anleitung einen Screenshot für den Abschlussbericht aufnehmen.
 - Nutze dafür konsequent das automatisierte Screenshot-System (`/api/dev/screenshot-session`) und dokumentiere die Zielroute – manuell aufgenommene Login-Screens helfen dem Review-Team nicht weiter.
+- In sämtlichen Texten und Kommentaren bitte auf gendergerechte Schreibweisen verzichten und ausschließlich generische Maskulina verwenden.
 - Diese `AGENTS.md` bei Bedarf fortschreiben, wenn bessere Kollaborationsmuster oder neue Tooling-Standards entstehen. Änderungen nachvollziehbar begründen.
 
 ## Ausnahmen & Sonderfälle


### PR DESCRIPTION
## Summary
- add a documentation guideline requesting the use of generisches Maskulinum without gendered phrasing

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5b0eda4cc832db53b804f6c6d1eb6