### PR TITLE
Fix profile age calculation hydration mismatch

### DIFF
--- a/src/components/members/profile-page-client.tsx
+++ b/src/components/members/profile-page-client.tsx
@@ -281,6 +281,9 @@ function ProfilePageContent({
   const [whatsappPending, setWhatsappPending] = useState(false);
   const { items: checklistItems, completed, total, isComplete } =
     useProfileCompletion();
+  const [age, setAge] = useState<number | null>(() =>
+    calculateAge(profileUser.dateOfBirth),
+  );
   const completionProgress = total > 0 ? Math.round((completed / total) * 100) : 0;
   const nextChecklistItem = checklistItems.find((item) => !item.complete) ?? null;
   const headerStatusState = isComplete ? "online" : total > 0 ? "warning" : "idle";
@@ -302,6 +305,13 @@ function ProfilePageContent({
     setWhatsappVisitedAtState(Number.isNaN(parsed.valueOf()) ? null : parsed);
   }, [whatsappLinkVisitedAt]);
 
+  useEffect(() => {
+    setAge((previousAge) => {
+      const nextAge = calculateAge(profileUser.dateOfBirth);
+      return nextAge === previousAge ? previousAge : nextAge;
+    });
+  }, [profileUser.dateOfBirth]);
+
   const displayName = getUserDisplayName(
     {
       firstName: profileUser.firstName,
@@ -318,7 +328,6 @@ function ProfilePageContent({
     ? AVATAR_SOURCE_LABELS[avatarSource]
     : "Automatisch";
   const avatarUpdatedAt = formatDate(profileUser.avatarUpdatedAt);
-  const age = calculateAge(profileUser.dateOfBirth);
 
   const dietaryStyle = resolveDietaryStyleLabel(
     preferenceState.style,


### PR DESCRIPTION
## Summary
- preserve the profile age value in component state to avoid hydration mismatches when rendering the profile dashboard
- recalculate the age after mount whenever the stored birthdate changes so the highlight card stays up to date

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d6e2cadb40832dbcabbd968bd551f1