### PR TITLE
Add short onboarding link for PDF invites

### DIFF
--- a/src/app/onboarding/i/[inviteId]/page.tsx
+++ b/src/app/onboarding/i/[inviteId]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound, redirect } from "next/navigation";
+
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+export default async function OnboardingInviteShortLinkPage({
+  params,
+}: {
+  params: Promise<{ inviteId: string }>;
+}) {
+  const resolvedParams = await params;
+  const rawInviteId = resolvedParams?.inviteId;
+  if (!rawInviteId || typeof rawInviteId !== "string") {
+    notFound();
+  }
+
+  const inviteId = decodeURIComponent(rawInviteId.trim());
+  if (!inviteId) {
+    notFound();
+  }
+
+  if (!/^c[a-z0-9]{24}$/i.test(inviteId)) {
+    notFound();
+  }
+
+  const invite = await prisma.memberInvite.findUnique({
+    where: { id: inviteId },
+    select: { tokenHash: true },
+  });
+
+  if (!invite) {
+    notFound();
+  }
+
+  redirect(`/onboarding/${invite.tokenHash}`);
+}

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -285,6 +285,9 @@ export function MemberInviteManager() {
         return;
       }
 
+      const shortPath = invite.id ? `/onboarding/i/${invite.id}` : null;
+      const absoluteDisplayLink = shortPath ? buildAbsoluteUrl(shortPath) : null;
+
       setDownloadingPdfFor(invite.id);
       try {
         const response = await fetch("/api/pdfs/onboarding-invite", {
@@ -292,6 +295,7 @@ export function MemberInviteManager() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             link: absoluteUrl,
+            displayLink: absoluteDisplayLink ?? absoluteUrl,
             headline: invite.label,
             inviteLabel: invite.label,
             note: invite.note,

--- a/src/lib/pdf/templates/onboarding-invite.ts
+++ b/src/lib/pdf/templates/onboarding-invite.ts
@@ -32,6 +32,7 @@ const onboardingInviteSchema = z.object({
     .string()
     .url()
     .transform((value) => value.trim()),
+  displayLink: optionalString,
   headline: optionalString,
   inviteLabel: optionalString,
   note: optionalString,
@@ -86,6 +87,20 @@ function formatDate(date: Date) {
 
 function formatDateTime(date: Date) {
   return new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" }).format(date);
+}
+
+function formatLinkForDisplay(link: string) {
+  try {
+    const url = new URL(link);
+    const host = url.host.replace(/^www\./i, "");
+    const pathname = url.pathname === "/" ? "" : url.pathname.replace(/\/$/, "");
+    const search = url.search ?? "";
+    const hash = url.hash ?? "";
+    const compact = `${host}${pathname}${search}${hash}`;
+    return compact || link;
+  } catch {
+    return link;
+  }
 }
 
 export const onboardingInviteTemplate: PdfTemplate<OnboardingInvitePdfData> = {
@@ -331,11 +346,13 @@ export const onboardingInviteTemplate: PdfTemplate<OnboardingInvitePdfData> = {
     doc.moveDown(0.9);
     doc.font("Helvetica-Bold").fontSize(14).fillColor(palette.text).text("Direkter Zugang", { align: "center" });
     doc.moveDown(0.25);
+    const displayLink = data.displayLink ?? data.link;
+    const manualLink = formatLinkForDisplay(displayLink);
     doc
       .font("Helvetica")
       .fontSize(12)
       .fillColor(palette.sunrise)
-      .text(data.link, { align: "center", link: data.link, underline: true });
+      .text(manualLink, { align: "center", link: data.link, underline: true });
 
     doc.moveDown(0.4);
     doc


### PR DESCRIPTION
## Summary
- add a dedicated short-link route that redirects onboarding invite IDs to their hashed tokens
- include the short link in PDF requests and render a compact version of the onboarding URL on the poster

## Testing
- pnpm lint
- pnpm test
- CI=1 AUTH_SECRET=placeholder pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d658ce43b4832db7a7c9d6307ea67b