### PR TITLE
Handle production action errors via form state

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -14,11 +14,8 @@ import { X } from "lucide-react";
 
 import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 
-import {
-  setActiveProductionAction,
-  updateOnboardingSettingsAction,
-  updateProductionTimelineAction,
-} from "../actions";
+import { updateOnboardingSettingsAction, updateProductionTimelineAction } from "../actions";
+import { SetActiveProductionForm } from "../production-forms-client";
 
 function formatShowTitle(show: { title: string | null; year: number }) {
   if (show.title && show.title.trim()) return show.title;
@@ -127,13 +124,13 @@ export default async function ProduktionDetailPage({
               <Link href="/mitglieder/produktionen/gewerke">Gewerke &amp; Teams</Link>
             </Button>
             {!isActive ? (
-              <form action={setActiveProductionAction} className="ml-auto flex-shrink-0">
-                <input type="hidden" name="showId" value={show.id} />
-                <input type="hidden" name="redirectPath" value={`/mitglieder/produktionen/${show.id}`} />
-                <Button type="submit" size="sm">
-                  Produktion aktiv setzen
-                </Button>
-              </form>
+              <SetActiveProductionForm
+                showId={show.id}
+                showTitle={title}
+                redirectPath={`/mitglieder/produktionen/${show.id}`}
+                isActive={isActive}
+                className="ml-auto flex-shrink-0"
+              />
             ) : null}
           </div>
         </CardContent>

--- a/src/app/(members)/mitglieder/produktionen/__tests__/create-production-form.test.tsx
+++ b/src/app/(members)/mitglieder/produktionen/__tests__/create-production-form.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createProductionActionMock } = vi.hoisted(() => ({
+  createProductionActionMock: vi.fn(),
+}));
+
+const { toastMock } = vi.hoisted(() => {
+  const base = Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() });
+  return { toastMock: base };
+});
+
+vi.mock("../actions", () => ({
+  createProductionAction: createProductionActionMock,
+  setActiveProductionAction: vi.fn(),
+  clearActiveProductionAction: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}));
+
+import { CreateProductionForm } from "../production-forms-client";
+
+describe("CreateProductionForm", () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { React?: typeof React }).React = React;
+    vi.clearAllMocks();
+  });
+
+  it("surfaces validation errors from the server action", async () => {
+    createProductionActionMock.mockResolvedValueOnce({ ok: false as const, error: "Bitte gib ein Jahr an." });
+    const user = userEvent.setup();
+
+    render(
+      <CreateProductionForm
+        redirectPath="/mitglieder/produktionen"
+        suggestedYear={2025}
+        shouldSetActiveByDefault={false}
+      />,
+    );
+
+    const submitButton = screen.getByRole("button", { name: "Produktion erstellen" });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Bitte gib ein Jahr an.");
+    });
+
+    expect(toastMock.error).toHaveBeenCalledWith("Bitte gib ein Jahr an.");
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -16,6 +16,19 @@ import { hasPermission } from "@/lib/permissions";
 import { ACTIVE_PRODUCTION_COOKIE } from "@/lib/active-production";
 import { setOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 
+export type ProductionActionResult =
+  | { ok: true; message?: string }
+  | { ok: false; error: string };
+
+function actionSuccess(message?: string): ProductionActionResult {
+  return message ? { ok: true, message } : { ok: true };
+}
+
+function actionFailure(error: unknown, fallbackMessage: string): ProductionActionResult {
+  const message = error instanceof Error ? error.message : fallbackMessage;
+  return { ok: false, error: message };
+}
+
 type ReadOptions = {
   minLength?: number;
   maxLength?: number;
@@ -44,7 +57,7 @@ function readOptionalString(formData: FormData, key: string, options?: ReadOptio
   return trimmed;
 }
 
-export async function setActiveProductionAction(formData: FormData): Promise<void> {
+export async function setActiveProductionAction(formData: FormData): Promise<ProductionActionResult> {
   try {
     const session = await requireAuth();
     const allowed = await hasPermission(session.user, "mitglieder.produktionen");
@@ -71,14 +84,13 @@ export async function setActiveProductionAction(formData: FormData): Promise<voi
     if (redirectPath) {
       revalidatePath(redirectPath);
     }
+    return actionSuccess("Aktive Produktion wurde gesetzt.");
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Aktive Produktion konnte nicht gesetzt werden.";
-    throw new Error(message);
+    return actionFailure(error, "Aktive Produktion konnte nicht gesetzt werden.");
   }
 }
 
-export async function clearActiveProductionAction(formData: FormData): Promise<void> {
+export async function clearActiveProductionAction(formData: FormData): Promise<ProductionActionResult> {
   try {
     const session = await requireAuth();
     const allowed = await hasPermission(session.user, "mitglieder.produktionen");
@@ -95,16 +107,13 @@ export async function clearActiveProductionAction(formData: FormData): Promise<v
     if (redirectPath) {
       revalidatePath(redirectPath);
     }
+    return actionSuccess("Aktive Produktion wurde zurückgesetzt.");
   } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "Aktive Produktion konnte nicht entfernt werden.";
-    throw new Error(message);
+    return actionFailure(error, "Aktive Produktion konnte nicht entfernt werden.");
   }
 }
 
-export async function createProductionAction(formData: FormData): Promise<void> {
+export async function createProductionAction(formData: FormData): Promise<ProductionActionResult> {
   try {
     const session = await requireAuth();
     const allowed = await hasPermission(session.user, "mitglieder.produktionen");
@@ -184,11 +193,10 @@ export async function createProductionAction(formData: FormData): Promise<void> 
     if (redirectPath) {
       revalidatePath(redirectPath);
     }
+    return actionSuccess("Produktion wurde erstellt.");
   } catch (error) {
     console.error("createProductionAction", error);
-    const message =
-      error instanceof Error ? error.message : "Produktion konnte nicht angelegt werden.";
-    throw new Error(message);
+    return actionFailure(error, "Produktion konnte nicht angelegt werden.");
   }
 }
 

--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -8,15 +8,13 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { ProductionWorkspaceHeader } from "@/components/production/workspace-header";
 
 import {
-  clearActiveProductionAction,
-  createProductionAction,
-  setActiveProductionAction,
-} from "./actions";
+  ClearActiveProductionForm,
+  CreateProductionForm,
+  SetActiveProductionForm,
+} from "./production-forms-client";
 
 function formatShowTitle(show: { title: string | null; year: number }) {
   if (show.title && show.title.trim()) {
@@ -98,12 +96,10 @@ export default async function ProduktionenPage() {
       <Button asChild variant="outline">
         <Link href="/mitglieder/produktionen/gewerke">Gewerke &amp; Teams verwalten</Link>
       </Button>
-      <form action={clearActiveProductionAction} className="ml-auto flex-shrink-0">
-        <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
-        <Button type="submit" variant="ghost" size="sm">
-          Aktive Auswahl zurücksetzen
-        </Button>
-      </form>
+      <ClearActiveProductionForm
+        redirectPath="/mitglieder/produktionen"
+        className="ml-auto flex-shrink-0"
+      />
     </>
   ) : null;
 
@@ -183,71 +179,11 @@ export default async function ProduktionenPage() {
             </p>
           </CardHeader>
           <CardContent>
-            <form action={createProductionAction} className="grid gap-6">
-              <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
-              <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 sm:grid-cols-2">
-                <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Basisdaten
-                </legend>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">Jahr</label>
-                  <Input type="number" name="year" min={1900} max={2200} defaultValue={suggestedYear} required />
-                </div>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">Titel</label>
-                  <Input name="title" placeholder="Titel der Produktion" maxLength={160} />
-                </div>
-                <div className="space-y-1 sm:col-span-2">
-                  <label className="text-sm font-medium">Kurzbeschreibung</label>
-                  <Textarea
-                    name="synopsis"
-                    rows={3}
-                    maxLength={600}
-                    placeholder="Optionaler Teaser, Autor oder kurzes Motto."
-                  />
-                </div>
-              </fieldset>
-
-              <details className="rounded-lg border border-border/60 bg-background/60 p-4 transition [&_summary::-webkit-details-marker]:hidden">
-                <summary className="flex cursor-pointer items-center justify-between text-sm font-semibold text-foreground">
-                  <span>Timeline &amp; Kommunikation (optional)</span>
-                  <span className="text-xs text-muted-foreground">Bereich öffnen</span>
-                </summary>
-                <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                  <div className="space-y-1">
-                    <label className="text-sm font-medium">Startdatum</label>
-                    <Input type="date" name="startDate" />
-                  </div>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">Enddatum</label>
-                  <Input type="date" name="endDate" />
-                </div>
-                <div className="space-y-1 sm:col-span-2">
-                  <label className="text-sm font-medium">Beginn der Endprobenwoche</label>
-                  <Input type="date" name="finalRehearsalWeekStart" />
-                </div>
-                <div className="space-y-1 sm:col-span-2">
-                  <label className="text-sm font-medium">Premierenankündigung</label>
-                  <Input type="date" name="revealDate" />
-                </div>
-              </div>
-              </details>
-
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <label className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <input
-                    type="checkbox"
-                    name="setActive"
-                    defaultChecked={shouldSetActiveByDefault}
-                    className="mt-1 h-4 w-4 rounded border border-border bg-background text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                  />
-                  <span className="leading-snug">Nach dem Anlegen als aktive Produktion setzen</span>
-                </label>
-                <Button type="submit" className="sm:w-auto">
-                  Produktion erstellen
-                </Button>
-              </div>
-            </form>
+            <CreateProductionForm
+              redirectPath="/mitglieder/produktionen"
+              suggestedYear={suggestedYear}
+              shouldSetActiveByDefault={shouldSetActiveByDefault}
+            />
           </CardContent>
         </Card>
 
@@ -283,13 +219,12 @@ export default async function ProduktionenPage() {
                       )}
                     </CardHeader>
                     <CardContent className="mt-auto flex flex-wrap items-center gap-2">
-                      <form action={setActiveProductionAction} className="flex-shrink-0">
-                        <input type="hidden" name="showId" value={show.id} />
-                        <input type="hidden" name="redirectPath" value="/mitglieder/produktionen" />
-                        <Button type="submit" size="sm" disabled={isActive}>
-                          {isActive ? "Aktiv ausgewählt" : "Als aktiv setzen"}
-                        </Button>
-                      </form>
+                      <SetActiveProductionForm
+                        showId={show.id}
+                        showTitle={title}
+                        redirectPath="/mitglieder/produktionen"
+                        isActive={isActive}
+                      />
                       <Button asChild size="sm" variant="outline" className="flex-shrink-0">
                         <Link href={`/mitglieder/produktionen/${show.id}`}>Details anzeigen</Link>
                       </Button>

--- a/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useActionState, useCallback, useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+import type { ProductionActionResult } from "./actions";
+import {
+  clearActiveProductionAction,
+  createProductionAction,
+  setActiveProductionAction,
+} from "./actions";
+
+const INITIAL_ACTION_STATE: ProductionActionResult = { ok: true };
+
+type CreateProductionFormProps = {
+  suggestedYear: number;
+  shouldSetActiveByDefault: boolean;
+  redirectPath: string;
+};
+
+export function CreateProductionForm({
+  suggestedYear,
+  shouldSetActiveByDefault,
+  redirectPath,
+}: CreateProductionFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const action = useCallback(
+    async (_state: ProductionActionResult, formData: FormData) => {
+      return createProductionAction(formData);
+    },
+    [],
+  );
+  const [state, formAction, isPending] = useActionState(action, INITIAL_ACTION_STATE);
+  const isInitialRender = useRef(true);
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+    if (!state.ok) {
+      toast.error(state.error);
+      return;
+    }
+    const message = state.message ?? "Produktion wurde erstellt.";
+    toast.success(message);
+    formRef.current?.reset();
+  }, [state]);
+
+  return (
+    <form ref={formRef} action={formAction} className="grid gap-6">
+      <input type="hidden" name="redirectPath" value={redirectPath} />
+      <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 sm:grid-cols-2">
+        <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Basisdaten
+        </legend>
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Jahr</label>
+          <Input type="number" name="year" min={1900} max={2200} defaultValue={suggestedYear} required />
+        </div>
+        <div className="space-y-1">
+          <label className="text-sm font-medium">Titel</label>
+          <Input name="title" placeholder="Titel der Produktion" maxLength={160} />
+        </div>
+        <div className="space-y-1 sm:col-span-2">
+          <label className="text-sm font-medium">Kurzbeschreibung</label>
+          <Textarea
+            name="synopsis"
+            rows={3}
+            maxLength={600}
+            placeholder="Optionaler Teaser, Autor oder kurzes Motto."
+          />
+        </div>
+      </fieldset>
+
+      <details className="rounded-lg border border-border/60 bg-background/60 p-4 transition [&_summary::-webkit-details-marker]:hidden">
+        <summary className="flex cursor-pointer items-center justify-between text-sm font-semibold text-foreground">
+          <span>Timeline &amp; Kommunikation (optional)</span>
+          <span className="text-xs text-muted-foreground">Bereich öffnen</span>
+        </summary>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Startdatum</label>
+            <Input type="date" name="startDate" />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Enddatum</label>
+            <Input type="date" name="endDate" />
+          </div>
+          <div className="space-y-1 sm:col-span-2">
+            <label className="text-sm font-medium">Beginn der Endprobenwoche</label>
+            <Input type="date" name="finalRehearsalWeekStart" />
+          </div>
+          <div className="space-y-1 sm:col-span-2">
+            <label className="text-sm font-medium">Premierenankündigung</label>
+            <Input type="date" name="revealDate" />
+          </div>
+        </div>
+      </details>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label className="flex items-start gap-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            name="setActive"
+            defaultChecked={shouldSetActiveByDefault}
+            className="mt-1 h-4 w-4 rounded border border-border bg-background text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          />
+          <span className="leading-snug">Nach dem Anlegen als aktive Produktion setzen</span>
+        </label>
+        <div className="flex flex-col items-start gap-2 sm:items-end">
+          <Button type="submit" className="sm:w-auto" disabled={isPending}>
+            Produktion erstellen
+          </Button>
+          {!state.ok ? (
+            <p role="alert" aria-live="assertive" className="text-sm text-destructive">
+              {state.error}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </form>
+  );
+}
+
+type SetActiveProductionFormProps = {
+  showId: string;
+  showTitle: string;
+  redirectPath: string;
+  isActive: boolean;
+  className?: string;
+};
+
+export function SetActiveProductionForm({
+  showId,
+  showTitle,
+  redirectPath,
+  isActive,
+  className,
+}: SetActiveProductionFormProps) {
+  const action = useCallback(
+    async (_state: ProductionActionResult, formData: FormData) => {
+      return setActiveProductionAction(formData);
+    },
+    [],
+  );
+  const [state, formAction, isPending] = useActionState(action, INITIAL_ACTION_STATE);
+  const isInitialRender = useRef(true);
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+    if (!state.ok) {
+      toast.error(state.error);
+      return;
+    }
+    const message = state.message ?? `Aktive Produktion: ${showTitle}`;
+    toast.success(message);
+  }, [showTitle, state]);
+
+  return (
+    <form action={formAction} className={cn("flex-shrink-0", className)}>
+      <input type="hidden" name="showId" value={showId} />
+      <input type="hidden" name="redirectPath" value={redirectPath} />
+      <Button type="submit" size="sm" disabled={isPending || isActive}>
+        {isActive ? "Aktiv ausgewählt" : "Als aktiv setzen"}
+      </Button>
+      {!state.ok ? (
+        <p role="alert" aria-live="assertive" className="mt-2 text-xs text-destructive">
+          {state.error}
+        </p>
+      ) : null}
+    </form>
+  );
+}
+
+type ClearActiveProductionFormProps = {
+  redirectPath: string;
+  className?: string;
+};
+
+export function ClearActiveProductionForm({ redirectPath, className }: ClearActiveProductionFormProps) {
+  const action = useCallback(
+    async (_state: ProductionActionResult, formData: FormData) => {
+      return clearActiveProductionAction(formData);
+    },
+    [],
+  );
+  const [state, formAction, isPending] = useActionState(action, INITIAL_ACTION_STATE);
+  const isInitialRender = useRef(true);
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+    if (!state.ok) {
+      toast.error(state.error);
+      return;
+    }
+    const message = state.message ?? "Aktive Produktion wurde zurückgesetzt.";
+    toast.success(message);
+  }, [state]);
+
+  return (
+    <form action={formAction} className={cn("flex-shrink-0", className)}>
+      <input type="hidden" name="redirectPath" value={redirectPath} />
+      <Button type="submit" variant="ghost" size="sm" disabled={isPending}>
+        Aktive Auswahl zurücksetzen
+      </Button>
+      {!state.ok ? (
+        <p role="alert" aria-live="assertive" className="mt-2 text-xs text-destructive">
+          {state.error}
+        </p>
+      ) : null}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- return structured {ok, error} results from production server actions instead of throwing
- add client-side production forms that surface inline errors and toast feedback using useActionState
- update production pages to consume the new forms and add a test covering an invalid submission

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5cd64c8d0832d8eed1da09ad7b87b