### PR TITLE
Scope finance data to productions

### DIFF
--- a/prisma/migrations/20251003120000_finance_scoped_to_production/migration.sql
+++ b/prisma/migrations/20251003120000_finance_scoped_to_production/migration.sql
@@ -1,0 +1,54 @@
+-- Scope finance data to productions
+
+-- Ensure nullable finance records adopt the newest production
+WITH latest_show AS (
+  SELECT "id"
+  FROM "Show"
+  ORDER BY "year" DESC NULLS LAST, "id" DESC
+  LIMIT 1
+)
+UPDATE "FinanceEntry" AS fe
+SET "showId" = ls."id"
+FROM latest_show AS ls
+WHERE fe."showId" IS NULL
+  AND ls."id" IS NOT NULL;
+
+WITH latest_show AS (
+  SELECT "id"
+  FROM "Show"
+  ORDER BY "year" DESC NULLS LAST, "id" DESC
+  LIMIT 1
+)
+UPDATE "FinanceBudget" AS fb
+SET "showId" = ls."id"
+FROM latest_show AS ls
+WHERE fb."showId" IS NULL
+  AND ls."id" IS NOT NULL;
+
+-- Abort if there are still orphaned finance records
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "FinanceEntry" WHERE "showId" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot enforce NOT NULL on "FinanceEntry"."showId" while null values remain. Please assign productions.';
+  END IF;
+  IF EXISTS (SELECT 1 FROM "FinanceBudget" WHERE "showId" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot enforce NOT NULL on "FinanceBudget"."showId" while null values remain. Please assign productions.';
+  END IF;
+END;
+$$;
+
+-- Strengthen foreign keys to cascade with productions
+ALTER TABLE "FinanceEntry" DROP CONSTRAINT IF EXISTS "FinanceEntry_showId_fkey";
+ALTER TABLE "FinanceBudget" DROP CONSTRAINT IF EXISTS "FinanceBudget_showId_fkey";
+
+ALTER TABLE "FinanceEntry"
+  ALTER COLUMN "showId" SET NOT NULL;
+ALTER TABLE "FinanceBudget"
+  ALTER COLUMN "showId" SET NOT NULL;
+
+ALTER TABLE "FinanceEntry"
+  ADD CONSTRAINT "FinanceEntry_showId_fkey"
+  FOREIGN KEY ("showId") REFERENCES "Show"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "FinanceBudget"
+  ADD CONSTRAINT "FinanceBudget_showId_fkey"
+  FOREIGN KEY ("showId") REFERENCES "Show"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -980,7 +980,7 @@ model FinanceEntry {
   donationSource  String?
   donorContact    String?
   tags            Json?
-  showId          String?
+  showId          String
   budgetId        String?
   visibilityScope VisibilityScope    @default(finance)
   createdById     String
@@ -989,7 +989,7 @@ model FinanceEntry {
   createdAt       DateTime           @default(now())
   updatedAt       DateTime           @updatedAt
 
-  show           Show?          @relation(fields: [showId], references: [id], onDelete: SetNull)
+  show           Show           @relation(fields: [showId], references: [id], onDelete: Cascade)
   budget         FinanceBudget? @relation(fields: [budgetId], references: [id], onDelete: SetNull)
   createdBy      User           @relation("FinanceEntryCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
   approvedBy     User?          @relation("FinanceEntryApprovedBy", fields: [approvedById], references: [id], onDelete: SetNull)
@@ -1018,14 +1018,14 @@ model FinanceAttachment {
 
 model FinanceBudget {
   id            String         @id @default(cuid())
-  showId        String?
+  showId        String
   category      String
   plannedAmount Float          @default(0)
   currency      String         @default("EUR")
   notes         String?
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
-  show          Show?          @relation(fields: [showId], references: [id], onDelete: SetNull)
+  show          Show           @relation(fields: [showId], references: [id], onDelete: Cascade)
   entries       FinanceEntry[]
 
   @@index([showId, category])

--- a/src/components/members/finance/finance-export-section.tsx
+++ b/src/components/members/finance/finance-export-section.tsx
@@ -14,7 +14,11 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "sonner";
 
-export function FinanceExportSection() {
+type FinanceExportSectionProps = {
+  showId: string;
+};
+
+export function FinanceExportSection({ showId }: FinanceExportSectionProps) {
   const [status, setStatus] = useState<string>("all");
   const [kind, setKind] = useState<string>("all");
   const [type, setType] = useState<string>("all");
@@ -24,13 +28,14 @@ export function FinanceExportSection() {
 
   const query = useMemo(() => {
     const params = new URLSearchParams();
+    params.set("showId", showId);
     if (status !== "all") params.set("status", status);
     if (kind !== "all") params.set("kind", kind);
     if (type !== "all") params.set("type", type);
     if (from) params.set("from", from);
     if (to) params.set("to", to);
     return params.toString();
-  }, [status, kind, type, from, to]);
+  }, [status, kind, type, from, to, showId]);
 
   const downloadUrl = query ? `/api/finance/export?${query}` : "/api/finance/export";
 


### PR DESCRIPTION
## Summary
- enforce production scoping for finance entries and budgets via schema updates and a data migration
- default member finance views to the active production while letting users switch productions consistently
- require `showId` through finance forms, exports, and API routes to keep entries and budgets tied to the chosen production

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d6c08eb4e4832dbd6c0f4c0cd9e775