### PR TITLE
Add onboarding dashboard realtime updates

### DIFF
--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -8,6 +8,7 @@ import { sortRoles, ROLES, type Role } from "@/lib/roles";
 import { hashPassword } from "@/lib/password";
 import { combineNameParts } from "@/lib/names";
 import { MAX_INTERESTS_PER_USER } from "@/data/profile";
+import { broadcastOnboardingDashboardSnapshot } from "@/lib/onboarding/dashboard-events";
 
 const MAX_DOCUMENT_BYTES = 8 * 1024 * 1024;
 const ALLOWED_DOCUMENT_TYPES = new Set([
@@ -498,6 +499,12 @@ export async function POST(request: NextRequest) {
 
       return { userId: user.id, email: user.email };
     });
+
+    try {
+      await broadcastOnboardingDashboardSnapshot(invite.showId);
+    } catch (error) {
+      console.error("[onboarding.complete] realtime update failed", error);
+    }
 
     return NextResponse.json({ ok: true, user: result });
   } catch (error) {

--- a/src/app/api/profile/interests/route.ts
+++ b/src/app/api/profile/interests/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { MAX_INTERESTS_PER_USER } from "@/data/profile";
+import { broadcastOnboardingDashboardForUser } from "@/lib/onboarding/dashboard-events";
 
 const MAX_INTEREST_LENGTH = 80;
 
@@ -146,6 +147,12 @@ export async function PUT(request: NextRequest) {
 
       return normalized.map((entry) => interestByLower.get(entry.lower)?.name ?? entry.value);
     });
+
+    try {
+      await broadcastOnboardingDashboardForUser(userId);
+    } catch (error) {
+      console.error("[profile.interests] realtime update failed", error);
+    }
 
     return NextResponse.json({ ok: true, interests: updatedNames });
   } catch (error) {

--- a/src/lib/onboarding/dashboard-events.ts
+++ b/src/lib/onboarding/dashboard-events.ts
@@ -1,0 +1,36 @@
+import { prisma } from '@/lib/prisma';
+import { broadcastOnboardingDashboardUpdate } from '@/lib/realtime/triggers';
+
+import { loadOnboardingDashboardSnapshot } from './dashboard-service';
+
+interface BroadcastOptions {
+  broadcastToGlobal?: boolean;
+}
+
+export async function broadcastOnboardingDashboardSnapshot(
+  onboardingId: string,
+  options: BroadcastOptions = {},
+) {
+  if (!onboardingId) return;
+  const dashboard = await loadOnboardingDashboardSnapshot(onboardingId);
+  if (!dashboard) return;
+  await broadcastOnboardingDashboardUpdate({
+    onboardingId,
+    dashboard,
+    broadcastToGlobal: options.broadcastToGlobal,
+  });
+}
+
+export async function broadcastOnboardingDashboardForUser(
+  userId: string,
+  options: BroadcastOptions = {},
+) {
+  if (!userId) return;
+  const profile = await prisma.memberOnboardingProfile.findUnique({
+    where: { userId },
+    select: { showId: true },
+  });
+  const onboardingId = profile?.showId;
+  if (!onboardingId) return;
+  await broadcastOnboardingDashboardSnapshot(onboardingId, options);
+}

--- a/src/lib/onboarding/dashboard-service.ts
+++ b/src/lib/onboarding/dashboard-service.ts
@@ -400,9 +400,10 @@ export const getAvailableOnboardings = cache(async (): Promise<OnboardingSummary
   });
 });
 
-export const getOnboardingDashboardData = cache(async (
+async function computeOnboardingDashboardData(
   onboardingId: string,
-): Promise<OnboardingDashboardData | null> => {
+): Promise<OnboardingDashboardData | null> {
+
   const show = await prisma.show.findUnique({
     where: { id: onboardingId },
     select: {
@@ -1044,4 +1045,11 @@ export const getOnboardingDashboardData = cache(async (
   });
 
   return dashboard;
-});
+}
+
+export async function loadOnboardingDashboardSnapshot(onboardingId: string) {
+  return computeOnboardingDashboardData(onboardingId);
+}
+
+export const getOnboardingDashboardData = cache(computeOnboardingDashboardData);
+

--- a/src/lib/realtime/triggers.ts
+++ b/src/lib/realtime/triggers.ts
@@ -1,3 +1,5 @@
+import type { OnboardingDashboardData } from '@/lib/onboarding/dashboard-schemas';
+
 import { emitRealtimeEvent } from './event-client';
 
 /**
@@ -91,6 +93,21 @@ export class RealtimeTriggers {
   }
 
   /**
+   * Broadcast updated onboarding dashboard snapshot to listeners
+   */
+  static async broadcastOnboardingDashboardUpdate(data: {
+    onboardingId: string;
+    dashboard: OnboardingDashboardData;
+    broadcastToGlobal?: boolean;
+  }) {
+    await emitRealtimeEvent('onboarding_dashboard_update', {
+      onboardingId: data.onboardingId,
+      dashboard: data.dashboard,
+      broadcastToGlobal: Boolean(data.broadcastToGlobal),
+    });
+  }
+
+  /**
    * Get list of users currently online in a rehearsal
    */
   static async getOnlineUsersInRehearsal(rehearsalId: string): Promise<string[]> {
@@ -121,6 +138,7 @@ export const {
   broadcastRehearsalCreated,
   broadcastRehearsalUpdated,
   sendNotification,
+  broadcastOnboardingDashboardUpdate,
   getOnlineUsersInRehearsal,
   isUserOnline,
   getOnlineUserCount,


### PR DESCRIPTION
## Summary
- extend the realtime server to emit `onboarding_dashboard_update` events and accept onboarding rooms
- add a trigger helper for onboarding dashboard snapshots and load uncached dashboard data
- broadcast updated onboarding dashboard snapshots from onboarding profile, dietary, interest, and completion mutations

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: Module not found: Can't resolve 'framer-motion')*

------
https://chatgpt.com/codex/tasks/task_e_68d7c910d374832d9304d5a5a93c1f94