### PR TITLE
Adjust QR spacing in onboarding PDF

### DIFF
--- a/src/lib/pdf/templates/onboarding-invite.ts
+++ b/src/lib/pdf/templates/onboarding-invite.ts
@@ -212,6 +212,8 @@ export const onboardingInviteTemplate: PdfTemplate<OnboardingInvitePdfData> = {
     doc.font("Helvetica-Bold").fontSize(16).fillColor(palette.sunrise).text("Backstage-Check-in", { align: "center" });
 
     doc.moveDown(0.8);
+    const qrTopPadding = Math.max(doc.currentLineHeight(true) * 0.8, 12);
+    doc.y += qrTopPadding;
     const qrData = QRCode.create(data.link, {
       errorCorrectionLevel: "H",
     });


### PR DESCRIPTION
## Summary
- add a fixed minimum top padding before rendering the onboarding PDF QR code to avoid overlapping the Backstage-Check-in heading

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5d4f0e044832dae50fb8c6535c59d