### PR TITLE
feat: enrich server analytics with real data

### DIFF
--- a/prisma/migrations/20251115093000_server_analytics_extensions/migration.sql
+++ b/prisma/migrations/20251115093000_server_analytics_extensions/migration.sql
@@ -1,0 +1,20 @@
+-- Add cache metrics and background job counters to HTTP summary
+ALTER TABLE "public"."analytics_http_summary"
+  ADD COLUMN IF NOT EXISTS "cacheHitRate" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "frontendCacheHitRate" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "apiBackgroundJobs" INTEGER NOT NULL DEFAULT 0;
+
+-- Create session summary table for peak concurrency and realtime usage
+CREATE TABLE IF NOT EXISTS "public"."analytics_session_summary" (
+  "id" TEXT NOT NULL,
+  "windowStart" TIMESTAMP(3) NOT NULL,
+  "windowEnd" TIMESTAMP(3) NOT NULL,
+  "peakConcurrentUsers" INTEGER NOT NULL DEFAULT 0,
+  "membersRealtimeEvents" INTEGER NOT NULL DEFAULT 0,
+  "membersAvgSessionDurationSeconds" DOUBLE PRECISION NOT NULL DEFAULT 0,
+  "generatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "analytics_session_summary_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "analytics_session_summary_windowEnd_idx"
+  ON "public"."analytics_session_summary"("windowEnd");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1405,11 +1405,14 @@ model AnalyticsHttpSummary {
   frontendRequests          Int      @default(0)
   frontendAvgResponseMs     Float    @default(0)
   frontendAvgPayloadBytes   Float    @default(0)
+  cacheHitRate              Float    @default(0)
+  frontendCacheHitRate      Float    @default(0)
   membersRequests           Int      @default(0)
   membersAvgResponseMs      Float    @default(0)
   apiRequests               Int      @default(0)
   apiAvgResponseMs          Float    @default(0)
   apiErrorRate              Float    @default(0)
+  apiBackgroundJobs         Int      @default(0)
   generatedAt               DateTime @default(now())
 
   @@map("analytics_http_summary")
@@ -1626,6 +1629,19 @@ model AnalyticsRealtimeSummary {
   generatedAt DateTime @default(now())
 
   @@map("analytics_realtime_summary")
+  @@index([windowEnd])
+}
+
+model AnalyticsSessionSummary {
+  id                                 String   @id @default(cuid())
+  windowStart                        DateTime
+  windowEnd                          DateTime
+  peakConcurrentUsers                Int      @default(0)
+  membersRealtimeEvents              Int      @default(0)
+  membersAvgSessionDurationSeconds   Float    @default(0)
+  generatedAt                        DateTime @default(now())
+
+  @@map("analytics_session_summary")
   @@index([windowEnd])
 }
 

--- a/scripts/cron/aggregate-http-metrics.ts
+++ b/scripts/cron/aggregate-http-metrics.ts
@@ -62,11 +62,14 @@ async function main() {
         frontendRequests: summary.frontendRequests,
         frontendAvgResponseMs: summary.frontendAvgResponseMs,
         frontendAvgPayloadBytes: summary.frontendAvgPayloadBytes,
+        cacheHitRate: summary.cacheHitRate,
+        frontendCacheHitRate: summary.frontendCacheHitRate,
         membersRequests: summary.membersRequests,
         membersAvgResponseMs: summary.membersAvgResponseMs,
         apiRequests: summary.apiRequests,
         apiAvgResponseMs: summary.apiAvgResponseMs,
         apiErrorRate: summary.apiErrorRate,
+        apiBackgroundJobs: summary.apiBackgroundJobs,
       },
     });
 

