### PR TITLE
Restore member profile overview placeholder

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -1,21 +1,259 @@
-import { requireAuth } from "@/lib/rbac";
+import { notFound } from "next/navigation";
+
+import { ProfileClient } from "./profile-client";
+import { PageHeader } from "@/components/members/page-header";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import { getUserDisplayName } from "@/lib/names";
+import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
+import { prisma } from "@/lib/prisma";
+import { buildProfileChecklist } from "@/lib/profile-completion";
 import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { sortRoles, type Role } from "@/lib/roles";
+import { buildPhotoConsentSummary } from "@/lib/photo-consent-summary";
+
+const membersBreadcrumb = membersNavigationBreadcrumb("/mitglieder/profil");
 
 export default async function ProfilePage() {
   const session = await requireAuth();
-  const allowed = await hasPermission(session.user, "mitglieder.profil");
+  const [allowed, canManageMeasurements] = await Promise.all([
+    hasPermission(session.user, "mitglieder.profil"),
+    hasPermission(session.user, "mitglieder.koerpermasse"),
+  ]);
 
   if (!allowed) {
-    return <div className="text-sm text-destructive">Kein Zugriff auf den Profilbereich</div>;
+    return (
+      <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-destructive">
+        Kein Zugriff auf den Profilbereich
+      </div>
+    );
   }
 
+  const userId = session.user?.id;
+  if (!userId) {
+    notFound();
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      email: true,
+      firstName: true,
+      lastName: true,
+      name: true,
+      createdAt: true,
+      dateOfBirth: true,
+      avatarSource: true,
+      avatarImageUpdatedAt: true,
+      role: true,
+      roles: { select: { role: true } },
+      appRoles: {
+        select: {
+          role: { select: { id: true, name: true, systemRole: true, isSystem: true } },
+        },
+      },
+      interests: {
+        select: {
+          interest: { select: { name: true } },
+        },
+      },
+      onboardingProfile: {
+        select: {
+          focus: true,
+          background: true,
+          backgroundClass: true,
+          notes: true,
+          memberSinceYear: true,
+          dietaryPreference: true,
+          dietaryPreferenceStrictness: true,
+          whatsappLinkVisitedAt: true,
+          updatedAt: true,
+          show: { select: { meta: true, title: true, year: true } },
+        },
+      },
+      photoConsent: {
+        select: {
+          id: true,
+          status: true,
+          createdAt: true,
+          updatedAt: true,
+          approvedAt: true,
+          rejectionReason: true,
+          documentUploadedAt: true,
+          documentName: true,
+          documentMime: true,
+          approvedBy: { select: { name: true } },
+        },
+      },
+    },
+  });
+
+  if (!user) {
+    notFound();
+  }
+
+  const [allergiesRaw, measurementsRaw] = await Promise.all([
+    prisma.dietaryRestriction.findMany({
+      where: { userId, isActive: true },
+      orderBy: { allergen: "asc" },
+      select: {
+        id: true,
+        allergen: true,
+        level: true,
+        symptoms: true,
+        treatment: true,
+        note: true,
+        updatedAt: true,
+      },
+    }),
+    canManageMeasurements
+      ? prisma.memberMeasurement.findMany({
+          where: { userId },
+          orderBy: { type: "asc" },
+          select: {
+            id: true,
+            type: true,
+            value: true,
+            unit: true,
+            note: true,
+            updatedAt: true,
+          },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const displayName = getUserDisplayName(
+    {
+      firstName: user.firstName,
+      lastName: user.lastName,
+      name: user.name,
+      email: user.email,
+    },
+    "Unbekanntes Mitglied",
+  );
+
+  const roles = sortRoles([
+    user.role as Role,
+    ...user.roles.map((entry) => entry.role as Role),
+  ]);
+
+  const customRoles = user.appRoles
+    .map((entry) => entry.role)
+    .filter((role): role is { id: string; name: string; systemRole: Role | null; isSystem: boolean } => Boolean(role))
+    .filter((role) => !role.systemRole)
+    .map((role) => ({ id: role.id, name: role.name }));
+
+  const interestNames = Array.from(
+    new Set(
+      user.interests
+        .map((entry) => entry.interest?.name?.trim() ?? null)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  const photoConsentSummary = buildPhotoConsentSummary({
+    dateOfBirth: user.dateOfBirth,
+    photoConsent: user.photoConsent
+      ? {
+          id: user.photoConsent.id,
+          status: user.photoConsent.status,
+          createdAt: user.photoConsent.createdAt,
+          updatedAt: user.photoConsent.updatedAt,
+          approvedAt: user.photoConsent.approvedAt,
+          rejectionReason: user.photoConsent.rejectionReason,
+          documentUploadedAt: user.photoConsent.documentUploadedAt,
+          documentName: user.photoConsent.documentName,
+          documentMime: user.photoConsent.documentMime,
+          approvedByName: user.photoConsent.approvedBy?.name ?? null,
+        }
+      : null,
+  });
+
+  const measurementSummaries = measurementsRaw.map((measurement) => ({
+    id: measurement.id,
+    type: measurement.type,
+    value: measurement.value,
+    unit: measurement.unit,
+    note: measurement.note ?? null,
+    updatedAt: measurement.updatedAt?.toISOString() ?? null,
+  }));
+
+  const allergies = allergiesRaw.map((allergy) => ({
+    id: allergy.id,
+    allergen: allergy.allergen,
+    level: allergy.level,
+    symptoms: allergy.symptoms ?? null,
+    treatment: allergy.treatment ?? null,
+    note: allergy.note ?? null,
+    updatedAt: allergy.updatedAt?.toISOString() ?? null,
+  }));
+
+  const hasMeasurements = canManageMeasurements ? measurementSummaries.length > 0 : undefined;
+  const hasBasicData = Boolean(user.firstName?.trim() && user.email?.trim());
+  const hasBirthdate = Boolean(user.dateOfBirth);
+  const hasDietaryPreference = Boolean(user.onboardingProfile?.dietaryPreference?.trim());
+
+  const checklist = buildProfileChecklist({
+    hasBasicData,
+    hasBirthdate,
+    hasDietaryPreference,
+    hasMeasurements,
+    photoConsent: { consentGiven: photoConsentSummary.status === "approved" },
+  });
+
+  const onboardingProfile = user.onboardingProfile;
+  const whatsappLink = onboardingProfile?.show
+    ? getOnboardingWhatsAppLink(onboardingProfile.show.meta)
+    : null;
+
+  const onboarding = onboardingProfile
+    ? {
+        focus: onboardingProfile.focus,
+        background: onboardingProfile.background ?? null,
+        backgroundClass: onboardingProfile.backgroundClass ?? null,
+        notes: onboardingProfile.notes ?? null,
+        memberSinceYear: onboardingProfile.memberSinceYear ?? null,
+        dietaryPreference: onboardingProfile.dietaryPreference ?? null,
+        dietaryPreferenceStrictness: onboardingProfile.dietaryPreferenceStrictness ?? null,
+        whatsappLinkVisitedAt: onboardingProfile.whatsappLinkVisitedAt?.toISOString() ?? null,
+        updatedAt: onboardingProfile.updatedAt?.toISOString() ?? null,
+        show: onboardingProfile.show
+          ? {
+              title: onboardingProfile.show.title ?? null,
+              year: onboardingProfile.show.year,
+            }
+          : null,
+      }
+    : null;
+
+  const headerDescription = "Pflege deine Stammdaten, Ernährungspräferenzen und Freigaben für unser Ensemble.";
+
   return (
-    <div className="space-y-4 text-sm text-muted-foreground">
-      <p className="font-semibold text-foreground">Profilbereich deaktiviert</p>
-      <p>
-        Der bisherige Profilbereich wurde entfernt und steht dir aktuell nicht zur Verfügung. Wir melden uns,
-        sobald eine neue Profilverwaltung verfügbar ist.
-      </p>
+    <div className="space-y-8">
+      <PageHeader title="Mein Profil" description={headerDescription} breadcrumbs={[membersBreadcrumb]} />
+      <ProfileClient
+        user={{
+          id: user.id,
+          email: user.email ?? "",
+          firstName: user.firstName ?? "",
+          lastName: user.lastName ?? "",
+          displayName,
+          createdAt: user.createdAt.toISOString(),
+          dateOfBirth: user.dateOfBirth?.toISOString() ?? null,
+          avatarSource: user.avatarSource,
+          avatarUpdatedAt: user.avatarImageUpdatedAt?.toISOString() ?? null,
+          roles,
+          customRoles,
+        }}
+        onboarding={onboarding}
+        interests={interestNames}
+        allergies={allergies}
+        measurements={measurementSummaries}
+        canManageMeasurements={canManageMeasurements}
+        checklist={checklist}
+        whatsappLink={whatsappLink}
+      />
     </div>
   );
 }

--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { UserAvatar } from "@/components/user-avatar";
+import { PhotoConsentCard } from "@/components/members/photo-consent-card";
+import type { ProfileCompletionSummary } from "@/lib/profile-completion";
+import type { Role } from "@prisma/client";
+
+import { ProfileCompletionProvider } from "./profile-completion-context";
+
+type ProfileClientProps = {
+  user: {
+    id: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+    displayName: string;
+    createdAt: string;
+    dateOfBirth: string | null;
+    avatarSource: string | null;
+    avatarUpdatedAt: string | null;
+    roles: Role[];
+    customRoles: { id: string; name: string }[];
+  };
+  onboarding: {
+    focus: string;
+    background: string | null;
+    backgroundClass: string | null;
+    notes: string | null;
+    memberSinceYear: number | null;
+    dietaryPreference: string | null;
+    dietaryPreferenceStrictness: string | null;
+    whatsappLinkVisitedAt: string | null;
+    updatedAt: string | null;
+    show: { title: string | null; year: number } | null;
+  } | null;
+  interests: string[];
+  allergies: Array<{
+    id: string;
+    allergen: string;
+    level: string;
+    symptoms: string | null;
+    treatment: string | null;
+    note: string | null;
+    updatedAt: string | null;
+  }>;
+  measurements: Array<{
+    id: string;
+    type: string;
+    value: number;
+    unit: string;
+    note: string | null;
+    updatedAt: string | null;
+  }>;
+  canManageMeasurements: boolean;
+  checklist: ProfileCompletionSummary;
+  whatsappLink: string | null;
+};
+
+export function ProfileClient({
+  user,
+  onboarding,
+  interests,
+  allergies,
+  measurements,
+  canManageMeasurements,
+  checklist,
+}: ProfileClientProps) {
+  return (
+    <ProfileCompletionProvider initialSummary={checklist}>
+      <div className="space-y-8">
+        <Card className="border border-border/60">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold">Profilüberblick</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4 sm:flex-row sm:items-center">
+            <UserAvatar
+              userId={user.id}
+              email={user.email}
+              firstName={user.firstName}
+              lastName={user.lastName}
+              name={user.displayName}
+              size={72}
+              className="h-18 w-18 border border-border/70"
+              avatarSource={user.avatarSource}
+              avatarUpdatedAt={user.avatarUpdatedAt}
+            />
+            <div className="space-y-2">
+              <div className="text-xl font-semibold text-foreground">{user.displayName}</div>
+              <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                {user.roles.map((role) => (
+                  <Badge key={role} variant="outline">
+                    {role}
+                  </Badge>
+                ))}
+                {user.customRoles.map((role) => (
+                  <Badge key={role.id} variant="secondary">
+                    {role.name}
+                  </Badge>
+                ))}
+              </div>
+              <div className="text-sm text-muted-foreground">{user.email}</div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Tabs defaultValue="overview" className="space-y-6">
+          <TabsList className="flex w-full flex-wrap gap-2">
+            <TabsTrigger value="overview">Überblick</TabsTrigger>
+            <TabsTrigger value="freigaben">Freigaben</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="overview" className="space-y-4 text-sm text-muted-foreground">
+            <p>Stammdaten, Interessen und Allergien werden demnächst bearbeitbar. Aktuelle Werte:</p>
+            <div className="grid gap-2">
+              <div>Interessen: {interests.length ? interests.join(", ") : "Keine"}</div>
+              <div>Allergien: {allergies.length}</div>
+              {canManageMeasurements ? (
+                <div>Maße: {measurements.length}</div>
+              ) : null}
+              <div>Ernährungsprofil: {onboarding?.dietaryPreference ?? "Kein Eintrag"}</div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="freigaben" className="space-y-4">
+            <PhotoConsentCard onSummaryChange={() => undefined} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </ProfileCompletionProvider>
+  );
+}

--- a/src/app/(members)/mitglieder/profil/profile-completion-context.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-completion-context.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+import type {
+  ProfileChecklistItemId,
+  ProfileCompletionSummary,
+} from "@/lib/profile-completion";
+
+type ProfileCompletionContextValue = {
+  summary: ProfileCompletionSummary;
+  setItemCompletion: (id: ProfileChecklistItemId, complete: boolean) => void;
+  replaceSummary: (summary: ProfileCompletionSummary) => void;
+};
+
+const ProfileCompletionContext = createContext<ProfileCompletionContextValue | null>(null);
+
+type ProfileCompletionProviderProps = {
+  initialSummary: ProfileCompletionSummary;
+  children: React.ReactNode;
+};
+
+export function ProfileCompletionProvider({ initialSummary, children }: ProfileCompletionProviderProps) {
+  const [summary, setSummary] = useState<ProfileCompletionSummary>(initialSummary);
+
+  const setItemCompletion = useCallback((id: ProfileChecklistItemId, complete: boolean) => {
+    setSummary((prev) => {
+      const items = prev.items.map((item) =>
+        item.id === id ? { ...item, complete } : item,
+      );
+      const completed = items.filter((item) => item.complete).length;
+      return {
+        items,
+        completed,
+        total: items.length,
+        complete: completed === items.length && items.length > 0,
+      } satisfies ProfileCompletionSummary;
+    });
+  }, []);
+
+  const replaceSummary = useCallback((value: ProfileCompletionSummary) => {
+    setSummary(value);
+  }, []);
+
+  const value = useMemo<ProfileCompletionContextValue>(
+    () => ({ summary, setItemCompletion, replaceSummary }),
+    [summary, setItemCompletion, replaceSummary],
+  );
+
+  return <ProfileCompletionContext.Provider value={value}>{children}</ProfileCompletionContext.Provider>;
+}
+
+export function useProfileCompletion() {
+  const context = useContext(ProfileCompletionContext);
+  if (!context) {
+    throw new Error("useProfileCompletion must be used within ProfileCompletionProvider");
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- replace the member profile placeholder with a server-side implementation that loads the signed-in user data and checklist metadata
- introduce a minimal client component to render an overview tab with current profile facts and expose the photo consent card
- add a simple profile completion context provider to allow checklist state to be shared across future client components

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d7ed107b88832d9c29b2486c7ee6b5