### PR TITLE
Add WhatsApp onboarding callout with tracking

### DIFF
--- a/src/app/(members)/mitglieder/profil/__stories__/onboarding-section.stories.tsx
+++ b/src/app/(members)/mitglieder/profil/__stories__/onboarding-section.stories.tsx
@@ -1,0 +1,53 @@
+import type { OnboardingSectionProps } from "../profile-client";
+import { OnboardingSection } from "../profile-client";
+
+const title = "Members/Profile/OnboardingSection";
+
+const createOnboarding = (
+  overrides: Partial<NonNullable<OnboardingSectionProps["onboarding"]>> = {},
+): NonNullable<OnboardingSectionProps["onboarding"]> => ({
+  focus: "acting",
+  background: "Musikschule",
+  backgroundClass: null,
+  notes: "Interessiert an Technik",
+  memberSinceYear: 2022,
+  dietaryPreference: "Vegetarisch",
+  dietaryPreferenceStrictness: "Flexibel",
+  whatsappLinkVisitedAt: null,
+  updatedAt: new Date().toISOString(),
+  show: { title: "Sommerproduktion", year: 2025 },
+  ...overrides,
+});
+
+const baseProps: OnboardingSectionProps = {
+  onboarding: createOnboarding(),
+  onOnboardingChange: () => undefined,
+  whatsappLink: "https://example.com/whatsapp",
+  whatsappVisitedAt: null,
+  onWhatsAppVisit: async () => ({ visitedAt: new Date().toISOString(), alreadyVisited: false }),
+  dietaryPreference: { label: "Vegetarisch", strictnessLabel: "Flexibel" },
+};
+
+const meta = { title };
+
+export default meta;
+
+export const WhatsAppCalloutPending = () => (
+  <div className="max-w-xl space-y-4 p-6">
+    <OnboardingSection {...baseProps} />
+  </div>
+);
+
+export const WhatsAppCalloutConfirmed = () => {
+  const visitedAt = "2025-01-02T00:00:00.000Z";
+  return (
+    <div className="max-w-xl space-y-4 p-6">
+      <OnboardingSection
+        {...baseProps}
+        onboarding={createOnboarding({ whatsappLinkVisitedAt: visitedAt })}
+        whatsappVisitedAt={visitedAt}
+        onWhatsAppVisit={async () => ({ visitedAt, alreadyVisited: true })}
+      />
+    </div>
+  );
+};

--- a/src/app/(members)/mitglieder/profil/__tests__/onboarding-section.test.tsx
+++ b/src/app/(members)/mitglieder/profil/__tests__/onboarding-section.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OnboardingSectionProps } from "../profile-client";
+import { OnboardingSection } from "../profile-client";
+
+const { successMock, errorMock } = vi.hoisted(() => ({
+  successMock: vi.fn(),
+  errorMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: successMock,
+    error: errorMock,
+  },
+}));
+
+function createProps(overrides: Partial<OnboardingSectionProps> = {}): OnboardingSectionProps {
+  const defaultOnWhatsAppVisit = vi
+    .fn<NonNullable<OnboardingSectionProps["onWhatsAppVisit"]>>()
+    .mockResolvedValue({ visitedAt: new Date().toISOString(), alreadyVisited: false });
+
+  return {
+    onboarding: null,
+    onOnboardingChange: vi.fn(),
+    whatsappLink: "https://example.com",
+    whatsappVisitedAt: null,
+    onWhatsAppVisit: defaultOnWhatsAppVisit,
+    dietaryPreference: { label: null, strictnessLabel: null },
+    ...overrides,
+  };
+}
+
+describe("OnboardingSection WhatsApp callout", () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { React?: typeof React }).React = React;
+    vi.clearAllMocks();
+  });
+
+  it("renders pending WhatsApp callout when visit is missing", () => {
+    render(<OnboardingSection {...createProps()} />);
+
+    expect(screen.getByText("WhatsApp-Onboarding steht noch aus.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "WhatsApp öffnen" })).toBeEnabled();
+  });
+
+  it("renders confirmed WhatsApp callout when visit timestamp exists", () => {
+    const visitedAt = "2025-01-02T00:00:00.000Z";
+    render(<OnboardingSection {...createProps({ whatsappVisitedAt: visitedAt })} />);
+
+    expect(screen.getByText(/WhatsApp-Onboarding bestätigt/)).toBeInTheDocument();
+  });
+
+  it("triggers the visit handler when CTA is clicked", async () => {
+    const onWhatsAppVisit = vi
+      .fn<NonNullable<OnboardingSectionProps["onWhatsAppVisit"]>>()
+      .mockResolvedValue({ visitedAt: "2025-01-02T00:00:00.000Z", alreadyVisited: false });
+
+    render(<OnboardingSection {...createProps({ onWhatsAppVisit })} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "WhatsApp öffnen" }));
+
+    expect(onWhatsAppVisit).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(successMock).toHaveBeenCalledWith("WhatsApp-Besuch vermerkt");
+    });
+  });
+
+  it("shows an error toast when the visit handler rejects", async () => {
+    const onWhatsAppVisit = vi
+      .fn<NonNullable<OnboardingSectionProps["onWhatsAppVisit"]>>()
+      .mockRejectedValue(new Error("Fehler"));
+
+    render(<OnboardingSection {...createProps({ onWhatsAppVisit })} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "WhatsApp öffnen" }));
+
+    await waitFor(() => {
+      expect(errorMock).toHaveBeenCalledWith("Fehler");
+    });
+  });
+});

