### PR TITLE
feat: derive optimization insights from analytics signals

### DIFF
--- a/docs/analytics-optimization.md
+++ b/docs/analytics-optimization.md
@@ -1,0 +1,56 @@
+# Ableitung von Optimierungsempfehlungen
+
+Dieses Dokument beschreibt die Heuristiken, mit denen `optimizationInsights` aus den in der Datenbank gespeicherten Metriken erzeugt werden. Die Regeln sind so formuliert, dass sie mit `analytics_page_metrics`, `analytics_session_insights`, `analytics_device_metrics` und `analytics_http_summary` funktionieren und nur dann auf statische Fallback-Daten zurückgreifen, wenn keine aktuellen Messwerte verfügbar sind.
+
+## Grundlagen
+
+* **Page Metrics (`analytics_page_metrics`)** liefern die Rohdaten für Ladezeiten und LCP pro Route. Sie werden mit den statischen Metadaten aus `server-analytics-static.json` angereichert.
+* **Device Metrics (`analytics_device_metrics`)** geben Sessions und Ladezeiten je Gerätetyp aus.
+* **Session Insights (`analytics_session_insights`)** enthalten Retention, Seiten pro Sitzung und Segment-Anteile.
+* **HTTP Summary (`analytics_http_summary`)** stellt Backend-spezifische Kennzahlen (Fehlerquoten, Cache-Hit-Rate, Payload-Größen) bereit.
+
+Alle Grenzwerte sind so gewählt, dass relevante Abweichungen gegenüber den Zielwerten auftauchen, ohne die Empfehlungen zu überfrachten.
+
+## Regelkatalog
+
+1. **Langsame Seiten (Frontend/Mitgliederbereich)**
+   * Trigger: `avgPageLoadMs ≥ 1,8 s`.
+   * Auswahl: Seite mit der höchsten Ladezeit und Gewichtung über Seitenaufrufe.
+   * Wirkung: Titel hebt die betroffene Route hervor, Beschreibung empfiehlt Asset-/JavaScript-Optimierungen.
+   * Impact: `≥ 3,2 s → Hoch`, sonst `≥ 1,8 s → Mittel`, darunter `Niedrig`.
+   * Bereich: über den Pfad (`/mitglieder` → Mitgliederbereich, sonst Frontend).
+
+2. **LCP-Optimierung**
+   * Trigger: `lcpMs ≥ 1,8 s` (LCP aus Page Metrics).
+   * Auswahl: Höchster LCP-Wert, wobei die bereits als „langsame Seite“ markierte Route übersprungen wird.
+   * Maßnahme: Fokus auf Hero-/Above-the-fold-Elemente, komprimierte Medien, kritische CSS.
+
+3. **Mitglieder-Latenzen**
+   * Trigger: `avgPageLoadMs ≥ 1,7 s` für Mitgliederseiten **oder** `membersAvgResponseMs ≥ 1,7 s` aus der HTTP-Summary.
+   * Beschreibung: Hinweis auf serverseitige Optimierungen (Caching, Streaming, Query-Tuning).
+
+4. **Segment-Retention**
+   * Trigger: `share ≥ 12 %` **und** `retentionRate ≤ 55 %` in den Session Insights.
+   * Impact: `≤ 40 % → Hoch`, sonst `Mittel`.
+   * Bereich: Segmente mit „Mitglied“ im Namen → Mitgliederbereich, sonst Frontend.
+
+5. **Geräte-Performance**
+   * Trigger: `share ≥ 20 %` **und** `avgPageLoadMs ≥ 1,4 s` für einen Device-Typ.
+   * Maßnahme: Responsive Bildgrößen, Ressourcensplitting.
+
+6. **API-/Infrastruktur-Hinweise**
+   * **API-Fehlerquote**: `apiErrorRate ≥ 5 %` → Infrastruktur-Empfehlung mit Log-/Retry-Hinweis.
+   * **Cache-Hit-Rate**: `cacheHitRate ≤ 60 %` → Edge-Caching ausbauen.
+   * **Payload-Größe**: `frontendAvgPayloadBytes ≥ 450 KB` → Payload reduzieren (Lazy Loading, Kompression).
+
+Die Heuristiken werden auf maximal sechs Empfehlungen begrenzt. Ergibt sich keine Empfehlung, kommen die drei Fallback-Einträge aus `server-analytics-static.json` zum Einsatz.
+
+## Fallback-Verhalten
+
+* Wird keine Datenbankverbindung hergestellt oder liefert keine der oben genannten Quellen Werte, bleiben die statischen Fallback-Einträge aktiv.
+* Sobald mindestens eine der Datenquellen Daten liefert, werden dynamische Insights berechnet. Reicht die Datenlage dennoch nicht für eine Empfehlung, greifen ebenfalls die Fallbacks.
+
+## Anpassung
+
+* Schwellenwerte können bei Bedarf zentral in `src/lib/analytics/derive-optimization-insights.ts` angepasst werden.
+* Neue Regeln sollten die bestehende Struktur (`deriveOptimizationInsights`) nutzen und klar dokumentiert werden.

