### PR TITLE
Implement Technik inventory categories and creation UI

### DIFF
--- a/prisma/migrations/20250301120000_technik_inventory_upgrade/migration.sql
+++ b/prisma/migrations/20250301120000_technik_inventory_upgrade/migration.sql
@@ -1,0 +1,48 @@
+-- CreateEnum
+CREATE TYPE "InventoryItemCategory" AS ENUM (
+    'light',
+    'sound',
+    'network',
+    'video',
+    'instruments',
+    'cables',
+    'cases',
+    'accessories'
+);
+
+-- AlterTable
+ALTER TABLE "public"."InventoryItem"
+    ADD COLUMN "sku" TEXT,
+    ADD COLUMN "category" "InventoryItemCategory" NOT NULL DEFAULT 'accessories',
+    ADD COLUMN "details" TEXT,
+    ADD COLUMN "lastUsedAt" TIMESTAMP(3),
+    ADD COLUMN "lastInventoryAt" TIMESTAMP(3),
+    ADD COLUMN "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Backfill SKU for existing rows
+UPDATE "public"."InventoryItem"
+SET "sku" = CONCAT('INV-', SUBSTRING(md5(random()::text || clock_timestamp()::text), 1, 12))
+WHERE "sku" IS NULL;
+
+-- Ensure SKU is not null
+ALTER TABLE "public"."InventoryItem"
+    ALTER COLUMN "sku" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InventoryItem_sku_key" ON "public"."InventoryItem"("sku");
+
+-- Trigger updatedAt on update
+CREATE OR REPLACE FUNCTION "public"."set_inventory_item_updated_at"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."updatedAt" = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "InventoryItem_updatedAt" ON "public"."InventoryItem";
+CREATE TRIGGER "InventoryItem_updatedAt"
+BEFORE UPDATE ON "public"."InventoryItem"
+FOR EACH ROW
+EXECUTE FUNCTION "public"."set_inventory_item_updated_at"();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,17 @@ enum SyncScope {
   tickets
 }
 
