### PR TITLE
Fix onboarding analytics role labels

### DIFF
--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -31,6 +31,7 @@ import { getUserDisplayName } from "@/lib/names";
 import { MemberTestNotificationCard } from "@/components/members/member-test-notification-card";
 import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 import { ImpersonationButton } from "./impersonation-button";
+import { getRolePreferenceDescription, getRolePreferenceTitle } from "@/lib/onboarding/role-preferences";
 
 const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "long" });
 const dateTimeFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" });
@@ -124,57 +125,6 @@ const PHOTO_STATUS_CLASSES: Record<PhotoConsentStatus, string> = {
   rejected: "border-destructive/45 bg-destructive/10 text-destructive",
 };
 
-const ROLE_PREFERENCE_DEFINITIONS: Record<string, { title: string; description: string }> = {
-  acting_statist: {
-    title: "Statistenrolle",
-    description: "Auf der Bühne ohne Text – Präsenz in Bildern und Szenen.",
-  },
-  acting_scout: {
-    title: "Schnupperrolle",
-    description: "Kleine Auftritte zum Reinschnuppern mit überschaubarer Textmenge.",
-  },
-  acting_medium: {
-    title: "Mittlere Rolle",
-    description: "Spürbar auf der Bühne, mit Verantwortung im Ensemble und regelmäßigem Proben.",
-  },
-  acting_lead: {
-    title: "Große Rolle",
-    description: "Haupt- oder zentrale Nebenrolle mit intensiver Vorbereitung und Bühnenpräsenz.",
-  },
-  crew_stage: {
-    title: "Bühnenbild & Ausstattung",
-    description: "Räume entwerfen, Kulissen bauen und für beeindruckende Bilder sorgen.",
-  },
-  crew_tech: {
-    title: "Licht & Ton",
-    description: "Shows inszenieren mit Licht, Klang, Effekten und technischer Präzision.",
-  },
-  crew_costume: {
-    title: "Kostüm",
-    description: "Looks entwickeln, nähen, Fundus pflegen und Outfits anpassen.",
-  },
-  crew_makeup: {
-    title: "Maske & Make-up",
-    description: "Maskenbild, Styling, Perücken und schnelle Verwandlungen hinter der Bühne.",
-  },
-  crew_direction: {
-    title: "Regieassistenz & Orga",
-    description: "Abläufe koordinieren, Proben strukturieren, Teams im Hintergrund führen.",
-  },
-  crew_music: {
-    title: "Musik & Klang",
-    description: "Arrangements entwickeln, Proben begleiten und Produktionen musikalisch tragen.",
-  },
-  crew_props: {
-    title: "Requisite",
-    description: "Requisiten gestalten, organisieren und für reibungslose Szenen sorgen.",
-  },
-  crew_marketing: {
-    title: "Werbung & Social Media",
-    description: "Kampagnen planen, Content erstellen und Produktionen sichtbar machen.",
-  },
-};
-
 const ROLE_PREFERENCE_WEIGHT_LABELS: { threshold: number; label: string }[] = [
   { threshold: 0, label: "Nur mal reinschauen" },
   { threshold: 25, label: "Locker interessiert" },
@@ -238,17 +188,11 @@ type RolePreferenceEntry = {
 };
 
 function resolveRolePreferenceTitle(code: string) {
-  if (code.startsWith("custom-")) {
-    return "Eigenes Gewerk";
-  }
-  return ROLE_PREFERENCE_DEFINITIONS[code]?.title ?? code;
+  return getRolePreferenceTitle(code);
 }
 
 function resolveRolePreferenceDescription(code: string) {
-  if (code.startsWith("custom-")) {
-    return "Vom Mitglied individuell ergänzt.";
-  }
-  return ROLE_PREFERENCE_DEFINITIONS[code]?.description ?? null;
+  return getRolePreferenceDescription(code);
 }
 
 function resolveRolePreferenceWeightLabel(weight: number) {

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { listRolePreferenceDefinitions } from "@/lib/onboarding/role-preferences";
 import {
   DIETARY_STYLE_OPTIONS,
   DIETARY_STRICTNESS_OPTIONS,
@@ -45,71 +46,8 @@ const allergyLevelLabels: Record<AllergyLevel, string> = {
   LETHAL: "Kritisch (Notfall)",
 };
 
-const actingOptions = [
-  {
-    code: "acting_statist",
-    title: "Statistenrolle",
-    description: "Auf der Bühne ohne Text – Präsenz in Bildern und Szenen.",
-  },
-  {
-    code: "acting_scout",
-    title: "Schnupperrolle",
-    description: "Kleine Auftritte zum Reinschnuppern mit überschaubarer Textmenge.",
-  },
-  {
-    code: "acting_medium",
-    title: "Mittlere Rolle",
-    description: "Spürbar auf der Bühne, mit Verantwortung im Ensemble und regelmäßigem Proben.",
-  },
-  {
-    code: "acting_lead",
-    title: "Große Rolle",
-    description: "Haupt- oder zentrale Nebenrolle mit intensiver Vorbereitung und Bühnenpräsenz.",
-  },
-];
-
-const crewOptions = [
-  {
-    code: "crew_stage",
-    title: "Bühnenbild & Ausstattung",
-    description: "Räume entwerfen, Kulissen bauen und für beeindruckende Bilder sorgen.",
-  },
-  {
-    code: "crew_tech",
-    title: "Licht & Ton",
-    description: "Shows inszenieren mit Licht, Klang, Effekten und technischer Präzision.",
-  },
-  {
-    code: "crew_costume",
-    title: "Kostüm",
-    description: "Looks entwickeln, nähen, Fundus pflegen und Outfits anpassen.",
-  },
-  {
-    code: "crew_makeup",
-    title: "Maske & Make-up",
-    description: "Maskenbild, Styling, Perücken und schnelle Verwandlungen hinter der Bühne.",
-  },
-  {
-    code: "crew_direction",
-    title: "Regieassistenz & Orga",
-    description: "Abläufe koordinieren, Proben strukturieren, Teams im Hintergrund führen.",
-  },
-  {
-    code: "crew_music",
-    title: "Musik & Klang",
-    description: "Arrangements entwickeln, Proben begleiten und Produktionen musikalisch tragen.",
-  },
-  {
-    code: "crew_props",
-    title: "Requisite",
-    description: "Requisiten gestalten, organisieren und für reibungslose Szenen sorgen.",
-  },
-  {
-    code: "crew_marketing",
-    title: "Werbung & Social Media",
-    description: "Kampagnen planen, Content erstellen und unsere Produktionen sichtbar machen.",
-  },
-];
+const actingOptions = listRolePreferenceDefinitions("acting");
+const crewOptions = listRolePreferenceDefinitions("crew");
 
 const genderOptions = [
   { value: "female", label: "Weiblich" },
@@ -234,7 +172,9 @@ type OnboardingWizardProps = {
 
 function createInitialActingPreferences(): PreferenceEntry[] {
   return actingOptions.map((option) => ({
-    ...option,
+    code: option.code,
+    title: option.title,
+    description: option.description,
     domain: "acting",
     enabled: false,
     weight: 50,
@@ -247,7 +187,9 @@ function createInitialCrewPreferences(variant: OnboardingWizardVariant): Prefere
     const enabled = variant === "regie" ? isDirection : false;
     const weight = variant === "regie" && isDirection ? 80 : 50;
     return {
-      ...option,
+      code: option.code,
+      title: option.title,
+      description: option.description,
       domain: "crew",
       enabled,
       weight,

--- a/src/lib/onboarding-analytics.ts
+++ b/src/lib/onboarding-analytics.ts
@@ -2,6 +2,7 @@ import type { AllergyLevel, OnboardingFocus, RolePreferenceDomain } from "@prism
 
 import { prisma } from "@/lib/prisma";
 import { calculateInviteStatus } from "@/lib/member-invites";
+import { getRolePreferenceTitle } from "@/lib/onboarding/role-preferences";
 
 export type OnboardingInviteSummary = {
   id: string;
@@ -22,6 +23,7 @@ export type OnboardingInterestStat = { name: string; count: number };
 export type OnboardingRolePreferenceStat = {
   code: string;
   domain: RolePreferenceDomain;
+  title: string;
   averageWeight: number;
   responses: number;
 };
@@ -309,6 +311,7 @@ export async function collectOnboardingAnalytics(now: Date = new Date()): Promis
     .map((bucket) => ({
       code: bucket.code,
       domain: bucket.domain,
+      title: getRolePreferenceTitle(bucket.code),
       responses: bucket.responses,
       averageWeight: bucket.responses ? Math.round((bucket.total / bucket.responses) * 10) / 10 : 0,
     }))
@@ -451,6 +454,7 @@ export async function collectOnboardingAnalytics(now: Date = new Date()): Promis
         .map((bucket) => ({
           code: bucket.code,
           domain: bucket.domain,
+          title: getRolePreferenceTitle(bucket.code),
           responses: bucket.responses,
           averageWeight: bucket.responses
             ? Math.round((bucket.total / bucket.responses) * 10) / 10

--- a/src/lib/onboarding/dashboard-service.ts
+++ b/src/lib/onboarding/dashboard-service.ts
@@ -3,6 +3,7 @@ import { differenceInYears, isAfter, isBefore, isWithinInterval } from "date-fns
 
 import { prisma } from "@/lib/prisma";
 import type { AllergyLevel, OnboardingFocus } from "@prisma/client";
+import { getRolePreferenceTitle } from "./role-preferences";
 import {
   onboardingDashboardSchema,
   onboardingSummarySchema,
@@ -548,8 +549,8 @@ async function computeOnboardingDashboardData(
     actingRoles.forEach((actingValue, actingRole) => {
       crewRoles.forEach((crewValue, crewRole) => {
         roleHeatmap.push({
-          x: actingRole,
-          y: crewRole,
+          x: getRolePreferenceTitle(actingRole),
+          y: getRolePreferenceTitle(crewRole),
           value: roundTo(actingValue * crewValue, 3),
         });
       });
@@ -727,7 +728,7 @@ async function computeOnboardingDashboardData(
 
     roleCandidates.set(roleId, candidates);
     allRoles.set(roleId, {
-      label: roleId,
+      label: getRolePreferenceTitle(roleId),
       domain: "acting",
       demand: value.userCount,
     });
@@ -759,7 +760,7 @@ async function computeOnboardingDashboardData(
 
     roleCandidates.set(roleId, candidates);
     allRoles.set(roleId, {
-      label: roleId,
+      label: getRolePreferenceTitle(roleId),
       domain: "crew",
       demand: value.userCount,
     });
@@ -926,14 +927,14 @@ async function computeOnboardingDashboardData(
       photoConsentRate: participants ? consentCount / participants : null,
       rolesActing: Array.from(actingTotals.entries()).map(([roleId, meta]) => ({
         roleId,
-        label: roleId,
+        label: getRolePreferenceTitle(roleId),
         domain: "acting",
         normalizedShare: roundTo(meta.shareSum / Math.max(meta.userCount, 1), 3),
         participantShare: toPercentage(meta.userCount, participants || 1),
       })),
       rolesCrew: Array.from(crewTotals.entries()).map(([roleId, meta]) => ({
         roleId,
-        label: roleId,
+        label: getRolePreferenceTitle(roleId),
         domain: "crew",
         normalizedShare: roundTo(meta.shareSum / Math.max(meta.userCount, 1), 3),
         participantShare: toPercentage(meta.userCount, participants || 1),

--- a/src/lib/onboarding/role-preferences.ts
+++ b/src/lib/onboarding/role-preferences.ts
@@ -1,0 +1,130 @@
+import type { RolePreferenceDomain } from "@prisma/client";
+
+type RolePreferenceDefinition = {
+  code: string;
+  domain: RolePreferenceDomain;
+  title: string;
+  description: string;
+};
+
+const ROLE_PREFERENCE_DEFINITIONS: Record<string, RolePreferenceDefinition> = {
+  acting_statist: {
+    code: "acting_statist",
+    domain: "acting",
+    title: "Statistenrolle",
+    description: "Auf der Bühne ohne Text – Präsenz in Bildern und Szenen.",
+  },
+  acting_scout: {
+    code: "acting_scout",
+    domain: "acting",
+    title: "Schnupperrolle",
+    description: "Kleine Auftritte zum Reinschnuppern mit überschaubarer Textmenge.",
+  },
+  acting_medium: {
+    code: "acting_medium",
+    domain: "acting",
+    title: "Mittlere Rolle",
+    description:
+      "Spürbar auf der Bühne, mit Verantwortung im Ensemble und regelmäßigem Proben.",
+  },
+  acting_lead: {
+    code: "acting_lead",
+    domain: "acting",
+    title: "Große Rolle",
+    description: "Haupt- oder zentrale Nebenrolle mit intensiver Vorbereitung und Bühnenpräsenz.",
+  },
+  crew_stage: {
+    code: "crew_stage",
+    domain: "crew",
+    title: "Bühnenbild & Ausstattung",
+    description: "Räume entwerfen, Kulissen bauen und für beeindruckende Bilder sorgen.",
+  },
+  crew_tech: {
+    code: "crew_tech",
+    domain: "crew",
+    title: "Licht & Ton",
+    description: "Shows inszenieren mit Licht, Klang, Effekten und technischer Präzision.",
+  },
+  crew_costume: {
+    code: "crew_costume",
+    domain: "crew",
+    title: "Kostüm",
+    description: "Looks entwickeln, nähen, Fundus pflegen und Outfits anpassen.",
+  },
+  crew_makeup: {
+    code: "crew_makeup",
+    domain: "crew",
+    title: "Maske & Make-up",
+    description: "Maskenbild, Styling, Perücken und schnelle Verwandlungen hinter der Bühne.",
+  },
+  crew_direction: {
+    code: "crew_direction",
+    domain: "crew",
+    title: "Regieassistenz & Orga",
+    description: "Abläufe koordinieren, Proben strukturieren, Teams im Hintergrund führen.",
+  },
+  crew_music: {
+    code: "crew_music",
+    domain: "crew",
+    title: "Musik & Klang",
+    description: "Arrangements entwickeln, Proben begleiten und Produktionen musikalisch tragen.",
+  },
+  crew_props: {
+    code: "crew_props",
+    domain: "crew",
+    title: "Requisite",
+    description: "Requisiten gestalten, organisieren und für reibungslose Szenen sorgen.",
+  },
+  crew_marketing: {
+    code: "crew_marketing",
+    domain: "crew",
+    title: "Werbung & Social Media",
+    description: "Kampagnen planen, Content erstellen und unsere Produktionen sichtbar machen.",
+  },
+};
+
+const ROLE_ORDER: Record<RolePreferenceDomain, readonly string[]> = {
+  acting: ["acting_statist", "acting_scout", "acting_medium", "acting_lead"],
+  crew: [
+    "crew_stage",
+    "crew_tech",
+    "crew_costume",
+    "crew_makeup",
+    "crew_direction",
+    "crew_music",
+    "crew_props",
+    "crew_marketing",
+  ],
+};
+
+export function listRolePreferenceDefinitions(
+  domain?: RolePreferenceDomain,
+): RolePreferenceDefinition[] {
+  if (domain) {
+    return ROLE_ORDER[domain].map((code) => ROLE_PREFERENCE_DEFINITIONS[code]);
+  }
+  return Object.values(ROLE_PREFERENCE_DEFINITIONS);
+}
+
+export function getRolePreferenceDefinition(code: string): RolePreferenceDefinition | undefined {
+  return ROLE_PREFERENCE_DEFINITIONS[code];
+}
+
+export function isCustomRolePreference(code: string): boolean {
+  return code.startsWith("custom-");
+}
+
+export function getRolePreferenceTitle(code: string): string {
+  if (isCustomRolePreference(code)) {
+    return "Eigenes Gewerk";
+  }
+  return ROLE_PREFERENCE_DEFINITIONS[code]?.title ?? code;
+}
+
+export function getRolePreferenceDescription(code: string): string | null {
+  if (isCustomRolePreference(code)) {
+    return "Vom Mitglied individuell ergänzt.";
+  }
+  return ROLE_PREFERENCE_DEFINITIONS[code]?.description ?? null;
+}
+


### PR DESCRIPTION
## Summary
- centralize onboarding role preference metadata in a shared helper
- ensure onboarding wizard, member profile, and dashboard analytics render human-readable role labels
- expose role labels in analytics responses so onboarding statistics avoid raw codes

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d7e9dd4c5c832db4f05df5ae2bb0ea