### PR TITLE
Add sync token authentication to offline sync endpoints

### DIFF
--- a/src/app/api/sync/initial/route.ts
+++ b/src/app/api/sync/initial/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const authResult = await authenticateSyncRequest(parseResult.data.scope);
+  const authResult = await authenticateSyncRequest(request, parseResult.data.scope);
   if (authResult.kind === "error") {
     return authResult.response;
   }

--- a/src/app/api/sync/pull/route.ts
+++ b/src/app/api/sync/pull/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const authResult = await authenticateSyncRequest(parsed.data.scope);
+  const authResult = await authenticateSyncRequest(request, parsed.data.scope);
   if (authResult.kind === "error") {
     return authResult.response;
   }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -19,9 +19,11 @@ function WebVitalsInitializer({ analyticsSessionId }: { analyticsSessionId?: str
 export function Providers({
   children,
   session,
+  syncToken,
 }: {
   children: React.ReactNode;
   session?: Session | null;
+  syncToken?: string | null;
 }) {
   const [client] = React.useState(() => new QueryClient());
   return (
@@ -29,7 +31,7 @@ export function Providers({
       <WebVitalsInitializer analyticsSessionId={session?.analyticsSessionId ?? null} />
       <QueryClientProvider client={client}>
         <OfflineStorageProvider>
-          <OfflineSyncStatusProvider>
+          <OfflineSyncStatusProvider authToken={syncToken}>
             <PwaProvider>
               <RealtimeProvider>
                 <FrontendEditingProvider>

--- a/src/lib/offline/hooks.tsx
+++ b/src/lib/offline/hooks.tsx
@@ -56,13 +56,19 @@ async function refreshScopeFromDb(scope: OfflineScope) {
 
 export function OfflineSyncStatusProvider({
   children,
+  authToken,
 }: {
   children: React.ReactNode;
+  authToken?: string | null;
 }) {
   const storage = useOfflineStorage();
   const isReady = storage.isSupported && storage.isReady;
-  const [client] = React.useState(() => new SyncClient());
+  const [client] = React.useState(() => new SyncClient(fetch, authToken ?? null));
   const [scopes, setScopes] = React.useState(createInitialScopeState);
+
+  React.useEffect(() => {
+    client.setAuthToken(authToken ?? null);
+  }, [authToken, client]);
 
   const updateScope = React.useCallback(
     (scope: OfflineScope, updater: (state: SyncScopeState) => SyncScopeState) => {

--- a/src/lib/sync/tokens.ts
+++ b/src/lib/sync/tokens.ts
@@ -1,0 +1,128 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+import { z } from "zod";
+
+const TOKEN_VERSION = "v1" as const;
+const DEFAULT_TTL_MS = 1000 * 60 * 60 * 6; // 6 hours
+
+const syncTokenSchema = z.object({
+  version: z.literal(TOKEN_VERSION),
+  userId: z.string().min(1),
+  issuedAt: z.number().int().nonnegative(),
+  expiresAt: z.number().int().nonnegative(),
+  nonce: z.string().min(1),
+});
+
+export type SyncTokenClaims = z.infer<typeof syncTokenSchema>;
+
+function getSyncTokenSecret(): string {
+  const secret = process.env.SYNC_TOKEN_SECRET ?? process.env.AUTH_SECRET;
+
+  if (!secret) {
+    throw new Error("SYNC_TOKEN_SECRET or AUTH_SECRET must be configured to sign sync tokens");
+  }
+
+  return secret;
+}
+
+function encodePayload(payload: SyncTokenClaims): { encoded: string; payloadBuffer: Buffer } {
+  const payloadJson = JSON.stringify(payload);
+  const payloadBuffer = Buffer.from(payloadJson, "utf8");
+  const encoded = payloadBuffer.toString("base64url");
+  return { encoded, payloadBuffer };
+}
+
+function decodePayload(encoded: string): SyncTokenClaims | null {
+  try {
+    const buffer = Buffer.from(encoded, "base64url");
+    const json = buffer.toString("utf8");
+    const parsed = JSON.parse(json);
+    const result = syncTokenSchema.safeParse(parsed);
+
+    if (!result.success) {
+      return null;
+    }
+
+    return result.data;
+  } catch {
+    return null;
+  }
+}
+
+function createSignature(encodedPayload: string): Buffer {
+  const hmac = createHmac("sha256", getSyncTokenSecret());
+  hmac.update(encodedPayload);
+  return hmac.digest();
+}
+
+export function createSyncToken(
+  userId: string,
+  options: { ttlMs?: number } = {},
+): string {
+  if (!userId || userId.trim().length === 0) {
+    throw new Error("Cannot create sync token without user id");
+  }
+
+  const now = Date.now();
+  const ttl = typeof options.ttlMs === "number" && options.ttlMs > 0 ? options.ttlMs : DEFAULT_TTL_MS;
+  const payload: SyncTokenClaims = {
+    version: TOKEN_VERSION,
+    userId,
+    issuedAt: now,
+    expiresAt: now + ttl,
+    nonce: randomUUID(),
+  };
+
+  const { encoded } = encodePayload(payload);
+  const signature = createSignature(encoded).toString("base64url");
+
+  return `${encoded}.${signature}`;
+}
+
+export function verifySyncToken(token: string | null | undefined): SyncTokenClaims | null {
+  if (!token || token.trim().length === 0) {
+    return null;
+  }
+
+  const segments = token.split(".");
+
+  if (segments.length !== 2) {
+    return null;
+  }
+
+  const [encoded, providedSignature] = segments;
+
+  if (!encoded || !providedSignature) {
+    return null;
+  }
+
+  let providedBuffer: Buffer;
+  try {
+    providedBuffer = Buffer.from(providedSignature, "base64url");
+  } catch {
+    return null;
+  }
+
+  const expectedBuffer = createSignature(encoded);
+
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return null;
+  }
+
+  if (!timingSafeEqual(providedBuffer, expectedBuffer)) {
+    return null;
+  }
+
+  const payload = decodePayload(encoded);
+
+  if (!payload) {
+    return null;
+  }
+
+  if (payload.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return payload;
+}
+


### PR DESCRIPTION
## Summary
- sign and verify X-Sync-Token headers for the offline sync API and gate requests behind session permission checks
- propagate the token through the offline sync client, app layout, and providers so every request authenticates and handles 401/403 errors
- whitelist accepted incoming event payloads on the server before persisting sync events and cover success as well as failure scenarios in updated tests

## Testing
- pnpm lint
- pnpm test
- AUTH_SECRET=test-secret CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d65e7c2310832d9de56bcf23616851