### PR TITLE
Add onboarding analytics page to members area

### DIFF
--- a/src/app/(members)/mitglieder/onboarding/page.tsx
+++ b/src/app/(members)/mitglieder/onboarding/page.tsx
@@ -1,0 +1,59 @@
+import { Suspense } from "react";
+import { notFound, redirect } from "next/navigation";
+
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  getAvailableOnboardings,
+  getOnboardingDashboardData,
+} from "@/lib/onboarding/dashboard-service";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+
+import { DashboardClient } from "@/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function MembersOnboardingAnalyticsPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.onboarding.analytics");
+
+  if (!allowed) {
+    redirect("/mitglieder");
+  }
+
+  const availableOnboardings = await getAvailableOnboardings();
+  const initialOnboarding = availableOnboardings[0];
+
+  if (!initialOnboarding) {
+    notFound();
+  }
+
+  const dashboard = await getOnboardingDashboardData(initialOnboarding.id);
+
+  if (!dashboard) {
+    notFound();
+  }
+
+  if (availableOnboardings.length === 1) {
+    redirect(`/dashboard/onboarding/${initialOnboarding.id}`);
+  }
+
+  const options = availableOnboardings.length
+    ? availableOnboardings
+    : [
+        {
+          id: initialOnboarding.id,
+          title: dashboard.onboarding.title,
+          periodLabel: dashboard.onboarding.timeSpan,
+          status: dashboard.onboarding.status,
+        },
+      ];
+
+  return (
+    <main id="main" className="space-y-6 pb-12">
+      <Suspense fallback={<Skeleton className="h-[480px] w-full rounded-2xl" />}>
+        <DashboardClient onboardings={options} initialData={dashboard} />
+      </Suspense>
+    </main>
+  );
+}

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -565,6 +565,12 @@ export const membersNavigation = [
         icon: ServerAnalyticsIcon,
       },
       {
+        href: "/mitglieder/onboarding",
+        label: "Onboarding-Statistiken",
+        permissionKey: "mitglieder.onboarding.analytics",
+        icon: DashboardIcon,
+      },
+      {
         href: "/mitglieder/rechte",
         label: "Rechteverwaltung",
         permissionKey: "mitglieder.rechte",


### PR DESCRIPTION
## Summary
- add an onboarding analytics entry to the members navigation
- create a members-only onboarding analytics page that enforces permissions and reuses the existing dashboard client

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d7cb2f2bec832db69349f532543161