### PR TITLE
Extend NextAuth session duration

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -245,7 +245,13 @@ export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   useSecureCookies,
   // Use JWT sessions for reliability in dev (works with Credentials + Email).
-  session: { strategy: "jwt" },
+  session: {
+    strategy: "jwt",
+    // Keep logins valid for roughly one month and refresh them regularly when the
+    // user returns to the site (sliding expiration).
+    maxAge: 30 * 24 * 60 * 60, // 30 days in seconds
+    updateAge: 24 * 60 * 60, // refresh token after one day of inactivity
+  },
   providers: [
     EmailProvider({
       server: process.env.EMAIL_SERVER,


### PR DESCRIPTION
## Summary
- configure the NextAuth session to keep JWT logins valid for roughly one month and refresh them on return visits

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5bca9deec832d8febd9bc710be814