### PR TITLE
feat: add onboarding dashboard with analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dexie": "4.0.4",
     "dexie-observable": "4.0.1-beta.13",
     "fontkit": "^2.0.4",
+    "framer-motion": "^12.23.22",
     "geist": "^1.5.1",
     "http-proxy": "^1.18.1",
     "idb-keyval": "^6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       fontkit:
         specifier: ^2.0.4
         version: 2.0.4
+      framer-motion:
+        specifier: ^12.23.22
+        version: 12.23.22(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       geist:
         specifier: ^1.5.1
         version: 1.5.1(next@15.5.3(@playwright/test@1.55.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))
@@ -2500,6 +2503,20 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
+  framer-motion@12.23.22:
+    resolution: {integrity: sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3067,6 +3084,12 @@ packages:
 
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
+
+  motion-dom@12.23.21:
+    resolution: {integrity: sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -6461,6 +6484,15 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  framer-motion@12.23.22(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      motion-dom: 12.23.21
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
   fsevents@2.3.2:
     optional: true
 
@@ -7014,6 +7046,12 @@ snapshots:
   moment@2.30.1: {}
 
   moo@0.5.2: {}
+
+  motion-dom@12.23.21:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
 
   ms@2.1.3: {}
 

--- a/src/app/api/dashboard/onboarding/[onboardingId]/route.ts
+++ b/src/app/api/dashboard/onboarding/[onboardingId]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { getOnboardingDashboardData } from "@/lib/onboarding/dashboard-service";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ onboardingId: string }> },
+) {
+  const params = await context.params;
+  const onboardingId = params?.onboardingId;
+
+  if (!onboardingId || typeof onboardingId !== "string") {
+    return NextResponse.json({ error: "Missing onboarding id" }, { status: 400 });
+  }
+
+  try {
+    const data = await getOnboardingDashboardData(onboardingId);
+    if (!data) {
+      return NextResponse.json({ error: "Onboarding not found" }, { status: 404 });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Failed to load onboarding dashboard", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/allocation-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/allocation-tab.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { motion } from "framer-motion";
+import { CheckCircle2, Loader2, UsersRound } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AllocationCandidate, AllocationRole, OnboardingDashboardData } from "@/lib/onboarding/dashboard-schemas";
+
+function computeAssignments(
+  roles: AllocationRole[],
+  capacities: Map<string, number>,
+): Array<{
+  role: AllocationRole;
+  capacity: number;
+  slots: Array<{
+    slotId: string;
+    candidate: AllocationCandidate | null;
+    alternatives: AllocationCandidate[];
+  }>;
+}> {
+  return roles.map((role) => {
+    const capacity = Math.max(0, capacities.get(role.roleId) ?? role.capacity);
+    const sorted = [...role.candidates].sort((a, b) => b.score - a.score);
+    const slots = Array.from({ length: capacity || 1 }).map((_, index) => {
+      const candidate = sorted[index] ?? null;
+      const alternatives = sorted.filter((_, idx) => idx !== index).slice(0, 2);
+      return {
+        slotId: `${role.roleId}-${index + 1}`,
+        candidate,
+        alternatives,
+      };
+    });
+    return { role, capacity, slots };
+  });
+}
+
+type AllocationTabProps = {
+  allocation: OnboardingDashboardData["allocation"];
+};
+
+export function AllocationTab({ allocation }: AllocationTabProps) {
+  const [draftCapacities, setDraftCapacities] = useState(() =>
+    new Map(allocation.roles.map((role) => [role.roleId, role.capacity])),
+  );
+  const [appliedCapacities, setAppliedCapacities] = useState(() =>
+    new Map(allocation.roles.map((role) => [role.roleId, role.capacity])),
+  );
+  const [isRecalculating, startTransition] = useTransition();
+
+  useEffect(() => {
+    setDraftCapacities(new Map(allocation.roles.map((role) => [role.roleId, role.capacity])));
+    setAppliedCapacities(new Map(allocation.roles.map((role) => [role.roleId, role.capacity])));
+  }, [allocation.roles]);
+
+  const assignments = useMemo(
+    () => computeAssignments(allocation.roles, appliedCapacities),
+    [allocation.roles, appliedCapacities],
+  );
+
+  const pendingChanges = useMemo(() => {
+    return allocation.roles.some((role) => {
+      const base = appliedCapacities.get(role.roleId) ?? role.capacity;
+      const draft = draftCapacities.get(role.roleId) ?? role.capacity;
+      return base !== draft;
+    });
+  }, [allocation.roles, appliedCapacities, draftCapacities]);
+
+  const capacityChart = useMemo(
+    () =>
+      allocation.roles.map((role) => ({
+        roleId: role.roleId,
+        label: role.label,
+        demand: role.demand,
+        capacity: appliedCapacities.get(role.roleId) ?? role.capacity,
+      })),
+    [allocation.roles, appliedCapacities],
+  );
+
+  const handleApply = () => {
+    startTransition(() => {
+      setAppliedCapacities(new Map(draftCapacities));
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+      <div className="space-y-4">
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">
+              Kapazitäten vs. Nachfrage
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Aktuelle Zielgrößen pro Rolle im Verhältnis zu gemeldeten Präferenzen.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {capacityChart.map((entry, index) => {
+              const overbooked = entry.demand > entry.capacity;
+              return (
+                <div key={entry.roleId} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm font-medium">
+                    <span className="text-muted-foreground">{entry.label}</span>
+                    <span className={overbooked ? "text-rose-500" : "text-foreground/80"}>
+                      {entry.capacity} / {entry.demand}
+                    </span>
+                  </div>
+                  <div className="flex h-2 overflow-hidden rounded-full bg-muted/50">
+                    <motion.div
+                      initial={{ width: 0 }}
+                      animate={{ width: `${Math.min(100, (entry.capacity / Math.max(entry.demand, 1)) * 100)}%` }}
+                      transition={{ delay: index * 0.04, duration: 0.45, ease: "easeOut" }}
+                      className={`h-full ${overbooked ? "bg-rose-400" : "bg-emerald-400"}`}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">
+              Vorschlagsliste
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Top-Kandidat:innen je Slot inkl. Alternativen und Score.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {assignments.map((assignment) => (
+              <div key={assignment.role.roleId} className="space-y-3 rounded-xl border border-border/40 bg-card/60 p-4 shadow-sm">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground/80">{assignment.role.label}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {assignment.capacity} Slots · Nachfrage {assignment.role.demand}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="gap-1 text-xs uppercase tracking-[0.14em]">
+                    <UsersRound className="h-3.5 w-3.5" />
+                    {assignment.role.domain === "acting" ? "Acting" : "Crew"}
+                  </Badge>
+                </div>
+                <div className="space-y-3">
+                  {assignment.slots.map((slot, index) => (
+                    <div
+                      key={slot.slotId}
+                      className="rounded-lg border border-border/30 bg-background/60 p-3"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="text-sm font-semibold text-foreground/85">
+                          Slot {index + 1}
+                        </span>
+                        {slot.candidate ? (
+                          <Badge variant="success" className="gap-1 text-xs">
+                            <CheckCircle2 className="h-3.5 w-3.5" />
+                            Score {slot.candidate.score.toFixed(2)} · Konfidenz {Math.round(slot.candidate.confidence * 100)}%
+                          </Badge>
+                        ) : (
+                          <Badge variant="warning" className="text-xs">Noch unbesetzt</Badge>
+                        )}
+                      </div>
+                      {slot.candidate ? (
+                        <div className="mt-2 space-y-1 text-sm">
+                          <p className="font-medium">{slot.candidate.name}</p>
+                          <p className="text-muted-foreground">{slot.candidate.justification}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Fokus {slot.candidate.focus ?? "–"} · Erfahrung {slot.candidate.experienceYears ?? 0} Jahre
+                          </p>
+                          {slot.candidate.interests.length ? (
+                            <p className="text-xs text-muted-foreground">
+                              Interessen: {slot.candidate.interests.slice(0, 3).join(", ")}
+                            </p>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <p className="mt-2 text-sm text-muted-foreground">Noch keine passende Zuordnung.</p>
+                      )}
+                      {slot.alternatives.length ? (
+                        <div className="mt-3 space-y-1">
+                          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                            Alternativen
+                          </p>
+                          <ul className="space-y-1 text-xs text-muted-foreground">
+                            {slot.alternatives.map((candidate) => (
+                              <li key={`${slot.slotId}-${candidate.userId}`}>
+                                {candidate.name} · Score {candidate.score.toFixed(2)} · Konfidenz {Math.round(candidate.confidence * 100)}%
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-4">
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">
+              Fairness-Ampeln
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">Kontrolle über zentrale Ausgleichsmetriken.</p>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {allocation.fairness.map((metric) => (
+              <div key={metric.id} className="flex flex-col gap-1">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-foreground/80">{metric.label}</span>
+                  <Badge
+                    variant={
+                      metric.status === "ok"
+                        ? "success"
+                        : metric.status === "warning"
+                          ? "warning"
+                          : "destructive"
+                    }
+                    className="uppercase tracking-[0.14em]"
+                  >
+                    {metric.value.toFixed(1)} (Ziel {metric.target})
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">{metric.description}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">
+              Kapazitäten anpassen
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">Setze Slots neu und starte die Optimierung.</p>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-3">
+              {allocation.roles.map((role) => {
+                const max = Math.max(role.demand, role.capacity + 3);
+                const current = draftCapacities.get(role.roleId) ?? role.capacity;
+                return (
+                  <div key={`slider-${role.roleId}`} className="space-y-1">
+                    <div className="flex items-center justify-between text-sm font-medium">
+                      <span className="text-muted-foreground">{role.label}</span>
+                      <span className="text-foreground/80">{current} Slots</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={Math.max(1, max)}
+                      value={current}
+                      onChange={(event) => {
+                        const value = Number(event.target.value);
+                        setDraftCapacities((prev) => {
+                          const next = new Map(prev);
+                          next.set(role.roleId, value);
+                          return next;
+                        });
+                      }}
+                      className="h-2 w-full cursor-pointer appearance-none rounded-full bg-muted/40 accent-primary"
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <Button
+              onClick={handleApply}
+              disabled={!pendingChanges}
+              className="w-full"
+              variant="secondary"
+              data-state={isRecalculating ? "loading" : undefined}
+            >
+              {isRecalculating ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" /> Neu berechnen …
+                </>
+              ) : (
+                "Neu berechnen"
+              )}
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">Konfliktliste</CardTitle>
+            <p className="text-sm text-muted-foreground">Gleich hohe Scores & notwendige Entscheidungshilfen.</p>
+          </CardHeader>
+          <CardContent>
+            {allocation.conflicts.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Keine Konflikte erkannt – alle Prioritäten sind eindeutig.</p>
+            ) : (
+              <div className="space-y-3">
+                {allocation.conflicts.map((conflict) => (
+                  <div key={conflict.roleId} className="rounded-lg border border-border/40 bg-background/60 p-3">
+                    <p className="text-sm font-semibold text-foreground/85">{conflict.label}</p>
+                    <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+                      {conflict.candidates.map((candidate) => (
+                        <li key={candidate.userId}>
+                          {candidate.name} · Score {candidate.score.toFixed(2)} · Kriterium: {candidate.tieBreaker}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { AnimatePresence, motion } from "framer-motion";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { OnboardingDashboardData, OnboardingSummary } from "@/lib/onboarding/dashboard-schemas";
+import { useRealtime } from "@/hooks/useRealtime";
+
+import { AllocationTab } from "./allocation-tab";
+import { GlobalOverviewTab } from "./global-tab";
+import { HeaderBar } from "./header-bar";
+import { HistoryTab } from "./history-tab";
+
+function dashboardQueryKey(onboardingId: string) {
+  return ["onboarding-dashboard", onboardingId] as const;
+}
+
+async function fetchDashboard(onboardingId: string): Promise<OnboardingDashboardData> {
+  const response = await fetch(`/api/dashboard/onboarding/${onboardingId}`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`Dashboard request failed (${response.status})`);
+  }
+  return (await response.json()) as OnboardingDashboardData;
+}
+
+type DashboardClientProps = {
+  initialData: OnboardingDashboardData;
+  onboardings: OnboardingSummary[];
+};
+
+export function DashboardClient({ initialData, onboardings }: DashboardClientProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { socket, joinRoom, leaveRoom } = useRealtime();
+  const [selectedOnboarding, setSelectedOnboarding] = useState(initialData.onboarding.id);
+  const [tabValue, setTabValue] = useState<"global" | "allocation" | "history">("global");
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setSelectedOnboarding(initialData.onboarding.id);
+    queryClient.setQueryData(dashboardQueryKey(initialData.onboarding.id), initialData);
+  }, [initialData, queryClient]);
+
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: dashboardQueryKey(selectedOnboarding),
+    queryFn: () => fetchDashboard(selectedOnboarding),
+    initialData: selectedOnboarding === initialData.onboarding.id ? initialData : undefined,
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+
+  useEffect(() => {
+    if (!selectedOnboarding) {
+      return;
+    }
+    const room = `onboarding_${selectedOnboarding}` as const;
+    joinRoom(room);
+    return () => {
+      leaveRoom(room);
+    };
+  }, [joinRoom, leaveRoom, selectedOnboarding]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handleUpdate = (event: { onboardingId: string; dashboard: OnboardingDashboardData }) => {
+      queryClient.setQueryData(dashboardQueryKey(event.onboardingId), event.dashboard);
+    };
+    socket.on("onboarding_dashboard_update", handleUpdate);
+    return () => {
+      socket.off("onboarding_dashboard_update", handleUpdate);
+    };
+  }, [socket, queryClient]);
+
+  const currentData = data ?? initialData;
+
+  useEffect(() => {
+    if (tabValue === "history" && !(currentData.history && currentData.history.length > 0)) {
+      setTabValue("global");
+    }
+  }, [tabValue, currentData.history]);
+
+  const handleSelect = (nextId: string) => {
+    if (!nextId) return;
+    setSelectedOnboarding(nextId);
+    startTransition(() => {
+      router.replace(`/dashboard/onboarding/${nextId}`);
+    });
+  };
+
+  const historyAvailable = (currentData.history?.length ?? 0) > 0;
+
+  return (
+    <div className="space-y-6">
+      <HeaderBar
+        onboardings={onboardings}
+        selectedId={selectedOnboarding}
+        statusLabel={currentData.onboarding.statusLabel}
+        status={currentData.onboarding.status}
+        timeSpan={currentData.onboarding.timeSpan}
+        participants={currentData.onboarding.participants}
+        isRefreshing={isFetching || isPending}
+        onSelect={handleSelect}
+        onRefresh={() => void refetch()}
+      />
+      <Tabs
+        value={tabValue}
+        onValueChange={(value) => setTabValue(value as typeof tabValue)}
+        className="space-y-6"
+      >
+        <TabsList>
+          <TabsTrigger value="global">Global</TabsTrigger>
+          <TabsTrigger value="allocation">Zuteilung</TabsTrigger>
+          {historyAvailable ? <TabsTrigger value="history">Historie</TabsTrigger> : null}
+        </TabsList>
+        <AnimatePresence mode="wait">
+          <TabsContent value="global" className="space-y-6">
+            <motion.div
+              key={`${currentData.onboarding.id}-global`}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.3, ease: "easeOut" }}
+            >
+              <GlobalOverviewTab data={currentData.global} participants={currentData.onboarding.participants} />
+            </motion.div>
+          </TabsContent>
+          <TabsContent value="allocation" className="space-y-6">
+            <motion.div
+              key={`${currentData.onboarding.id}-allocation`}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.3, ease: "easeOut" }}
+            >
+              <AllocationTab allocation={currentData.allocation} />
+            </motion.div>
+          </TabsContent>
+          {historyAvailable ? (
+            <TabsContent value="history" className="space-y-6">
+              <motion.div
+                key={`${currentData.onboarding.id}-history`}
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -12 }}
+                transition={{ duration: 0.3, ease: "easeOut" }}
+              >
+                <HistoryTab history={currentData.history} />
+              </motion.div>
+            </TabsContent>
+          ) : null}
+        </AnimatePresence>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/distribution-bars.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/distribution-bars.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { z } from "zod";
+
+import { distributionEntrySchema } from "@/lib/onboarding/dashboard-schemas";
+
+type DistributionBarsProps = {
+  title: string;
+  items: Array<z.infer<typeof distributionEntrySchema>>;
+  subtitle?: string;
+  className?: string;
+};
+
+const intentPalette: Record<string, string> = {
+  default: "bg-primary/40",
+  success: "bg-emerald-500/80",
+  warning: "bg-amber-500/80",
+  critical: "bg-rose-500/80",
+};
+
+export function DistributionBars({ title, items, subtitle, className }: DistributionBarsProps) {
+  return (
+    <Card className={cn("h-full", className)}>
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">{title}</CardTitle>
+        {subtitle ? <p className="text-sm text-muted-foreground">{subtitle}</p> : null}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine Daten vorhanden.</p>
+        ) : (
+          <ul className="space-y-2">
+            {items.map((item, index) => {
+              const width = Math.min(100, item.percentage ?? item.value ?? 0);
+              const palette = intentPalette[item.intent ?? "default"] ?? intentPalette.default;
+              return (
+                <li key={item.label} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm font-medium">
+                    <span className="text-muted-foreground">{item.label}</span>
+                    <span>{item.value.toLocaleString("de-DE", { maximumFractionDigits: 1 })}</span>
+                  </div>
+                  <div className="h-2 rounded-full bg-muted/60">
+                    <motion.div
+                      initial={{ width: 0 }}
+                      animate={{ width: `${width}%` }}
+                      transition={{ delay: index * 0.04, duration: 0.4, ease: "easeOut" }}
+                      className={`h-full rounded-full ${palette}`}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/global-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/global-tab.tsx
@@ -1,0 +1,129 @@
+"use client";
+import { motion } from "framer-motion";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { OnboardingDashboardData } from "@/lib/onboarding/dashboard-schemas";
+
+import { DistributionBars } from "./distribution-bars";
+import { InterestsSection } from "./interests-section";
+import { MetricCard } from "./metric-card";
+import { NutritionSection } from "./nutrition-section";
+import { ProcessSection } from "./process-section";
+import { RoleHeatmap } from "./role-heatmap";
+
+type GlobalOverviewTabProps = {
+  data: OnboardingDashboardData["global"];
+  participants: number;
+};
+
+function RoleDistribution({
+  title,
+  roles,
+  coverage,
+}: {
+  title: string;
+  roles: OnboardingDashboardData["global"]["rolesActing"];
+  coverage: number;
+}) {
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">{title}</CardTitle>
+          <Badge variant={coverage >= 70 ? "success" : coverage >= 40 ? "warning" : "destructive"}>
+            {coverage.toFixed(0)}% Coverage
+          </Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">Normierte Präferenzen & Anteil beteiligter Personen.</p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {roles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine Präferenzdaten vorhanden.</p>
+        ) : (
+          <ul className="space-y-3">
+            {roles.map((role, index) => (
+              <li key={role.roleId} className="space-y-1">
+                <div className="flex items-center justify-between text-sm font-medium">
+                  <span className="text-muted-foreground">{role.label}</span>
+                  <span className="text-foreground/80">{(role.normalizedShare * 100).toFixed(0)}%</span>
+                </div>
+                <div className="h-2 rounded-full bg-muted/50">
+                  <motion.div
+                    initial={{ width: 0 }}
+                    animate={{ width: `${Math.min(100, role.normalizedShare * 100)}%` }}
+                    transition={{ delay: index * 0.05, duration: 0.45, ease: "easeOut" }}
+                    className="h-full rounded-full bg-primary/60"
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Beteiligung: {role.participantShare.toFixed(0)}% der Teilnehmenden
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function GlobalOverviewTab({ data, participants }: GlobalOverviewTabProps) {
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {data.kpis.map((metric, index) => (
+          <MetricCard key={metric.id} metric={metric} index={index} />
+        ))}
+      </div>
+      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+        <DistributionBars title="Altersgruppen" items={data.ageGroups} subtitle="Verteilung der angegebenen Altersgruppen" />
+        <DistributionBars title="Geschlechter" items={data.genderDistribution} subtitle="Selbstangaben" />
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">Fotoeinverständnis</CardTitle>
+            <p className="text-sm text-muted-foreground">Quote bestätigter Einverständnisse.</p>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="text-4xl font-semibold">
+              {data.photoConsentRate !== null ? `${(data.photoConsentRate * 100).toFixed(0)}%` : "–"}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {data.photoConsentRate !== null
+                ? `${Math.round((data.photoConsentRate || 0) * participants)} von ${participants} Personen`
+                : "Es liegen keine Angaben vor."}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+      <div className="grid gap-4 lg:grid-cols-3">
+        <RoleDistribution
+          title="Rollenpräferenzen (Acting)"
+          roles={data.rolesActing}
+          coverage={data.roleCoverage.acting}
+        />
+        <RoleDistribution
+          title="Gewerkepräferenzen (Crew)"
+          roles={data.rolesCrew}
+          coverage={data.roleCoverage.crew}
+        />
+        <RoleHeatmap
+          data={data.roleHeatmap}
+          subtitle="Intensität der Doppel-Präferenzen acting × crew"
+          title="Heatmap"
+        />
+      </div>
+      <InterestsSection
+        topTags={data.interestTopTags}
+        wordCloud={data.interestWordCloud}
+        coOccurrences={data.interestCoOccurrences}
+        clusters={data.interestClusters}
+        diversity={data.diversity}
+      />
+      <div className="grid gap-4 lg:grid-cols-2">
+        <NutritionSection data={data.nutrition} totalParticipants={participants} />
+        <ProcessSection steps={data.process.steps} documents={data.process.documents} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { Share2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { OnboardingSummary } from "@/lib/onboarding/dashboard-schemas";
+
+const statusVariant: Record<OnboardingSummary["status"], "success" | "warning" | "muted"> = {
+  active: "success",
+  draft: "warning",
+  completed: "muted",
+  archived: "muted",
+};
+
+type HeaderBarProps = {
+  onboardings: OnboardingSummary[];
+  selectedId: string;
+  statusLabel: string;
+  status: OnboardingSummary["status"];
+  timeSpan: string | null;
+  participants: number;
+  isRefreshing: boolean;
+  onSelect: (id: string) => void;
+  onRefresh?: () => void;
+};
+
+export function HeaderBar({
+  onboardings,
+  selectedId,
+  statusLabel,
+  status,
+  timeSpan,
+  participants,
+  isRefreshing,
+  onSelect,
+  onRefresh,
+}: HeaderBarProps) {
+  const [shareState, setShareState] = useState<"idle" | "success" | "error">("idle");
+
+  const statusText = useMemo(() => {
+    switch (status) {
+      case "active":
+        return "Aktiv";
+      case "draft":
+        return "In Vorbereitung";
+      case "completed":
+        return "Abgeschlossen";
+      case "archived":
+        return "Archiviert";
+      default:
+        return statusLabel;
+    }
+  }, [status, statusLabel]);
+
+  const handleShare = useCallback(async () => {
+    try {
+      const url = typeof window !== "undefined" ? window.location.href : "";
+      if (navigator.share) {
+        await navigator.share({ title: "Onboarding Dashboard", url });
+      } else if (navigator.clipboard && url) {
+        await navigator.clipboard.writeText(url);
+      }
+      setShareState("success");
+      setTimeout(() => setShareState("idle"), 2000);
+    } catch (error) {
+      console.error("Share failed", error);
+      setShareState("error");
+      setTimeout(() => setShareState("idle"), 2500);
+    }
+  }, []);
+
+  return (
+    <Card className="flex flex-col gap-4 rounded-2xl border border-border/40 bg-card/70 p-4 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+      <div className="flex flex-1 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-semibold leading-tight tracking-tight sm:text-2xl">
+              Onboarding-Dashboard
+            </h1>
+            <Badge variant={statusVariant[status] ?? "muted"}>{statusText}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {timeSpan ? `Zeitraum ${timeSpan}` : "Zeitraum in Planung"} · {participants} Teilnehmende
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <Select value={selectedId} onValueChange={onSelect}>
+            <SelectTrigger className="w-full min-w-[220px] sm:w-60">
+              <SelectValue placeholder="Onboarding auswählen" />
+            </SelectTrigger>
+            <SelectContent className="max-h-72">
+              {onboardings.map((option) => (
+                <SelectItem key={option.id} value={option.id}>
+                  <div className="flex flex-col">
+                    <span className="font-medium text-foreground/90">{option.title}</span>
+                    {option.periodLabel ? (
+                      <span className="text-xs text-muted-foreground">{option.periodLabel}</span>
+                    ) : null}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            type="button"
+            variant="secondary"
+            className="w-full sm:w-auto"
+            onClick={handleShare}
+          >
+            <Share2 className="h-4 w-4" />
+            {shareState === "success" ? "Link kopiert" : shareState === "error" ? "Fehler" : "Teilen"}
+          </Button>
+        </div>
+      </div>
+      {onRefresh ? (
+        <Button
+          type="button"
+          variant="ghost"
+          className="self-end text-sm text-muted-foreground hover:text-foreground"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+        >
+          {isRefreshing ? "Aktualisiere…" : "Refresh"}
+        </Button>
+      ) : null}
+    </Card>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/history-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/history-tab.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { OnboardingDashboardData } from "@/lib/onboarding/dashboard-schemas";
+
+import { DistributionBars } from "./distribution-bars";
+
+type HistoryTabProps = {
+  history: OnboardingDashboardData["history"] | undefined;
+};
+
+export function HistoryTab({ history }: HistoryTabProps) {
+  if (!history || history.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">
+            Historie
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Für dieses Onboarding liegen noch keine Vergleichsdaten vor.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const participants = history.map((item) => ({
+    label: item.label,
+    value: item.participants,
+  }));
+  const medianAge = history
+    .filter((item) => item.medianAge !== null)
+    .map((item) => ({
+      label: item.label,
+      value: item.medianAge ?? 0,
+    }));
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">
+            Historischer Vergleich
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="overflow-x-auto">
+            <table className="min-w-full border-collapse text-sm">
+              <thead>
+                <tr className="text-left text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                  <th className="px-3 py-2">Onboarding</th>
+                  <th className="px-3 py-2">Teilnehmer</th>
+                  <th className="px-3 py-2">Medianalter</th>
+                  <th className="px-3 py-2">Fokus both</th>
+                  <th className="px-3 py-2">Start</th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.map((item) => (
+                  <tr key={item.onboardingId} className="border-t border-border/40">
+                    <td className="px-3 py-2 font-medium text-foreground/80">{item.label}</td>
+                    <td className="px-3 py-2">{item.participants}</td>
+                    <td className="px-3 py-2">{item.medianAge ? `${item.medianAge.toFixed(1)} Jahre` : "–"}</td>
+                    <td className="px-3 py-2">{item.focusBothShare ? `${item.focusBothShare.toFixed(0)}%` : "–"}</td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {new Date(item.createdAt).toLocaleDateString("de-DE", {
+                        day: "2-digit",
+                        month: "short",
+                        year: "numeric",
+                      })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+      <div className="grid gap-4 md:grid-cols-2">
+        <DistributionBars title="Teilnehmende" items={participants} />
+        <DistributionBars title="Medianalter" items={medianAge} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/interests-section.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/interests-section.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { z } from "zod";
+
+import {
+  clusterNodeSchema,
+  coOccurrenceEdgeSchema,
+  diversityMetricSchema,
+  distributionEntrySchema,
+} from "@/lib/onboarding/dashboard-schemas";
+
+import { DistributionBars } from "./distribution-bars";
+
+type InterestsSectionProps = {
+  topTags: Array<z.infer<typeof distributionEntrySchema>>;
+  wordCloud: Array<{ tag: string; weight: number }>;
+  coOccurrences: Array<z.infer<typeof coOccurrenceEdgeSchema>>;
+  clusters: Array<z.infer<typeof clusterNodeSchema>>;
+  diversity: z.infer<typeof diversityMetricSchema>;
+};
+
+const clusterColors: Record<string, string> = {
+  schauspiel: "from-rose-500/60 to-rose-500/15",
+  technik: "from-sky-500/60 to-sky-500/15",
+  musik: "from-indigo-500/60 to-indigo-500/15",
+  orga: "from-emerald-500/60 to-emerald-500/15",
+  allgemein: "from-amber-500/60 to-amber-500/15",
+};
+
+export function InterestsSection({ topTags, wordCloud, coOccurrences, clusters, diversity }: InterestsSectionProps) {
+  const sortedEdges = [...coOccurrences]
+    .sort((a, b) => b.weight - a.weight)
+    .slice(0, 8);
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-3">
+      <DistributionBars title="Top-Interessen" items={topTags} subtitle="Häufigste Angaben" />
+      <Card className="h-full">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">Wordcloud</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Schriftgröße entspricht relativer Häufigkeit der Nennung.
+          </p>
+        </CardHeader>
+        <CardContent>
+          {wordCloud.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Keine Interessen hinterlegt.</p>
+          ) : (
+            <div className="flex flex-wrap gap-3">
+              {wordCloud.map((entry) => {
+                const scale = Math.min(2.4, 0.8 + entry.weight / (wordCloud[0]?.weight ?? 1));
+                return (
+                  <motion.span
+                    key={`${entry.tag}-${entry.weight}`}
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale }}
+                    transition={{ duration: 0.35 }}
+                    className="rounded-full bg-muted/60 px-3 py-1 text-sm font-medium text-foreground/80 shadow-sm"
+                  >
+                    {entry.tag}
+                  </motion.span>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <Card className="h-full">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">Diversität</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Mischung der Interessensgebiete & Häufigkeit.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge variant={diversity.status === "ok" ? "success" : diversity.status === "warning" ? "warning" : "destructive"}>
+              {diversity.status === "ok" ? "sehr vielfältig" : diversity.status === "warning" ? "ausbalanciert" : "monoton"}
+            </Badge>
+            <span className="text-sm text-muted-foreground">{diversity.explanation}</span>
+          </div>
+          <dl className="grid gap-2 text-sm">
+            <div className="flex items-center justify-between">
+              <dt className="text-muted-foreground">Shannon</dt>
+              <dd className="font-medium">{diversity.shannon.toFixed(2)}</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-muted-foreground">Gini</dt>
+              <dd className="font-medium">{diversity.gini.toFixed(2)}</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-muted-foreground">Normalisiert</dt>
+              <dd className="font-medium">{(diversity.normalized * 100).toFixed(0)}%</dd>
+            </div>
+          </dl>
+          <div className="grid gap-2">
+            {clusters.map((cluster) => {
+              const gradient = clusterColors[cluster.id] ?? clusterColors.allgemein;
+              return (
+                <div
+                  key={cluster.id}
+                  className={`flex items-center justify-between rounded-xl border border-border/40 bg-gradient-to-r ${gradient} px-3 py-2`}
+                >
+                  <span className="text-sm font-semibold uppercase tracking-[0.12em] text-foreground/85">
+                    {cluster.label}
+                  </span>
+                  <span className="text-sm font-medium">{cluster.value.toLocaleString("de-DE")}</span>
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+      <Card className="xl:col-span-3">
+        <CardHeader className="space-y-1">
+          <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">Co-Occurrences</CardTitle>
+          <p className="text-sm text-muted-foreground">Gemeinsame Tags pro Person (Top 8).</p>
+        </CardHeader>
+        <CardContent>
+          {sortedEdges.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Keine Kombinationen erfasst.</p>
+          ) : (
+            <div className="grid gap-2 md:grid-cols-2">
+              {sortedEdges.map((edge, index) => (
+                <motion.div
+                  key={`${edge.source}-${edge.target}`}
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.05 }}
+                  className="flex items-center justify-between rounded-lg border border-border/50 bg-muted/40 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 text-sm font-medium text-foreground/80">
+                    <span className="rounded-full bg-background/80 px-2 py-0.5 text-xs uppercase tracking-[0.12em]">
+                      {edge.source}
+                    </span>
+                    <span className="text-muted-foreground">×</span>
+                    <span className="rounded-full bg-background/80 px-2 py-0.5 text-xs uppercase tracking-[0.12em]">
+                      {edge.target}
+                    </span>
+                  </div>
+                  <span className="text-sm font-semibold">{edge.weight}</span>
+                </motion.div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/metric-card.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/metric-card.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { z } from "zod";
+
+import { kpiCardSchema } from "@/lib/onboarding/dashboard-schemas";
+
+type MetricCardProps = {
+  metric: z.infer<typeof kpiCardSchema>;
+  index: number;
+};
+
+const intentStyles: Record<string, string> = {
+  default: "bg-gradient-to-br from-muted/50 to-muted/20",
+  success: "bg-gradient-to-br from-emerald-500/20 to-emerald-500/5 border-emerald-500/40",
+  warning: "bg-gradient-to-br from-amber-500/20 to-amber-500/5 border-amber-500/40",
+  critical: "bg-gradient-to-br from-rose-500/25 to-rose-500/5 border-rose-500/40",
+};
+
+const trendIntent: Record<string, string> = {
+  up: "success",
+  down: "critical",
+  flat: "muted",
+};
+
+export function MetricCard({ metric, index }: MetricCardProps) {
+  const intentClass = intentStyles[metric.intent ?? "default"] ?? intentStyles.default;
+  const trendVariant = metric.trend ? trendIntent[metric.trend.direction] ?? "muted" : null;
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.05, duration: 0.35, ease: "easeOut" }}
+      className="h-full"
+    >
+      <Card className={`h-full border border-border/40 ${intentClass}`}>
+        <CardHeader className="mb-3 space-y-2">
+          <div className="flex items-start justify-between gap-3">
+            <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">
+              {metric.label}
+            </CardTitle>
+            {metric.intent && metric.intent !== "default" ? (
+              <Badge
+                variant={metric.intent === "critical" ? "destructive" : metric.intent === "warning" ? "warning" : "success"}
+                className="uppercase tracking-[0.08em]"
+              >
+                {metric.intent === "critical"
+                  ? "kritisch"
+                  : metric.intent === "warning"
+                    ? "beobachten"
+                    : "im grünen Bereich"}
+              </Badge>
+            ) : null}
+          </div>
+          {metric.helper ? (
+            <p className="text-sm text-muted-foreground">{metric.helper}</p>
+          ) : null}
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            {typeof metric.value === "number"
+              ? metric.value.toLocaleString("de-DE", {
+                  maximumFractionDigits: 1,
+                })
+              : metric.value}
+          </div>
+          {metric.trend ? (
+            <div className="flex flex-wrap items-center gap-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              <Badge variant={trendVariant === "success" ? "success" : trendVariant === "critical" ? "destructive" : "muted"}>
+                {metric.trend.direction === "up"
+                  ? "Trend steigend"
+                  : metric.trend.direction === "down"
+                    ? "Trend sinkend"
+                    : "Stabil"}
+              </Badge>
+              {metric.trend.percentage !== undefined ? (
+                <span>{metric.trend.percentage.toFixed(1)}%</span>
+              ) : null}
+              {metric.trend.label ? <span className="text-muted-foreground/80">{metric.trend.label}</span> : null}
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+    </motion.div>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/nutrition-section.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/nutrition-section.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { z } from "zod";
+
+import { nutritionBreakdownSchema } from "@/lib/onboarding/dashboard-schemas";
+
+type NutritionSectionProps = {
+  data: z.infer<typeof nutritionBreakdownSchema>;
+  totalParticipants: number;
+  className?: string;
+};
+
+const dietPalette = [
+  "#5eead4",
+  "#60a5fa",
+  "#fbbf24",
+  "#f97316",
+  "#f87171",
+  "#c084fc",
+];
+
+const severityOrder = ["mild", "moderat", "schwer", "akut"];
+
+export function NutritionSection({ data, totalParticipants, className }: NutritionSectionProps) {
+  const totalDiets = data.diets.reduce((sum, entry) => sum + entry.count, 0);
+  const donutGradient = useMemo(() => {
+    if (!data.diets.length) {
+      return "conic-gradient(#94a3b8 0deg 360deg)";
+    }
+    let currentAngle = 0;
+    const segments = data.diets.map((entry, index) => {
+      const ratio = totalDiets > 0 ? entry.count / totalDiets : 0;
+      const degrees = ratio * 360;
+      const start = currentAngle;
+      const end = currentAngle + degrees;
+      currentAngle = end;
+      const color = dietPalette[index % dietPalette.length];
+      return `${color} ${start}deg ${end}deg`;
+    });
+    return `conic-gradient(${segments.join(", ")})`;
+  }, [data.diets, totalDiets]);
+
+  return (
+    <Card className={cn("h-full", className)}>
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">Ernährung & Allergien</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Überblick über Ernährungspräferenzen und gemeldete Unverträglichkeiten.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-col gap-4 lg:flex-row">
+          <div className="flex flex-1 items-center gap-4">
+            <div
+              className="h-36 w-36 rounded-full border border-border/40 shadow-inner"
+              style={{ background: donutGradient }}
+            >
+              <div className="flex h-full w-full items-center justify-center">
+                <span className="text-sm font-semibold text-foreground/80">
+                  {totalDiets > 0 ? `${Math.round((totalDiets / Math.max(totalParticipants, 1)) * 100)}%` : "–"}
+                </span>
+              </div>
+            </div>
+            <ul className="flex-1 space-y-2 text-sm">
+              {data.diets.length === 0 ? (
+                <li className="text-muted-foreground">Keine Angaben zu Ernährungspräferenzen vorhanden.</li>
+              ) : (
+                data.diets.map((entry, index) => (
+                  <li key={entry.label} className="flex items-center justify-between gap-3">
+                    <span className="flex items-center gap-2 text-muted-foreground">
+                      <span
+                        className="h-2.5 w-6 rounded-full"
+                        style={{ backgroundColor: dietPalette[index % dietPalette.length] }}
+                        aria-hidden
+                      />
+                      {entry.label}
+                    </span>
+                    <span className="font-medium">{entry.count}</span>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </div>
+        <div>
+          <h4 className="mb-2 text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            Allergien nach Schweregrad
+          </h4>
+          {data.allergies.length === 0 ? (
+            <p className="text-sm text-muted-foreground">Keine Allergien gemeldet.</p>
+          ) : (
+            <div className="space-y-2">
+              {data.allergies.map((entry) => {
+                const total = severityOrder.reduce((sum, key) => sum + (entry.severities[key] ?? 0), 0);
+                return (
+                  <div key={entry.allergen} className="space-y-1">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="font-medium text-foreground/80">{entry.allergen}</span>
+                      <span className="text-muted-foreground">{total} Meldungen</span>
+                    </div>
+                    <div className="flex h-2 overflow-hidden rounded-full border border-border/30 bg-muted/40">
+                      {severityOrder.map((severity, index) => {
+                        const value = entry.severities[severity] ?? 0;
+                        if (value <= 0) {
+                          return null;
+                        }
+                        const width = `${Math.max(4, (value / Math.max(total, 1)) * 100)}%`;
+                        const colors = ["bg-emerald-400", "bg-amber-400", "bg-orange-500", "bg-rose-500"];
+                        return (
+                          <motion.div
+                            key={severity}
+                            initial={{ width: 0 }}
+                            animate={{ width }}
+                            transition={{ duration: 0.4, delay: index * 0.05 }}
+                            className={cn("h-full", colors[index])}
+                          />
+                        );
+                      })}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                      {severityOrder.map((severity) => {
+                        const value = entry.severities[severity] ?? 0;
+                        return value > 0 ? (
+                          <span key={severity}>
+                            {severity}: {value}
+                          </span>
+                        ) : null;
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/process-section.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/process-section.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { z } from "zod";
+
+import { documentStatusSchema, processStepSchema } from "@/lib/onboarding/dashboard-schemas";
+
+type ProcessSectionProps = {
+  steps: Array<z.infer<typeof processStepSchema>>;
+  documents: z.infer<typeof documentStatusSchema>;
+};
+
+export function ProcessSection({ steps, documents }: ProcessSectionProps) {
+  const totalDocuments = documents.uploaded + documents.skipped + documents.pending;
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">Prozess & Dokumente</CardTitle>
+        <p className="text-sm text-muted-foreground">Fortschritt entlang der Onboarding-Schritte.</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          {steps.map((step, index) => {
+            const completion = Math.min(100, Math.max(0, step.completionRate));
+            const dropout = Math.min(100, Math.max(0, step.dropoutRate));
+            const barColor = completion >= 75 ? "bg-emerald-400" : completion >= 50 ? "bg-amber-400" : "bg-rose-400";
+            return (
+              <div key={step.id} className="space-y-1">
+                <div className="flex items-center justify-between text-sm font-medium">
+                  <span className="text-muted-foreground">{step.label}</span>
+                  <span className="text-foreground/80">{completion.toFixed(0)}%</span>
+                </div>
+                <div className="h-2 rounded-full bg-muted/50">
+                  <motion.div
+                    initial={{ width: 0 }}
+                    animate={{ width: `${completion}%` }}
+                    transition={{ delay: index * 0.05, duration: 0.45, ease: "easeOut" }}
+                    className={`h-full rounded-full ${barColor}`}
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground">Abbruchquote: {dropout.toFixed(0)}%</p>
+              </div>
+            );
+          })}
+        </div>
+        <div className="rounded-lg border border-border/40 bg-muted/30 p-3">
+          <h4 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Dokumentstatus</h4>
+          {totalDocuments === 0 ? (
+            <p className="mt-2 text-sm text-muted-foreground">Noch keine Dokumente eingereicht.</p>
+          ) : (
+            <dl className="mt-2 grid gap-2 text-sm">
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Uploads</dt>
+                <dd className="font-medium">{documents.uploaded}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Übersprungen</dt>
+                <dd className="font-medium">{documents.skipped}</dd>
+              </div>
+              <div className="flex items-center justify-between">
+                <dt className="text-muted-foreground">Ausstehend</dt>
+                <dd className="font-medium">{documents.pending}</dd>
+              </div>
+            </dl>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/role-heatmap.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/role-heatmap.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { z } from "zod";
+
+import { heatmapCellSchema } from "@/lib/onboarding/dashboard-schemas";
+
+type HeatmapCell = z.infer<typeof heatmapCellSchema>;
+
+type RoleHeatmapProps = {
+  title?: string;
+  data: HeatmapCell[];
+  subtitle?: string;
+};
+
+export function RoleHeatmap({ title = "Kombinationen", data, subtitle }: RoleHeatmapProps) {
+  const axes = useMemo(() => {
+    const acting = Array.from(new Set(data.map((cell) => cell.x))).sort();
+    const crew = Array.from(new Set(data.map((cell) => cell.y))).sort();
+    return { acting, crew };
+  }, [data]);
+
+  const maxValue = useMemo(() => {
+    return data.reduce((max, cell) => Math.max(max, cell.value), 0) || 1;
+  }, [data]);
+
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">{title}</CardTitle>
+        {subtitle ? <p className="text-sm text-muted-foreground">{subtitle}</p> : null}
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Noch keine Überschneidungen vorhanden.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full border-collapse">
+              <thead>
+                <tr>
+                  <th className="p-2 text-left text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                    Acting ↓ / Crew →
+                  </th>
+                  {axes.crew.map((crewRole) => (
+                    <th
+                      key={crewRole}
+                      className="px-2 py-1 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground"
+                    >
+                      {crewRole}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {axes.acting.map((actingRole) => (
+                  <tr key={actingRole}>
+                    <th className="whitespace-nowrap px-2 py-1 text-left text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                      {actingRole}
+                    </th>
+                    {axes.crew.map((crewRole, cellIndex) => {
+                      const cell = data.find((item) => item.x === actingRole && item.y === crewRole);
+                      const intensity = cell ? Math.min(1, cell.value / maxValue) : 0;
+                      const background = `rgba(45,212,191,${0.12 + intensity * 0.55})`;
+                      return (
+                        <td key={crewRole} className="px-2 py-1 text-center align-middle">
+                          <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: intensity, scale: 1 }}
+                            transition={{ delay: cellIndex * 0.02, duration: 0.3 }}
+                            className="flex h-8 items-center justify-center rounded-md border border-border/30"
+                            style={{ backgroundColor: background }}
+                          >
+                            <span className="text-xs font-medium text-foreground/80">
+                              {cell ? cell.value.toFixed(2) : "–"}
+                            </span>
+                          </motion.div>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/layout.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export default function OnboardingDashboardLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <section className="mx-auto w-full max-w-7xl px-4 pb-12 pt-8 sm:px-6 lg:px-8">
+      {children}
+    </section>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/loading.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function LoadingOnboardingDashboard() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-20 w-full rounded-xl" />
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 9 }).map((_, index) => (
+          <Skeleton key={index} className="h-48 rounded-2xl" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/onboarding/[onboardingId]/page.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/page.tsx
@@ -1,0 +1,53 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  getAvailableOnboardings,
+  getOnboardingDashboardData,
+} from "@/lib/onboarding/dashboard-service";
+
+import { DashboardClient } from "./_components/dashboard-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function OnboardingDashboardPage({
+  params,
+}: {
+  params: Promise<{ onboardingId: string }>;
+}) {
+  const resolvedParams = await params;
+  const onboardingId = resolvedParams?.onboardingId;
+
+  if (!onboardingId) {
+    notFound();
+  }
+
+  const [availableOnboardings, dashboard] = await Promise.all([
+    getAvailableOnboardings(),
+    getOnboardingDashboardData(onboardingId),
+  ]);
+
+  if (!dashboard) {
+    notFound();
+  }
+
+  const options = availableOnboardings.length
+    ? availableOnboardings
+    : [
+        {
+          id: onboardingId,
+          title: dashboard.onboarding.title,
+          periodLabel: dashboard.onboarding.timeSpan,
+          status: dashboard.onboarding.status,
+        },
+      ];
+
+  return (
+    <main id="main" className="space-y-6 pb-12">
+      <Suspense fallback={<Skeleton className="h-[480px] w-full rounded-2xl" />}>
+        <DashboardClient onboardings={options} initialData={dashboard} />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/lib/onboarding/dashboard-schemas.ts
+++ b/src/lib/onboarding/dashboard-schemas.ts
@@ -1,0 +1,197 @@
+import { z } from "zod";
+
+export const onboardingStatusSchema = z.enum(["draft", "active", "completed", "archived"]);
+
+export const onboardingSummarySchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  periodLabel: z.string().nullable(),
+  status: onboardingStatusSchema,
+});
+
+export const kpiCardSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  value: z.union([z.string(), z.number()]),
+  helper: z.string().optional(),
+  trend: z
+    .object({
+      direction: z.enum(["up", "down", "flat"]),
+      percentage: z.number().optional(),
+      label: z.string().optional(),
+    })
+    .optional(),
+  intent: z.enum(["default", "success", "warning", "critical"]).optional(),
+});
+
+export const distributionEntrySchema = z.object({
+  label: z.string(),
+  value: z.number(),
+  percentage: z.number().optional(),
+  intent: z.enum(["default", "success", "warning", "critical"]).optional(),
+});
+
+export const heatmapCellSchema = z.object({
+  x: z.string(),
+  y: z.string(),
+  value: z.number(),
+});
+
+export const coOccurrenceEdgeSchema = z.object({
+  source: z.string(),
+  target: z.string(),
+  weight: z.number(),
+});
+
+export const clusterNodeSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  value: z.number(),
+  intent: z.enum(["default", "success", "warning", "critical"]).optional(),
+});
+
+export const diversityMetricSchema = z.object({
+  shannon: z.number(),
+  gini: z.number(),
+  normalized: z.number(),
+  status: z.enum(["ok", "warning", "critical"]),
+  explanation: z.string(),
+});
+
+export const nutritionBreakdownSchema = z.object({
+  diets: z.array(
+    z.object({
+      label: z.string(),
+      count: z.number(),
+    }),
+  ),
+  allergies: z.array(
+    z.object({
+      allergen: z.string(),
+      severities: z.record(z.string(), z.number()),
+    }),
+  ),
+});
+
+export const processStepSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  completionRate: z.number(),
+  dropoutRate: z.number(),
+});
+
+export const documentStatusSchema = z.object({
+  uploaded: z.number(),
+  skipped: z.number(),
+  pending: z.number(),
+});
+
+export const roleAggregateSchema = z.object({
+  roleId: z.string(),
+  label: z.string(),
+  domain: z.enum(["acting", "crew"]),
+  normalizedShare: z.number(),
+  participantShare: z.number(),
+});
+
+export const allocationCandidateSchema = z.object({
+  userId: z.string(),
+  name: z.string(),
+  focus: z.enum(["acting", "tech", "both"]).optional(),
+  normalizedShare: z.number(),
+  qualityFactor: z.number(),
+  score: z.number(),
+  confidence: z.number(),
+  justification: z.string(),
+  interests: z.array(z.string()).default([]),
+  experienceYears: z.number().optional(),
+});
+
+export const allocationRoleSchema = z.object({
+  roleId: z.string(),
+  label: z.string(),
+  domain: z.enum(["acting", "crew"]),
+  capacity: z.number(),
+  demand: z.number(),
+  candidates: z.array(allocationCandidateSchema),
+});
+
+export const fairnessMetricSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  value: z.number(),
+  target: z.number(),
+  status: z.enum(["ok", "warning", "critical"]),
+  description: z.string(),
+});
+
+export const conflictItemSchema = z.object({
+  roleId: z.string(),
+  label: z.string(),
+  candidates: z.array(
+    z.object({
+      userId: z.string(),
+      name: z.string(),
+      score: z.number(),
+      tieBreaker: z.string(),
+    }),
+  ),
+});
+
+export const historySnapshotSchema = z.object({
+  onboardingId: z.string(),
+  label: z.string(),
+  participants: z.number(),
+  medianAge: z.number().nullable(),
+  focusBothShare: z.number().nullable(),
+  createdAt: z.string(),
+});
+
+export const onboardingGlobalSectionSchema = z.object({
+  kpis: z.array(kpiCardSchema),
+  ageGroups: z.array(distributionEntrySchema),
+  genderDistribution: z.array(distributionEntrySchema),
+  focusDistribution: z.array(distributionEntrySchema),
+  photoConsentRate: z.number().nullable(),
+  rolesActing: z.array(roleAggregateSchema),
+  rolesCrew: z.array(roleAggregateSchema),
+  roleCoverage: z.object({ acting: z.number(), crew: z.number() }),
+  roleHeatmap: z.array(heatmapCellSchema),
+  interestTopTags: z.array(distributionEntrySchema),
+  interestWordCloud: z.array(
+    z.object({
+      tag: z.string(),
+      weight: z.number(),
+    }),
+  ),
+  interestCoOccurrences: z.array(coOccurrenceEdgeSchema),
+  interestClusters: z.array(clusterNodeSchema),
+  diversity: diversityMetricSchema,
+  nutrition: nutritionBreakdownSchema,
+  process: z.object({
+    steps: z.array(processStepSchema),
+    documents: documentStatusSchema,
+  }),
+});
+
+export const onboardingAllocationSectionSchema = z.object({
+  roles: z.array(allocationRoleSchema),
+  fairness: z.array(fairnessMetricSchema),
+  conflicts: z.array(conflictItemSchema),
+});
+
+export const onboardingDashboardSchema = z.object({
+  onboarding: onboardingSummarySchema.extend({
+    statusLabel: z.string(),
+    timeSpan: z.string().nullable(),
+    participants: z.number(),
+  }),
+  global: onboardingGlobalSectionSchema,
+  allocation: onboardingAllocationSectionSchema,
+  history: z.array(historySnapshotSchema).optional(),
+});
+
+export type OnboardingDashboardData = z.infer<typeof onboardingDashboardSchema>;
+export type OnboardingSummary = z.infer<typeof onboardingSummarySchema>;
+export type AllocationRole = z.infer<typeof allocationRoleSchema>;
+export type AllocationCandidate = z.infer<typeof allocationCandidateSchema>;

--- a/src/lib/onboarding/dashboard-service.ts
+++ b/src/lib/onboarding/dashboard-service.ts
@@ -1,0 +1,1047 @@
+import { cache } from "react";
+import { differenceInYears, isAfter, isBefore, isWithinInterval } from "date-fns";
+
+import { prisma } from "@/lib/prisma";
+import type { AllergyLevel, OnboardingFocus } from "@prisma/client";
+import {
+  onboardingDashboardSchema,
+  onboardingSummarySchema,
+  type AllocationCandidate,
+  type AllocationRole,
+  type OnboardingDashboardData,
+  type OnboardingSummary,
+} from "./dashboard-schemas";
+
+interface DateRange {
+  start?: Date | null;
+  end?: Date | null;
+}
+
+function normalizeTitle(show: { title: string | null; year: number }): string {
+  if (show.title && show.title.trim()) {
+    return show.title.trim();
+  }
+  return `Produktion ${show.year}`;
+}
+
+function extractDateRange(raw: unknown): DateRange {
+  if (!raw) {
+    return {};
+  }
+
+  if (Array.isArray(raw)) {
+    const parsed = raw
+      .map((value) => {
+        if (typeof value === "string" || value instanceof Date) {
+          const date = value instanceof Date ? value : new Date(value);
+          return Number.isNaN(date.getTime()) ? null : date;
+        }
+        if (value && typeof value === "object" && "date" in (value as Record<string, unknown>)) {
+          const extracted = (value as Record<string, unknown>).date;
+          if (typeof extracted === "string" || extracted instanceof Date) {
+            const date = extracted instanceof Date ? extracted : new Date(extracted);
+            return Number.isNaN(date.getTime()) ? null : date;
+          }
+        }
+        return null;
+      })
+      .filter((date): date is Date => Boolean(date));
+
+    if (parsed.length === 0) {
+      return {};
+    }
+
+    const sorted = parsed.sort((a, b) => a.getTime() - b.getTime());
+    return { start: sorted[0], end: sorted[sorted.length - 1] };
+  }
+
+  if (typeof raw === "object" && raw) {
+    const candidate = raw as Record<string, unknown>;
+    const startRaw = candidate.start ?? candidate.begin ?? candidate.from;
+    const endRaw = candidate.end ?? candidate.until ?? candidate.to;
+    const start =
+      typeof startRaw === "string" || startRaw instanceof Date ? new Date(startRaw) : undefined;
+    const end = typeof endRaw === "string" || endRaw instanceof Date ? new Date(endRaw) : undefined;
+
+    return {
+      start: start && !Number.isNaN(start.getTime()) ? start : undefined,
+      end: end && !Number.isNaN(end.getTime()) ? end : undefined,
+    };
+  }
+
+  if (typeof raw === "string" || raw instanceof Date) {
+    const date = raw instanceof Date ? raw : new Date(raw);
+    return Number.isNaN(date.getTime()) ? {} : { start: date, end: date };
+  }
+
+  return {};
+}
+
+function formatDateRange(range: DateRange): string | null {
+  const { start, end } = range;
+  if (!start && !end) {
+    return null;
+  }
+
+  const formatterLong = new Intl.DateTimeFormat("de-DE", {
+    month: "short",
+    year: "numeric",
+  });
+  const formatterDay = new Intl.DateTimeFormat("de-DE", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+
+  if (start && end) {
+    if (start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth()) {
+      return `${formatterDay.format(start)} – ${formatterDay.format(end)}`;
+    }
+    return `${formatterLong.format(start)} – ${formatterLong.format(end)}`;
+  }
+
+  const single = start ?? end;
+  return single ? formatterLong.format(single) : null;
+}
+
+function deriveStatus(
+  show: {
+    revealedAt: Date | null;
+    finalRehearsalWeekStart: Date | null;
+  },
+  range: DateRange,
+): { status: OnboardingSummary["status"]; label: string } {
+  const now = new Date();
+  const start = range.start ?? show.revealedAt ?? null;
+  const end = range.end ?? show.finalRehearsalWeekStart ?? null;
+
+  if (!show.revealedAt || isAfter(now, show.revealedAt) === false) {
+    return { status: "draft", label: "In Vorbereitung" };
+  }
+
+  if (end && isBefore(end, now)) {
+    return { status: "completed", label: "Abgeschlossen" };
+  }
+
+  if (start && isBefore(start, now) && (!end || isAfter(end, now))) {
+    return { status: "active", label: "Aktiv" };
+  }
+
+  return { status: "active", label: "Aktiv" };
+}
+
+function roundTo(value: number, fractionDigits = 1): number {
+  const factor = 10 ** fractionDigits;
+  return Math.round(value * factor) / factor;
+}
+
+function toPercentage(value: number, total: number): number {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || total <= 0) {
+    return 0;
+  }
+  return (value / total) * 100;
+}
+
+function computeAge(dateOfBirth: Date | null | undefined): number | null {
+  if (!dateOfBirth) {
+    return null;
+  }
+  const age = differenceInYears(new Date(), dateOfBirth);
+  return Number.isFinite(age) && age >= 0 ? age : null;
+}
+
+function classifyAge(age: number): string {
+  if (age < 18) return "<18";
+  if (age < 26) return "18–25";
+  if (age < 41) return "26–40";
+  return ">40";
+}
+
+function shannonIndex(counts: number[]): number {
+  const total = counts.reduce((sum, value) => sum + value, 0);
+  if (total === 0) {
+    return 0;
+  }
+  return counts.reduce((entropy, count) => {
+    if (count <= 0) return entropy;
+    const p = count / total;
+    return entropy - p * Math.log(p);
+  }, 0);
+}
+
+function giniIndex(counts: number[]): number {
+  const total = counts.reduce((sum, value) => sum + value, 0);
+  if (total === 0) {
+    return 0;
+  }
+  const sorted = [...counts].sort((a, b) => a - b);
+  const cumulative = sorted.reduce(
+    (acc, value, index) => acc + value * (index + 1),
+    0,
+  );
+  return (2 * cumulative) / (total * counts.length) - (counts.length + 1) / counts.length;
+}
+
+function severityLabel(level: AllergyLevel): "mild" | "moderat" | "schwer" | "akut" {
+  switch (level) {
+    case "MILD":
+      return "mild";
+    case "MODERATE":
+      return "moderat";
+    case "SEVERE":
+      return "schwer";
+    case "LETHAL":
+      return "akut";
+    default:
+      return "mild";
+  }
+}
+
+function formatPercentage(value: number, fractionDigits = 1): string {
+  return `${roundTo(value, fractionDigits).toLocaleString("de-DE", {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })}%`;
+}
+
+function determineFocusIntent(focus: OnboardingFocus): "success" | "warning" | "default" {
+  switch (focus) {
+    case "acting":
+      return "success";
+    case "tech":
+      return "warning";
+    default:
+      return "default";
+  }
+}
+
+function normalizeConfidence(score: number, maxScore: number): number {
+  if (maxScore <= 0) {
+    return 0;
+  }
+  return Math.min(1, score / maxScore);
+}
+
+interface CandidateInput {
+  userId: string;
+  name: string;
+  focus: OnboardingFocus | null;
+  interests: string[];
+  experienceYears: number | null;
+  actingShares: Map<string, number>;
+  crewShares: Map<string, number>;
+}
+
+interface BuildAllocationArgs {
+  roles: AllocationRole[];
+  candidates: CandidateInput[];
+}
+
+function recomputeAllocation({ roles, candidates }: BuildAllocationArgs): AllocationRole[] {
+  const candidateLookup = new Map<string, CandidateInput>();
+  candidates.forEach((candidate) => {
+    candidateLookup.set(candidate.userId, candidate);
+  });
+
+  return roles.map((role) => {
+    const baseCandidates = role.candidates
+      .map((candidate) => {
+        const source = candidateLookup.get(candidate.userId);
+        if (!source) {
+          return candidate;
+        }
+        const share =
+          role.domain === "acting"
+            ? source.actingShares.get(role.roleId) ?? candidate.normalizedShare
+            : source.crewShares.get(role.roleId) ?? candidate.normalizedShare;
+
+        const focusAlignment = source.focus === "both" || source.focus === (role.domain === "acting" ? "acting" : "tech");
+        const qualityFactor = focusAlignment ? candidate.qualityFactor + 0.1 : candidate.qualityFactor;
+        const score = share * qualityFactor;
+        const maxScore = Math.max(...role.candidates.map((item) => item.score), 1);
+
+        return {
+          ...candidate,
+          normalizedShare: share,
+          qualityFactor,
+          score,
+          confidence: normalizeConfidence(score, maxScore),
+        } satisfies AllocationCandidate;
+      })
+      .sort((a, b) => b.score - a.score);
+
+    return {
+      ...role,
+      candidates: baseCandidates,
+    } satisfies AllocationRole;
+  });
+}
+
+function buildConflictList(roles: AllocationRole[]): OnboardingDashboardData["allocation"]["conflicts"] {
+  return roles
+    .flatMap((role) => {
+      if (role.candidates.length < 2) {
+        return [];
+      }
+      const [primary, secondary] = role.candidates;
+      const delta = Math.abs(primary.score - secondary.score);
+      if (delta > 0.05) {
+        return [];
+      }
+      return [
+        {
+          roleId: role.roleId,
+          label: role.label,
+          candidates: role.candidates.slice(0, 3).map((candidate) => ({
+            userId: candidate.userId,
+            name: candidate.name,
+            score: roundTo(candidate.score, 3),
+            tieBreaker: candidate.justification,
+          })),
+        },
+      ];
+    })
+    .slice(0, 12);
+}
+
+function buildFairnessMetrics(
+  profiles: Array<{
+    gender: string | null;
+    memberSinceYear: number | null;
+    focus: OnboardingFocus;
+  }>,
+): OnboardingDashboardData["allocation"]["fairness"] {
+  const genders = profiles.reduce(
+    (acc, profile) => {
+      const key = profile.gender?.toLowerCase() ?? "divers";
+      acc.set(key, (acc.get(key) ?? 0) + 1);
+      return acc;
+    },
+    new Map<string, number>(),
+  );
+
+  const total = profiles.length || 1;
+  const femaleShare = genders.get("weiblich") ?? genders.get("f") ?? 0;
+  const maleShare = genders.get("männlich") ?? genders.get("m") ?? 0;
+  const otherShare = total - femaleShare - maleShare;
+  const femalePercentage = toPercentage(femaleShare, total);
+  const malePercentage = toPercentage(maleShare, total);
+  const target = 50;
+  const genderDelta = Math.abs(femalePercentage - malePercentage);
+
+  const fairnessStatus = genderDelta <= 15 ? "ok" : genderDelta <= 25 ? "warning" : "critical";
+
+  const now = new Date();
+  const experienceYears = profiles
+    .map((profile) => (profile.memberSinceYear ? now.getFullYear() - profile.memberSinceYear : null))
+    .filter((value): value is number => value !== null && Number.isFinite(value));
+  const averageExperience =
+    experienceYears.length > 0
+      ? experienceYears.reduce((sum, value) => sum + value, 0) / experienceYears.length
+      : 0;
+
+  const noviceShare = toPercentage(
+    experienceYears.filter((value) => value <= 1).length,
+    profiles.length || 1,
+  );
+  const veteranShare = toPercentage(
+    experienceYears.filter((value) => value >= 5).length,
+    profiles.length || 1,
+  );
+
+  const focusBothShare = toPercentage(
+    profiles.filter((profile) => profile.focus === "both").length,
+    profiles.length || 1,
+  );
+
+  return [
+    {
+      id: "gender-balance",
+      label: "Geschlechterverteilung",
+      value: roundTo(femalePercentage),
+      target,
+      status: fairnessStatus,
+      description: `♀︎ ${roundTo(femalePercentage)}% / ♂︎ ${roundTo(malePercentage)}% / Divers ${roundTo(otherShare ? toPercentage(otherShare, total) : 0)}%`,
+    },
+    {
+      id: "experience-mix",
+      label: "Erfahrungsmix",
+      value: roundTo(averageExperience, 1),
+      target: 3,
+      status: averageExperience >= 2 && averageExperience <= 4 ? "ok" : averageExperience < 2 ? "warning" : "critical",
+      description: `Newcomer ${roundTo(noviceShare)}% · Veteranen ${roundTo(veteranShare)}%`,
+    },
+    {
+      id: "focus-balance",
+      label: "Fokus-Balance",
+      value: roundTo(focusBothShare),
+      target: 35,
+      status: focusBothShare >= 25 && focusBothShare <= 45 ? "ok" : focusBothShare < 25 ? "warning" : "critical",
+      description: "Anteil Personen mit Doppel-Fokus acting/tech",
+    },
+  ];
+}
+
+export const getAvailableOnboardings = cache(async (): Promise<OnboardingSummary[]> => {
+  const shows = await prisma.show.findMany({
+    orderBy: { year: "desc" },
+    take: 12,
+  });
+
+  return shows.map((show) => {
+    const range = extractDateRange(show.dates);
+    const summary = onboardingSummarySchema.parse({
+      id: show.id,
+      title: normalizeTitle(show),
+      periodLabel: formatDateRange(range),
+      status: deriveStatus(show, range).status,
+    });
+    return summary;
+  });
+});
+
+export const getOnboardingDashboardData = cache(async (
+  onboardingId: string,
+): Promise<OnboardingDashboardData | null> => {
+  const show = await prisma.show.findUnique({
+    where: { id: onboardingId },
+    select: {
+      id: true,
+      year: true,
+      title: true,
+      dates: true,
+      revealedAt: true,
+      finalRehearsalWeekStart: true,
+      meta: true,
+      onboardingProfiles: {
+        select: {
+          id: true,
+          user: {
+            select: {
+              id: true,
+              name: true,
+              firstName: true,
+              lastName: true,
+              dateOfBirth: true,
+              photoConsent: {
+                select: {
+                  status: true,
+                  consentGiven: true,
+                  documentUploadedAt: true,
+                },
+              },
+              dietaryRestrictions: {
+                select: {
+                  allergen: true,
+                  level: true,
+                  isActive: true,
+                },
+              },
+            },
+          },
+          gender: true,
+          focus: true,
+          dietaryPreference: true,
+          dietaryPreferenceStrictness: true,
+          memberSinceYear: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  if (!show) {
+    return null;
+  }
+
+  const profileUserIds = show.onboardingProfiles.map((profile) => profile.user.id);
+
+  const [rolePreferences, interests, memberships] = await Promise.all([
+    prisma.memberRolePreference.findMany({
+      where: { userId: { in: profileUserIds } },
+      select: {
+        userId: true,
+        code: true,
+        domain: true,
+        weight: true,
+      },
+    }),
+    prisma.userInterest.findMany({
+      where: { userId: { in: profileUserIds } },
+      include: {
+        interest: { select: { name: true } },
+      },
+    }),
+    prisma.productionMembership.findMany({
+      where: {
+        showId: onboardingId,
+      },
+      select: {
+        userId: true,
+        joinedAt: true,
+      },
+    }),
+  ]);
+
+  const range = extractDateRange(show.dates);
+  const status = deriveStatus(show, range);
+  const timeSpan = formatDateRange(range);
+  const participants = show.onboardingProfiles.length;
+
+  const onboardingSummary = onboardingSummarySchema.parse({
+    id: show.id,
+    title: normalizeTitle(show),
+    periodLabel: timeSpan,
+    status: status.status,
+  });
+
+  const now = new Date();
+  const newLastWeek = show.onboardingProfiles.filter((profile) =>
+    isWithinInterval(profile.createdAt, {
+      start: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
+      end: now,
+    }),
+  ).length;
+  const newLastMonth = show.onboardingProfiles.filter((profile) =>
+    isWithinInterval(profile.createdAt, {
+      start: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+      end: now,
+    }),
+  ).length;
+
+  const ages = show.onboardingProfiles
+    .map((profile) => computeAge(profile.user.dateOfBirth))
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => a - b);
+  const medianAge =
+    ages.length === 0
+      ? null
+      : ages.length % 2 === 1
+        ? ages[(ages.length - 1) / 2]
+        : (ages[ages.length / 2 - 1] + ages[ages.length / 2]) / 2;
+
+  const ageGroups = show.onboardingProfiles.reduce(
+    (acc, profile) => {
+      const age = computeAge(profile.user.dateOfBirth);
+      if (age === null) {
+        return acc;
+      }
+      const label = classifyAge(age);
+      acc.set(label, (acc.get(label) ?? 0) + 1);
+      return acc;
+    },
+    new Map<string, number>(),
+  );
+
+  const genderDistribution = show.onboardingProfiles.reduce(
+    (acc, profile) => {
+      const key = profile.gender?.trim().toLowerCase() || "divers";
+      acc.set(key, (acc.get(key) ?? 0) + 1);
+      return acc;
+    },
+    new Map<string, number>(),
+  );
+
+  const focusDistribution = show.onboardingProfiles.reduce(
+    (acc, profile) => {
+      acc.set(profile.focus, (acc.get(profile.focus) ?? 0) + 1);
+      return acc;
+    },
+    new Map<OnboardingFocus, number>(),
+  );
+
+  const consentCount = show.onboardingProfiles.filter(
+    (profile) => profile.user.photoConsent?.consentGiven && profile.user.photoConsent.status === "approved",
+  ).length;
+
+  const actingTotals = new Map<string, { shareSum: number; userCount: number }>();
+  const crewTotals = new Map<string, { shareSum: number; userCount: number }>();
+  const userDomainTotals = new Map<string, { acting: number; crew: number }>();
+
+  rolePreferences.forEach((preference) => {
+    const totals = userDomainTotals.get(preference.userId) ?? { acting: 0, crew: 0 };
+    if (preference.domain === "acting") {
+      totals.acting += Math.max(0, preference.weight);
+    } else {
+      totals.crew += Math.max(0, preference.weight);
+    }
+    userDomainTotals.set(preference.userId, totals);
+  });
+
+  const actingSharesByUser = new Map<string, Map<string, number>>();
+  const crewSharesByUser = new Map<string, Map<string, number>>();
+
+  rolePreferences.forEach((preference) => {
+    const totals = userDomainTotals.get(preference.userId);
+    const total = preference.domain === "acting" ? totals?.acting ?? 0 : totals?.crew ?? 0;
+    const normalized = total > 0 ? preference.weight / total : 0;
+
+    const targetMap = preference.domain === "acting" ? actingSharesByUser : crewSharesByUser;
+    const existing = targetMap.get(preference.userId) ?? new Map<string, number>();
+    existing.set(preference.code, normalized);
+    targetMap.set(preference.userId, existing);
+
+    if (preference.domain === "acting") {
+      const aggregate = actingTotals.get(preference.code) ?? { shareSum: 0, userCount: 0 };
+      aggregate.shareSum += normalized;
+      aggregate.userCount += normalized > 0 ? 1 : 0;
+      actingTotals.set(preference.code, aggregate);
+    } else {
+      const aggregate = crewTotals.get(preference.code) ?? { shareSum: 0, userCount: 0 };
+      aggregate.shareSum += normalized;
+      aggregate.userCount += normalized > 0 ? 1 : 0;
+      crewTotals.set(preference.code, aggregate);
+    }
+  });
+
+  const uniqueActingUsers = new Set(actingSharesByUser.keys());
+  const uniqueCrewUsers = new Set(crewSharesByUser.keys());
+
+  const roleHeatmap: Array<{ x: string; y: string; value: number }> = [];
+  actingSharesByUser.forEach((actingRoles, userId) => {
+    const crewRoles = crewSharesByUser.get(userId);
+    if (!crewRoles) {
+      return;
+    }
+    actingRoles.forEach((actingValue, actingRole) => {
+      crewRoles.forEach((crewValue, crewRole) => {
+        roleHeatmap.push({
+          x: actingRole,
+          y: crewRole,
+          value: roundTo(actingValue * crewValue, 3),
+        });
+      });
+    });
+  });
+
+  const interestCounts = new Map<string, number>();
+  const userInterestMap = new Map<string, string[]>();
+  interests.forEach((entry) => {
+    const tag = entry.interest?.name?.trim();
+    if (!tag) {
+      return;
+    }
+    interestCounts.set(tag, (interestCounts.get(tag) ?? 0) + 1);
+    const collection = userInterestMap.get(entry.userId) ?? [];
+    collection.push(tag);
+    userInterestMap.set(entry.userId, collection);
+  });
+
+  const interestCoOccurrences = new Map<string, Map<string, number>>();
+  userInterestMap.forEach((tags) => {
+    const uniqueTags = Array.from(new Set(tags)).sort();
+    for (let i = 0; i < uniqueTags.length; i += 1) {
+      for (let j = i + 1; j < uniqueTags.length; j += 1) {
+        const a = uniqueTags[i];
+        const b = uniqueTags[j];
+        const source = interestCoOccurrences.get(a) ?? new Map<string, number>();
+        source.set(b, (source.get(b) ?? 0) + 1);
+        interestCoOccurrences.set(a, source);
+      }
+    }
+  });
+
+  const interestClusters = new Map<string, number>();
+  interestCounts.forEach((count, tag) => {
+    const lower = tag.toLowerCase();
+    let cluster = "allgemein";
+    if (/(schauspiel|theater|rolle)/.test(lower)) {
+      cluster = "Schauspiel";
+    } else if (/(technik|bühne|licht|ton)/.test(lower)) {
+      cluster = "Technik";
+    } else if (/(musik|chor|instrument)/.test(lower)) {
+      cluster = "Musik";
+    } else if (/(orga|produktion|management)/.test(lower)) {
+      cluster = "Orga";
+    }
+    interestClusters.set(cluster, (interestClusters.get(cluster) ?? 0) + count);
+  });
+
+  const diversityCounts = Array.from(interestCounts.values());
+  const shannon = shannonIndex(diversityCounts);
+  const maxShannon = diversityCounts.length > 0 ? Math.log(diversityCounts.length) : 1;
+  const normalizedDiversity = maxShannon > 0 ? shannon / maxShannon : 0;
+  const gini = giniIndex(diversityCounts);
+  const diversityStatus =
+    normalizedDiversity >= 0.65 ? "ok" : normalizedDiversity >= 0.45 ? "warning" : "critical";
+
+  const diets = show.onboardingProfiles.reduce(
+    (acc, profile) => {
+      if (!profile.dietaryPreference) {
+        return acc;
+      }
+      const key = profile.dietaryPreference;
+      acc.set(key, (acc.get(key) ?? 0) + 1);
+      return acc;
+    },
+    new Map<string, number>(),
+  );
+
+  const allergies = new Map<string, Map<string, number>>();
+  show.onboardingProfiles.forEach((profile) => {
+    profile.user.dietaryRestrictions.forEach((restriction) => {
+      if (!restriction.isActive) {
+        return;
+      }
+      const allergen = restriction.allergen;
+      const severity = severityLabel(restriction.level);
+      const store = allergies.get(allergen) ?? new Map<string, number>();
+      store.set(severity, (store.get(severity) ?? 0) + 1);
+      allergies.set(allergen, store);
+    });
+  });
+
+  const steps = [
+    {
+      id: "signup",
+      label: "Registrierung",
+      completionRate: toPercentage(profileUserIds.length, profileUserIds.length || 1),
+    },
+    {
+      id: "profile",
+      label: "Profil ausgefüllt",
+      completionRate: toPercentage(
+        show.onboardingProfiles.filter((profile) => profile.focus && profile.gender).length,
+        profileUserIds.length || 1,
+      ),
+    },
+    {
+      id: "preferences",
+      label: "Präferenzen",
+      completionRate: toPercentage(rolePreferences.length, profileUserIds.length || 1),
+    },
+    {
+      id: "documents",
+      label: "Dokumente",
+      completionRate: toPercentage(
+        show.onboardingProfiles.filter((profile) => profile.user.photoConsent?.documentUploadedAt).length,
+        profileUserIds.length || 1,
+      ),
+    },
+    {
+      id: "casting",
+      label: "Casting",
+      completionRate: toPercentage(memberships.length, profileUserIds.length || 1),
+    },
+  ].map((step) => ({
+    ...step,
+    dropoutRate: Math.max(0, 100 - step.completionRate),
+  }));
+
+  const documents = {
+    uploaded: show.onboardingProfiles.filter((profile) => profile.user.photoConsent?.documentUploadedAt).length,
+    skipped: show.onboardingProfiles.filter((profile) => profile.user.photoConsent?.status === "rejected").length,
+    pending: show.onboardingProfiles.filter((profile) => !profile.user.photoConsent).length,
+  };
+
+  const candidateInputs: CandidateInput[] = show.onboardingProfiles.map((profile) => {
+    const fullName =
+      profile.user.name ||
+      [profile.user.firstName, profile.user.lastName].filter(Boolean).join(" ") ||
+      "Unbekannt";
+    const experienceYears = profile.memberSinceYear
+      ? now.getFullYear() - profile.memberSinceYear
+      : null;
+
+    return {
+      userId: profile.user.id,
+      name: fullName,
+      focus: profile.focus,
+      interests: userInterestMap.get(profile.user.id) ?? [],
+      experienceYears,
+      actingShares: actingSharesByUser.get(profile.user.id) ?? new Map<string, number>(),
+      crewShares: crewSharesByUser.get(profile.user.id) ?? new Map<string, number>(),
+    };
+  });
+
+  const roleCandidates = new Map<string, AllocationCandidate[]>();
+  const allRoles = new Map<string, { label: string; domain: "acting" | "crew"; demand: number }>();
+
+  actingTotals.forEach((value, roleId) => {
+    const candidates = candidateInputs
+      .map((candidate) => {
+        const share = candidate.actingShares.get(roleId) ?? 0;
+        const focusAlignment = candidate.focus === "acting" || candidate.focus === "both";
+        const quality = 1 + (candidate.experienceYears ?? 0) / 10 + (focusAlignment ? 0.2 : 0);
+        const score = share * quality;
+        return {
+          userId: candidate.userId,
+          name: candidate.name,
+          focus: candidate.focus ?? undefined,
+          normalizedShare: share,
+          qualityFactor: quality,
+          score,
+          confidence: normalizeConfidence(score, 1.2),
+          justification: focusAlignment
+            ? "Hohe Acting-Präferenz"
+            : "Acting als Zweitfokus",
+          interests: candidate.interests,
+          experienceYears: candidate.experienceYears ?? undefined,
+        } satisfies AllocationCandidate;
+      })
+      .filter((candidate) => candidate.normalizedShare > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 12);
+
+    roleCandidates.set(roleId, candidates);
+    allRoles.set(roleId, {
+      label: roleId,
+      domain: "acting",
+      demand: value.userCount,
+    });
+  });
+
+  crewTotals.forEach((value, roleId) => {
+    const candidates = candidateInputs
+      .map((candidate) => {
+        const share = candidate.crewShares.get(roleId) ?? 0;
+        const focusAlignment = candidate.focus === "tech" || candidate.focus === "both";
+        const quality = 1 + (candidate.experienceYears ?? 0) / 10 + (focusAlignment ? 0.2 : 0);
+        const score = share * quality;
+        return {
+          userId: candidate.userId,
+          name: candidate.name,
+          focus: candidate.focus ?? undefined,
+          normalizedShare: share,
+          qualityFactor: quality,
+          score,
+          confidence: normalizeConfidence(score, 1.2),
+          justification: focusAlignment ? "Technik-Fokus" : "Unterstützender Fokus",
+          interests: candidate.interests,
+          experienceYears: candidate.experienceYears ?? undefined,
+        } satisfies AllocationCandidate;
+      })
+      .filter((candidate) => candidate.normalizedShare > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 12);
+
+    roleCandidates.set(roleId, candidates);
+    allRoles.set(roleId, {
+      label: roleId,
+      domain: "crew",
+      demand: value.userCount,
+    });
+  });
+
+  const defaultCapacity = (demand: number): number => {
+    if (demand <= 2) return demand;
+    if (demand <= 4) return Math.max(1, Math.round(demand * 0.75));
+    return Math.max(2, Math.round(demand * 0.6));
+  };
+
+  const allocationRoles: AllocationRole[] = Array.from(allRoles.entries()).map(([roleId, meta]) => ({
+    roleId,
+    label: meta.label,
+    domain: meta.domain,
+    demand: meta.demand,
+    capacity: defaultCapacity(meta.demand),
+    candidates: roleCandidates.get(roleId) ?? [],
+  }));
+
+  const recalculatedRoles = recomputeAllocation({ roles: allocationRoles, candidates: candidateInputs });
+
+  const history = await prisma.show.findMany({
+    where: {
+      id: { not: show.id },
+    },
+    orderBy: { year: "desc" },
+    take: 5,
+    select: {
+      id: true,
+      year: true,
+      title: true,
+      dates: true,
+      onboardingProfiles: {
+        select: {
+          createdAt: true,
+          focus: true,
+          user: { select: { dateOfBirth: true } },
+        },
+      },
+    },
+  });
+
+  const historySnapshots = history.map((item) => {
+    const itemRange = extractDateRange(item.dates);
+    const agesHistory = item.onboardingProfiles
+      .map((profile) => computeAge(profile.user.dateOfBirth))
+      .filter((value): value is number => value !== null)
+      .sort((a, b) => a - b);
+    const medianHistory =
+      agesHistory.length === 0
+        ? null
+        : agesHistory.length % 2 === 1
+          ? agesHistory[(agesHistory.length - 1) / 2]
+          : (agesHistory[agesHistory.length / 2 - 1] + agesHistory[agesHistory.length / 2]) / 2;
+
+    const focusBoth = toPercentage(
+      item.onboardingProfiles.filter((profile) => profile.focus === "both").length,
+      item.onboardingProfiles.length || 1,
+    );
+
+    return {
+      onboardingId: item.id,
+      label: normalizeTitle(item),
+      participants: item.onboardingProfiles.length,
+      medianAge: medianHistory,
+      focusBothShare: focusBoth,
+      createdAt: itemRange.start?.toISOString() ?? new Date(item.year, 0, 1).toISOString(),
+    };
+  });
+
+  const dashboard = onboardingDashboardSchema.parse({
+    onboarding: {
+      ...onboardingSummary,
+      statusLabel: status.label,
+      timeSpan,
+      participants,
+    },
+    global: {
+      kpis: [
+        {
+          id: "participants",
+          label: "Teilnehmer gesamt",
+          value: participants,
+          helper: `${newLastWeek} neue in 7 Tagen`,
+          trend: {
+            direction: newLastWeek > newLastMonth / 4 ? "up" : "flat",
+            percentage: toPercentage(newLastWeek, participants || 1),
+            label: "Woche",
+          },
+        },
+        {
+          id: "new-per-month",
+          label: "Neue Teilnehmer (30T)",
+          value: newLastMonth,
+          trend: {
+            direction: newLastMonth > newLastWeek ? "up" : "flat",
+            percentage: toPercentage(newLastMonth, participants || 1),
+            label: "Monat",
+          },
+        },
+        {
+          id: "median-age",
+          label: "Medianalter",
+          value: medianAge ? roundTo(medianAge, 1) : "–",
+          helper: medianAge ? "Jahre" : "keine Daten",
+        },
+        {
+          id: "focus",
+          label: "Fokus acting/tech",
+          value: `${formatPercentage(toPercentage(focusDistribution.get("acting") ?? 0, participants || 1))} acting`,
+          helper: `${formatPercentage(toPercentage(focusDistribution.get("tech") ?? 0, participants || 1))} tech`,
+        },
+        {
+          id: "photo",
+          label: "Fotoeinverständnis",
+          value: `${formatPercentage(toPercentage(consentCount, participants || 1))}`,
+          intent: consentCount / (participants || 1) > 0.8 ? "success" : "warning",
+        },
+        {
+          id: "gender",
+          label: "Geschlechter",
+          value: `${formatPercentage(toPercentage(genderDistribution.get("weiblich") ?? 0, participants || 1))} ♀︎`,
+          helper: `${formatPercentage(toPercentage(genderDistribution.get("männlich") ?? 0, participants || 1))} ♂︎`,
+        },
+      ],
+      ageGroups: Array.from(ageGroups.entries()).map(([label, value]) => ({
+        label,
+        value,
+        percentage: toPercentage(value, participants || 1),
+      })),
+      genderDistribution: Array.from(genderDistribution.entries()).map(([label, value]) => ({
+        label,
+        value,
+        percentage: toPercentage(value, participants || 1),
+      })),
+      focusDistribution: Array.from(focusDistribution.entries()).map(([label, value]) => ({
+        label,
+        value,
+        percentage: toPercentage(value, participants || 1),
+        intent: determineFocusIntent(label),
+      })),
+      photoConsentRate: participants ? consentCount / participants : null,
+      rolesActing: Array.from(actingTotals.entries()).map(([roleId, meta]) => ({
+        roleId,
+        label: roleId,
+        domain: "acting",
+        normalizedShare: roundTo(meta.shareSum / Math.max(meta.userCount, 1), 3),
+        participantShare: toPercentage(meta.userCount, participants || 1),
+      })),
+      rolesCrew: Array.from(crewTotals.entries()).map(([roleId, meta]) => ({
+        roleId,
+        label: roleId,
+        domain: "crew",
+        normalizedShare: roundTo(meta.shareSum / Math.max(meta.userCount, 1), 3),
+        participantShare: toPercentage(meta.userCount, participants || 1),
+      })),
+      roleCoverage: {
+        acting: toPercentage(uniqueActingUsers.size, participants || 1),
+        crew: toPercentage(uniqueCrewUsers.size, participants || 1),
+      },
+      roleHeatmap,
+      interestTopTags: Array.from(interestCounts.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 10)
+        .map(([label, value]) => ({
+          label,
+          value,
+          percentage: toPercentage(value, participants || 1),
+        })),
+      interestWordCloud: Array.from(interestCounts.entries())
+        .sort((a, b) => b[1] - a[1])
+        .map(([tag, weight]) => ({
+          tag,
+          weight,
+        })),
+      interestCoOccurrences: Array.from(interestCoOccurrences.entries()).flatMap(([source, targets]) =>
+        Array.from(targets.entries()).map(([target, weight]) => ({
+          source,
+          target,
+          weight,
+        })),
+      ),
+      interestClusters: Array.from(interestClusters.entries()).map(([label, value]) => ({
+        id: label.toLowerCase(),
+        label,
+        value,
+        intent: value >= 8 ? "success" : value >= 4 ? "default" : "warning",
+      })),
+      diversity: {
+        shannon: roundTo(shannon, 3),
+        gini: roundTo(gini, 3),
+        normalized: roundTo(normalizedDiversity, 3),
+        status: diversityStatus,
+        explanation: `Shannon ${roundTo(shannon, 2)} · Gini ${roundTo(gini, 2)}`,
+      },
+      nutrition: {
+        diets: Array.from(diets.entries()).map(([label, count]) => ({
+          label,
+          count,
+        })),
+        allergies: Array.from(allergies.entries()).map(([allergen, severities]) => ({
+          allergen,
+          severities: Object.fromEntries(severities.entries()),
+        })),
+      },
+      process: {
+        steps,
+        documents,
+      },
+    },
+    allocation: {
+      roles: recalculatedRoles,
+      fairness: buildFairnessMetrics(
+        show.onboardingProfiles.map((profile) => ({
+          gender: profile.gender,
+          memberSinceYear: profile.memberSinceYear,
+          focus: profile.focus,
+        })),
+      ),
+      conflicts: buildConflictList(recalculatedRoles),
+    },
+    history: historySnapshots,
+  });
+
+  return dashboard;
+});

--- a/src/lib/realtime/types.ts
+++ b/src/lib/realtime/types.ts
@@ -3,6 +3,7 @@ import { AttendanceStatus } from "@prisma/client";
 import type { InventoryItemRecord, TicketRecord } from "@/lib/offline/types";
 import type { ServerSyncEvent } from "@/lib/offline/sync-client";
 import type { ServerAnalytics } from "@/lib/server-analytics";
+import type { OnboardingDashboardData } from "@/lib/onboarding/dashboard-schemas";
 
 // Base Event Interface
 export interface BaseRealtimeEvent {
@@ -97,6 +98,12 @@ export interface TicketScanRealtimeEvent extends BaseRealtimeEvent {
   payload: TicketRealtimePayload;
 }
 
+export interface OnboardingDashboardUpdateEvent extends BaseRealtimeEvent {
+  type: 'onboarding_dashboard_update';
+  onboardingId: string;
+  dashboard: OnboardingDashboardData;
+}
+
 export interface UserPresenceEvent extends BaseRealtimeEvent {
   type: 'user_presence';
   action: 'join' | 'leave';
@@ -159,6 +166,7 @@ export type RealtimeEvent =
   | NotificationCreatedEvent
   | InventoryRealtimeEvent
   | TicketScanRealtimeEvent
+  | OnboardingDashboardUpdateEvent
   | UserPresenceEvent
   | OnlineStatsUpdateEvent
   | ServerAnalyticsRealtimeEvent
@@ -171,6 +179,7 @@ export type RoomType =
   | `user_${string}`           // User-specific room
   | `rehearsal_${string}`      // Rehearsal-specific room
   | `show_${string}`           // Show-specific room
+  | `onboarding_${string}`     // Onboarding dashboard room
   | 'global';                  // Global announcements
 
 // Client to Server Events
@@ -192,6 +201,7 @@ export interface ServerToClientEvents {
   notification_created: (event: NotificationCreatedEvent) => void;
   inventory_event: (event: InventoryRealtimeEvent) => void;
   ticket_scan_event: (event: TicketScanRealtimeEvent) => void;
+  onboarding_dashboard_update: (event: OnboardingDashboardUpdateEvent) => void;
   user_presence: (event: UserPresenceEvent) => void;
   online_stats_update: (event: OnlineStatsUpdateEvent) => void;
   server_analytics_update: (event: ServerAnalyticsRealtimeEvent) => void;


### PR DESCRIPTION
## Summary
- introduce an analytics-ready onboarding dashboard route with global metrics, allocation planning, and history tabs
- provide a Prisma-backed dashboard service and API endpoint that aggregate cohort, preference, and fairness data
- extend realtime typings for onboarding updates and add framer-motion for animated UI components

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d7a721f0ac832d862392f04381a0be