### PR TITLE
Fix onboarding analytics filter default option

### DIFF
--- a/src/app/(members)/mitglieder/onboarding-analytics/onboarding-show-filter.tsx
+++ b/src/app/(members)/mitglieder/onboarding-analytics/onboarding-show-filter.tsx
@@ -11,6 +11,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+export const ONBOARDING_SHOW_FILTER_ALL_VALUE = "__all__";
+
 type OnboardingShowFilterOption = {
   value: string;
   label: string;
@@ -29,7 +31,7 @@ export function OnboardingShowFilter({ options, value }: OnboardingShowFilterPro
 
   const handleChange = (nextValue: string) => {
     const params = new URLSearchParams(searchParams?.toString() ?? "");
-    if (!nextValue) {
+    if (nextValue === ONBOARDING_SHOW_FILTER_ALL_VALUE) {
       params.delete("show");
     } else {
       params.set("show", nextValue);
@@ -55,7 +57,7 @@ export function OnboardingShowFilter({ options, value }: OnboardingShowFilterPro
         </SelectTrigger>
         <SelectContent>
           {options.map((option) => (
-            <SelectItem key={option.value || "__all"} value={option.value}>
+            <SelectItem key={option.value} value={option.value}>
               {option.label}
             </SelectItem>
           ))}

--- a/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
+++ b/src/app/(members)/mitglieder/onboarding-analytics/page.tsx
@@ -14,7 +14,10 @@ import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 
 import { RenewOnboardingInviteButton } from "./renew-onboarding-invite-button";
-import { OnboardingShowFilter } from "./onboarding-show-filter";
+import {
+  ONBOARDING_SHOW_FILTER_ALL_VALUE,
+  OnboardingShowFilter,
+} from "./onboarding-show-filter";
 
 const numberFormat = new Intl.NumberFormat("de-DE");
 const percentFormat = new Intl.NumberFormat("de-DE", {
@@ -73,7 +76,7 @@ export default async function OnboardingAnalyticsPage({
     : null;
 
   const showFilterOptions = [
-    { value: "", label: "Alle Onboardings" },
+    { value: ONBOARDING_SHOW_FILTER_ALL_VALUE, label: "Alle Onboardings" },
     ...analytics.shows.map((show) => ({ value: show.id, label: formatShowTitle(show) })),
   ];
 
@@ -114,7 +117,7 @@ export default async function OnboardingAnalyticsPage({
   const dietaryStats = selectedShow ? summarizeDietary(visibleProfiles) : analytics.dietary;
 
   const visibleShowSummaries = selectedShow ? [selectedShow] : analytics.shows;
-  const showFilterValue = selectedShow?.id ?? "";
+  const showFilterValue = selectedShow?.id ?? ONBOARDING_SHOW_FILTER_ALL_VALUE;
 
   const summaryByShowId = new Map(analytics.shows.map((show) => [show.id, show] as const));
 


### PR DESCRIPTION
## Summary
- add a dedicated constant for the "all onboardings" option in the show filter
- update the onboarding analytics page to use the non-empty default option and keep query clearing logic intact

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d678499588832d878e846fe2d9d19a