### PR TITLE
Fix maintenance notice header visibility

### DIFF
--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,3 +1,4 @@
+import { unstable_noStore as noStore } from "next/cache";
 import type { Session } from "next-auth";
 import { getServerSession } from "next-auth";
 import { execSync } from "node:child_process";
@@ -70,6 +71,8 @@ function getCommitInfo(): CommitInfo | null {
 }
 
 export default async function SiteLayout({ children }: { children: React.ReactNode }) {
+  noStore();
+
   let session: Session | null = null;
   try {
     session = await getServerSession(authOptions);


### PR DESCRIPTION
## Summary
- disable caching in the public site layout so maintenance mode immediately hides the header and footer for visitors

## Testing
- pnpm lint
- pnpm test
- AUTH_SECRET=dummy NEXTAUTH_URL=http://localhost:3000 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d65c84e844832d9f16f8fd45b1b2b2