### PR TITLE
Add shared auth secret helper for dev screenshot session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@
 # Shared application secrets and toggles
 # ------------------------------------------------------------------------------
 AUTH_SECRET=change-me-with-a-long-random-string
+#NEXTAUTH_SECRET=mirror-auth-secret-when-using-nextauth-default
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/theater?schema=public
 
 # Mirror to the client to avoid hydration mismatches ("1" enables dev-only login)

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ the predefined development roles. The helper is only available when
 to set the session cookie and get redirected to the protected page. Append
 `mode=json` to receive a JSON payload instead of a redirect or pass a custom
 `email` query parameter to reuse a specific test account. The route reuses the
-test users from `@/lib/auth-dev-test-users` and relies on `AUTH_SECRET` for JWT
-signing.
+test users from `@/lib/auth-dev-test-users` and relies on the configured
+NextAuth secret (`AUTH_SECRET`/`NEXTAUTH_SECRET`) for JWT signing.
 
 ## Docker overview
 

--- a/src/app/api/dev/screenshot-session/route.ts
+++ b/src/app/api/dev/screenshot-session/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/auth-dev-test-users";
 import { ensureDevTestUser } from "@/lib/dev-auth";
 import { ROLES, type Role } from "@/lib/roles";
+import { getAuthSecret } from "@/lib/auth-secret";
 
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
 const SESSION_COOKIE_NAME = IS_PRODUCTION
@@ -59,10 +60,7 @@ async function createSessionCookie({
   email: string;
   role: Role;
 }) {
-  const secret = process.env.AUTH_SECRET;
-  if (!secret) {
-    throw new Error("AUTH_SECRET missing");
-  }
+  const secret = getAuthSecret();
 
   const devUser = await ensureDevTestUser(email, role);
   const now = Math.floor(Date.now() / 1000);

--- a/src/lib/auth-secret.ts
+++ b/src/lib/auth-secret.ts
@@ -1,0 +1,16 @@
+export function getAuthSecret(): string {
+  const rawSecret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+  const secret = rawSecret?.trim();
+
+  if (!secret) {
+    if (process.env.NODE_ENV === "test") {
+      return "test-secret";
+    }
+    if (process.env.NODE_ENV !== "production") {
+      return "development-secret";
+    }
+    throw new Error("AUTH_SECRET missing");
+  }
+
+  return secret;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -14,6 +14,7 @@ import { verifyPassword } from "@/lib/password";
 import { combineNameParts } from "@/lib/names";
 import { ensureDevTestUser } from "@/lib/dev-auth";
 import { recordSessionEnd, recordSessionStart } from "@/lib/auth/session";
+import { getAuthSecret } from "@/lib/auth-secret";
 
 type MutableToken = JWT & {
   id?: string;
@@ -410,5 +411,5 @@ export const authOptions: NextAuthOptions = {
       });
     },
   },
-  secret: process.env.AUTH_SECRET,
+  secret: getAuthSecret(),
 };


### PR DESCRIPTION
## Summary
- add a reusable helper that resolves the NextAuth secret with sensible fallbacks in dev/test
- update the dev screenshot session endpoint and NextAuth options to use the shared helper
- document the accepted secret environment variables for local tooling

## Testing
- pnpm lint
- pnpm test
- AUTH_SECRET=dev-secret NEXTAUTH_SECRET=dev-secret CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d64fb57a30832d9c2901641952659d