--- a/src/data/server-analytics-static.json
+++ b/src/data/server-analytics-static.json
@@ -273,36 +273,28 @@
   ],
   "optimizationInsights": [
     {
-      "id": "homepage-lcp",
+      "id": "fallback-lcp-home",
       "area": "Frontend",
-      "title": "Hero-Sektion der Startseite optimieren",
-      "description": "Das große Titelbild verursacht 220 ms LCP-Verzögerung. Eine WebP-Variante oder serverseitige Skalierung würde den Wert deutlich verbessern.",
+      "title": "LCP auf Startseite verbessern",
+      "description": "Der Hero-Abschnitt bremst den First Paint. Komprimierte Medien und priorisierte Fonts helfen, unter 1,5 s zu kommen.",
       "impact": "Hoch",
-      "metric": "LCP Startseite 1,82 s (Ziel < 1,5 s)"
+      "metric": "LCP Startseite 1,82 s"
     },
     {
-      "id": "gallery-images",
+      "id": "fallback-device-mobile",
       "area": "Frontend",
-      "title": "Galerie-Bilder stärker komprimieren",
-      "description": "49 % der Galerie-Aufrufe erfolgen mobil. Größere JPEG-Dateien bremsen das Laden – eine zusätzliche 1200px-Variante hilft.",
+      "title": "Performance auf Mobil-Geräten verbessern",
+      "description": "Mobilgeräte stellen 39 % der Sitzungen, warten aber länger auf den Seitenaufbau. Responsive Bildgrößen und Code-Splitting reduzieren die Ladezeit.",
       "impact": "Mittel",
-      "metric": "Durchschnittliche Bildgröße 1,8 MB"
+      "metric": "Ladezeit Mobil 1,62 s bei 39 % Anteil"
     },
     {
-      "id": "members-cache",
-      "area": "Mitgliederbereich",
-      "title": "Produktionslisten stärker cachen",
-      "description": "Die Tabellen für Produktionen werden bei jedem Seitenaufruf neu berechnet. Eine Cache-Schicht reduziert die Antwortzeit um ~40 ms.",
-      "impact": "Hoch",
-      "metric": "Antwortzeit Produktionen 214 ms (Ziel < 180 ms)"
-    },
-    {
-      "id": "issues-index",
-      "area": "Infrastruktur",
-      "title": "Index für Feedback-Suche ergänzen",
-      "description": "Die Volltextsuche über das Issue-Board scannt aktuell 42k Einträge sequenziell. Ein GIN-Index verkürzt die Dauer deutlich.",
+      "id": "fallback-segment-new-visitors",
+      "area": "Frontend",
+      "title": "Neue Besucher: Rückkehrquote steigern",
+      "description": "Neue Besucher brechen nach wenigen Seiten ab. Eine kürzere Intro-Strecke und klarere CTAs stärken die Retention.",
       "impact": "Mittel",
-      "metric": "Suche im Issue-Board 420 ms (Ziel < 250 ms)"
+      "metric": "Retention 36 % bei 41 % Anteil"
     }
   ],
   "serverLogs": [

--- a/src/lib/analytics/__tests__/derive-optimization-insights.test.ts
+++ b/src/lib/analytics/__tests__/derive-optimization-insights.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import type { AnalyticsHttpSummary } from "@prisma/client";
+
+import { deriveOptimizationInsights } from "@/lib/analytics/derive-optimization-insights";
+import type { DeviceStat, OptimizationInsight, PagePerformanceEntry, SessionInsight } from "@/lib/server-analytics";
+
+const baseFallback: OptimizationInsight[] = [
+  {
+    id: "fallback-1",
+    area: "Frontend",
+    title: "Fallback",
+    description: "Fallback description",
+    impact: "Mittel",
+    metric: "-",
+  },
+];
+
+const emptyPage: PagePerformanceEntry = {
+  path: "/",
+  title: "Home",
+  views: 0,
+  uniqueVisitors: 0,
+  avgTimeOnPageSeconds: 0,
+  loadTimeMs: 0,
+  lcpMs: 0,
+  bounceRate: 0,
+  exitRate: 0,
+  avgScrollDepth: 0,
+  goalCompletionRate: 0,
+};
+
+describe("deriveOptimizationInsights", () => {
+  it("returns fallback entries when requested", () => {
+    const result = deriveOptimizationInsights({
+      publicPages: [emptyPage],
+      memberPages: [],
+      deviceStats: [],
+      sessionInsights: [],
+      httpSummary: null,
+      fallback: baseFallback,
+      useFallbackOnly: true,
+    });
+
+    expect(result).toEqual(baseFallback);
+    expect(result).not.toBe(baseFallback);
+  });
+
+  it("returns fallback when no rule matches", () => {
+    const result = deriveOptimizationInsights({
+      publicPages: [emptyPage],
+      memberPages: [],
+      deviceStats: [],
+      sessionInsights: [],
+      httpSummary: null,
+      fallback: baseFallback,
+    });
+
+    expect(result).toEqual(baseFallback);
+  });
+
+  it("derives insights from analytics data", () => {
+    const publicPages: PagePerformanceEntry[] = [
+      {
+        ...emptyPage,
+        path: "/events/sommerfest",
+        title: "Sommerfest",
+        views: 4200,
+        loadTimeMs: 2600,
+        lcpMs: 2100,
+      },
+      {
+        ...emptyPage,
+        path: "/home",
+        title: "Startseite",
+        views: 8000,
+        loadTimeMs: 1500,
+        lcpMs: 2400,
+      },
+    ];
+
+    const memberPages: PagePerformanceEntry[] = [
+      {
+        ...emptyPage,
+        path: "/mitglieder/produktionen",
+        title: "Produktionen",
+        views: 1800,
+        loadTimeMs: 2100,
+        lcpMs: 1800,
+      },
+    ];
+
+    const sessionInsights: SessionInsight[] = [
+      {
+        segment: "Neue Besucher",
+        avgSessionDurationSeconds: 220,
+        pagesPerSession: 2.8,
+        retentionRate: 0.32,
+        share: 0.25,
+      },
+    ];
+
+    const deviceStats: DeviceStat[] = [
+      { device: "Mobile", sessions: 5200, avgPageLoadMs: 1750, share: 0.42 },
+    ];
+
+    const httpSummary: AnalyticsHttpSummary = {
+      id: "sum-1",
+      windowStart: new Date("2024-10-01T00:00:00Z"),
+      windowEnd: new Date("2024-10-02T00:00:00Z"),
+      totalRequests: 10000,
+      successfulRequests: 9000,
+      clientErrorRequests: 500,
+      serverErrorRequests: 500,
+      averageDurationMs: 320,
+      p95DurationMs: 580,
+      averagePayloadBytes: 420000,
+      uptimePercentage: 99.5,
+      frontendRequests: 6000,
+      frontendAvgResponseMs: 280,
+      frontendAvgPayloadBytes: 520000,
+      cacheHitRate: 0.48,
+      frontendCacheHitRate: 0.55,
+      membersRequests: 2200,
+      membersAvgResponseMs: 1950,
+      apiRequests: 1800,
+      apiAvgResponseMs: 640,
+      apiErrorRate: 0.07,
+      apiBackgroundJobs: 45,
+      generatedAt: new Date("2024-10-02T00:00:00Z"),
+    };
+
+    const result = deriveOptimizationInsights({
+      publicPages,
+      memberPages,
+      deviceStats,
+      sessionInsights,
+      httpSummary,
+      fallback: baseFallback,
+    });
+
+    const ids = result.map((entry) => entry.id);
+
+    expect(ids).toContain("page-speed-events-sommerfest");
+    expect(ids).toContain("lcp-home");
+    expect(ids).toContain("member-speed-mitglieder-produktionen");
+    expect(ids).toContain("segment-neue-besucher");
+    expect(ids).toContain("device-mobile");
+    expect(ids).toContain("api-error-rate");
+    expect(ids).toContain("cache-hit-rate");
+    expect(ids).toContain("member-api-latency");
+  });
+});

--- a/src/lib/analytics/derive-optimization-insights.ts
+++ b/src/lib/analytics/derive-optimization-insights.ts
@@ -1,0 +1,249 @@
+import type { AnalyticsHttpSummary } from "@prisma/client";
+
+import type {
+  DeviceStat,
+  OptimizationArea,
+  OptimizationImpact,
+  OptimizationInsight,
+  PagePerformanceEntry,
+  SessionInsight,
+} from "@/lib/server-analytics";
+
+const MS_FRONTEND_HIGH_THRESHOLD = 3200;
+const MS_FRONTEND_MEDIUM_THRESHOLD = 1800;
+const MS_MEMBER_THRESHOLD = 1700;
+const MS_DEVICE_THRESHOLD = 1400;
+const RETENTION_CRITICAL = 0.4;
+const RETENTION_WARNING = 0.55;
+const SHARE_MINIMUM = 0.12;
+const DEVICE_SHARE_MINIMUM = 0.2;
+const API_ERROR_WARNING = 0.05;
+const CACHE_HIT_WARNING = 0.6;
+const FRONTEND_PAYLOAD_WARNING = 450_000; // ~440 KB
+
+function formatId(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "unknown";
+}
+
+function formatMilliseconds(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return "0 ms";
+  }
+  if (ms >= 1000) {
+    const seconds = ms / 1000;
+    return `${seconds.toLocaleString("de-DE", { maximumFractionDigits: 2, minimumFractionDigits: 1 })} s`;
+  }
+  return `${Math.round(ms).toLocaleString("de-DE")} ms`;
+}
+
+function formatShare(value: number): string {
+  return `${(value * 100).toLocaleString("de-DE", { maximumFractionDigits: 1 })} %`;
+}
+
+function chooseImpact(value: number, high: number, medium: number): OptimizationImpact {
+  if (value >= high) {
+    return "Hoch";
+  }
+  if (value >= medium) {
+    return "Mittel";
+  }
+  return "Niedrig";
+}
+
+function resolveAreaFromPath(path: string): OptimizationArea {
+  const lower = path.toLowerCase();
+  if (lower.startsWith("/mitglieder") || lower.startsWith("/members")) {
+    return "Mitgliederbereich";
+  }
+  return "Frontend";
+}
+
+function cloneFallback(fallback: OptimizationInsight[]): OptimizationInsight[] {
+  return fallback.map((entry) => ({ ...entry }));
+}
+
+export type DeriveOptimizationContext = {
+  publicPages: PagePerformanceEntry[];
+  memberPages: PagePerformanceEntry[];
+  deviceStats: DeviceStat[];
+  sessionInsights: SessionInsight[];
+  httpSummary: AnalyticsHttpSummary | null;
+  fallback: OptimizationInsight[];
+  useFallbackOnly?: boolean;
+};
+
+export function deriveOptimizationInsights({
+  publicPages,
+  memberPages,
+  deviceStats,
+  sessionInsights,
+  httpSummary,
+  fallback,
+  useFallbackOnly = false,
+}: DeriveOptimizationContext): OptimizationInsight[] {
+  if (useFallbackOnly) {
+    return cloneFallback(fallback);
+  }
+
+  const insights: OptimizationInsight[] = [];
+  const seen = new Set<string>();
+
+  function pushInsight(insight: OptimizationInsight | null | undefined) {
+    if (!insight) return;
+    if (seen.has(insight.id)) return;
+    insights.push(insight);
+    seen.add(insight.id);
+  }
+
+  const pageCandidates: PagePerformanceEntry[] = [...publicPages, ...memberPages];
+
+  const slowestPage = pageCandidates
+    .filter((page) => Number.isFinite(page.loadTimeMs) && page.loadTimeMs >= MS_FRONTEND_MEDIUM_THRESHOLD)
+    .sort((a, b) => b.loadTimeMs - a.loadTimeMs || b.views - a.views)[0];
+
+  if (slowestPage) {
+    const impact = chooseImpact(slowestPage.loadTimeMs, MS_FRONTEND_HIGH_THRESHOLD, MS_FRONTEND_MEDIUM_THRESHOLD);
+    pushInsight({
+      id: `page-speed-${formatId(slowestPage.path)}`,
+      area: resolveAreaFromPath(slowestPage.path),
+      title: `Antwortzeit von ${slowestPage.title ?? slowestPage.path} reduzieren`,
+      description:
+        "Die Seite lädt im Schnitt zu langsam. Komprimierte Assets und weniger blockierendes JavaScript reduzieren die Ladezeit.",
+      impact,
+      metric: `Durchschnittliche Ladezeit ${formatMilliseconds(slowestPage.loadTimeMs)}`,
+    });
+  }
+
+  const lcpCandidate = pageCandidates
+    .filter((page) => Number.isFinite(page.lcpMs) && (page.lcpMs ?? 0) >= MS_FRONTEND_MEDIUM_THRESHOLD)
+    .sort((a, b) => (b.lcpMs ?? 0) - (a.lcpMs ?? 0) || b.views - a.views)
+    .find((page) => !slowestPage || page.path !== slowestPage.path);
+
+  if (lcpCandidate) {
+    const impact = chooseImpact(lcpCandidate.lcpMs ?? 0, MS_FRONTEND_HIGH_THRESHOLD, MS_FRONTEND_MEDIUM_THRESHOLD);
+    pushInsight({
+      id: `lcp-${formatId(lcpCandidate.path)}`,
+      area: resolveAreaFromPath(lcpCandidate.path),
+      title: `LCP auf ${lcpCandidate.title ?? lcpCandidate.path} verbessern`,
+      description:
+        "Der Largest-Contentful-Paint liegt über dem Zielwert. Größere Hero-Elemente sollten verzögert oder komprimiert geladen werden.",
+      impact,
+      metric: `LCP ${formatMilliseconds(lcpCandidate.lcpMs ?? 0)}`,
+    });
+  }
+
+  const memberLatency = memberPages
+    .filter((page) => Number.isFinite(page.loadTimeMs) && page.loadTimeMs >= MS_MEMBER_THRESHOLD)
+    .sort((a, b) => b.loadTimeMs - a.loadTimeMs || b.views - a.views)[0];
+
+  if (memberLatency) {
+    const impact = chooseImpact(memberLatency.loadTimeMs, MS_FRONTEND_HIGH_THRESHOLD, MS_MEMBER_THRESHOLD);
+    pushInsight({
+      id: `member-speed-${formatId(memberLatency.path)}`,
+      area: "Mitgliederbereich",
+      title: `${memberLatency.title ?? memberLatency.path} schneller laden`,
+      description:
+        "Die Seite im Mitgliederbereich reagiert spürbar träge. Caching für serverseitige Berechnungen oder Streaming kann helfen.",
+      impact,
+      metric: `Antwortzeit ${formatMilliseconds(memberLatency.loadTimeMs)}`,
+    });
+  }
+
+  const strugglingSegment = sessionInsights
+    .filter((segment) => segment.share >= SHARE_MINIMUM && segment.retentionRate <= RETENTION_WARNING)
+    .sort((a, b) => a.retentionRate - b.retentionRate)[0];
+
+  if (strugglingSegment) {
+    const impact = strugglingSegment.retentionRate <= RETENTION_CRITICAL ? "Hoch" : "Mittel";
+    pushInsight({
+      id: `segment-${formatId(strugglingSegment.segment)}`,
+      area: strugglingSegment.segment.toLowerCase().includes("mitglied") ? "Mitgliederbereich" : "Frontend",
+      title: `${strugglingSegment.segment}: Rückkehrquote steigern`,
+      description:
+        "Dieses Segment springt früh ab. Angepasste Onboarding-Inhalte oder personalisierte Empfehlungen können die Bindung erhöhen.",
+      impact,
+      metric: `Retention ${formatShare(strugglingSegment.retentionRate)} bei ${formatShare(strugglingSegment.share)} Anteil`,
+    });
+  }
+
+  const slowDevice = deviceStats
+    .filter((device) => device.share >= DEVICE_SHARE_MINIMUM && device.avgPageLoadMs >= MS_DEVICE_THRESHOLD)
+    .sort((a, b) => b.share - a.share || b.avgPageLoadMs - a.avgPageLoadMs)[0];
+
+  if (slowDevice) {
+    const impact = chooseImpact(slowDevice.avgPageLoadMs, MS_FRONTEND_HIGH_THRESHOLD, MS_DEVICE_THRESHOLD + 200);
+    pushInsight({
+      id: `device-${formatId(slowDevice.device)}`,
+      area: "Frontend",
+      title: `Performance auf ${slowDevice.device}-Geräten verbessern`,
+      description:
+        "Nutzer auf diesem Gerätetyp warten länger auf den First Paint. Adaptive Bildgrößen und Ressourcensplitting schaffen Abhilfe.",
+      impact,
+      metric: `Ladezeit ${formatMilliseconds(slowDevice.avgPageLoadMs)} bei ${formatShare(slowDevice.share)} Anteil`,
+    });
+  }
+
+  if (httpSummary) {
+    if (httpSummary.apiErrorRate >= API_ERROR_WARNING) {
+      const impact = httpSummary.apiErrorRate >= API_ERROR_WARNING * 2 ? "Hoch" : "Mittel";
+      pushInsight({
+        id: "api-error-rate",
+        area: "Infrastruktur",
+        title: "API-Fehlerquote senken",
+        description:
+          "Mehrere API-Aufrufe schlagen fehl. Logs auf Zeitüberschreitungen prüfen und Timeout-Strategien bzw. Retries anpassen.",
+        impact,
+        metric: `API-Fehlerquote ${(httpSummary.apiErrorRate * 100).toLocaleString("de-DE", { maximumFractionDigits: 1 })} %`,
+      });
+    }
+
+    if (httpSummary.cacheHitRate <= CACHE_HIT_WARNING) {
+      pushInsight({
+        id: "cache-hit-rate",
+        area: "Infrastruktur",
+        title: "Edge-Caching erweitern",
+        description:
+          "Der Cache greift zu selten. Zusätzliche Cache-Tags oder längere TTLs reduzieren Backend-Last und Antwortzeiten.",
+        impact: httpSummary.cacheHitRate <= CACHE_HIT_WARNING / 2 ? "Hoch" : "Mittel",
+        metric: `Cache-Hit-Rate ${(httpSummary.cacheHitRate * 100).toLocaleString("de-DE", { maximumFractionDigits: 1 })} %`,
+      });
+    }
+
+    if (httpSummary.membersAvgResponseMs >= MS_MEMBER_THRESHOLD && !seen.has("member-api-latency")) {
+      const impact = chooseImpact(httpSummary.membersAvgResponseMs, MS_FRONTEND_HIGH_THRESHOLD, MS_MEMBER_THRESHOLD);
+      pushInsight({
+        id: "member-api-latency",
+        area: "Mitgliederbereich",
+        title: "Mitglieder-Endpunkte beschleunigen",
+        description:
+          "Server-Antwortzeiten für eingeloggte Nutzer liegen über dem Zielwert. Datenbankabfragen prüfen und Caching einschalten.",
+        impact,
+        metric: `Antwortzeit Mitglieder-Endpunkte ${formatMilliseconds(httpSummary.membersAvgResponseMs)}`,
+      });
+    }
+
+    if (httpSummary.frontendAvgPayloadBytes >= FRONTEND_PAYLOAD_WARNING) {
+      pushInsight({
+        id: "frontend-payload",
+        area: "Frontend",
+        title: "Frontend-Payload verkleinern",
+        description:
+          "Die durchschnittliche Antwortgröße ist hoch. Nicht kritische Skripte lazy laden und Assets stärker komprimieren.",
+        impact: httpSummary.frontendAvgPayloadBytes >= FRONTEND_PAYLOAD_WARNING * 1.5 ? "Hoch" : "Mittel",
+        metric: `Durchschnittliche Payload ${(httpSummary.frontendAvgPayloadBytes / 1024).toLocaleString("de-DE", {
+          maximumFractionDigits: 0,
+        })} KB`,
+      });
+    }
+  }
+
+  if (insights.length === 0) {
+    return cloneFallback(fallback);
+  }
+
+  return insights.slice(0, 8).map((entry) => ({ ...entry }));
+}


### PR DESCRIPTION
## Summary
- document the rules that map page, device, session and HTTP metrics to optimization insights
- derive `optimizationInsights` dynamically from analytics data and fall back to static entries when nothing is available
- refresh the fallback data set and add unit coverage for the new derivation logic

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d7f9dfd354832d90f9961afb722940