### PR TITLE
Add members file library with role-based permissions

### DIFF
--- a/prisma/migrations/20250930120000_file_library/migration.sql
+++ b/prisma/migrations/20250930120000_file_library/migration.sql
@@ -1,0 +1,56 @@
+-- CreateEnum
+CREATE TYPE "FileLibraryAccessType" AS ENUM ('VIEW', 'DOWNLOAD', 'UPLOAD');
+CREATE TYPE "FileLibraryAccessTargetType" AS ENUM ('SYSTEM_ROLE', 'APP_ROLE');
+
+-- CreateTable
+CREATE TABLE "FileLibraryFolder" (
+    "id" TEXT NOT NULL,
+    "parentId" TEXT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "allowAllView" BOOLEAN NOT NULL DEFAULT true,
+    "allowAllDownload" BOOLEAN NOT NULL DEFAULT true,
+    "allowAllUpload" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" TEXT,
+    CONSTRAINT "FileLibraryFolder_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "FileLibraryItem" (
+    "id" TEXT NOT NULL,
+    "folderId" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "data" BYTEA NOT NULL,
+    "description" TEXT,
+    "uploadedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "FileLibraryItem_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "FileLibraryFolderAccess" (
+    "id" TEXT NOT NULL,
+    "folderId" TEXT NOT NULL,
+    "accessType" "FileLibraryAccessType" NOT NULL,
+    "targetType" "FileLibraryAccessTargetType" NOT NULL,
+    "systemRole" "Role",
+    "appRoleId" TEXT,
+    CONSTRAINT "FileLibraryFolderAccess_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes
+CREATE INDEX "FileLibraryFolder_parentId_idx" ON "FileLibraryFolder"("parentId");
+CREATE INDEX "FileLibraryItem_folderId_createdAt_idx" ON "FileLibraryItem"("folderId", "createdAt");
+CREATE INDEX "FileLibraryFolderAccess_folderId_accessType_idx" ON "FileLibraryFolderAccess"("folderId", "accessType");
+CREATE UNIQUE INDEX "FileLibraryFolderAccess_folderId_accessType_systemRole_appRoleId_key" ON "FileLibraryFolderAccess"("folderId", "accessType", "systemRole", "appRoleId");
+
+-- Foreign keys
+ALTER TABLE "FileLibraryFolder" ADD CONSTRAINT "FileLibraryFolder_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "FileLibraryFolder" ADD CONSTRAINT "FileLibraryFolder_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "FileLibraryItem" ADD CONSTRAINT "FileLibraryItem_folderId_fkey" FOREIGN KEY ("folderId") REFERENCES "FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "FileLibraryItem" ADD CONSTRAINT "FileLibraryItem_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "FileLibraryFolderAccess" ADD CONSTRAINT "FileLibraryFolderAccess_folderId_fkey" FOREIGN KEY ("folderId") REFERENCES "FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "FileLibraryFolderAccess" ADD CONSTRAINT "FileLibraryFolderAccess_appRoleId_fkey" FOREIGN KEY ("appRoleId") REFERENCES "AppRole"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,17 @@ enum GalleryMediaType {
   video
 }
 
+enum FileLibraryAccessType {
+  VIEW
+  DOWNLOAD
+  UPLOAD
+}
+
+enum FileLibraryAccessTargetType {
+  SYSTEM_ROLE
+  APP_ROLE
+}
+
 enum AvailabilityStatus {
   blocked
   available
@@ -300,6 +311,8 @@ model User {
   finalRehearsalDutiesAssigned FinalRehearsalDuty[] @relation("FinalRehearsalDutyAssignee")
   finalRehearsalDutiesCreated  FinalRehearsalDuty[] @relation("FinalRehearsalDutyCreatedBy")
   galleryItems           GalleryItem[]
+  fileLibraryFoldersCreated FileLibraryFolder[] @relation("FileLibraryFoldersCreated")
+  fileLibraryItemsUploaded  FileLibraryItem[]   @relation("FileLibraryItemsUploaded")
 }
 
 model Account {
@@ -789,6 +802,7 @@ model AppRole {
   sortIndex  Int     @default(0)
   grants     AppRolePermission[]
   users      UserAppRole[]
+  fileLibraryAccesses FileLibraryFolderAccess[]
 }
 
 model AppRolePermission {
@@ -1145,6 +1159,60 @@ model GalleryItem {
   uploadedBy   User             @relation(fields: [uploadedById], references: [id], onDelete: Cascade)
 
   @@index([year, createdAt])
+}
+
+model FileLibraryFolder {
+  id              String                    @id @default(cuid())
+  parentId        String?
+  name            String
+  description     String?
+  allowAllView    Boolean                   @default(true)
+  allowAllDownload Boolean                  @default(true)
+  allowAllUpload  Boolean                   @default(false)
+  createdAt       DateTime                  @default(now())
+  updatedAt       DateTime                  @updatedAt
+  createdById     String?
+
+  parent          FileLibraryFolder?        @relation("FileLibraryFolderHierarchy", fields: [parentId], references: [id], onDelete: Cascade)
+  children        FileLibraryFolder[]       @relation("FileLibraryFolderHierarchy")
+  createdBy       User?                     @relation("FileLibraryFoldersCreated", fields: [createdById], references: [id], onDelete: SetNull)
+  files           FileLibraryItem[]
+  accessRules     FileLibraryFolderAccess[]
+
+  @@index([parentId])
+}
+
+model FileLibraryItem {
+  id           String             @id @default(cuid())
+  folderId     String
+  fileName     String
+  mimeType     String
+  fileSize     Int
+  data         Bytes
+  description  String?
+  uploadedById String?
+  createdAt    DateTime           @default(now())
+  updatedAt    DateTime           @updatedAt
+
+  folder       FileLibraryFolder  @relation(fields: [folderId], references: [id], onDelete: Cascade)
+  uploadedBy   User?              @relation("FileLibraryItemsUploaded", fields: [uploadedById], references: [id], onDelete: SetNull)
+
+  @@index([folderId, createdAt])
+}
+
+model FileLibraryFolderAccess {
+  id          String                     @id @default(cuid())
+  folderId    String
+  accessType  FileLibraryAccessType
+  targetType  FileLibraryAccessTargetType
+  systemRole  Role?
+  appRoleId   String?
+
+  folder      FileLibraryFolder          @relation(fields: [folderId], references: [id], onDelete: Cascade)
+  appRole     AppRole?                   @relation(fields: [appRoleId], references: [id], onDelete: Cascade)
+
+  @@index([folderId, accessType])
+  @@unique([folderId, accessType, systemRole, appRoleId])
 }
 
 model MemberInvite {

--- a/src/app/(members)/mitglieder/dateisystem/[folderId]/page.tsx
+++ b/src/app/(members)/mitglieder/dateisystem/[folderId]/page.tsx
@@ -1,0 +1,546 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PageHeader } from "@/components/members/page-header";
+import { FileLibraryManager, type FileLibraryItemEntry } from "@/components/members/file-library/file-library-manager";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import {
+  computeFolderStats,
+  formatFileLibraryFileSize,
+  getFolderBreadcrumb,
+  loadFolderItems,
+  loadFolderWithDetails,
+  resolveFileLibraryAccessContext,
+  userHasFileLibraryAccess,
+} from "@/lib/file-library";
+import { createMembersBreadcrumbItems, membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import { formatRelativeWithAbsolute } from "@/lib/datetime";
+import { ROLES, ROLE_LABELS, type Role } from "@/lib/roles";
+import { FileLibraryAccessTargetType, FileLibraryAccessType } from "@prisma/client";
+import { createFileLibraryFolder, updateFileLibraryPermissions } from "../actions";
+
+const latestFormatter = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function summarizeViewAccess(
+  folder: {
+    allowAllView: boolean;
+    accessRules: { targetType: FileLibraryAccessTargetType; systemRole: Role | null; appRoleId: string | null }[];
+  },
+  appRoleNames: Map<string, string>,
+) {
+  if (folder.allowAllView) {
+    return "Alle Mitglieder";
+  }
+  const entries = folder.accessRules
+    .filter((rule) => rule.targetType === FileLibraryAccessTargetType.SYSTEM_ROLE)
+    .map((rule) => (rule.systemRole ? ROLE_LABELS[rule.systemRole] ?? rule.systemRole : "Unbekannte Rolle"));
+  const appRoleEntries = folder.accessRules
+    .filter((rule) => rule.targetType === FileLibraryAccessTargetType.APP_ROLE)
+    .map((rule) => (rule.appRoleId ? appRoleNames.get(rule.appRoleId) ?? "Unbenannte Gruppe" : "Unbenannte Gruppe"));
+  const labels = [...entries, ...appRoleEntries];
+  if (!labels.length) {
+    return "Keine Freigaben";
+  }
+  return labels.join(", ");
+}
+
+function formatLatest(date: Date | null) {
+  if (!date) {
+    return "Noch keine Uploads";
+  }
+  return formatRelativeWithAbsolute(date, {
+    absoluteFormatter: latestFormatter,
+  }).combined;
+}
+
+function collectRoleSet(
+  rules: {
+    accessType: FileLibraryAccessType;
+    targetType: FileLibraryAccessTargetType;
+    systemRole: Role | null;
+    appRoleId: string | null;
+  }[],
+  type: FileLibraryAccessType,
+  target: FileLibraryAccessTargetType,
+) {
+  return new Set(
+    rules
+      .filter((rule) => rule.accessType === type && rule.targetType === target)
+      .map((rule) => (target === FileLibraryAccessTargetType.SYSTEM_ROLE ? rule.systemRole : rule.appRoleId))
+      .filter((value): value is string | Role => Boolean(value)),
+  );
+}
+
+export default async function FileLibraryFolderPage({
+  params,
+}: {
+  params: Promise<{ folderId: string }>;
+}) {
+  const { folderId } = await params;
+  if (!folderId) {
+    notFound();
+  }
+
+  const session = await requireAuth();
+  const canAccess = await hasPermission(session.user, "mitglieder.dateisystem");
+  const baseBreadcrumb = membersNavigationBreadcrumb("/mitglieder/dateisystem");
+
+  if (!canAccess) {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title="Dateisystem"
+          description="Du benötigst eine zusätzliche Freigabe, um diesen Ordner zu öffnen."
+          breadcrumbs={baseBreadcrumb ? [baseBreadcrumb] : []}
+          actions={
+            <Button asChild variant="outline">
+              <Link href="/mitglieder/dateisystem">
+                <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+              </Link>
+            </Button>
+          }
+        />
+        <Card>
+          <CardContent className="py-10 text-sm text-muted-foreground">
+            Bitte kontaktiere das Admin-Team, um Zugriff auf das Dateisystem zu erhalten.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const folder = await loadFolderWithDetails(folderId);
+  if (!folder) {
+    notFound();
+  }
+
+  const currentUser = session.user ?? { id: null };
+  const accessContext = await resolveFileLibraryAccessContext(currentUser);
+  const canViewFolder = await userHasFileLibraryAccess(currentUser, folder, "view", accessContext);
+
+  const trail = await getFolderBreadcrumb(folder.id);
+  const breadcrumbs = [baseBreadcrumb, ...trail.map((entry) => ({ id: entry.id, label: entry.name }))].filter(Boolean);
+  const breadcrumbItems = createMembersBreadcrumbItems(
+    breadcrumbs.map((entry, index) => {
+      if (!entry) return null;
+      const href =
+        index === 0
+          ? (entry as { href?: string }).href ?? "/mitglieder/dateisystem"
+          : `/mitglieder/dateisystem/${entry.id}`;
+      const isCurrent = index === breadcrumbs.length - 1;
+      return {
+        id: `folder-${entry.id ?? href}`,
+        label: entry.label,
+        href: isCurrent ? undefined : href,
+        isCurrent,
+      };
+    }),
+  );
+
+  if (!canViewFolder) {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title={folder.name}
+          description="Dir fehlt die Freigabe, um diesen Ordner einzusehen."
+          breadcrumbs={breadcrumbItems}
+          actions={
+            <Button asChild variant="outline">
+              <Link href="/mitglieder/dateisystem">
+                <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+              </Link>
+            </Button>
+          }
+        />
+        <Card>
+          <CardContent className="py-10 text-sm text-muted-foreground">
+            Frage bitte im Admin-Team nach einer entsprechenden Freigabe.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const [rawItems, appRoles] = await Promise.all([
+    loadFolderItems(folder.id),
+    prisma.appRole.findMany({ orderBy: { sortIndex: "asc" }, select: { id: true, name: true } }),
+  ]);
+
+  const canUpload = await userHasFileLibraryAccess(currentUser, folder, "upload", accessContext);
+  const canDownload = await userHasFileLibraryAccess(currentUser, folder, "download", accessContext);
+  const canManage = accessContext.canManage;
+  const userId = session.user?.id ?? "";
+
+  const initialItems: FileLibraryItemEntry[] = rawItems.map((item) => ({
+    id: item.id,
+    fileName: item.fileName,
+    mimeType: item.mimeType,
+    fileSize: item.fileSize,
+    description: item.description ?? null,
+    createdAt: item.createdAt.toISOString(),
+    uploadedBy: item.uploadedBy
+      ? { id: item.uploadedBy.id, name: item.uploadedBy.name, email: item.uploadedBy.email }
+      : null,
+    downloadUrl: `/api/file-library/items/${item.id}/file`,
+    canDelete: canManage || item.uploadedById === userId,
+  }));
+
+  const stats = computeFolderStats(
+    rawItems.map((item) => ({
+      id: item.id,
+      fileName: item.fileName,
+      mimeType: item.mimeType,
+      fileSize: item.fileSize,
+      description: item.description ?? null,
+      uploadedById: item.uploadedById,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+      uploadedBy: item.uploadedBy,
+    })),
+  );
+
+  const appRoleNames = new Map(appRoles.map((role) => [role.id, role.name ?? "Unbenannte Gruppe"]));
+
+  const viewSystemRoles = collectRoleSet(folder.accessRules, FileLibraryAccessType.VIEW, FileLibraryAccessTargetType.SYSTEM_ROLE) as Set<Role>;
+  const downloadSystemRoles = collectRoleSet(
+    folder.accessRules,
+    FileLibraryAccessType.DOWNLOAD,
+    FileLibraryAccessTargetType.SYSTEM_ROLE,
+  ) as Set<Role>;
+  const uploadSystemRoles = collectRoleSet(
+    folder.accessRules,
+    FileLibraryAccessType.UPLOAD,
+    FileLibraryAccessTargetType.SYSTEM_ROLE,
+  ) as Set<Role>;
+
+  const viewAppRoles = collectRoleSet(
+    folder.accessRules,
+    FileLibraryAccessType.VIEW,
+    FileLibraryAccessTargetType.APP_ROLE,
+  ) as Set<string>;
+  const downloadAppRoles = collectRoleSet(
+    folder.accessRules,
+    FileLibraryAccessType.DOWNLOAD,
+    FileLibraryAccessTargetType.APP_ROLE,
+  ) as Set<string>;
+  const uploadAppRoles = collectRoleSet(
+    folder.accessRules,
+    FileLibraryAccessType.UPLOAD,
+    FileLibraryAccessTargetType.APP_ROLE,
+  ) as Set<string>;
+
+  const childFolders = [] as {
+    id: string;
+    name: string;
+    description: string | null;
+    fileCount: number;
+    totalSize: number;
+    latestUpload: Date | null;
+    accessLabel: string;
+  }[];
+
+  for (const child of folder.children) {
+    const canViewChild = await userHasFileLibraryAccess(currentUser, child, "view", accessContext);
+    if (!canViewChild) continue;
+
+    let totalSize = 0;
+    let latest: Date | null = null;
+    for (const file of child.files) {
+      totalSize += file.fileSize;
+      const created = new Date(file.createdAt);
+      if (!latest || created > latest) {
+        latest = created;
+      }
+    }
+
+    childFolders.push({
+      id: child.id,
+      name: child.name,
+      description: child.description,
+      fileCount: child.files.length,
+      totalSize,
+      latestUpload: latest,
+      accessLabel: summarizeViewAccess(child, appRoleNames),
+    });
+  }
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={folder.name}
+        description={folder.description ?? ""}
+        breadcrumbs={breadcrumbItems}
+        actions={
+          <Button asChild variant="outline">
+            <Link href="/mitglieder/dateisystem">
+              <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+            </Link>
+          </Button>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,3fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Ordnerinformationen</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              Dateien: <span className="text-foreground">{stats.fileCount}</span>
+            </p>
+            <p>
+              Gesamtgröße: <span className="text-foreground">{formatFileLibraryFileSize(stats.totalSize)}</span>
+            </p>
+            <p>Letztes Update: {formatLatest(stats.latestUpload)}</p>
+            <p>
+              Uploads erlaubt:{" "}
+              {folder.allowAllUpload
+                ? "Alle Mitglieder"
+                : uploadSystemRoles.size + uploadAppRoles.size > 0
+                  ? `${uploadSystemRoles.size + uploadAppRoles.size} definierte Freigaben`
+                  : "Keine"}
+            </p>
+            <p>
+              Downloads erlaubt:{" "}
+              {folder.allowAllDownload
+                ? "Alle Mitglieder"
+                : downloadSystemRoles.size + downloadAppRoles.size > 0
+                  ? `${downloadSystemRoles.size + downloadAppRoles.size} definierte Freigaben`
+                  : "Keine"}
+            </p>
+            <p>Zugriff sichtbar: {summarizeViewAccess(folder, appRoleNames)}</p>
+          </CardContent>
+        </Card>
+
+        {canManage ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Unterordner erstellen</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form action={createFileLibraryFolder} className="space-y-4">
+                <input type="hidden" name="parentId" value={folder.id} />
+                <div className="grid gap-2">
+                  <Label htmlFor="subfolder-name">Name</Label>
+                  <Input id="subfolder-name" name="name" required maxLength={120} placeholder="z. B. Verträge" />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="subfolder-description">Beschreibung (optional)</Label>
+                  <Textarea
+                    id="subfolder-description"
+                    name="description"
+                    maxLength={500}
+                    placeholder="Kurze Hinweise zum Ordnerinhalt"
+                  />
+                </div>
+                <div className="flex justify-end">
+                  <Button type="submit">Unterordner anlegen</Button>
+                </div>
+              </form>
+            </CardContent>
+          </Card>
+        ) : null}
+      </div>
+
+      {childFolders.length ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Unterordner</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {childFolders.map((child) => (
+                <Card key={child.id} className="flex h-full flex-col justify-between border border-border/60">
+                  <CardHeader className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <CardTitle className="text-base font-semibold">{child.name}</CardTitle>
+                      <Badge variant="outline">{child.fileCount} Dateien</Badge>
+                    </div>
+                    {child.description ? (
+                      <p className="text-sm text-muted-foreground">{child.description}</p>
+                    ) : null}
+                  </CardHeader>
+                  <CardContent className="space-y-3 text-sm text-muted-foreground">
+                    <p>Speicher: {formatFileLibraryFileSize(child.totalSize)}</p>
+                    <p>Letztes Update: {formatLatest(child.latestUpload)}</p>
+                    <p>Zugriff: {child.accessLabel}</p>
+                    <Button asChild>
+                      <Link href={`/mitglieder/dateisystem/${child.id}`}>Ordner öffnen</Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {canManage ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Zugriffsrechte verwalten</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form action={updateFileLibraryPermissions} className="space-y-6">
+              <input type="hidden" name="folderId" value={folder.id} />
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label className="font-semibold">Ansehen</Label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input type="checkbox" name="allowAllView" defaultChecked={folder.allowAllView} className="h-4 w-4" />
+                    Alle Mitglieder dürfen diesen Ordner sehen
+                  </label>
+                  <div className="grid gap-2 pl-1 text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">Systemrollen</p>
+                    <div className="grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                      {ROLES.map((role) => (
+                        <label key={`view-${role}`} className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            name="viewSystemRoles"
+                            value={role}
+                            defaultChecked={viewSystemRoles.has(role)}
+                            className="h-4 w-4"
+                          />
+                          {ROLE_LABELS[role] ?? role}
+                        </label>
+                      ))}
+                    </div>
+                    <p className="font-medium text-foreground">Gruppenrollen</p>
+                    <div className="grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                      {appRoles.map((role) => (
+                        <label key={`view-app-${role.id}`} className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            name="viewAppRoles"
+                            value={role.id}
+                            defaultChecked={viewAppRoles.has(role.id)}
+                            className="h-4 w-4"
+                          />
+                          {role.name ?? "Unbenannte Gruppe"}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label className="font-semibold">Downloads</Label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      name="allowAllDownload"
+                      defaultChecked={folder.allowAllDownload}
+                      className="h-4 w-4"
+                    />
+                    Alle Mitglieder dürfen Dateien herunterladen
+                  </label>
+                  <div className="grid gap-2 pl-1 text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">Systemrollen</p>
+                    <div className="grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                      {ROLES.map((role) => (
+                        <label key={`download-${role}`} className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            name="downloadSystemRoles"
+                            value={role}
+                            defaultChecked={downloadSystemRoles.has(role)}
+                            className="h-4 w-4"
+                          />
+                          {ROLE_LABELS[role] ?? role}
+                        </label>
+                      ))}
+                    </div>
+                    <p className="font-medium text-foreground">Gruppenrollen</p>
+                    <div className="grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                      {appRoles.map((role) => (
+                        <label key={`download-app-${role.id}`} className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            name="downloadAppRoles"
+                            value={role.id}
+                            defaultChecked={downloadAppRoles.has(role.id)}
+                            className="h-4 w-4"
+                          />
+                          {role.name ?? "Unbenannte Gruppe"}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label className="font-semibold">Uploads</Label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      name="allowAllUpload"
+                      defaultChecked={folder.allowAllUpload}
+                      className="h-4 w-4"
+                    />
+                    Alle Mitglieder dürfen Dateien hochladen
+                  </label>
+                  <div className="grid gap-2 pl-1 text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">Systemrollen</p>
+                    <div className="grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                      {ROLES.map((role) => (
+                        <label key={`upload-${role}`} className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            name="uploadSystemRoles"
+                            value={role}
+                            defaultChecked={uploadSystemRoles.has(role)}
+                            className="h-4 w-4"
+                          />
+                          {ROLE_LABELS[role] ?? role}
+                        </label>
+                      ))}
+                    </div>
+                    <p className="font-medium text-foreground">Gruppenrollen</p>
+                    <div className="grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                      {appRoles.map((role) => (
+                        <label key={`upload-app-${role.id}`} className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            name="uploadAppRoles"
+                            value={role.id}
+                            defaultChecked={uploadAppRoles.has(role.id)}
+                            className="h-4 w-4"
+                          />
+                          {role.name ?? "Unbenannte Gruppe"}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="flex justify-end">
+                <Button type="submit">Speichern</Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <FileLibraryManager
+        folderId={folder.id}
+        canUpload={canUpload}
+        canDownload={canDownload}
+        canManage={canManage}
+        initialItems={initialItems}
+      />
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/dateisystem/actions.ts
+++ b/src/app/(members)/mitglieder/dateisystem/actions.ts
@@ -1,0 +1,206 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { ROLES, type Role } from "@/lib/roles";
+import {
+  FileLibraryAccessTargetType,
+  FileLibraryAccessType,
+} from "@prisma/client";
+
+const folderSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(2, "Bitte gib einen Namen mit mindestens 2 Zeichen ein.")
+    .max(120),
+  description: z.string().trim().max(500).optional(),
+  parentId: z.string().trim().min(1).optional(),
+});
+
+function parseCheckboxArray(values: FormDataEntryValue[]): string[] {
+  const entries: string[] = [];
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      entries.push(value.trim());
+    }
+  }
+  return Array.from(new Set(entries));
+}
+
+function normalizeSystemRoles(values: FormDataEntryValue[]): Role[] {
+  const normalized = parseCheckboxArray(values);
+  const allowed = new Set<Role>(ROLES);
+  return normalized.filter((value): value is Role => allowed.has(value as Role));
+}
+
+async function filterValidAppRoleIds(ids: string[]) {
+  if (!ids.length) return [] as string[];
+  const rows = await prisma.appRole.findMany({
+    where: { id: { in: ids } },
+    select: { id: true },
+  });
+  const allowed = new Set(rows.map((row) => row.id));
+  return ids.filter((id) => allowed.has(id));
+}
+
+export async function createFileLibraryFolder(formData: FormData) {
+  const session = await requireAuth();
+  const canManage = await hasPermission(session.user, "mitglieder.dateisystem.manage");
+  if (!canManage) {
+    throw new Error("Keine Berechtigung");
+  }
+
+  const parsed = folderSchema.safeParse({
+    name: formData.get("name"),
+    description: formData.get("description"),
+    parentId: formData.get("parentId") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message ?? "Eingabe ungültig");
+  }
+
+  const data = parsed.data;
+  const parentId = data.parentId?.trim() || null;
+
+  if (parentId) {
+    const parentExists = await prisma.fileLibraryFolder.findUnique({
+      where: { id: parentId },
+      select: { id: true },
+    });
+    if (!parentExists) {
+      throw new Error("Übergeordneter Ordner wurde nicht gefunden.");
+    }
+  }
+
+  const folder = await prisma.fileLibraryFolder.create({
+    data: {
+      name: data.name,
+      description: data.description?.trim() || null,
+      parentId,
+      createdById: session.user?.id ?? null,
+    },
+    select: { id: true },
+  });
+
+  const basePath = "/mitglieder/dateisystem";
+  if (parentId) {
+    revalidatePath(`${basePath}/${parentId}`);
+  }
+  revalidatePath(basePath);
+
+  redirect(`${basePath}/${folder.id}`);
+}
+
+export async function updateFileLibraryPermissions(formData: FormData) {
+  const session = await requireAuth();
+  const canManage = await hasPermission(session.user, "mitglieder.dateisystem.manage");
+  if (!canManage) {
+    throw new Error("Keine Berechtigung");
+  }
+
+  const rawFolderId = formData.get("folderId");
+  const folderId = typeof rawFolderId === "string" ? rawFolderId.trim() : "";
+  if (!folderId) {
+    throw new Error("Ordnerkennung fehlt");
+  }
+
+  const folder = await prisma.fileLibraryFolder.findUnique({
+    where: { id: folderId },
+    select: { id: true },
+  });
+
+  if (!folder) {
+    throw new Error("Ordner nicht gefunden");
+  }
+
+  const allowAllView = Boolean(formData.get("allowAllView"));
+  const allowAllDownload = Boolean(formData.get("allowAllDownload"));
+  const allowAllUpload = Boolean(formData.get("allowAllUpload"));
+
+  const viewSystemRoles = normalizeSystemRoles(formData.getAll("viewSystemRoles"));
+  const downloadSystemRoles = normalizeSystemRoles(formData.getAll("downloadSystemRoles"));
+  const uploadSystemRoles = normalizeSystemRoles(formData.getAll("uploadSystemRoles"));
+
+  const viewAppRoles = await filterValidAppRoleIds(parseCheckboxArray(formData.getAll("viewAppRoles")));
+  const downloadAppRoles = await filterValidAppRoleIds(parseCheckboxArray(formData.getAll("downloadAppRoles")));
+  const uploadAppRoles = await filterValidAppRoleIds(parseCheckboxArray(formData.getAll("uploadAppRoles")));
+
+  await prisma.$transaction(async (tx) => {
+    await tx.fileLibraryFolder.update({
+      where: { id: folderId },
+      data: {
+        allowAllView,
+        allowAllDownload,
+        allowAllUpload,
+      },
+    });
+
+    const configurations: {
+      accessType: FileLibraryAccessType;
+      allowAll: boolean;
+      systemRoles: Role[];
+      appRoles: string[];
+    }[] = [
+      {
+        accessType: FileLibraryAccessType.VIEW,
+        allowAll: allowAllView,
+        systemRoles: viewSystemRoles,
+        appRoles: viewAppRoles,
+      },
+      {
+        accessType: FileLibraryAccessType.DOWNLOAD,
+        allowAll: allowAllDownload,
+        systemRoles: downloadSystemRoles,
+        appRoles: downloadAppRoles,
+      },
+      {
+        accessType: FileLibraryAccessType.UPLOAD,
+        allowAll: allowAllUpload,
+        systemRoles: uploadSystemRoles,
+        appRoles: uploadAppRoles,
+      },
+    ];
+
+    for (const config of configurations) {
+      await tx.fileLibraryFolderAccess.deleteMany({
+        where: { folderId, accessType: config.accessType },
+      });
+
+      if (config.allowAll) {
+        continue;
+      }
+
+      const entries = [
+        ...config.systemRoles.map((role) => ({
+          folderId,
+          accessType: config.accessType,
+          targetType: FileLibraryAccessTargetType.SYSTEM_ROLE,
+          systemRole: role,
+          appRoleId: null,
+        })),
+        ...config.appRoles.map((roleId) => ({
+          folderId,
+          accessType: config.accessType,
+          targetType: FileLibraryAccessTargetType.APP_ROLE,
+          systemRole: null,
+          appRoleId: roleId,
+        })),
+      ];
+
+      if (entries.length) {
+        await tx.fileLibraryFolderAccess.createMany({ data: entries });
+      }
+    }
+  });
+
+  const basePath = "/mitglieder/dateisystem";
+  revalidatePath(basePath);
+  revalidatePath(`${basePath}/${folderId}`);
+}

