### PR TITLE
Refine highlight cards on Über uns page

### DIFF
--- a/src/app/(site)/ueber-uns/page.tsx
+++ b/src/app/(site)/ueber-uns/page.tsx
@@ -315,15 +315,18 @@ export default async function AboutPage() {
             </Text>
           </div>
 
-          <div className="mt-10 grid gap-4 sm:grid-cols-3">
+          <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {highlights.map((item) => (
-              <Card key={item.label} className="bg-card/70">
-                <CardHeader>
-                  <p className="text-sm uppercase tracking-wide text-muted-foreground/80">{item.label}</p>
+              <Card
+                key={item.label}
+                className="border border-primary/20 bg-primary/5 shadow-md shadow-primary/10 backdrop-blur"
+              >
+                <CardHeader className="pb-3">
+                  <p className="text-xs uppercase tracking-[0.18em] text-primary/80">{item.label}</p>
                 </CardHeader>
-                <CardContent>
-                  <p className="text-3xl font-semibold text-primary">{item.value}</p>
-                  <p className="mt-2 text-sm text-muted-foreground">{item.detail}</p>
+                <CardContent className="pt-0">
+                  <p className="text-2xl font-semibold text-primary">{item.value}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">{item.detail}</p>
                 </CardContent>
               </Card>
             ))}


### PR DESCRIPTION
## Summary
- adjust the Über uns highlight grid so the first four cards sit comfortably side-by-side on wider viewports
- refresh the highlight card styling to better reflect the primary color palette

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d676be34d0832da748c94bca8c9619