### PR TITLE
Refine profile overview layout

### DIFF
--- a/src/components/members/profile-page-client.tsx
+++ b/src/components/members/profile-page-client.tsx
@@ -5,12 +5,13 @@ import type { ReactNode } from "react";
 import type { AllergyLevel, MeasurementType, MeasurementUnit, Role } from "@prisma/client";
 
 import { PageHeader } from "@/components/members/page-header";
-import { ProfileSummaryCard } from "@/components/members/profile-summary-card";
 import { ProfileForm } from "@/components/members/profile-form";
 import { ProfileInterestsCard } from "@/components/members/profile-interests-card";
 import { MemberMeasurementsManager } from "@/components/members/measurements/member-measurements-manager";
-import { ProfileCompletionProvider } from "@/components/members/profile-completion-context";
-import { ProfileChecklistCard } from "@/components/members/profile-checklist-card";
+import {
+  ProfileCompletionProvider,
+  useProfileCompletion,
+} from "@/components/members/profile-completion-context";
 import { ProfilePhotoConsentNotice } from "@/components/members/profile-photo-consent-notice";
 import { ProfileDietaryPreferences } from "@/components/members/profile-dietary-preferences";
 import { PhotoConsentCard } from "@/components/members/photo-consent-card";
@@ -25,7 +26,6 @@ import type {
   DietaryStrictnessOption,
   DietaryStyleOption,
 } from "@/data/dietary-preferences";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -37,29 +37,18 @@ import {
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import {
-  ROLE_BADGE_VARIANTS,
-  ROLE_DESCRIPTIONS,
-  ROLE_LABELS,
-} from "@/lib/roles";
+import { ROLE_BADGE_VARIANTS, ROLE_LABELS } from "@/lib/roles";
 import { getUserDisplayName } from "@/lib/names";
 import {
   Calendar,
-  CheckCircle2,
   ClipboardList,
-  Crown,
   FileBadge,
-  Gavel,
   IdCard,
   Mail,
-  PiggyBank,
   Ruler,
   Sparkles,
-  ShieldCheck,
   UserRoundCheck,
   UsersRound,
-  VenetianMask,
-  Wrench,
   UtensilsCrossed,
   MessageCircle,
 } from "lucide-react";
@@ -114,29 +103,6 @@ function toAvatarSource(value: string | null): AvatarSource | null {
     ? (normalized as AvatarSource)
     : null;
 }
-
-const ROLE_ICON_MAP: Record<Role, LucideIcon> = {
-  member: UsersRound,
-  cast: VenetianMask,
-  tech: Wrench,
-  board: Gavel,
-  finance: PiggyBank,
-  owner: Crown,
-  admin: ShieldCheck,
-};
-
-const ROLE_ICON_ACCENTS: Record<Role, string> = {
-  member: "border-emerald-400/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-200",
-  cast: "border-fuchsia-400/40 bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-200",
-  tech: "border-sky-400/40 bg-sky-500/10 text-sky-600 dark:text-sky-200",
-  board: "border-teal-400/40 bg-teal-500/10 text-teal-600 dark:text-teal-200",
-  finance: "border-amber-400/40 bg-amber-500/10 text-amber-600 dark:text-amber-200",
-  owner: "border-purple-400/40 bg-purple-500/10 text-purple-600 dark:text-purple-200",
-  admin: "border-rose-400/40 bg-rose-500/10 text-rose-600 dark:text-rose-200",
-};
-
-const ROLE_STATUS_BADGE_CLASSES =
-  "border-emerald-400/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200";
 
 type ProfileTabId = ProfileChecklistTarget | "interessen" | "onboarding";
 
@@ -267,93 +233,19 @@ interface ProfilePageClientProps {
   whatsappLinkVisitedAt: string | null;
 }
 
-function ProfileRolesCard({ roles }: { roles: Role[] }) {
-  if (!roles.length) {
-    return (
-      <Card className="rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10">
-        <CardHeader className="px-0 pt-0">
-          <CardTitle className="text-xl">Rollen &amp; Berechtigungen</CardTitle>
-        </CardHeader>
-        <CardContent className="px-0 pt-0">
-          <div className="rounded-2xl border border-dashed border-border/50 bg-muted/20 p-4 text-sm text-muted-foreground">
-            Dir sind aktuell keine Rollen zugewiesen. Wende dich an die Produktionsleitung, wenn dir Inhalte fehlen.
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
-
+export function ProfilePageClient({
+  checklist,
+  ...rest
+}: ProfilePageClientProps) {
   return (
-    <Card className="rounded-3xl border border-border/60 bg-card/80 p-0 shadow-lg shadow-primary/10">
-      <CardHeader className="space-y-3 px-6 pb-4 pt-6 sm:px-8">
-        <CardTitle className="text-xl">Rollen &amp; Berechtigungen</CardTitle>
-        <p className="text-sm text-muted-foreground">
-          Deine Rollen steuern Sichtbarkeit und Handlungsrechte im Mitgliederportal. Wende dich bei fehlenden Rechten an die Administration.
-        </p>
-      </CardHeader>
-      <CardContent className="space-y-6 px-6 pb-6 sm:px-8">
-        <div className="flex flex-wrap gap-2">
-          {roles.map((role) => (
-            <Badge
-              key={role}
-              className={cn(
-                "px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide shadow-sm",
-                ROLE_BADGE_VARIANTS[role],
-              )}
-            >
-              {ROLE_LABELS[role] ?? role}
-            </Badge>
-          ))}
-        </div>
-        <ul className="space-y-3">
-          {roles.map((role) => {
-            const Icon = ROLE_ICON_MAP[role];
-            const description =
-              ROLE_DESCRIPTIONS[role] ?? "Diese Rolle ist aktuell aktiv.";
-            return (
-              <li
-                key={role}
-                className="flex gap-3 rounded-2xl border border-border/60 bg-background/70 p-4 shadow-sm backdrop-blur"
-              >
-                <div
-                  className={cn(
-                    "flex h-11 w-11 items-center justify-center rounded-full border text-sm",
-                    ROLE_ICON_ACCENTS[role],
-                  )}
-                  aria-hidden
-                >
-                  <Icon className="h-5 w-5" />
-                </div>
-                <div className="space-y-1.5">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-semibold text-foreground">
-                      {ROLE_LABELS[role] ?? role}
-                    </span>
-                    <Badge
-                      variant="outline"
-                      className={cn(
-                        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide",
-                        ROLE_STATUS_BADGE_CLASSES,
-                      )}
-                    >
-                      <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
-                      Aktiv
-                    </Badge>
-                  </div>
-                  <p className="text-xs text-muted-foreground">{description}</p>
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      </CardContent>
-    </Card>
+    <ProfileCompletionProvider initialItems={checklist}>
+      <ProfilePageContent {...rest} />
+    </ProfileCompletionProvider>
   );
 }
 
-export function ProfilePageClient({
+function ProfilePageContent({
   user,
-  checklist,
   canManageMeasurements,
   measurements,
   dietaryPreference,
@@ -362,7 +254,7 @@ export function ProfilePageClient({
   photoConsent,
   whatsappLink,
   whatsappLinkVisitedAt,
-}: ProfilePageClientProps) {
+}: Omit<ProfilePageClientProps, "checklist">) {
   const [activeTab, setActiveTab] = useState<ProfileTabId>("stammdaten");
   const [activeEditor, setActiveEditor] = useState<ProfileTabId | null>(null);
   const [profileUser, setProfileUser] = useState<ProfileUserSummary>(user);
@@ -385,6 +277,10 @@ export function ProfilePageClient({
     return Number.isNaN(parsed.valueOf()) ? null : parsed;
   });
   const [whatsappPending, setWhatsappPending] = useState(false);
+  const { items: checklistItems, completed, total, isComplete } =
+    useProfileCompletion();
+  const completionProgress = total > 0 ? Math.round((completed / total) * 100) : 0;
+  const nextChecklistItem = checklistItems.find((item) => !item.complete) ?? null;
 
   const measurementEntries = canManageMeasurements ? measurementState : [];
 
@@ -449,39 +345,45 @@ export function ProfilePageClient({
         return false;
       }
       setActiveTab(section);
-      setActiveEditor(section);
       return true;
     },
     [canManageMeasurements],
   );
 
+  const focusTabs = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.requestAnimationFrame(() => {
+      const element = document.getElementById("profile-tabs");
+      if (element instanceof HTMLElement) {
+        element.scrollIntoView({ behavior: "smooth", block: "start" });
+        element.classList.add("ring-2", "ring-primary/40");
+        window.setTimeout(() => {
+          element.classList.remove("ring-2", "ring-primary/40");
+        }, 1200);
+      }
+    });
+  }, []);
+
   const handleTabChange = useCallback(
     (value: string) => {
+      setActiveEditor(null);
       selectTab(value as ProfileTabId);
     },
     [selectTab],
   );
 
-  const handleNavigateToSection = useCallback(
+  const openEditor = useCallback(
     (section: ProfileTabId) => {
       const didSelect = selectTab(section);
       if (!didSelect) {
         return;
       }
-      if (typeof window !== "undefined") {
-        window.requestAnimationFrame(() => {
-          const element = document.getElementById("profile-tabs");
-          if (element instanceof HTMLElement) {
-            element.scrollIntoView({ behavior: "smooth", block: "start" });
-            element.classList.add("ring-2", "ring-primary/40");
-            window.setTimeout(() => {
-              element.classList.remove("ring-2", "ring-primary/40");
-            }, 1200);
-          }
-        });
-      }
+      focusTabs();
+      setActiveEditor(section);
     },
-    [selectTab],
+    [focusTabs, selectTab],
   );
 
   const closeEditor = useCallback(() => {
@@ -489,8 +391,8 @@ export function ProfilePageClient({
   }, []);
 
   const handleManagePhoto = useCallback(() => {
-    selectTab("freigaben");
-  }, [selectTab]);
+    openEditor("freigaben");
+  }, [openEditor]);
 
   const handlePhotoSummaryChange = useCallback(
     (summary: PhotoConsentSummary | null) => {
@@ -817,7 +719,7 @@ export function ProfilePageClient({
   }
 
   return (
-    <ProfileCompletionProvider initialItems={checklist}>
+    <>
       <div className="relative space-y-10 sm:space-y-12">
         <div
           aria-hidden="true"
@@ -895,186 +797,231 @@ export function ProfilePageClient({
               })}
             </div>
           </div>
-          {shouldShowPhotoNotice ? (
-            <div className="relative border-t border-border/60 bg-background/70 px-6 py-6 sm:px-8">
-              <ProfilePhotoConsentNotice
-                summary={photoSummary}
-                onManage={handleManagePhoto}
-              />
-            </div>
-          ) : null}
-        </section>
-
-        <div className="grid gap-6 lg:gap-8 xl:grid-cols-[minmax(0,380px)_minmax(0,1fr)] xl:items-start xl:gap-10 2xl:grid-cols-[minmax(0,420px)_minmax(0,1fr)] 2xl:gap-12">
-          <aside className="space-y-6 xl:space-y-8">
-            <ProfileSummaryCard
-              userId={profileUser.id}
-              firstName={profileUser.firstName}
-              lastName={profileUser.lastName}
-              name={profileUser.name}
-              email={profileUser.email}
-              roles={profileUser.roles}
-              avatarSource={profileUser.avatarSource}
-              avatarUpdatedAt={profileUser.avatarUpdatedAt}
-            />
-
-            <ProfileRolesCard roles={profileUser.roles} />
-
-            <ProfileChecklistCard onNavigateToSection={handleNavigateToSection} />
-          </aside>
-
-          <section
-            id="profile-tabs"
-            className="space-y-6 rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 sm:p-8"
-          >
-            <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
-                Profilbereiche
-              </p>
-              <div className="space-y-1">
-                <h2 className="text-xl font-semibold text-foreground">Alles an einem Ort</h2>
-                <p className="text-sm text-muted-foreground">
-                  Bearbeite die Bereiche deines Profils und halte deine Angaben auf dem aktuellen Stand.
+          <div className="space-y-8">
+            <div className="rounded-3xl border border-border/60 bg-background/80 p-5 shadow-lg shadow-primary/10 sm:flex sm:items-center sm:justify-between sm:gap-8">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  Profilstatus
+                </p>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-foreground">
+                    {isComplete
+                      ? "Alle Pflichtangaben sind aktuell"
+                      : "Noch Aufgaben offen"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {isComplete
+                      ? "Fantastisch! Du bist startklar."
+                      : nextChecklistItem
+                          ? `Nächster Schritt: ${nextChecklistItem.label}`
+                          : `Du hast ${completed} von ${total} Aufgaben abgeschlossen.`}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 w-full max-w-xs space-y-2 sm:mt-0">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-muted/30">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-primary via-primary/80 to-secondary"
+                    style={{ width: `${completionProgress}%` }}
+                  />
+                </div>
+                <p className="text-xs font-medium text-muted-foreground">
+                  {completionProgress}% vollständig
                 </p>
               </div>
             </div>
 
-            <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-8">
-              <TabsList className="!grid grid-cols-1 gap-2 rounded-2xl border border-border/60 bg-muted/30 p-2 sm:grid-cols-2 xl:grid-cols-3">
-                {visibleTabItems.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                  <TabsTrigger
-                    key={item.id}
-                    value={item.id}
-                    onClick={() => {
-                      if (activeTab === item.id) {
-                        selectTab(item.id);
-                      }
-                    }}
-                    className="!flex h-full flex-col items-start gap-2 rounded-2xl px-3 py-3 text-left shadow-sm transition hover:bg-primary/5 hover:text-foreground sm:px-4 sm:py-4"
-                  >
-                      <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
-                        <Icon className="h-4 w-4" aria-hidden />
-                        {item.label}
-                      </span>
-                      <span className="text-xs text-muted-foreground">{item.description}</span>
-                    </TabsTrigger>
-                  );
-                })}
-              </TabsList>
+            <section
+              id="profile-tabs"
+              className="space-y-6 rounded-3xl border border-border/60 bg-card/80 p-6 shadow-lg shadow-primary/10 sm:p-8"
+            >
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                  Profilbereiche
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Wähle eine Rubrik, um Angaben anzusehen und zu bearbeiten.
+                </p>
+              </div>
 
-              <div className="space-y-8">
-                <TabsContent value="stammdaten" className="space-y-6">
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <SummaryField label="Vorname">
-                      {renderText(profileUser.firstName)}
-                    </SummaryField>
-                    <SummaryField label="Nachname">
-                      {renderText(profileUser.lastName)}
-                    </SummaryField>
-                    <SummaryField label="Anzeigename">
-                      {renderText(displayName || null)}
-                    </SummaryField>
-                    <SummaryField
-                      label="E-Mail-Adresse"
-                      description="Wir verwenden diese Adresse für Login und Benachrichtigungen."
-                    >
-                      {renderText(profileUser.email)}
-                    </SummaryField>
-                    <SummaryField
-                      label="Geburtsdatum"
-                      description="Hilft bei der Verwaltung notwendiger Einverständnisse."
-                    >
-                      {birthdate ? (
-                        <span>{birthdate}</span>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">
-                          {EMPTY_VALUE_LABEL}
+              <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-8">
+                <TabsList className="!grid grid-cols-1 gap-2 rounded-2xl border border-border/60 bg-muted/30 p-2 sm:grid-cols-2 xl:grid-cols-3">
+                  {visibleTabItems.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <TabsTrigger
+                        key={item.id}
+                        value={item.id}
+                        className="!flex h-full flex-col items-start gap-2 rounded-2xl px-3 py-3 text-left shadow-sm transition hover:bg-primary/5 hover:text-foreground sm:px-4 sm:py-4"
+                      >
+                        <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                          <Icon className="h-4 w-4" aria-hidden />
+                          {item.label}
                         </span>
-                      )}
-                    </SummaryField>
-                    <SummaryField
-                      label="Profilbild"
-                      description="Quelle und Aktualisierung deines Avatars."
-                    >
+                        <span className="text-xs text-muted-foreground">{item.description}</span>
+                      </TabsTrigger>
+                    );
+                  })}
+                </TabsList>
+
+                <div className="space-y-8">
+                  <TabsContent value="stammdaten" className="space-y-6">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
                       <div className="space-y-1">
-                        <span>{avatarSourceLabel}</span>
-                        {avatarUpdatedAt ? (
-                          <span className="text-xs text-muted-foreground">
-                            Aktualisiert am {avatarUpdatedAt}
-                          </span>
+                        <h3 className="text-base font-semibold text-foreground">Basisangaben</h3>
+                        <p className="text-xs text-muted-foreground">
+                          Kontakt, Namen und Rollen im Überblick.
+                        </p>
+                      </div>
+                      <Button size="sm" variant="outline" onClick={() => openEditor("stammdaten")}>
+                        Bearbeiten
+                      </Button>
+                    </div>
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <SummaryField label="Vorname">
+                        {renderText(profileUser.firstName)}
+                      </SummaryField>
+                      <SummaryField label="Nachname">
+                        {renderText(profileUser.lastName)}
+                      </SummaryField>
+                      <SummaryField label="Anzeigename">
+                        {renderText(displayName || null)}
+                      </SummaryField>
+                      <SummaryField
+                        label="E-Mail-Adresse"
+                        description="Wir verwenden diese Adresse für Login und Benachrichtigungen."
+                      >
+                        {renderText(profileUser.email)}
+                      </SummaryField>
+                      <SummaryField
+                        label="Geburtsdatum"
+                        description="Hilft bei der Verwaltung notwendiger Einverständnisse."
+                      >
+                        {birthdate ? (
+                          <span>{birthdate}</span>
                         ) : (
                           <span className="text-xs text-muted-foreground">
-                            Noch kein Upload gespeichert.
+                            {EMPTY_VALUE_LABEL}
                           </span>
                         )}
+                      </SummaryField>
+                      <SummaryField
+                        label="Profilbild"
+                        description="Quelle und Aktualisierung deines Avatars."
+                      >
+                        <div className="space-y-1">
+                          <span>{avatarSourceLabel}</span>
+                          {avatarUpdatedAt ? (
+                            <span className="text-xs text-muted-foreground">
+                              Aktualisiert am {avatarUpdatedAt}
+                            </span>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">
+                              Noch kein Upload gespeichert.
+                            </span>
+                          )}
+                        </div>
+                      </SummaryField>
+                      <SummaryField label="Rollen &amp; Berechtigungen">
+                        {profileUser.roles.length ? (
+                          <div className="flex flex-wrap gap-2">
+                            {profileUser.roles.map((role) => (
+                              <Badge
+                                key={role}
+                                className={cn(
+                                  "px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-wide shadow-sm",
+                                  ROLE_BADGE_VARIANTS[role],
+                                )}
+                              >
+                                {ROLE_LABELS[role] ?? role}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
+                        )}
+                      </SummaryField>
+                    </div>
+                  </TabsContent>
+
+                  <TabsContent value="onboarding" className="space-y-6">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="space-y-1">
+                        <h3 className="text-base font-semibold text-foreground">Onboarding-Angaben</h3>
+                        <p className="text-xs text-muted-foreground">
+                          Schwerpunkt, Hintergrund und Hinweise aus deinem Einstieg.
+                        </p>
+                      </div>
+                      <Button size="sm" variant="outline" onClick={() => openEditor("onboarding")}>
+                        Bearbeiten
+                      </Button>
+                    </div>
+                    <SummaryField
+                      label="Schwerpunkt"
+                      description={
+                        onboardingUpdatedAtDetail
+                          ? `Zuletzt bearbeitet am ${onboardingUpdatedAtDetail}`
+                          : "Noch keine Angaben aus dem Onboarding."
+                      }
+                    >
+                      <div className="space-y-1">
+                        {onboardingFocusLabel ? (
+                          <span>{onboardingFocusLabel}</span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
+                        )}
+                        {onboardingFocusDescription ? (
+                          <p className="text-xs text-muted-foreground">{onboardingFocusDescription}</p>
+                        ) : null}
                       </div>
                     </SummaryField>
-                  </div>
 
-                </TabsContent>
-
-                <TabsContent value="onboarding" className="space-y-6">
-                  <SummaryField
-                    label="Schwerpunkt"
-                    description={
-                      onboardingUpdatedAtDetail
-                        ? `Zuletzt bearbeitet am ${onboardingUpdatedAtDetail}`
-                        : "Noch keine Angaben aus dem Onboarding."
-                    }
-                  >
-                    <div className="space-y-1">
-                      {onboardingFocusLabel ? (
-                        <span>{onboardingFocusLabel}</span>
+                    <SummaryField label="Hintergrund">
+                      {onboardingState.background ? (
+                        <span>{onboardingState.background}</span>
                       ) : (
                         <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
                       )}
-                      {onboardingFocusDescription ? (
-                        <p className="text-xs text-muted-foreground">{onboardingFocusDescription}</p>
-                      ) : null}
+                    </SummaryField>
+
+                    <SummaryField label="Klasse/Jahrgang">
+                      {onboardingState.backgroundClass ? (
+                        <span>{onboardingState.backgroundClass}</span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
+                      )}
+                    </SummaryField>
+
+                    <SummaryField label="Mitglied seit">
+                      {onboardingMemberSince ? (
+                        <span>{onboardingMemberSince}</span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
+                      )}
+                    </SummaryField>
+
+                    <SummaryField label="Notizen">
+                      {onboardingState.notes ? (
+                        <p className="whitespace-pre-wrap text-sm">{onboardingState.notes}</p>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
+                      )}
+                    </SummaryField>
+                  </TabsContent>
+
+                  <TabsContent value="ernaehrung" className="space-y-6">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="space-y-1">
+                        <h3 className="text-base font-semibold text-foreground">Ernährung &amp; Gesundheit</h3>
+                        <p className="text-xs text-muted-foreground">
+                          Präferenzen und medizinische Hinweise für Teams vor Ort.
+                        </p>
+                      </div>
+                      <Button size="sm" variant="outline" onClick={() => openEditor("ernaehrung")}>
+                        Bearbeiten
+                      </Button>
                     </div>
-                  </SummaryField>
-
-                  <SummaryField label="Hintergrund">
-                    {onboardingState.background ? (
-                      <span>{onboardingState.background}</span>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
-                    )}
-                  </SummaryField>
-
-                  <SummaryField label="Klasse/Jahrgang">
-                    {onboardingState.backgroundClass ? (
-                      <span>{onboardingState.backgroundClass}</span>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
-                    )}
-                  </SummaryField>
-
-                  <SummaryField label="Mitglied seit">
-                    {onboardingMemberSince ? (
-                      <span>{onboardingMemberSince}</span>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
-                    )}
-                  </SummaryField>
-
-                  <SummaryField label="Notizen">
-                    {onboardingState.notes ? (
-                      <p className="whitespace-pre-wrap text-sm">{onboardingState.notes}</p>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">{EMPTY_VALUE_LABEL}</span>
-                    )}
-                  </SummaryField>
-
-                </TabsContent>
-
-                <TabsContent value="ernaehrung" className="space-y-6">
-                  <div className="grid gap-4">
-                    <SummaryField
-                      label="Ernährungsstil"
-                    >
+                    <SummaryField label="Ernährungsstil">
                       <div className="space-y-1">
                         <span>{dietaryStyle.label}</span>
                         {preferenceState.customLabel ? (
@@ -1084,189 +1031,218 @@ export function ProfilePageClient({
                         ) : null}
                       </div>
                     </SummaryField>
-                  </div>
 
-                  <SummaryField label="Allergien & Unverträglichkeiten">
-                    {allergyState.length ? (
-                      <div className="flex flex-wrap gap-2">
-                        {allergyState.slice(0, 6).map((entry) => (
-                          <Badge
-                            key={entry.allergen}
-                            variant="outline"
-                            className={cn("text-xs", ALLERGY_LEVEL_STYLES[entry.level])}
-                          >
-                            {entry.allergen}
-                          </Badge>
-                        ))}
-                        {allergyState.length > 6 ? (
-                          <span className="text-xs text-muted-foreground">
-                            +{allergyState.length - 6} weitere
-                          </span>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">
-                        {EMPTY_VALUE_LABEL}
-                      </span>
-                    )}
-                  </SummaryField>
-
-                </TabsContent>
-
-                {canManageMeasurements ? (
-                  <TabsContent value="masse" className="space-y-6">
-                    <SummaryField
-                      label="Erfasste Maße"
-                      description="Gib dem Kostüm-Team aktuelle Werte an die Hand."
-                    >
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Badge
-                          variant="outline"
-                          className="border-primary/40 bg-primary/10 text-primary"
-                        >
-                          {measurementEntries.length} Werte
-                        </Badge>
-                        {measurementEntries.length && latestMeasurementUpdate ? (
-                          <span className="text-xs text-muted-foreground">
-                            Aktualisiert am {formatDate(latestMeasurementUpdate)}
-                          </span>
-                        ) : (
-                          <span className="text-xs text-muted-foreground">
-                            Noch keine Werte hinterlegt.
-                          </span>
-                        )}
-                      </div>
-                    </SummaryField>
-
-                    {measurementEntries.length ? (
-                      <div className="grid gap-4 md:grid-cols-2">
-                        {measurementEntries.slice(0, 4).map((entry) => (
-                          <SummaryField
-                            key={entry.type}
-                            label={MEASUREMENT_TYPE_LABELS[entry.type]}
-                          >
-                            <div className="flex flex-wrap items-baseline gap-2">
-                              <span className="text-base font-semibold text-foreground">
-                                {formatMeasurementValue(entry.value)}
-                              </span>
-                              <span className="text-xs text-muted-foreground">
-                                {MEASUREMENT_UNIT_LABELS[entry.unit] ?? entry.unit}
-                              </span>
-                            </div>
-                            {entry.note ? (
-                              <p className="text-xs text-muted-foreground">{entry.note}</p>
-                            ) : null}
-                            <p className="text-[11px] text-muted-foreground">
-                              Aktualisiert am {formatDate(entry.updatedAt) ?? "-"}
-                            </p>
-                          </SummaryField>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-xs text-muted-foreground">
-                        Erfasse deine Maße, damit das Kostüm-Team planen kann.
-                      </p>
-                    )}
-
-                    {measurementEntries.length > 4 ? (
-                      <p className="text-xs text-muted-foreground">
-                        Weitere Maße findest du im Bearbeitungsmodus.
-                      </p>
-                    ) : null}
-
-                  </TabsContent>
-                ) : null}
-
-                <TabsContent value="interessen" className="space-y-6">
-                  <SummaryField
-                    label="Status"
-                    description="Öffne den Bereich, um deine Interessen zu pflegen."
-                  >
-                    <span className="text-sm text-muted-foreground">
-                      Interessen werden beim Öffnen geladen.
-                    </span>
-                  </SummaryField>
-
-                </TabsContent>
-
-                <TabsContent value="freigaben" className="space-y-6">
-                  <SummaryField
-                    label="Status"
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant="outline" className={cn("text-xs", photoStatusBadge)}>
-                        {photoStatusLabel}
-                      </Badge>
-                      {photoUpdatedAt ? (
+                    <SummaryField label="Allergien &amp; Unverträglichkeiten">
+                      {allergyState.length ? (
+                        <div className="flex flex-wrap gap-2">
+                          {allergyState.slice(0, 6).map((entry) => (
+                            <Badge
+                              key={entry.allergen}
+                              variant="outline"
+                              className={cn("text-xs", ALLERGY_LEVEL_STYLES[entry.level])}
+                            >
+                              {entry.allergen}
+                            </Badge>
+                          ))}
+                          {allergyState.length > 6 ? (
+                            <span className="text-xs text-muted-foreground">
+                              +{allergyState.length - 6} weitere
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : (
                         <span className="text-xs text-muted-foreground">
-                          Aktualisiert am {photoUpdatedAt}
+                          {EMPTY_VALUE_LABEL}
                         </span>
-                      ) : null}
-                    </div>
-                  </SummaryField>
-
-                  <SummaryField
-                    label="Geburtsdatum & Alter"
-                  >
-                    {photoSummary?.dateOfBirth ? (
-                      <div className="space-y-1">
-                        <span>{formatDate(photoSummary.dateOfBirth)}</span>
-                        {photoSummary.age !== null ? (
-                          <span className="text-xs text-muted-foreground">
-                            {photoSummary.age} Jahre
-                          </span>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">
-                        {photoSummary?.requiresDateOfBirth
-                          ? "Bitte ergänze dein Geburtsdatum."
-                          : EMPTY_VALUE_LABEL}
-                      </span>
-                    )}
-                  </SummaryField>
-
-                  <SummaryField
-                    label="Dokumente"
-                  >
-                    {photoSummary ? (
-                      <div className="space-y-1">
-                        <span>
-                          {photoSummary.requiresDocument
-                            ? photoSummary.hasDocument
-                              ? "Dokument liegt vor."
-                              : "Dokument erforderlich – bitte hochladen."
-                            : "Kein Dokument notwendig."}
-                        </span>
-                        {photoSummary.documentUploadedAt ? (
-                          <span className="text-xs text-muted-foreground">
-                            Hochgeladen am {" "}
-                            {formatDate(photoSummary.documentUploadedAt)}
-                          </span>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">
-                        {EMPTY_VALUE_LABEL}
-                      </span>
-                    )}
-                  </SummaryField>
-
-                  {photoSummary?.rejectionReason ? (
-                    <SummaryField
-                      label="Hinweis"
-                    >
-                      <span className="text-sm text-destructive">
-                        {photoSummary.rejectionReason}
-                      </span>
+                      )}
                     </SummaryField>
+                  </TabsContent>
+
+                  {canManageMeasurements ? (
+                    <TabsContent value="masse" className="space-y-6">
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="space-y-1">
+                          <h3 className="text-base font-semibold text-foreground">Maße &amp; Kostümplanung</h3>
+                          <p className="text-xs text-muted-foreground">
+                            Unterstützt Kostüm- und Ausstattungsteams bei der Planung.
+                          </p>
+                        </div>
+                        <Button size="sm" variant="outline" onClick={() => openEditor("masse")}>
+                          Bearbeiten
+                        </Button>
+                      </div>
+                      <SummaryField
+                        label="Erfasste Maße"
+                        description="Gib dem Kostüm-Team aktuelle Werte an die Hand."
+                      >
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className="border-primary/40 bg-primary/10 text-primary"
+                          >
+                            {measurementEntries.length} Werte
+                          </Badge>
+                          {measurementEntries.length && latestMeasurementUpdate ? (
+                            <span className="text-xs text-muted-foreground">
+                              Aktualisiert am {formatDate(latestMeasurementUpdate)}
+                            </span>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">
+                              Noch keine Werte hinterlegt.
+                            </span>
+                          )}
+                        </div>
+                      </SummaryField>
+
+                      {measurementEntries.length ? (
+                        <div className="grid gap-4 md:grid-cols-2">
+                          {measurementEntries.slice(0, 4).map((entry) => (
+                            <SummaryField
+                              key={entry.type}
+                              label={MEASUREMENT_TYPE_LABELS[entry.type]}
+                            >
+                              <div className="flex flex-wrap items-baseline gap-2">
+                                <span className="text-base font-semibold text-foreground">
+                                  {formatMeasurementValue(entry.value)}
+                                </span>
+                                <span className="text-xs text-muted-foreground">
+                                  {MEASUREMENT_UNIT_LABELS[entry.unit] ?? entry.unit}
+                                </span>
+                              </div>
+                              {entry.note ? (
+                                <p className="text-xs text-muted-foreground">{entry.note}</p>
+                              ) : null}
+                              <p className="text-[11px] text-muted-foreground">
+                                Aktualisiert am {formatDate(entry.updatedAt) ?? "-"}
+                              </p>
+                            </SummaryField>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">
+                          Erfasse deine Maße, damit das Kostüm-Team planen kann.
+                        </p>
+                      )}
+
+                      {measurementEntries.length > 4 ? (
+                        <p className="text-xs text-muted-foreground">
+                          Weitere Maße findest du im Bearbeitungsmodus.
+                        </p>
+                      ) : null}
+                    </TabsContent>
                   ) : null}
 
-                </TabsContent>
-              </div>
-            </Tabs>
-          </section>
-        </div>
+                  <TabsContent value="interessen" className="space-y-6">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="space-y-1">
+                        <h3 className="text-base font-semibold text-foreground">Interessen &amp; Engagement</h3>
+                        <p className="text-xs text-muted-foreground">
+                          Schlagworte helfen, passende Aufgaben zu finden.
+                        </p>
+                      </div>
+                      <Button size="sm" variant="outline" onClick={() => openEditor("interessen")}>
+                        Bearbeiten
+                      </Button>
+                    </div>
+                    <SummaryField
+                      label="Status"
+                      description="Öffne den Bereich, um deine Interessen zu pflegen."
+                    >
+                      <span className="text-sm text-muted-foreground">
+                        Interessen werden beim Öffnen geladen.
+                      </span>
+                    </SummaryField>
+                  </TabsContent>
+
+                  <TabsContent value="freigaben" className="space-y-6">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="space-y-1">
+                        <h3 className="text-base font-semibold text-foreground">Freigaben &amp; Dokumente</h3>
+                        <p className="text-xs text-muted-foreground">
+                          Fotoeinverständnisse und Nachweise im Überblick.
+                        </p>
+                      </div>
+                      <Button size="sm" variant="outline" onClick={() => openEditor("freigaben")}>
+                        Bearbeiten
+                      </Button>
+                    </div>
+                    <SummaryField label="Status">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="outline" className={cn("text-xs", photoStatusBadge)}>
+                          {photoStatusLabel}
+                        </Badge>
+                        {photoUpdatedAt ? (
+                          <span className="text-xs text-muted-foreground">
+                            Aktualisiert am {photoUpdatedAt}
+                          </span>
+                        ) : null}
+                      </div>
+                    </SummaryField>
+
+                    <SummaryField label="Geburtsdatum &amp; Alter">
+                      {photoSummary?.dateOfBirth ? (
+                        <div className="space-y-1">
+                          <span>{formatDate(photoSummary.dateOfBirth)}</span>
+                          {photoSummary.age !== null ? (
+                            <span className="text-xs text-muted-foreground">
+                              {photoSummary.age} Jahre
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          {photoSummary?.requiresDateOfBirth
+                            ? "Bitte ergänze dein Geburtsdatum."
+                            : EMPTY_VALUE_LABEL}
+                        </span>
+                      )}
+                    </SummaryField>
+
+                    <SummaryField label="Dokumente">
+                      {photoSummary ? (
+                        <div className="space-y-1">
+                          <span>
+                            {photoSummary.requiresDocument
+                              ? photoSummary.hasDocument
+                                ? "Dokument liegt vor."
+                                : "Dokument erforderlich – bitte hochladen."
+                              : "Kein Dokument notwendig."}
+                          </span>
+                          {photoSummary.documentUploadedAt ? (
+                            <span className="text-xs text-muted-foreground">
+                              Hochgeladen am {" "}
+                              {formatDate(photoSummary.documentUploadedAt)}
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          {EMPTY_VALUE_LABEL}
+                        </span>
+                      )}
+                    </SummaryField>
+
+                    {photoSummary?.rejectionReason ? (
+                      <SummaryField label="Hinweis">
+                        <span className="text-sm text-destructive">
+                          {photoSummary.rejectionReason}
+                        </span>
+                      </SummaryField>
+                    ) : null}
+                  </TabsContent>
+                </div>
+              </Tabs>
+            </section>
+          </div>
+          {shouldShowPhotoNotice ? (
+            <div className="relative border-t border-border/60 bg-background/70 px-6 py-6 sm:px-8">
+              <ProfilePhotoConsentNotice
+                summary={photoSummary}
+                onManage={handleManagePhoto}
+              />
+            </div>
+          ) : null}
+        </section>
       </div>
       <Dialog
         open={!!editorDialog}
@@ -1293,6 +1269,6 @@ export function ProfilePageClient({
           </DialogContent>
         ) : null}
       </Dialog>
-    </ProfileCompletionProvider>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- collapse the profile experience into a single card by wrapping the client in `ProfileCompletionProvider` and moving the stateful logic into a dedicated `ProfilePageContent` component
- add an inline profile status panel, tab headers, and section-specific edit buttons so members can view and manage data without redundant cards
- surface role badges and other key fields directly inside the tabs while keeping dialogs available through the new editor helpers

## Testing
- `pnpm lint`
- `pnpm test`
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68d6c9619e3c832db8e65ce796f0d734