--- a/src/app/(members)/mitglieder/dateisystem/page.tsx
+++ b/src/app/(members)/mitglieder/dateisystem/page.tsx
@@ -1,0 +1,222 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { PageHeader } from "@/components/members/page-header";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import {
+  formatFileLibraryFileSize,
+  resolveFileLibraryAccessContext,
+  userHasFileLibraryAccess,
+} from "@/lib/file-library";
+import { ROLE_LABELS, type Role } from "@/lib/roles";
+import { FileLibraryAccessTargetType } from "@prisma/client";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import { formatRelativeWithAbsolute } from "@/lib/datetime";
+import { createFileLibraryFolder } from "./actions";
+
+export const metadata: Metadata = {
+  title: "Dateisystem",
+  description:
+    "Verwalte gemeinsame Dokumente, teile Dateien in strukturierten Ordnern und steuere zielgerichtete Freigaben für das Ensemble.",
+};
+
+function summarizeViewAccess(
+  folder: {
+    allowAllView: boolean;
+    accessRules: { targetType: FileLibraryAccessTargetType; systemRole: Role | null; appRoleId: string | null }[];
+  },
+  appRoleNames: Map<string, string>,
+) {
+  if (folder.allowAllView) {
+    return "Alle Mitglieder";
+  }
+  const entries = folder.accessRules
+    .filter((rule) => rule.targetType === FileLibraryAccessTargetType.SYSTEM_ROLE)
+    .map((rule) => {
+      const label = rule.systemRole ? ROLE_LABELS[rule.systemRole] : null;
+      return label ?? rule.systemRole ?? "Unbekannte Rolle";
+    });
+  const appRoleEntries = folder.accessRules
+    .filter((rule) => rule.targetType === FileLibraryAccessTargetType.APP_ROLE)
+    .map((rule) => (rule.appRoleId ? appRoleNames.get(rule.appRoleId) ?? "Unbenannte Gruppe" : "Unbenannte Gruppe"));
+  const labels = [...entries, ...appRoleEntries];
+  if (!labels.length) {
+    return "Keine Freigaben";
+  }
+  return labels.join(", ");
+}
+
+const latestFormatter = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatLatest(date: Date | null) {
+  if (!date) {
+    return "Noch keine Uploads";
+  }
+  return formatRelativeWithAbsolute(date, {
+    absoluteFormatter: latestFormatter,
+  }).combined;
+}
+
+export default async function FileLibraryOverviewPage() {
+  const session = await requireAuth();
+  const canAccess = await hasPermission(session.user, "mitglieder.dateisystem");
+  const baseBreadcrumb = membersNavigationBreadcrumb("/mitglieder/dateisystem");
+
+  if (!canAccess) {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title="Dateisystem"
+          description="Du benötigst eine zusätzliche Freigabe, um auf das Dateisystem zugreifen zu können."
+          breadcrumbs={baseBreadcrumb ? [baseBreadcrumb] : []}
+        />
+        <Card>
+          <CardContent className="py-10 text-sm text-muted-foreground">
+            Ohne entsprechende Berechtigung bleibt das Dateisystem im Mitgliederbereich ausgeblendet.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const currentUser = session.user ?? { id: null };
+  const accessContext = await resolveFileLibraryAccessContext(currentUser);
+
+  const [folders, appRoles] = await Promise.all([
+    prisma.fileLibraryFolder.findMany({
+      where: { parentId: null },
+      include: {
+        accessRules: true,
+        files: { select: { id: true, fileSize: true, createdAt: true } },
+      },
+      orderBy: { name: "asc" },
+    }),
+    prisma.appRole.findMany({ orderBy: { sortIndex: "asc" }, select: { id: true, name: true } }),
+  ]);
+
+  const appRoleNames = new Map(appRoles.map((role) => [role.id, role.name ?? "Unbenannte Gruppe"]));
+
+  const accessible = [] as {
+    id: string;
+    name: string;
+    description: string | null;
+    fileCount: number;
+    totalSize: number;
+    latestUpload: Date | null;
+    accessLabel: string;
+  }[];
+
+  for (const folder of folders) {
+    const canViewFolder = await userHasFileLibraryAccess(currentUser, folder, "view", accessContext);
+    if (!canViewFolder) continue;
+
+    let totalSize = 0;
+    let latest: Date | null = null;
+    for (const file of folder.files) {
+      totalSize += file.fileSize;
+      const created = new Date(file.createdAt);
+      if (!latest || created > latest) {
+        latest = created;
+      }
+    }
+
+    accessible.push({
+      id: folder.id,
+      name: folder.name,
+      description: folder.description,
+      fileCount: folder.files.length,
+      totalSize,
+      latestUpload: latest,
+      accessLabel: summarizeViewAccess(folder, appRoleNames),
+    });
+  }
+
+  const canManage = accessContext.canManage;
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Dateisystem"
+        description="Organisiere Dateien in strukturierten Ordnern, teile Unterlagen mit ausgewählten Rollen und behalte Freigaben im Blick."
+        breadcrumbs={baseBreadcrumb ? [baseBreadcrumb] : []}
+      />
+
+      {canManage ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Neuen Hauptordner anlegen</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form action={createFileLibraryFolder} className="space-y-4">
+              <div className="grid gap-2">
+                <Label htmlFor="file-library-name">Name</Label>
+                <Input id="file-library-name" name="name" required maxLength={120} placeholder="z. B. Verträge" />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="file-library-description">Beschreibung (optional)</Label>
+                <Textarea
+                  id="file-library-description"
+                  name="description"
+                  maxLength={500}
+                  placeholder="Kurze Hinweise zum Inhalt des Ordners"
+                />
+              </div>
+              <div className="flex justify-end">
+                <Button type="submit">Ordner erstellen</Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {accessible.length ? (
+        <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+          {accessible.map((folder) => (
+            <Card key={folder.id} className="flex h-full flex-col justify-between">
+              <CardHeader className="space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <CardTitle className="text-lg font-semibold">{folder.name}</CardTitle>
+                  <Badge variant="outline">{folder.fileCount} Dateien</Badge>
+                </div>
+                {folder.description ? (
+                  <p className="text-sm text-muted-foreground">{folder.description}</p>
+                ) : null}
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-1 text-sm text-muted-foreground">
+                  <p>
+                    Speicher: <span className="text-foreground">{formatFileLibraryFileSize(folder.totalSize)}</span>
+                  </p>
+                  <p>Letztes Update: {formatLatest(folder.latestUpload)}</p>
+                  <p>Zugriff: {folder.accessLabel}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button asChild>
+                    <Link href={`/mitglieder/dateisystem/${folder.id}`}>Ordner öffnen</Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <Card>
+          <CardContent className="py-10 text-sm text-muted-foreground">
+            Aktuell sind keine freigegebenen Ordner sichtbar. Bitte wende dich an das Admin-Team, wenn du Zugriff benötigst.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/file-library/folders/[folderId]/route.ts
+++ b/src/app/api/file-library/folders/[folderId]/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Buffer } from "node:buffer";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import {
+  MAX_FILE_LIBRARY_DESCRIPTION_LENGTH,
+  MAX_FILE_LIBRARY_FILE_BYTES,
+  MAX_FILE_LIBRARY_FILES_PER_UPLOAD,
+  resolveFileLibraryAccessContext,
+  userHasFileLibraryAccess,
+} from "@/lib/file-library";
+import { revalidatePath } from "next/cache";
+
+function isFileLike(value: unknown): value is File {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as File).arrayBuffer === "function" &&
+    typeof (value as File).size === "number"
+  );
+}
+
+function normalizeDescription(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, MAX_FILE_LIBRARY_DESCRIPTION_LENGTH);
+}
+
+function sanitizeFilename(name: string) {
+  const fallback = "datei";
+  const trimmed = name?.trim();
+  if (!trimmed) return fallback;
+  return trimmed.replace(/[\\/:*?"<>|]+/g, "-").slice(0, 160) || fallback;
+}
+
+export async function POST(request: NextRequest, context: { params: Promise<{ folderId: string }> }) {
+  const { folderId } = await context.params;
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const currentUser = session.user ?? { id: null };
+
+  const [canAccessArea, folder] = await Promise.all([
+    hasPermission(session.user, "mitglieder.dateisystem"),
+    prisma.fileLibraryFolder.findUnique({
+      where: { id: folderId },
+      include: { accessRules: true },
+    }),
+  ]);
+
+  if (!canAccessArea || !folder) {
+    return NextResponse.json({ error: "Keine Berechtigung" }, { status: 403 });
+  }
+
+  const accessContext = await resolveFileLibraryAccessContext(currentUser);
+  const canUpload = await userHasFileLibraryAccess(currentUser, folder, "upload", accessContext);
+
+  if (!canUpload) {
+    return NextResponse.json({ error: "Keine Berechtigung zum Hochladen" }, { status: 403 });
+  }
+
+  const formData = await request.formData();
+  const files = formData.getAll("files").filter(isFileLike) as File[];
+  const descriptionEntries = formData.getAll("descriptions").map((entry) =>
+    typeof entry === "string" ? entry : "",
+  );
+
+  if (!files.length) {
+    return NextResponse.json({ error: "Bitte wähle mindestens eine Datei aus." }, { status: 400 });
+  }
+
+  if (files.length > MAX_FILE_LIBRARY_FILES_PER_UPLOAD) {
+    return NextResponse.json(
+      { error: `Es können maximal ${MAX_FILE_LIBRARY_FILES_PER_UPLOAD} Dateien auf einmal hochgeladen werden.` },
+      { status: 400 },
+    );
+  }
+
+  const payloads: { file: File; description: string | null; fileName: string; mimeType: string }[] = [];
+  const errors: string[] = [];
+
+  files.forEach((file, index) => {
+    if (file.size <= 0) {
+      errors.push(`${file.name || "Unbenannte Datei"}: Datei ist leer.`);
+      return;
+    }
+    if (file.size > MAX_FILE_LIBRARY_FILE_BYTES) {
+      errors.push(
+        `${file.name || "Unbenannte Datei"}: Datei ist zu groß (maximal ${Math.floor(MAX_FILE_LIBRARY_FILE_BYTES / (1024 * 1024))} MB).`,
+      );
+      return;
+    }
+
+    const description = normalizeDescription(descriptionEntries[index]);
+    const fileName = sanitizeFilename(file.name || "datei");
+    const mimeType = file.type?.trim() || "application/octet-stream";
+
+    payloads.push({ file, description, fileName, mimeType });
+  });
+
+  if (errors.length) {
+    return NextResponse.json({ error: errors.join(" ") }, { status: 400 });
+  }
+
+  try {
+    const created = await Promise.all(
+      payloads.map(async ({ file, description, fileName, mimeType }) => {
+        const buffer = Buffer.from(await file.arrayBuffer());
+        return prisma.fileLibraryItem.create({
+          data: {
+            folderId,
+            description,
+            fileName,
+            mimeType,
+            fileSize: buffer.length,
+            data: buffer,
+            uploadedById: userId,
+          },
+          include: { uploadedBy: { select: { id: true, name: true, email: true } } },
+        });
+      }),
+    );
+
+    const items = created.map((item) => ({
+      id: item.id,
+      fileName: item.fileName,
+      mimeType: item.mimeType,
+      fileSize: item.fileSize,
+      description: item.description ?? null,
+      createdAt: item.createdAt.toISOString(),
+      uploadedBy: item.uploadedBy
+        ? { id: item.uploadedBy.id, name: item.uploadedBy.name, email: item.uploadedBy.email }
+        : null,
+      downloadUrl: `/api/file-library/items/${item.id}/file`,
+      canDelete: true,
+    }));
+
+    revalidatePath(`/mitglieder/dateisystem/${folderId}`);
+    revalidatePath("/mitglieder/dateisystem");
+
+    return NextResponse.json({ items });
+  } catch (error) {
+    console.error("[file-library] upload", error);
+    return NextResponse.json(
+      { error: "Upload fehlgeschlagen. Bitte versuche es erneut." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/file-library/items/[id]/file/route.ts
+++ b/src/app/api/file-library/items/[id]/file/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Buffer } from "node:buffer";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { resolveFileLibraryAccessContext, userHasFileLibraryAccess } from "@/lib/file-library";
+
+function buildContentDisposition(filename: string) {
+  const encoded = encodeURIComponent(filename);
+  const fallback = filename.replace(/"/g, "'");
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+export async function GET(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const session = await requireAuth();
+
+  const currentUser = session.user ?? { id: null };
+  const canAccessArea = await hasPermission(session.user, "mitglieder.dateisystem");
+  if (!canAccessArea) {
+    return NextResponse.json({ error: "Keine Berechtigung" }, { status: 403 });
+  }
+
+  const item = await prisma.fileLibraryItem.findUnique({
+    where: { id },
+    include: {
+      folder: { include: { accessRules: true } },
+    },
+  });
+
+  if (!item || !item.data) {
+    return NextResponse.json({ error: "Datei nicht gefunden" }, { status: 404 });
+  }
+
+  const accessContext = await resolveFileLibraryAccessContext(currentUser);
+  const canDownload = await userHasFileLibraryAccess(currentUser, item.folder, "download", accessContext);
+  const canView = await userHasFileLibraryAccess(currentUser, item.folder, "view", accessContext);
+
+  if (!canView || !canDownload) {
+    return NextResponse.json({ error: "Keine Berechtigung" }, { status: 403 });
+  }
+
+  const headers = new Headers();
+  headers.set("Content-Type", item.mimeType);
+  headers.set("Content-Length", String(item.fileSize));
+  headers.set("Content-Disposition", buildContentDisposition(item.fileName));
+  headers.set("Cache-Control", "private, max-age=0, must-revalidate");
+  headers.set("Last-Modified", item.updatedAt.toUTCString());
+
+  const buffer = item.data instanceof Buffer ? item.data : Buffer.from(item.data);
+  const body = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+
+  return new NextResponse(body, { status: 200, headers });
+}

--- a/src/app/api/file-library/items/[id]/route.ts
+++ b/src/app/api/file-library/items/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+import { resolveFileLibraryAccessContext, userHasFileLibraryAccess } from "@/lib/file-library";
+import { revalidatePath } from "next/cache";
+
+export async function DELETE(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id } = await context.params;
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const canAccessArea = await hasPermission(session.user, "mitglieder.dateisystem");
+  if (!canAccessArea) {
+    return NextResponse.json({ error: "Keine Berechtigung" }, { status: 403 });
+  }
+
+  const item = await prisma.fileLibraryItem.findUnique({
+    where: { id },
+    include: {
+      folder: { include: { accessRules: true } },
+    },
+  });
+
+  if (!item) {
+    return NextResponse.json({ error: "Datei nicht gefunden" }, { status: 404 });
+  }
+
+  const currentUser = session.user ?? { id: null };
+  const accessContext = await resolveFileLibraryAccessContext(currentUser);
+  const canManage = accessContext.canManage;
+  const canUpload = await userHasFileLibraryAccess(currentUser, item.folder, "upload", accessContext);
+  const canView = await userHasFileLibraryAccess(currentUser, item.folder, "view", accessContext);
+
+  if (!canView) {
+    return NextResponse.json({ error: "Keine Berechtigung" }, { status: 403 });
+  }
+
+  if (!canManage && (!canUpload || item.uploadedById !== userId)) {
+    return NextResponse.json({ error: "Nur eigene Uploads können gelöscht werden." }, { status: 403 });
+  }
+
+  try {
+    await prisma.fileLibraryItem.delete({ where: { id } });
+    revalidatePath(`/mitglieder/dateisystem/${item.folderId}`);
+    revalidatePath("/mitglieder/dateisystem");
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("[file-library] delete", error);
+    return NextResponse.json({ error: "Löschen fehlgeschlagen." }, { status: 500 });
+  }
+}

--- a/src/components/members/file-library/file-library-manager.tsx
+++ b/src/components/members/file-library/file-library-manager.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { FileText, Loader2, Trash2, UploadCloud } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import {
+  FILE_LIBRARY_ACCEPT_MIME_TYPES,
+  MAX_FILE_LIBRARY_DESCRIPTION_LENGTH,
+  MAX_FILE_LIBRARY_FILE_BYTES,
+  MAX_FILE_LIBRARY_FILES_PER_UPLOAD,
+  formatFileLibraryFileSize,
+} from "@/lib/file-library";
+
+const ACCEPT_SET = new Set(FILE_LIBRARY_ACCEPT_MIME_TYPES.map((entry) => entry.toLowerCase()));
+
+export type FileLibraryItemEntry = {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+  description: string | null;
+  createdAt: string;
+  uploadedBy: {
+    id: string | null;
+    name: string | null;
+    email: string | null;
+  } | null;
+  downloadUrl: string;
+  canDelete: boolean;
+};
+
+type FileLibraryManagerProps = {
+  folderId: string;
+  canUpload: boolean;
+  canDownload: boolean;
+  canManage: boolean;
+  initialItems: FileLibraryItemEntry[];
+};
+
+type UploadCandidate = {
+  file: File;
+  key: string;
+  description: string;
+};
+
+function getFileKey(file: File) {
+  return `${file.name}-${file.size}-${file.lastModified}`;
+}
+
+function mergeItems(existing: FileLibraryItemEntry[], incoming: FileLibraryItemEntry[]) {
+  const map = new Map<string, FileLibraryItemEntry>();
+  for (const item of incoming) {
+    map.set(item.id, item);
+  }
+  for (const item of existing) {
+    if (!map.has(item.id)) {
+      map.set(item.id, item);
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => {
+    const timeA = new Date(a.createdAt).getTime();
+    const timeB = new Date(b.createdAt).getTime();
+    return timeB - timeA;
+  });
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) {
+    return "Unbekannt";
+  }
+  return new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" }).format(date);
+}
+
+function resolveUploaderLabel(uploadedBy: FileLibraryItemEntry["uploadedBy"]) {
+  if (!uploadedBy) {
+    return "Unbekannt";
+  }
+  return uploadedBy.name?.trim() || uploadedBy.email?.trim() || "Unbekannt";
+}
+
+function isFileLike(value: unknown): value is File {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as File).arrayBuffer === "function" &&
+    typeof (value as File).size === "number"
+  );
+}
+
+export function FileLibraryManager({ folderId, canUpload, canDownload, canManage, initialItems }: FileLibraryManagerProps) {
+  const [items, setItems] = useState<FileLibraryItemEntry[]>(() =>
+    [...initialItems].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
+  );
+  const [selectedFiles, setSelectedFiles] = useState<UploadCandidate[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const dragCounterRef = useRef(0);
+
+  const selectedTotalSize = useMemo(
+    () => selectedFiles.reduce((total, entry) => total + entry.file.size, 0),
+    [selectedFiles],
+  );
+
+  const handleFileSelection = (incoming: File[]) => {
+    if (!incoming.length) {
+      return;
+    }
+
+    const nextFiles: UploadCandidate[] = [];
+    const rejected: string[] = [];
+    const existingKeys = new Set(selectedFiles.map((entry) => entry.key));
+
+    for (const file of incoming) {
+      const key = getFileKey(file);
+      if (existingKeys.has(key)) {
+        continue;
+      }
+
+      if (file.size > MAX_FILE_LIBRARY_FILE_BYTES) {
+        rejected.push(
+          `${file.name}: Datei ist zu groß (maximal ${Math.floor(MAX_FILE_LIBRARY_FILE_BYTES / (1024 * 1024))} MB).`,
+        );
+        continue;
+      }
+
+      const normalizedMime = file.type?.trim().toLowerCase();
+      if (normalizedMime && ACCEPT_SET.size && !ACCEPT_SET.has(normalizedMime)) {
+        rejected.push(`${file.name}: Dateityp wird nicht unterstützt.`);
+        continue;
+      }
+
+      nextFiles.push({ file, key, description: "" });
+      existingKeys.add(key);
+    }
+
+    if (rejected.length) {
+      toast.error(rejected.join(" "));
+    }
+
+    if (!nextFiles.length) {
+      return;
+    }
+
+    setSelectedFiles((previous) => {
+      const merged = [...previous, ...nextFiles];
+      if (merged.length > MAX_FILE_LIBRARY_FILES_PER_UPLOAD) {
+        toast.error(`Es können maximal ${MAX_FILE_LIBRARY_FILES_PER_UPLOAD} Dateien pro Upload ausgewählt werden.`);
+        return merged.slice(0, MAX_FILE_LIBRARY_FILES_PER_UPLOAD);
+      }
+      return merged;
+    });
+  };
+
+  const handleFileInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const list = Array.from(event.target.files ?? []);
+    if (list.length) {
+      handleFileSelection(list);
+    }
+    event.target.value = "";
+  };
+
+  const handleRemoveCandidate = (key: string) => {
+    setSelectedFiles((previous) => previous.filter((entry) => entry.key !== key));
+  };
+
+  const handleDescriptionChange = (key: string, value: string) => {
+    setSelectedFiles((previous) =>
+      previous.map((entry) =>
+        entry.key === key
+          ? { ...entry, description: value.slice(0, MAX_FILE_LIBRARY_DESCRIPTION_LENGTH) }
+          : entry,
+      ),
+    );
+  };
+
+  const handleUpload = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedFiles.length) {
+      toast.error("Bitte wähle mindestens eine Datei aus.");
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      selectedFiles.forEach((entry) => {
+        formData.append("files", entry.file);
+        formData.append("descriptions", entry.description ?? "");
+      });
+
+      const response = await fetch(`/api/file-library/folders/${folderId}`, {
+        method: "POST",
+        body: formData,
+      });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Upload fehlgeschlagen.");
+      }
+
+      const uploaded = Array.isArray(data?.items) ? (data.items as FileLibraryItemEntry[]) : [];
+      setItems((previous) => mergeItems(previous, uploaded));
+      setSelectedFiles([]);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      if (uploaded.length) {
+        toast.success(
+          uploaded.length === 1 ? "Datei wurde hochgeladen." : `${uploaded.length} Dateien wurden hochgeladen.`,
+        );
+      } else {
+        toast.success("Upload abgeschlossen.");
+      }
+    } catch (error) {
+      console.error("[file-library] upload", error);
+      toast.error(error instanceof Error ? error.message : "Upload fehlgeschlagen.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
+    try {
+      const response = await fetch(`/api/file-library/items/${id}`, { method: "DELETE" });
+      const data = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Löschen fehlgeschlagen.");
+      }
+      setItems((previous) => previous.filter((item) => item.id !== id));
+      toast.success("Datei wurde entfernt.");
+    } catch (error) {
+      console.error("[file-library] delete", error);
+      toast.error(error instanceof Error ? error.message : "Löschen fehlgeschlagen.");
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragCounterRef.current += 1;
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragging(false);
+    const files = Array.from(event.dataTransfer.files ?? []).filter(isFileLike);
+    if (files.length) {
+      handleFileSelection(files);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {canUpload ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Dateien hochladen</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleUpload} className="space-y-4">
+              <div
+                className={cn(
+                  "flex flex-col items-center justify-center gap-3 rounded-md border border-dashed border-border/70 bg-muted/40 p-6 text-center",
+                  isDragging && "border-primary bg-primary/10",
+                )}
+                onDragEnter={handleDragEnter}
+                onDragLeave={handleDragLeave}
+                onDragOver={handleDragOver}
+                onDrop={handleDrop}
+              >
+                <UploadCloud className="h-8 w-8 text-muted-foreground" aria-hidden />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">Dateien hierhin ziehen oder auswählen</p>
+                  <p className="text-xs text-muted-foreground">
+                    Unterstützte Formate: {FILE_LIBRARY_ACCEPT_MIME_TYPES.join(", ")}. Maximal {MAX_FILE_LIBRARY_FILES_PER_UPLOAD}
+                    {" "}
+                    Dateien pro Upload, je bis {Math.floor(MAX_FILE_LIBRARY_FILE_BYTES / (1024 * 1024))} MB.
+                  </p>
+                </div>
+                <div>
+                  <Input
+                    ref={fileInputRef}
+                    type="file"
+                    multiple
+                    accept={FILE_LIBRARY_ACCEPT_MIME_TYPES.join(",")}
+                    onChange={handleFileInputChange}
+                    className="hidden"
+                    id="file-library-upload"
+                  />
+                  <Label htmlFor="file-library-upload">
+                    <span className="inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90">
+                      Dateien auswählen
+                    </span>
+                  </Label>
+                </div>
+              </div>
+
+              {selectedFiles.length ? (
+                <div className="space-y-3 rounded-md border border-border/60 p-4">
+                  <div className="flex items-center justify-between text-sm">
+                    <span>{selectedFiles.length} Dateien ausgewählt</span>
+                    <span className="text-muted-foreground">Gesamt: {formatFileLibraryFileSize(selectedTotalSize)}</span>
+                  </div>
+                  <div className="space-y-4">
+                    {selectedFiles.map((entry) => (
+                      <div key={entry.key} className="space-y-2 rounded-md border border-border/50 p-3">
+                        <div className="flex items-center justify-between gap-3 text-sm">
+                          <span className="font-medium">{entry.file.name}</span>
+                          <Button type="button" size="sm" variant="ghost" onClick={() => handleRemoveCandidate(entry.key)}>
+                            Entfernen
+                          </Button>
+                        </div>
+                        <Textarea
+                          placeholder="Optionale Beschreibung"
+                          value={entry.description}
+                          maxLength={MAX_FILE_LIBRARY_DESCRIPTION_LENGTH}
+                          onChange={(event) => handleDescriptionChange(entry.key, event.target.value)}
+                          rows={2}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <div className="flex justify-end">
+                    <Button type="submit" disabled={uploading}>
+                      {uploading ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Upload läuft…
+                        </>
+                      ) : (
+                        "Upload starten"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+            </form>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Bestehende Dateien</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {items.length ? (
+            <div className="space-y-3">
+              {items.map((item) => (
+                <div key={item.id} className="flex flex-col gap-3 rounded-md border border-border/60 p-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex flex-1 items-start gap-3">
+                    <FileText className="mt-1 h-5 w-5 text-muted-foreground" aria-hidden />
+                    <div className="space-y-1">
+                      <p className="font-medium text-foreground">{item.fileName}</p>
+                      {item.description ? (
+                        <p className="text-sm text-muted-foreground">{item.description}</p>
+                      ) : null}
+                      <p className="text-xs text-muted-foreground">
+                        {formatFileLibraryFileSize(item.fileSize)} · {formatDateTime(item.createdAt)} · {resolveUploaderLabel(item.uploadedBy)}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {canDownload ? (
+                      <Button asChild size="sm" variant="outline">
+                        <a href={item.downloadUrl} target="_blank" rel="noreferrer">
+                          Herunterladen
+                        </a>
+                      </Button>
+                    ) : (
+                      <Button size="sm" variant="outline" disabled>
+                        Herunterladen
+                      </Button>
+                    )}
+                    {(canManage || item.canDelete) && (
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => handleDelete(item.id)}
+                        disabled={deletingId === item.id}
+                        aria-label="Datei löschen"
+                      >
+                        {deletingId === item.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Es wurden noch keine Dateien hochgeladen.</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -76,6 +76,15 @@ const ArchiveIcon = createMembersNavIcon(
   </>,
 );
 
+const FileLibraryIcon = createMembersNavIcon(
+  <>
+    <path d="M4 6a2 2 0 0 1 2-2h5l3 3h4a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2Z" />
+    <path d="M11 4v4h5" />
+    <path d="M8 13h8" />
+    <path d="M8 17h5" />
+  </>,
+);
+
 const IssuesIcon = createMembersNavIcon(
   <>
     <path d="M21 15a2 2 0 0 1-2 2H9l-4 4v-4H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z" />
@@ -355,6 +364,12 @@ export const membersNavigation = [
         label: "Archiv und Bilder",
         permissionKey: "mitglieder.galerie",
         icon: ArchiveIcon,
+      },
+      {
+        href: "/mitglieder/dateisystem",
+        label: "Dateisystem",
+        permissionKey: "mitglieder.dateisystem",
+        icon: FileLibraryIcon,
       },
       {
         href: "/mitglieder/sperrliste",

--- a/src/lib/file-library.ts
+++ b/src/lib/file-library.ts
@@ -1,0 +1,216 @@
+import { cache } from "react";
+
+import {
+  FileLibraryAccessTargetType,
+  FileLibraryAccessType,
+  type FileLibraryFolder,
+  type FileLibraryFolderAccess,
+  type FileLibraryItem,
+} from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { hasPermission, getPermissionRoleContext, type PermissionRoleContext } from "@/lib/permissions";
+import type { Role } from "@/lib/roles";
+
+export const FILE_LIBRARY_ACCEPT_MIME_TYPES = [
+  "application/pdf",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-powerpoint",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/zip",
+  "application/x-zip-compressed",
+  "text/plain",
+  "text/csv",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/svg+xml",
+  "video/mp4",
+  "audio/mpeg",
+];
+
+export const MAX_FILE_LIBRARY_FILE_BYTES = 50 * 1024 * 1024; // 50 MB
+export const MAX_FILE_LIBRARY_FILES_PER_UPLOAD = 10;
+export const MAX_FILE_LIBRARY_DESCRIPTION_LENGTH = 500;
+
+export type FileLibraryAccessKind = "view" | "download" | "upload";
+
+const ACCESS_KIND_TO_ENUM: Record<FileLibraryAccessKind, FileLibraryAccessType> = {
+  view: FileLibraryAccessType.VIEW,
+  download: FileLibraryAccessType.DOWNLOAD,
+  upload: FileLibraryAccessType.UPLOAD,
+};
+
+export type FileLibraryFolderWithAccess = FileLibraryFolder & {
+  accessRules: FileLibraryFolderAccess[];
+};
+
+export type FileLibraryItemSummary = Pick<
+  FileLibraryItem,
+  "id" | "fileName" | "fileSize" | "mimeType" | "description" | "uploadedById" | "createdAt" | "updatedAt"
+> & {
+  uploadedBy?: {
+    id: string | null;
+    name: string | null;
+    email: string | null;
+  } | null;
+};
+
+export type FileLibraryAccessContext = PermissionRoleContext & {
+  canManage: boolean;
+};
+
+function getAllowAllFlag(folder: FileLibraryFolder, kind: FileLibraryAccessKind) {
+  switch (kind) {
+    case "view":
+      return folder.allowAllView;
+    case "download":
+      return folder.allowAllDownload;
+    case "upload":
+      return folder.allowAllUpload;
+    default:
+      return false;
+  }
+}
+
+function matchesAccessRule(
+  context: PermissionRoleContext,
+  rule: FileLibraryFolderAccess,
+) {
+  if (rule.targetType === FileLibraryAccessTargetType.SYSTEM_ROLE && rule.systemRole) {
+    return context.systemRoles.includes(rule.systemRole as Role);
+  }
+  if (rule.targetType === FileLibraryAccessTargetType.APP_ROLE && rule.appRoleId) {
+    return context.customRoleIds.includes(rule.appRoleId);
+  }
+  return false;
+}
+
+export const resolveFileLibraryAccessContext = cache(async (user: { id?: string | null }) => {
+  const userLike = user?.id != null ? { id: user.id } : null;
+  const baseContext = await getPermissionRoleContext(userLike);
+  const canManage = await hasPermission(userLike, "mitglieder.dateisystem.manage");
+  return { ...baseContext, canManage } satisfies FileLibraryAccessContext;
+});
+
+export async function userHasFileLibraryAccess(
+  user: { id?: string | null },
+  folder: FileLibraryFolderWithAccess,
+  kind: FileLibraryAccessKind,
+  context?: FileLibraryAccessContext,
+) {
+  if (!user?.id) return false;
+  const resolved = context ?? (await resolveFileLibraryAccessContext(user));
+
+  if (resolved.canManage) {
+    return true;
+  }
+
+  const allowAll = getAllowAllFlag(folder, kind);
+  if (allowAll) {
+    return true;
+  }
+
+  const targetType = ACCESS_KIND_TO_ENUM[kind];
+  const relevantRules = folder.accessRules.filter((entry) => entry.accessType === targetType);
+  if (!relevantRules.length) {
+    return false;
+  }
+
+  return relevantRules.some((rule) => matchesAccessRule(resolved, rule));
+}
+
+export function formatFileLibraryFileSize(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let size = bytes;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  return `${size.toFixed(unitIndex === 0 ? 0 : size >= 10 ? 1 : 2)} ${units[unitIndex]}`;
+}
+
+export async function getFolderBreadcrumb(folderId: string) {
+  const breadcrumbs: { id: string; name: string }[] = [];
+  let currentId: string | null = folderId;
+
+  while (currentId) {
+    const folder: { id: string; name: string; parentId: string | null } | null =
+      await prisma.fileLibraryFolder.findUnique({
+        where: { id: currentId },
+        select: { id: true, name: true, parentId: true },
+      });
+    if (!folder) break;
+    breadcrumbs.unshift({ id: folder.id, name: folder.name });
+    currentId = folder.parentId;
+  }
+
+  return breadcrumbs;
+}
+
+export async function loadFolderWithDetails(folderId: string) {
+  return prisma.fileLibraryFolder.findUnique({
+    where: { id: folderId },
+    include: {
+      accessRules: true,
+      files: { select: { id: true, fileSize: true, createdAt: true } },
+      children: {
+        orderBy: { name: "asc" },
+        include: {
+          accessRules: true,
+          files: { select: { id: true, fileSize: true, createdAt: true } },
+        },
+      },
+    },
+  });
+}
+
+export async function loadFolderItems(folderId: string) {
+  return prisma.fileLibraryItem.findMany({
+    where: { folderId },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      fileName: true,
+      mimeType: true,
+      fileSize: true,
+      description: true,
+      createdAt: true,
+      updatedAt: true,
+      uploadedById: true,
+      uploadedBy: { select: { id: true, name: true, email: true } },
+    },
+  });
+}
+
+export type FolderStats = {
+  fileCount: number;
+  totalSize: number;
+  latestUpload: Date | null;
+};
+
+export function computeFolderStats(items: FileLibraryItemSummary[]): FolderStats {
+  if (!items.length) {
+    return { fileCount: 0, totalSize: 0, latestUpload: null };
+  }
+
+  let totalSize = 0;
+  let latest: Date | null = null;
+
+  for (const item of items) {
+    totalSize += item.fileSize;
+    const created = new Date(item.createdAt);
+    if (!latest || created > latest) {
+      latest = created;
+    }
+  }
+
+  return { fileCount: items.length, totalSize, latestUpload: latest };
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -96,6 +96,20 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     category: "self",
   },
   {
+    key: "mitglieder.dateisystem",
+    label: "Dateisystem öffnen",
+    description:
+      "Greift auf das gemeinsame Dateisystem mit Ordnerstruktur, Dokumenten und Downloads zu.",
+    category: "self",
+  },
+  {
+    key: "mitglieder.dateisystem.manage",
+    label: "Dateisystem verwalten",
+    description:
+      "Struktur und Zugriffsrechte des Dateisystems pflegen, Dateien moderieren und Freigaben steuern.",
+    category: "membership",
+  },
+  {
     key: "mitglieder.issues",
     label: "Feedback & Support nutzen",
     description:
@@ -595,6 +609,12 @@ async function resolveRoleContext(user: UserLike): Promise<ResolvedRoleContext> 
   );
 
   return { systemRoles, customRoleIds, departmentIds };
+}
+
+export type PermissionRoleContext = ResolvedRoleContext;
+
+export async function getPermissionRoleContext(user: UserLike): Promise<PermissionRoleContext> {
+  return resolveRoleContext(user);
 }
 
 function getBaselinePermissions(user: UserLike) {


### PR DESCRIPTION
## Summary
- add Prisma schema and migration for file library folders, items, and access rules
- build members “Dateisystem” pages, server actions, and client manager for managing folders and files
- expose API endpoints for uploads/downloads/deletes and surface navigation + permission updates

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d6bf115548832d91aafb4b781ffeaa