--- a/scripts/cron/aggregate-session-metrics.ts
+++ b/scripts/cron/aggregate-session-metrics.ts
@@ -98,6 +98,7 @@ async function main() {
     await tx.analyticsSessionInsight.deleteMany({});
     await tx.analyticsTrafficSource.deleteMany({});
     await tx.analyticsRealtimeSummary.deleteMany({});
+    await tx.analyticsSessionSummary.deleteMany({});
 
     if (result.sessionInsights.length > 0) {
       await tx.analyticsSessionInsight.createMany({
@@ -130,6 +131,16 @@ async function main() {
         windowEnd: result.realtimeSummary.windowEnd,
         totalEvents: result.realtimeSummary.totalEvents,
         eventCounts: result.realtimeSummary.eventCounts,
+      },
+    });
+
+    await tx.analyticsSessionSummary.create({
+      data: {
+        windowStart: result.sessionSummary.windowStart,
+        windowEnd: result.sessionSummary.windowEnd,
+        peakConcurrentUsers: result.sessionSummary.peakConcurrentUsers,
+        membersRealtimeEvents: result.sessionSummary.membersRealtimeEvents,
+        membersAvgSessionDurationSeconds: result.sessionSummary.membersAvgSessionDurationSeconds,
       },
     });
 

--- a/src/app/(members)/mitglieder/server-analytics/__tests__/collect-server-analytics.test.ts
+++ b/src/app/(members)/mitglieder/server-analytics/__tests__/collect-server-analytics.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AnalyticsHttpSummary, AnalyticsRealtimeSummary, AnalyticsSessionSummary } from "@prisma/client";
+
+import { collectServerAnalytics } from "@/lib/server-analytics";
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: {
+    analyticsHttpSummary: { findFirst: vi.fn() },
+    analyticsHttpPeakHour: { findMany: vi.fn() },
+    analyticsSessionSummary: { findFirst: vi.fn() },
+    analyticsSessionInsight: { findMany: vi.fn() },
+    analyticsTrafficSource: { findMany: vi.fn() },
+    analyticsRealtimeSummary: { findFirst: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("@/lib/analytics/load-server-logs", () => ({
+  loadLatestCriticalServerLogs: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/server-analytics-data", () => ({
+  loadDeviceBreakdownFromDatabase: vi.fn().mockResolvedValue([]),
+  loadPagePerformanceMetrics: vi.fn().mockResolvedValue([]),
+}));
+
+describe("collectServerAnalytics", () => {
+  beforeEach(() => {
+    prismaMock.analyticsHttpSummary.findFirst.mockReset();
+    prismaMock.analyticsHttpPeakHour.findMany.mockReset();
+    prismaMock.analyticsSessionSummary.findFirst.mockReset();
+    prismaMock.analyticsSessionInsight.findMany.mockReset();
+    prismaMock.analyticsTrafficSource.findMany.mockReset();
+    prismaMock.analyticsRealtimeSummary.findFirst.mockReset();
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  it("overrides static metrics with aggregated database values", async () => {
+    const httpSummary: Partial<AnalyticsHttpSummary> = {
+      windowStart: new Date("2024-01-01T10:00:00.000Z"),
+      windowEnd: new Date("2024-01-01T11:00:00.000Z"),
+      totalRequests: 200,
+      successfulRequests: 180,
+      clientErrorRequests: 15,
+      serverErrorRequests: 5,
+      averageDurationMs: 120,
+      frontendRequests: 80,
+      frontendAvgResponseMs: 90,
+      frontendAvgPayloadBytes: 40_960,
+      cacheHitRate: 0.42,
+      frontendCacheHitRate: 0.6,
+      membersRequests: 70,
+      membersAvgResponseMs: 140,
+      apiRequests: 50,
+      apiAvgResponseMs: 160,
+      apiErrorRate: 0.08,
+      apiBackgroundJobs: 21,
+    };
+
+    const sessionSummary: Partial<AnalyticsSessionSummary> = {
+      windowStart: new Date("2024-01-01T10:00:00.000Z"),
+      windowEnd: new Date("2024-01-01T11:00:00.000Z"),
+      peakConcurrentUsers: 5,
+      membersRealtimeEvents: 12,
+      membersAvgSessionDurationSeconds: 450,
+    };
+
+    const realtimeSummary: Partial<AnalyticsRealtimeSummary> = {
+      windowStart: new Date("2024-01-01T10:00:00.000Z"),
+      windowEnd: new Date("2024-01-01T11:00:00.000Z"),
+      totalEvents: 40,
+      eventCounts: { ping: 20 },
+    };
+
+    prismaMock.analyticsHttpSummary.findFirst.mockResolvedValue(httpSummary as AnalyticsHttpSummary);
+    prismaMock.analyticsHttpPeakHour.findMany.mockResolvedValue([]);
+    prismaMock.analyticsSessionSummary.findFirst.mockResolvedValue(
+      sessionSummary as AnalyticsSessionSummary,
+    );
+    prismaMock.analyticsSessionInsight.findMany.mockResolvedValue([]);
+    prismaMock.analyticsTrafficSource.findMany.mockResolvedValue([]);
+    prismaMock.analyticsRealtimeSummary.findFirst.mockResolvedValue(
+      realtimeSummary as AnalyticsRealtimeSummary,
+    );
+
+    const analytics = await collectServerAnalytics();
+
+    expect(analytics.summary.cacheHitRate).toBeCloseTo(0.42, 5);
+    expect(analytics.summary.peakConcurrentUsers).toBe(5);
+    expect(analytics.summary.realtimeEventsLast24h).toBe(40);
+    expect(analytics.requestBreakdown.frontend.cacheHitRate).toBeCloseTo(0.6, 5);
+    expect(analytics.requestBreakdown.members.realtimeEvents).toBe(12);
+    expect(analytics.requestBreakdown.members.avgSessionDurationSeconds).toBe(450);
+    expect(analytics.requestBreakdown.api.backgroundJobs).toBe(21);
+  });
+});

--- a/src/lib/analytics/__tests__/aggregate-session-metrics.test.ts
+++ b/src/lib/analytics/__tests__/aggregate-session-metrics.test.ts
@@ -170,5 +170,10 @@ describe("aggregateSessionMetrics", () => {
     expect(result.realtimeSummary.windowStart.toISOString()).toBe(
       new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(),
     );
+
+    expect(result.sessionSummary.peakConcurrentUsers).toBe(1);
+    expect(result.sessionSummary.membersRealtimeEvents).toBe(3);
+    expect(result.sessionSummary.membersAvgSessionDurationSeconds).toBe(3150);
+    expect(result.sessionSummary.windowEnd.toISOString()).toBe(now.toISOString());
   });
 });


### PR DESCRIPTION
## Summary
- extend HTTP aggregation with cache hit and background job metrics and persist them
- compute session summaries including peak concurrency and member realtime usage and store them
- update server analytics collection to use aggregated data and cover new behavior with tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f59f0410832d96c0e555e8f3c33f