### PR TITLE
Handle NextAuth secret resolution during production build

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -242,7 +242,7 @@ const credentialsProvider = Credentials({
   },
 });
 
-export const authOptions: NextAuthOptions = {
+export const authOptions = {
   adapter: PrismaAdapter(prisma),
   useSecureCookies,
   // Use JWT sessions for reliability in dev (works with Credentials + Email).
@@ -411,5 +411,7 @@ export const authOptions: NextAuthOptions = {
       });
     },
   },
-  secret: getAuthSecret(),
-};
+  get secret() {
+    return getAuthSecret();
+  },
+} satisfies NextAuthOptions;


### PR DESCRIPTION
## Summary
- lazily instantiate the NextAuth route handler so builds no longer require AUTH_SECRET at bundle time
- expose the authOptions secret via a getter to preserve runtime validation without tripping production builds

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d65ecac0c4832d99244ce3c3e3170d