### PR TITLE
Allow production managers to access active shows after creation

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -159,6 +159,24 @@ export async function createProductionAction(formData: FormData): Promise<void> 
         sameSite: "lax",
         path: "/",
       });
+
+      if (session.user?.id) {
+        await prisma.productionMembership.upsert({
+          where: {
+            showId_userId: {
+              showId: show.id,
+              userId: session.user.id,
+            },
+          },
+          update: {
+            leftAt: null,
+          },
+          create: {
+            showId: show.id,
+            userId: session.user.id,
+          },
+        });
+      }
     }
 
     revalidatePath("/mitglieder", "layout");

--- a/src/lib/__tests__/active-production.test.ts
+++ b/src/lib/__tests__/active-production.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCookies = vi.fn();
+const mockShowFindFirst = vi.fn();
+const mockMembershipFindFirst = vi.fn();
+const mockMembershipFindMany = vi.fn();
+const mockHasPermission = vi.fn();
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    productionMembership: {
+      findFirst: mockMembershipFindFirst,
+      findMany: mockMembershipFindMany,
+    },
+    show: {
+      findFirst: mockShowFindFirst,
+    },
+  },
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  hasPermission: mockHasPermission,
+}));
+
+describe("getActiveProduction", () => {
+beforeEach(async () => {
+  await vi.resetModules();
+  vi.clearAllMocks();
+});
+
+  it("allows production managers to access active shows without memberships", async () => {
+    const userId = "user-123";
+    const showId = "show-456";
+    const cookieStore = {
+      get: vi.fn(() => ({ value: showId })),
+    };
+
+    mockCookies.mockResolvedValue(cookieStore);
+    mockHasPermission.mockResolvedValue(true);
+    mockShowFindFirst.mockResolvedValue({
+      id: showId,
+      title: "Neue Show",
+      year: 2025,
+      synopsis: "Test",
+    });
+
+    const { getActiveProduction } = await import("../active-production");
+
+    const result = await getActiveProduction(userId);
+
+    expect(mockHasPermission).toHaveBeenCalledWith({ id: userId }, "mitglieder.produktionen");
+    expect(mockMembershipFindFirst).not.toHaveBeenCalled();
+    expect(mockShowFindFirst).toHaveBeenCalledWith({
+      where: { id: showId },
+      select: { id: true, title: true, year: true, synopsis: true },
+    });
+    expect(result).toEqual({
+      id: showId,
+      title: "Neue Show",
+      year: 2025,
+      synopsis: "Test",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- bypass membership checks in the active production helpers when the user can manage productions
- upsert a productionMembership for the creator when a new show is marked active
- add a regression test that ensures production managers can open the workspace of a freshly activated show

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5c88a710c832d8572443b6bf24120