### PR TITLE
Add WhatsApp onboarding callouts and tracking

### DIFF
--- a/prisma/migrations/20250321000000_onboarding_whatsapp_visit/migration.sql
+++ b/prisma/migrations/20250321000000_onboarding_whatsapp_visit/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "MemberInviteRedemption"
+  ADD COLUMN "whatsappLinkVisitedAt" TIMESTAMP(3);
+
+ALTER TABLE "MemberOnboardingProfile"
+  ADD COLUMN "whatsappLinkVisitedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1157,6 +1157,7 @@ model MemberInviteRedemption {
   createdAt    DateTime  @default(now())
   completedAt  DateTime?
   payload      Json?
+  whatsappLinkVisitedAt DateTime?
 
   invite   MemberInvite @relation(fields: [inviteId], references: [id], onDelete: Cascade)
   user     User?        @relation(fields: [userId], references: [id], onDelete: SetNull)
@@ -1215,6 +1216,7 @@ model MemberOnboardingProfile {
   memberSinceYear Int?
   dietaryPreference String?
   dietaryPreferenceStrictness String?
+  whatsappLinkVisitedAt DateTime?
   createdAt    DateTime         @default(now())
   updatedAt    DateTime         @updatedAt
 

--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -19,6 +19,7 @@ import {
   parseDietaryStyleFromLabel,
   type DietaryStrictnessOption,
 } from "@/data/dietary-preferences";
+import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 
 export default async function ProfilePage() {
   const session = await requireAuth();
@@ -64,6 +65,8 @@ export default async function ProfilePage() {
             dietaryPreference: true,
             dietaryPreferenceStrictness: true,
             updatedAt: true,
+            whatsappLinkVisitedAt: true,
+            show: { select: { meta: true } },
           },
         },
         photoConsent: {
@@ -203,6 +206,10 @@ export default async function ProfilePage() {
         memberSinceYear: user.onboardingProfile?.memberSinceYear ?? null,
         updatedAt: user.onboardingProfile?.updatedAt?.toISOString() ?? null,
       }}
+      whatsappLink={getOnboardingWhatsAppLink(user.onboardingProfile?.show?.meta ?? null)}
+      whatsappLinkVisitedAt={
+        user.onboardingProfile?.whatsappLinkVisitedAt?.toISOString() ?? null
+      }
       photoConsent={photoSummary}
     />
   );

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -28,6 +28,7 @@ const onboardingProfileSelect = Prisma.validator<Prisma.MemberOnboardingProfileS
   updatedAt: true,
   dietaryPreference: true,
   dietaryPreferenceStrictness: true,
+  whatsappLinkVisitedAt: true,
   show: { select: { meta: true } },
 });
 
@@ -259,6 +260,9 @@ export async function GET() {
       backgroundClass: onboardingProfile?.backgroundClass ?? null,
       notes: onboardingProfile?.notes ?? null,
       whatsappLink,
+      whatsappLinkVisitedAt: onboardingProfile?.whatsappLinkVisitedAt
+        ? onboardingProfile.whatsappLinkVisitedAt.toISOString()
+        : null,
       stats: {
         acting: { count: actingPreferences.length, averageWeight: averageWeight(actingPreferences) },
         crew: { count: crewPreferences.length, averageWeight: averageWeight(crewPreferences) },

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -293,6 +293,7 @@ export async function POST(request: NextRequest) {
   }
 
   const invite = redemption.invite;
+  const whatsappLinkVisitedAt = redemption.whatsappLinkVisitedAt ?? null;
   if (!isInviteUsable(invite)) {
     return NextResponse.json({ error: "Dieser Einladungslink ist nicht mehr gültig" }, { status: 400 });
   }
@@ -404,6 +405,7 @@ export async function POST(request: NextRequest) {
           memberSinceYear: memberSinceYear ?? undefined,
           dietaryPreference: dietaryStyleDisplay,
           dietaryPreferenceStrictness: dietaryStrictnessDisplay,
+          whatsappLinkVisitedAt: whatsappLinkVisitedAt ?? undefined,
         },
       });
 