+enum InventoryItemCategory {
+  light
+  sound
+  network
+  video
+  instruments
+  cables
+  cases
+  accessories
+}
+
 enum TicketStatus {
   unused
   checked_in
@@ -901,11 +912,18 @@ model Task {
 
 model InventoryItem {
   id        String  @id @default(cuid())
+  sku       String  @unique @default(cuid())
   name      String
   qty       Int
   location  String?
   owner     String?
   condition String?
+  category         InventoryItemCategory @default(accessories)
+  details          String?
+  lastUsedAt       DateTime?
+  lastInventoryAt  DateTime?
+  createdAt        DateTime              @default(now())
+  updatedAt        DateTime              @updatedAt
 }
 
 model SyncEvent {

--- a/src/app/(members)/mitglieder/inventar-aufkleber/inventory-stickers-page-client.tsx
+++ b/src/app/(members)/mitglieder/inventar-aufkleber/inventory-stickers-page-client.tsx
@@ -36,6 +36,7 @@ import { cn } from "@/lib/utils";
 
 type InventoryItemOption = {
   id: string;
+  sku: string;
   name: string;
   location: string | null;
   owner: string | null;
@@ -300,10 +301,11 @@ export default function InventoryStickersPageClient({
 
     return inventoryItems
       .filter((item) => {
+        const skuMatch = item.sku.toLowerCase().includes(normalized);
         const idMatch = item.id.toLowerCase().includes(normalized);
         const nameMatch = item.name.toLowerCase().includes(normalized);
         const locationMatch = item.location?.toLowerCase().includes(normalized) ?? false;
-        return idMatch || nameMatch || locationMatch;
+        return skuMatch || idMatch || nameMatch || locationMatch;
       })
       .slice(0, 12);
   }, [inventoryItems, inventoryQuery]);
@@ -315,7 +317,7 @@ export default function InventoryStickersPageClient({
         .join(" • ");
 
       setStickers((previous) => {
-        const existingIndex = previous.findIndex((entry) => entry.code === item.id);
+        const existingIndex = previous.findIndex((entry) => entry.code === item.sku);
         if (existingIndex >= 0) {
           const next = [...previous];
           const current = next[existingIndex];
@@ -331,7 +333,7 @@ export default function InventoryStickersPageClient({
         return [
           ...previous,
           createStickerEntry({
-            code: item.id,
+            code: item.sku,
             primaryText: item.name,
             secondaryText: details.length > 0 ? details : undefined,
             copies: 1,
@@ -535,7 +537,7 @@ export default function InventoryStickersPageClient({
 
                         return (
                           <div
-                            key={item.id}
+                            key={item.sku}
                             className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm"
                           >
                             <div className="min-w-0 space-y-1">
@@ -547,7 +549,7 @@ export default function InventoryStickersPageClient({
                                 tone="muted"
                                 className="flex items-center gap-2 text-xs"
                               >
-                                <span className="font-mono">{item.id}</span>
+                                <span className="font-mono">{item.sku}</span>
                                 {subtitleParts.length > 0 ? (
                                   <span className="truncate">{subtitleParts.join(" • ")}</span>
                                 ) : null}

--- a/src/app/(members)/mitglieder/inventar-aufkleber/page.tsx
+++ b/src/app/(members)/mitglieder/inventar-aufkleber/page.tsx
@@ -14,6 +14,7 @@ export default async function InventoryStickersPage() {
 
   let inventoryItems: {
     id: string;
+    sku: string;
     name: string;
     location: string | null;
     owner: string | null;
@@ -21,12 +22,13 @@ export default async function InventoryStickersPage() {
 
   if (hasDatabase) {
     const records = await prisma.inventoryItem.findMany({
-      select: { id: true, name: true, location: true, owner: true },
-      orderBy: [{ name: "asc" }, { id: "asc" }],
+      select: { id: true, sku: true, name: true, location: true, owner: true },
+      orderBy: [{ name: "asc" }, { sku: "asc" }, { id: "asc" }],
     });
 
     inventoryItems = records.map((item) => ({
       id: item.id,
+      sku: item.sku,
       name: item.name,
       location: item.location ?? null,
       owner: item.owner ?? null,

--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/actions.ts
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/actions.ts
@@ -1,0 +1,151 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { Prisma, type InventoryItemCategory } from "@prisma/client";
+import { z } from "zod";
+
+import { hasPermission } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+
+import {
+  TECH_CATEGORY_LABEL,
+  TECH_CATEGORY_PREFIX,
+  TECH_CATEGORY_VALUES,
+  type TechnikInventoryCategory,
+} from "./config";
+
+export type TechnikInventoryActionState =
+  | { status: "idle" }
+  | { status: "success"; message: string }
+  | { status: "error"; error: string };
+
+const createItemSchema = z.object({
+  category: z.enum(TECH_CATEGORY_VALUES),
+  name: z
+    .string()
+    .trim()
+    .min(2, "Bitte einen Artikelnamen mit mindestens zwei Zeichen angeben.")
+    .max(160, "Der Artikelnamen darf höchstens 160 Zeichen enthalten."),
+  quantity: z
+    .coerce
+    .number()
+    .int("Die Menge muss eine ganze Zahl sein.")
+    .min(0, "Die Menge darf nicht negativ sein."),
+  details: z
+    .string()
+    .trim()
+    .max(500, "Details dürfen höchstens 500 Zeichen enthalten.")
+    .optional()
+    .transform((value) => (value && value.length > 0 ? value : undefined)),
+  lastUsedAt: z
+    .string()
+    .optional()
+    .transform((value) => value?.trim() ?? "")
+    .transform((value) => (value ? new Date(`${value}T00:00:00`) : undefined))
+    .refine(
+      (value) => value === undefined || !Number.isNaN(value.getTime()),
+      "Ungültiges Datum für zuletzt benutzt.",
+    ),
+  lastInventoryAt: z
+    .string()
+    .optional()
+    .transform((value) => value?.trim() ?? "")
+    .transform((value) => (value ? new Date(`${value}T00:00:00`) : undefined))
+    .refine(
+      (value) => value === undefined || !Number.isNaN(value.getTime()),
+      "Ungültiges Datum für die letzte Inventur.",
+    ),
+});
+
+async function generateSku(
+  client: Prisma.TransactionClient,
+  category: TechnikInventoryCategory,
+): Promise<string> {
+  const prefix = TECH_CATEGORY_PREFIX[category];
+  const recent = await client.inventoryItem.findMany({
+    where: { category: category as InventoryItemCategory },
+    select: { sku: true },
+    orderBy: { sku: "desc" },
+    take: 20,
+  });
+
+  let highest = 0;
+  for (const entry of recent) {
+    if (!entry.sku.startsWith(prefix)) {
+      continue;
+    }
+
+    const numericPart = Number.parseInt(entry.sku.slice(prefix.length), 10);
+    if (Number.isFinite(numericPart) && numericPart > highest) {
+      highest = numericPart;
+    }
+  }
+
+  const nextValue = highest + 1;
+  const digits = nextValue.toString().padStart(3, "0");
+  return `${prefix}${digits}`;
+}
+
+export async function createTechnikInventoryItem(
+  _prevState: TechnikInventoryActionState,
+  formData: FormData,
+): Promise<TechnikInventoryActionState> {
+  try {
+    const session = await requireAuth();
+    const allowed = await hasPermission(session.user, "mitglieder.lager.technik");
+
+    if (!allowed) {
+      throw new Error("Du hast keinen Zugriff auf das Technik-Lager.");
+    }
+
+    const parsed = createItemSchema.safeParse({
+      category: formData.get("category"),
+      name: formData.get("name"),
+      quantity: formData.get("quantity"),
+      details: formData.get("details") ?? undefined,
+      lastUsedAt: formData.get("lastUsedAt") ?? undefined,
+      lastInventoryAt: formData.get("lastInventoryAt") ?? undefined,
+    });
+
+    if (!parsed.success) {
+      const firstError = parsed.error.issues.at(0)?.message ?? "Ungültige Eingabe.";
+      return { status: "error", error: firstError };
+    }
+
+    const values = parsed.data;
+
+    const result = await prisma.$transaction(async (tx) => {
+      const sku = await generateSku(tx, values.category);
+
+      const item = await tx.inventoryItem.create({
+        data: {
+          name: values.name,
+          qty: values.quantity,
+          details: values.details ?? null,
+          sku,
+          category: values.category as InventoryItemCategory,
+          lastUsedAt: values.lastUsedAt ?? null,
+          lastInventoryAt: values.lastInventoryAt ?? null,
+        },
+        select: { id: true, sku: true },
+      });
+
+      return item;
+    });
+
+    revalidatePath("/mitglieder/lagerverwaltung/technik");
+
+    const label = TECH_CATEGORY_LABEL[values.category];
+    return {
+      status: "success",
+      message: `Artikel ${result.sku} (${label}) wurde angelegt.`,
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Der Artikel konnte nicht angelegt werden.";
+    return { status: "error", error: message };
+  }
+}

--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/add-item-dialog.tsx
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/add-item-dialog.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useActionState, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+import {
+  createTechnikInventoryItem,
+  type TechnikInventoryActionState,
+} from "./actions";
+import {
+  TECH_CATEGORY_LABEL,
+  TECH_CATEGORY_PREFIX,
+  type TechnikInventoryCategory,
+} from "./config";
+
+const INITIAL_STATE: TechnikInventoryActionState = { status: "idle" };
+
+interface AddTechnikItemDialogProps {
+  category: TechnikInventoryCategory;
+}
+
+export function AddTechnikItemDialog({ category }: AddTechnikItemDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [state, formAction, isPending] = useActionState(
+    createTechnikInventoryItem,
+    INITIAL_STATE,
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const categoryLabel = TECH_CATEGORY_LABEL[category];
+  const prefix = TECH_CATEGORY_PREFIX[category];
+
+  useEffect(() => {
+    if (state.status === "success") {
+      toast.success(state.message);
+      formRef.current?.reset();
+      setOpen(false);
+      setErrorMessage(null);
+    }
+
+    if (state.status === "error") {
+      toast.error(state.error);
+      setErrorMessage(state.error);
+    }
+  }, [state]);
+
+  useEffect(() => {
+    if (!open) {
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm">Artikel hinzufügen</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Artikel in {categoryLabel} anlegen</DialogTitle>
+          <DialogDescription>
+            Die Artikelnummer wird automatisch als{" "}
+            <span className="font-mono">
+              {prefix}
+              001
+            </span>{" "}
+            vergeben und fortlaufend erhöht.
+          </DialogDescription>
+        </DialogHeader>
+        <form ref={formRef} action={formAction} className="space-y-4">
+          <input type="hidden" name="category" value={category} />
+          <div className="grid gap-1.5">
+            <Label htmlFor={`technik-name-${category}`}>Artikelname</Label>
+            <Input
+              id={`technik-name-${category}`}
+              name="name"
+              placeholder="z. B. LED-Fluter"
+              required
+              maxLength={160}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor={`technik-quantity-${category}`}>Menge</Label>
+            <Input
+              id={`technik-quantity-${category}`}
+              name="quantity"
+              type="number"
+              min={0}
+              step={1}
+              defaultValue={1}
+              required
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor={`technik-details-${category}`}>Details</Label>
+            <Textarea
+              id={`technik-details-${category}`}
+              name="details"
+              placeholder="Besonderheiten, Zubehör, Zustand …"
+              maxLength={500}
+              rows={3}
+            />
+            <p className="text-xs text-muted-foreground">
+              Optional: kurze Beschreibung oder Hinweise für das Team.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="grid gap-1.5">
+              <Label htmlFor={`technik-lastUsedAt-${category}`}>
+                Zuletzt benutzt
+              </Label>
+              <Input
+                id={`technik-lastUsedAt-${category}`}
+                name="lastUsedAt"
+                type="date"
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor={`technik-lastInventoryAt-${category}`}>
+                Letzte Inventur
+              </Label>
+              <Input
+                id={`technik-lastInventoryAt-${category}`}
+                name="lastInventoryAt"
+                type="date"
+              />
+            </div>
+          </div>
+          {errorMessage ? (
+            <p className="text-sm text-red-600">{errorMessage}</p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="submit"
+              disabled={isPending}
+              className="w-full sm:w-auto"
+            >
+              {isPending ? "Speichere …" : "Artikel speichern"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/config.ts
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/config.ts
@@ -1,0 +1,84 @@
+export const TECH_CATEGORY_VALUES = [
+  "light",
+  "sound",
+  "network",
+  "video",
+  "instruments",
+  "cables",
+  "cases",
+  "accessories",
+] as const;
+
+export const TECH_INVENTORY_CATEGORIES = [
+  {
+    value: TECH_CATEGORY_VALUES[0],
+    label: "Licht",
+    prefix: "L",
+    description:
+      "Scheinwerfer, Dimmer, Lichtpulte und Zubehör für die Ausleuchtung der Bühne.",
+  },
+  {
+    value: TECH_CATEGORY_VALUES[1],
+    label: "Ton",
+    prefix: "T",
+    description:
+      "Mikrofone, Lautsprecher, Mischpulte und Outboard-Equipment für den perfekten Klang.",
+  },
+  {
+    value: TECH_CATEGORY_VALUES[2],
+    label: "Netzwerk",
+    prefix: "N",
+    description:
+      "Switches, Router, Access Points und alles für stabile Verbindungen im Haus.",
+  },
+  {
+    value: TECH_CATEGORY_VALUES[3],
+    label: "Video",
+    prefix: "V",
+    description:
+      "Kameras, Projektoren, Bildmischer und Playback-Systeme für visuelle Effekte.",
+  },
+  {
+    value: TECH_CATEGORY_VALUES[4],
+    label: "Instrumente",
+    prefix: "I",
+    description:
+      "Instrumente, Verstärker und Zubehör für Orchestergraben und Bandproben.",
+  },
+  {
+    value: TECH_CATEGORY_VALUES[5],
+    label: "Kabel",
+    prefix: "K",
+    description:
+      "Strom-, Audio-, Daten- und Spezialkabel inklusive Adapter und Verbindungen.",
+  },
+  {
+    value: TECH_CATEGORY_VALUES[6],
+    label: "Cases",
+    prefix: "C",
+    description:
+      "Flightcases, Taschen und Transportlösungen für sicheres Equipment-Handling.",
+  },
+  {
+    value: TECH_CATEGORY_VALUES[7],
+    label: "Zubehör",
+    prefix: "Z",
+    description:
+      "Werkzeuge, Verbrauchsmaterial, Ersatzteile und sonstige Helferlein.",
+  },
+] as const;
+
+export type TechnikInventoryCategory =
+  (typeof TECH_INVENTORY_CATEGORIES)[number]["value"];
+
+export const TECH_CATEGORY_PREFIX: Record<TechnikInventoryCategory, string> =
+  TECH_INVENTORY_CATEGORIES.reduce(
+    (acc, entry) => ({ ...acc, [entry.value]: entry.prefix }),
+    {} as Record<TechnikInventoryCategory, string>,
+  );
+
+export const TECH_CATEGORY_LABEL: Record<TechnikInventoryCategory, string> =
+  TECH_INVENTORY_CATEGORIES.reduce(
+    (acc, entry) => ({ ...acc, [entry.value]: entry.label }),
+    {} as Record<TechnikInventoryCategory, string>,
+  );

--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/page.tsx
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/page.tsx
@@ -1,5 +1,185 @@
-import { createInventoryCategoryPage } from "../inventory-category-page";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { PageHeader } from "@/components/members/page-header";
+import { hasPermission } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import { requireAuth } from "@/lib/rbac";
+import type { InventoryItemCategory } from "@prisma/client";
+
+import { AddTechnikItemDialog } from "./add-item-dialog";
+import {
+  TECH_CATEGORY_VALUES,
+  TECH_INVENTORY_CATEGORIES,
+  type TechnikInventoryCategory,
+} from "./config";
 
 export const dynamic = "force-dynamic";
 
-export default createInventoryCategoryPage("technik");
+const QUANTITY_FORMATTER = new Intl.NumberFormat("de-DE");
+const DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+
+type TechnikInventoryItem = {
+  id: string;
+  sku: string;
+  name: string;
+  quantity: number;
+  details: string | null;
+  category: TechnikInventoryCategory;
+  lastUsedAt: Date | null;
+  lastInventoryAt: Date | null;
+};
+
+function formatDate(value: Date | null): string {
+  if (!value) {
+    return "–";
+  }
+
+  return DATE_FORMATTER.format(value);
+}
+
+export default async function TechnikInventoryPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.lager.technik");
+
+  if (!allowed) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-red-600">
+        Kein Zugriff auf diesen Lagerbereich.
+      </div>
+    );
+  }
+
+  const breadcrumb =
+    membersNavigationBreadcrumb("/mitglieder/lagerverwaltung/technik") ??
+    ({ label: "Technik-Lager", href: "/mitglieder/lagerverwaltung/technik" } as const);
+
+  const categoryFilter = TECH_CATEGORY_VALUES.map(
+    (value) => value as InventoryItemCategory,
+  );
+
+  const items = await prisma.inventoryItem.findMany({
+    where: { category: { in: categoryFilter } },
+    orderBy: [{ category: "asc" }, { sku: "asc" }],
+    select: {
+      id: true,
+      sku: true,
+      name: true,
+      qty: true,
+      category: true,
+      details: true,
+      lastUsedAt: true,
+      lastInventoryAt: true,
+    },
+  });
+
+  const grouped = TECH_INVENTORY_CATEGORIES.map((categoryConfig) => {
+    const categoryItems: TechnikInventoryItem[] = items
+      .filter((item) => item.category === categoryConfig.value)
+      .map((item) => ({
+        id: item.id,
+        sku: item.sku,
+        name: item.name,
+        quantity: item.qty,
+        details: item.details ?? null,
+        category: item.category as TechnikInventoryCategory,
+        lastUsedAt: item.lastUsedAt,
+        lastInventoryAt: item.lastInventoryAt,
+      }));
+
+    const itemCount = categoryItems.length;
+    const totalQuantity = categoryItems.reduce((sum, item) => sum + item.quantity, 0);
+
+    return {
+      config: categoryConfig,
+      items: categoryItems,
+      itemCount,
+      totalQuantity,
+    };
+  });
+
+  const totalItems = grouped.reduce((sum, group) => sum + group.itemCount, 0);
+  const totalQuantity = grouped.reduce((sum, group) => sum + group.totalQuantity, 0);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Technik-Lager"
+        description="Alle Geräte, Kabel und Zubehör des Techniklagers in strukturierten Kategorien – ideal für Inventur und schnelle Ausgaben."
+        breadcrumbs={[breadcrumb]}
+      />
+      <Card>
+        <CardHeader>
+          <CardTitle>Gesamtübersicht</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {totalItems > 0
+              ? `${totalItems} Artikel, Gesamtbestand ${QUANTITY_FORMATTER.format(totalQuantity)} Einheiten.`
+              : "Noch keine Technik-Artikel erfasst."}
+          </p>
+        </CardHeader>
+      </Card>
+      <div className="grid gap-6">
+        {grouped.map(({ config, items: categoryItems, itemCount, totalQuantity: categoryQuantity }) => (
+          <Card key={config.value}>
+            <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <CardTitle>{config.label}</CardTitle>
+                <p className="text-sm text-muted-foreground">{config.description}</p>
+                <p className="text-sm text-muted-foreground">
+                  {itemCount > 0
+                    ? `${itemCount} Artikel, ${QUANTITY_FORMATTER.format(categoryQuantity)} Einheiten insgesamt.`
+                    : "Noch keine Artikel in dieser Kategorie angelegt."}
+                </p>
+              </div>
+              <AddTechnikItemDialog category={config.value} />
+            </CardHeader>
+            <CardContent>
+              {categoryItems.length > 0 ? (
+                <div className="overflow-hidden rounded-md border border-border/60">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Artikel</TableHead>
+                        <TableHead className="w-[120px]">Art.-Nr.</TableHead>
+                        <TableHead className="w-[100px] text-right">Menge</TableHead>
+                        <TableHead>Details</TableHead>
+                        <TableHead className="w-[140px]">Zuletzt benutzt</TableHead>
+                        <TableHead className="w-[160px]">Letzte Inventur</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {categoryItems.map((item) => (
+                        <TableRow key={item.id}>
+                          <TableCell className="font-medium">{item.name}</TableCell>
+                          <TableCell className="font-mono text-sm">{item.sku}</TableCell>
+                          <TableCell className="text-right">
+                            {QUANTITY_FORMATTER.format(item.quantity)}
+                          </TableCell>
+                          <TableCell className="max-w-[320px]">
+                            {item.details ? (
+                              <span className="block whitespace-pre-line text-sm text-muted-foreground">
+                                {item.details}
+                              </span>
+                            ) : (
+                              <span className="text-sm text-muted-foreground">–</span>
+                            )}
+                          </TableCell>
+                          <TableCell>{formatDate(item.lastUsedAt)}</TableCell>
+                          <TableCell>{formatDate(item.lastInventoryAt)}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Lege den ersten Artikel für die Kategorie {config.label} an, um den Bestand zu tracken.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(members)/scan/__tests__/sync-api.test.tsx
+++ b/src/app/(members)/scan/__tests__/sync-api.test.tsx
@@ -27,8 +27,14 @@ type TicketStatusValue = "unused" | "checked_in" | "invalid" | "pending";
 
 interface InventoryItemRow {
   id: string;
+  sku: string;
   name: string;
   qty: number;
+  category: string;
+  details: string | null;
+  lastUsedAt: Date | null;
+  lastInventoryAt: Date | null;
+  updatedAt: Date;
 }
 
 interface TicketRow {
@@ -115,7 +121,12 @@ function toDate(value: Date | string | number | null | undefined): Date {
 }
 
 function cloneInventoryItem(item: InventoryItemRow): InventoryItemRow {
-  return { ...item };
+  return {
+    ...item,
+    lastUsedAt: item.lastUsedAt ? new Date(item.lastUsedAt.getTime()) : null,
+    lastInventoryAt: item.lastInventoryAt ? new Date(item.lastInventoryAt.getTime()) : null,
+    updatedAt: new Date(item.updatedAt.getTime()),
+  };
 }
 
 function cloneTicket(ticket: TicketRow): TicketRow {
@@ -416,8 +427,33 @@ const prismaStub = {
       const records = Array.isArray(data) ? data : [data];
       const normalized = records.map((item, index) => ({
         id: item.id ?? `inventory-${fakeDb.inventoryItems.length + index + 1}`,
+        sku: item.sku ??
+          (item.id ?? `inventory-${fakeDb.inventoryItems.length + index + 1}`),
         name: item.name ?? "",
         qty: item.qty ?? 0,
+        category: (item.category as string | undefined) ?? "accessories",
+        details:
+          typeof item.details === "string"
+            ? item.details
+            : item.details == null
+              ? null
+              : String(item.details),
+        lastUsedAt:
+          item.lastUsedAt instanceof Date
+            ? new Date(item.lastUsedAt.getTime())
+            : item.lastUsedAt
+                ? toDate(item.lastUsedAt as Date | string | number)
+                : null,
+        lastInventoryAt:
+          item.lastInventoryAt instanceof Date
+            ? new Date(item.lastInventoryAt.getTime())
+            : item.lastInventoryAt
+                ? toDate(item.lastInventoryAt as Date | string | number)
+                : null,
+        updatedAt:
+          item.updatedAt instanceof Date
+            ? new Date(item.updatedAt.getTime())
+            : new Date(),
       }));
 
       fakeDb.inventoryItems.push(...normalized);

--- a/src/lib/offline/sync-client.ts
+++ b/src/lib/offline/sync-client.ts
@@ -19,6 +19,27 @@ import type {
   TicketRecord,
 } from "./types";
 
+const INVENTORY_CATEGORY_VALUES: InventoryItemRecord["category"][] = [
+  "light",
+  "sound",
+  "network",
+  "video",
+  "instruments",
+  "cables",
+  "cases",
+  "accessories",
+];
+
+function isInventoryCategoryValue(
+  value: string | null,
+): value is InventoryItemRecord["category"] {
+  if (!value) {
+    return false;
+  }
+
+  return (INVENTORY_CATEGORY_VALUES as readonly string[]).includes(value);
+}
+
 const DEFAULT_RETRY_ATTEMPTS = 3;
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_FLUSH_LIMIT = 50;
@@ -978,12 +999,38 @@ export class SyncClient {
     const updatedAt =
       this.pickString(record, ["updatedAt", "occurredAt"]) ?? occurredAt;
 
+    const categoryValue = this.pickString(record, ["category", "type"]);
+    const category = isInventoryCategoryValue(categoryValue)
+      ? categoryValue
+      : ("accessories" as InventoryItemRecord["category"]);
+    const details = this.pickString(record, ["details", "description"]);
+    const lastUsedAt = this.pickString(record, ["lastUsedAt", "usedAt"]);
+    const lastInventoryAt = this.pickString(record, [
+      "lastInventoryAt",
+      "inventoryCheckedAt",
+      "countedAt",
+    ]);
+    const location = this.pickString(record, ["location", "place", "room"]);
+    const owner = this.pickString(record, ["owner", "responsible", "contact"]);
+    const condition = this.pickString(record, [
+      "condition",
+      "state",
+      "status",
+    ]);
+
     return {
       id,
       sku,
       name,
       quantity,
       updatedAt,
+      category,
+      details: details ?? null,
+      lastUsedAt: lastUsedAt ?? null,
+      lastInventoryAt: lastInventoryAt ?? null,
+      location: location ?? null,
+      owner: owner ?? null,
+      condition: condition ?? null,
     } satisfies InventoryItemRecord;
   }
 

--- a/src/lib/offline/types.ts
+++ b/src/lib/offline/types.ts
@@ -1,11 +1,28 @@
 export type OfflineScope = "inventory" | "tickets";
 
+export type InventoryItemCategoryValue =
+  | "light"
+  | "sound"
+  | "network"
+  | "video"
+  | "instruments"
+  | "cables"
+  | "cases"
+  | "accessories";
+
 export interface InventoryItemRecord {
   id: string;
   sku: string;
   name: string;
   quantity: number;
   updatedAt: string;
+  category: InventoryItemCategoryValue;
+  details?: string | null;
+  lastUsedAt?: string | null;
+  lastInventoryAt?: string | null;
+  location?: string | null;
+  owner?: string | null;
+  condition?: string | null;
 }
 
 export type TicketStatus = "unused" | "checked_in" | "invalid" | "pending";

--- a/src/lib/sync/server.ts
+++ b/src/lib/sync/server.ts
@@ -239,7 +239,7 @@ export async function selectBaseline(
 
   if (scope === "inventory") {
     const items = await prisma.inventoryItem.findMany({
-      orderBy: { id: "asc" },
+      orderBy: [{ category: "asc" }, { sku: "asc" }, { id: "asc" }],
       take: limit + 1,
       ...(options.cursor
         ? {
@@ -254,10 +254,17 @@ export async function selectBaseline(
 
     const mapped: InventoryItemRecord[] = records.map((item) => ({
       id: item.id,
-      sku: item.id,
+      sku: item.sku,
       name: item.name,
       quantity: item.qty,
-      updatedAt: capturedAt,
+      updatedAt: item.updatedAt.toISOString(),
+      category: item.category,
+      details: item.details ?? null,
+      lastUsedAt: item.lastUsedAt?.toISOString() ?? null,
+      lastInventoryAt: item.lastInventoryAt?.toISOString() ?? null,
+      location: item.location ?? null,
+      owner: item.owner ?? null,
+      condition: item.condition ?? null,
     }));
 
     return {


### PR DESCRIPTION
## Summary
- add inventory item categories and metadata fields to the Prisma schema with a matching migration
- build a Technik inventory overview that groups items by category and allows creating articles with auto-generated SKUs
- update offline sync logic, tests, and inventory sticker tooling to work with the new SKU/category fields

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d674f15c10832d83a359457d7bd22a