### PR TITLE
Lock preset website themes from member editing

### DIFF
--- a/src/app/api/website/settings/route.ts
+++ b/src/app/api/website/settings/route.ts
@@ -6,6 +6,7 @@ import { themeDescriptionSchema, themeIdSchema, themeNameSchema, themeTokensSche
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 import {
+  LockedWebsiteThemeError,
   ensureWebsiteSettingsRecord,
   readWebsiteSettings,
   resolveWebsiteSettings,
@@ -134,6 +135,9 @@ export async function PUT(request: NextRequest) {
       theme: savedTheme ? toClientWebsiteTheme(resolveWebsiteTheme(savedTheme)) : undefined,
     });
   } catch (error) {
+    if (error instanceof LockedWebsiteThemeError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("Failed to save website settings", error);
     return NextResponse.json({ error: "Die Einstellungen konnten nicht gespeichert werden." }, { status: 500 });
   }

--- a/src/app/api/website/themes/[themeId]/route.ts
+++ b/src/app/api/website/themes/[themeId]/route.ts
@@ -5,7 +5,11 @@ import { themeDescriptionSchema, themeNameSchema, themeTokensSchema } from "../.
 
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
-import { getWebsiteTheme, saveWebsiteTheme } from "@/lib/website-settings";
+import {
+  LockedWebsiteThemeError,
+  getWebsiteTheme,
+  saveWebsiteTheme,
+} from "@/lib/website-settings";
 
 const updateThemeSchema = z
   .object({
@@ -80,6 +84,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
     return NextResponse.json({ theme: await getWebsiteTheme(updated.id) });
   } catch (error) {
+    if (error instanceof LockedWebsiteThemeError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("Failed to update website theme", error);
     return NextResponse.json({ error: "Theme konnte nicht aktualisiert werden." }, { status: 500 });
   }

--- a/src/app/api/website/themes/route.ts
+++ b/src/app/api/website/themes/route.ts
@@ -72,6 +72,7 @@ export async function POST(request: NextRequest) {
       name: theme.name,
       description: theme.description,
       isDefault: theme.isDefault,
+      isPreset: theme.isPreset,
       updatedAt: theme.updatedAt,
     };
     return NextResponse.json({ theme, summary });


### PR DESCRIPTION
## Summary
- prevent edits to preset website themes by marking them as locked on the server and surfacing an explicit error
- return clear API errors when a locked theme edit is attempted and expose preset metadata to the client
- disable the member UI for locked themes while encouraging duplication instead of direct changes

## Testing
- pnpm lint
- pnpm test
- AUTH_SECRET=placeholder CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d656852d78832d93da9af69c1c6bb9