### PR TITLE
Fix badge pluralization on productions overview

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -167,7 +167,10 @@ export default async function ProduktionenPage() {
             </p>
           </div>
           {shows.length > 0 ? (
-            <Badge variant="outline">{shows.length} Eintr{shows.length === 1 ? "ag" : "äge"}</Badge>
+            <Badge variant="outline">
+              {shows.length} Eintr
+              {shows.length === 1 ? "ag" : "äge"}
+            </Badge>
           ) : null}
         </div>
 


### PR DESCRIPTION
## Summary
- fix the productions overview badge label to avoid invalid JSX interpolation

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d66e0ddbec832d908ec9f91b93dda1