--- a/src/app/api/onboarding/whatsapp-visit/route.ts
+++ b/src/app/api/onboarding/whatsapp-visit/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+
+const requestSchema = z
+  .object({
+    sessionToken: z.string().min(16).optional(),
+  })
+  .transform((value) => ({
+    sessionToken: value.sessionToken?.trim() ?? undefined,
+  }));
+
+export async function POST(request: NextRequest) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    payload = {};
+  }
+
+  const parsed = requestSchema.safeParse(payload ?? {});
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Ungültige Daten" }, { status: 400 });
+  }
+
+  const { sessionToken } = parsed.data;
+  const visitedAt = new Date();
+
+  if (sessionToken) {
+    try {
+      const redemption = await prisma.memberInviteRedemption.findUnique({
+        where: { sessionToken },
+        select: { id: true, whatsappLinkVisitedAt: true, userId: true },
+      });
+
+      if (!redemption) {
+        return NextResponse.json({ error: "Einladung nicht gefunden" }, { status: 404 });
+      }
+
+      if (redemption.whatsappLinkVisitedAt) {
+        return NextResponse.json({
+          ok: true,
+          visitedAt: redemption.whatsappLinkVisitedAt.toISOString(),
+        });
+      }
+
+      const updated = await prisma.memberInviteRedemption.update({
+        where: { id: redemption.id },
+        data: { whatsappLinkVisitedAt: visitedAt },
+        select: { whatsappLinkVisitedAt: true, userId: true },
+      });
+
+      if (updated.userId) {
+        await prisma.memberOnboardingProfile
+          .update({
+            where: { userId: updated.userId },
+            data: { whatsappLinkVisitedAt: visitedAt },
+          })
+          .catch(() => null);
+      }
+
+      return NextResponse.json({
+        ok: true,
+        visitedAt: updated.whatsappLinkVisitedAt?.toISOString() ?? null,
+      });
+    } catch (error) {
+      console.error("[onboarding.whatsapp-visit] redemption", error);
+      return NextResponse.json({ error: "Aktion fehlgeschlagen" }, { status: 500 });
+    }
+  }
+
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  try {
+    const profile = await prisma.memberOnboardingProfile.findUnique({
+      where: { userId },
+      select: { id: true, redemptionId: true, whatsappLinkVisitedAt: true },
+    });
+
+    if (!profile) {
+      return NextResponse.json({ ok: true, visitedAt: null });
+    }
+
+    if (profile.whatsappLinkVisitedAt) {
+      return NextResponse.json({
+        ok: true,
+        visitedAt: profile.whatsappLinkVisitedAt.toISOString(),
+      });
+    }
+
+    const updatedProfile = await prisma.memberOnboardingProfile.update({
+      where: { userId },
+      data: { whatsappLinkVisitedAt: visitedAt },
+      select: { whatsappLinkVisitedAt: true, redemptionId: true },
+    });
+
+    if (profile.redemptionId) {
+      await prisma.memberInviteRedemption
+        .update({
+          where: { id: profile.redemptionId },
+          data: { whatsappLinkVisitedAt: visitedAt },
+        })
+        .catch(() => null);
+    }
+
+    return NextResponse.json({
+      ok: true,
+      visitedAt: updatedProfile.whatsappLinkVisitedAt?.toISOString() ?? null,
+    });
+  } catch (error) {
+    console.error("[onboarding.whatsapp-visit] profile", error);
+    return NextResponse.json({ error: "Aktion fehlgeschlagen" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add tracking columns and API route to persist when members open the onboarding WhatsApp link
- highlight the WhatsApp call-to-action during onboarding, on the dashboard, and in the profile if not yet opened
- expose visit status via the dashboard/profile APIs so reminders disappear after the link is clicked

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d66d3fbffc832dad07dfc8b4117535