### PR TITLE
Handle notification action URLs in browser alerts

### DIFF
--- a/src/hooks/useBrowserNotifications.ts
+++ b/src/hooks/useBrowserNotifications.ts
@@ -180,12 +180,18 @@ export function useBrowserNotifications(
       }
 
       const baseData = isRecord(data) ? data : {};
+      const combinedData: Record<string, unknown> = { ...baseData };
+
+      const resolvedUrl = url ?? baseData.url;
+      if (typeof resolvedUrl === "string" && resolvedUrl.trim()) {
+        combinedData.url = resolvedUrl;
+      } else if ("url" in combinedData) {
+        delete combinedData.url;
+      }
+
       const options: NotificationOptions = {
         ...rest,
-        data: {
-          ...baseData,
-          url: url ?? baseData.url,
-        },
+        ...(Object.keys(combinedData).length > 0 ? { data: combinedData } : {}),
       };
 
       const registrationInstance = registrationRef.current;


### PR DESCRIPTION
## Summary
- extend realtime notifications with optional action URLs and validate them before showing browser alerts
- ensure browser notifications default to the members area when no specific action URL is provided
- avoid attaching empty URL metadata to browser notifications so the service worker only navigates when a valid target exists

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d651cd8bd8832d856dd8e19ece741f