### PR TITLE
Fix members onboarding analytics navigation

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
@@ -31,9 +31,14 @@ async function fetchDashboard(onboardingId: string): Promise<OnboardingDashboard
 type DashboardClientProps = {
   initialData: OnboardingDashboardData;
   onboardings: OnboardingSummary[];
+  navigateHrefTemplate?: string;
 };
 
-export function DashboardClient({ initialData, onboardings }: DashboardClientProps) {
+export function DashboardClient({
+  initialData,
+  onboardings,
+  navigateHrefTemplate = "/dashboard/onboarding/%s",
+}: DashboardClientProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { socket, joinRoom, leaveRoom } = useRealtime();
@@ -88,7 +93,10 @@ export function DashboardClient({ initialData, onboardings }: DashboardClientPro
     if (!nextId) return;
     setSelectedOnboarding(nextId);
     startTransition(() => {
-      router.replace(`/dashboard/onboarding/${nextId}`);
+      const targetHref = navigateHrefTemplate.includes("%s")
+        ? navigateHrefTemplate.replace("%s", nextId)
+        : `${navigateHrefTemplate}${navigateHrefTemplate.endsWith("/") ? "" : "/"}${nextId}`;
+      router.replace(targetHref);
     });
   };
 


### PR DESCRIPTION
## Summary
- keep the members onboarding analytics inside the members layout even when a single onboarding is available
- allow selecting specific onboarding dashboards via a query parameter
- make the shared dashboard client support a custom navigation href template

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d7faecc554832d93ac26a8cb349f41