### PR TITLE
Hide header and footer in maintenance mode

### DIFF
--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -100,7 +100,7 @@ export default async function SiteLayout({ children }: { children: React.ReactNo
   return (
     <div className="app-shell">
       <MysticBackground />
-      <SiteHeader siteTitle={siteTitle} />
+      {!showMaintenanceNotice ? <SiteHeader siteTitle={siteTitle} /> : null}
       <main id="main" className="site-main">
         {showMaintenanceNotice ? (
           <div className="flex min-h-[60svh] items-center justify-center px-6 py-16">
@@ -110,7 +110,9 @@ export default async function SiteLayout({ children }: { children: React.ReactNo
           children
         )}
       </main>
-      <SiteFooter buildInfo={buildInfo} isDevBuild={isDevBuild} siteTitle={siteTitle} />
+      {!showMaintenanceNotice ? (
+        <SiteFooter buildInfo={buildInfo} isDevBuild={isDevBuild} siteTitle={siteTitle} />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- hide the global header and footer when the maintenance notice is displayed to visitors

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d650e096ac832db78be5d1cf0ad7b2