### PR TITLE
Ensure minors confirm photo consent during onboarding

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1040,6 +1040,10 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
       return;
     }
     if (step === 4) {
+      if (isMinor && !form.photoConsent.consent) {
+        setError("Bitte bestätige dein eigenes Fotoeinverständnis über das Kästchen oben.");
+        return;
+      }
       if (form.photoConsent.consent && !form.photoConsent.skipDocument && !documentFile) {
         setError(
           isMinor
@@ -1921,7 +1925,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                   Wir benötigen die unterschriebene Foto-Einverständniserklärung deiner Erziehungsberechtigten. Lade das Dokument
                   als PDF oder Bilddatei hoch oder markiere unten, dass du es später nachreichst.
                 </p>
-                <p>Deine eigene Zustimmung gibst du direkt über das Kästchen oben.</p>
+                <p>Deine eigene Zustimmung gibst du direkt über das Kästchen oben – sie ist verpflichtend.</p>
               </div>
             ) : (
               <div className="space-y-2 rounded-lg border border-emerald-200 bg-emerald-50/70 p-4 text-sm text-emerald-900">


### PR DESCRIPTION
## Summary
- block minors from advancing in the onboarding wizard until they confirm their own photo consent
- clarify the onboarding copy that their personal consent checkbox is mandatory while the guardian document can still be deferred

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d68a77fec8832d93c42cc41354a96a