--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -194,18 +194,19 @@ export default async function ProfilePage() {
   const hasBirthdate = Boolean(user.dateOfBirth);
   const hasDietaryPreference = Boolean(user.onboardingProfile?.dietaryPreference?.trim());
 
+  const onboardingProfile = user.onboardingProfile;
+  const whatsappLink = onboardingProfile?.show
+    ? getOnboardingWhatsAppLink(onboardingProfile.show.meta)
+    : null;
+
   const checklist = buildProfileChecklist({
     hasBasicData,
     hasBirthdate,
     hasDietaryPreference,
     hasMeasurements,
     photoConsent: { consentGiven: photoConsentSummary.status === "approved" },
+    hasWhatsappVisit: whatsappLink ? Boolean(onboardingProfile?.whatsappLinkVisitedAt) : undefined,
   });
-
-  const onboardingProfile = user.onboardingProfile;
-  const whatsappLink = onboardingProfile?.show
-    ? getOnboardingWhatsAppLink(onboardingProfile.show.meta)
-    : null;
 
   const onboarding = onboardingProfile
     ? {

--- a/src/lib/profile-completion.ts
+++ b/src/lib/profile-completion.ts
@@ -3,14 +3,16 @@ export type ProfileChecklistItemId =
   | "birthdate"
   | "dietary"
   | "measurements"
-  | "photo-consent";
+  | "photo-consent"
+  | "whatsapp";
 
 export type ProfileChecklistTarget =
   | "stammdaten"
   | "ernaehrung"
   | "masse"
   | "interessen"
-  | "freigaben";
+  | "freigaben"
+  | "onboarding";
 
 export type ProfileChecklistItem = {
   id: ProfileChecklistItemId;
@@ -33,6 +35,7 @@ type ChecklistInput = {
   hasDietaryPreference: boolean;
   hasMeasurements?: boolean;
   photoConsent?: { consentGiven: boolean };
+  hasWhatsappVisit?: boolean;
 };
 
 export function buildProfileChecklist(
@@ -69,6 +72,16 @@ export function buildProfileChecklist(
       description: "Ermöglicht dem Kostüm-Team passgenaue Planung.",
       complete: Boolean(input.hasMeasurements),
       targetSection: "masse",
+    });
+  }
+
+  if (input.hasWhatsappVisit !== undefined) {
+    items.push({
+      id: "whatsapp",
+      label: "WhatsApp-Infokanal bestätigt",
+      description: "Bestätige den Zugriff auf unseren WhatsApp-Infokanal.",
+      complete: Boolean(input.hasWhatsappVisit),
+      targetSection: "onboarding",
     });
   }
 


### PR DESCRIPTION
## Summary
- integrate WhatsApp onboarding handling in the profile client and highlight tiles
- persist WhatsApp visit status in the profile checklist and server data mapping
- add dedicated tests and Storybook examples covering pending and confirmed callout states

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d80fe79a58832db32c7143cd06e96a