### PR TITLE
Allow managing and deleting file library folders

### DIFF
--- a/src/app/(members)/mitglieder/dateisystem/[folderId]/page.tsx
+++ b/src/app/(members)/mitglieder/dateisystem/[folderId]/page.tsx
@@ -26,7 +26,7 @@ import { createMembersBreadcrumbItems, membersNavigationBreadcrumb } from "@/lib
 import { formatRelativeWithAbsolute } from "@/lib/datetime";
 import { ROLES, ROLE_LABELS, type Role } from "@/lib/roles";
 import { FileLibraryAccessTargetType, FileLibraryAccessType } from "@prisma/client";
-import { createFileLibraryFolder, updateFileLibraryPermissions } from "../actions";
+import { createFileLibraryFolder, deleteFileLibraryFolder, updateFileLibraryPermissions } from "../actions";
 
 const latestFormatter = new Intl.DateTimeFormat("de-DE", {
   dateStyle: "medium",
@@ -283,11 +283,21 @@ export default async function FileLibraryFolderPage({
         description={folder.description ?? ""}
         breadcrumbs={breadcrumbItems}
         actions={
-          <Button asChild variant="outline">
-            <Link href="/mitglieder/dateisystem">
-              <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
-            </Link>
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button asChild variant="outline">
+              <Link href="/mitglieder/dateisystem">
+                <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+              </Link>
+            </Button>
+            {canManage ? (
+              <form action={deleteFileLibraryFolder}>
+                <input type="hidden" name="folderId" value={folder.id} />
+                <Button type="submit" variant="destructive">
+                  Ordner löschen
+                </Button>
+              </form>
+            ) : null}
+          </div>
         }
       />
 

--- a/src/app/api/file-library/items/[id]/route.ts
+++ b/src/app/api/file-library/items/[id]/route.ts
@@ -34,14 +34,13 @@ export async function DELETE(request: NextRequest, context: { params: Promise<{ 
   const currentUser = session.user ?? { id: null };
   const accessContext = await resolveFileLibraryAccessContext(currentUser);
   const canManage = accessContext.canManage;
-  const canUpload = await userHasFileLibraryAccess(currentUser, item.folder, "upload", accessContext);
   const canView = await userHasFileLibraryAccess(currentUser, item.folder, "view", accessContext);
 
   if (!canView) {
     return NextResponse.json({ error: "Keine Berechtigung" }, { status: 403 });
   }
 
-  if (!canManage && (!canUpload || item.uploadedById !== userId)) {
+  if (!canManage && item.uploadedById !== userId) {
     return NextResponse.json({ error: "Nur eigene Uploads können gelöscht werden." }, { status: 403 });
   }
 


### PR DESCRIPTION
## Summary
- allow berechtigte Nutzerinnen, Ordner direkt von der Detailansicht aus zu löschen
- ergänze eine Server Action, die Ordner löscht, alle relevanten Pfade neu validiert und passend weiterleitet
- ermögliche Uploaderinnen, ihre eigenen Dateien zu entfernen, auch wenn keine Upload-Berechtigung mehr vorliegt

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d6ce7305c4832d98bceae3f4e157d3