### PR TITLE
Add category filtering to Technik inventory list

### DIFF
--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/config.ts
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/config.ts
@@ -82,3 +82,62 @@ export const TECH_CATEGORY_LABEL: Record<TechnikInventoryCategory, string> =
     (acc, entry) => ({ ...acc, [entry.value]: entry.label }),
     {} as Record<TechnikInventoryCategory, string>,
   );
+
+export const TECH_CATEGORY_TYPE_OPTIONS = {
+  light: [
+    "Scheinwerfer",
+    "Moving Head",
+    "LED-Bar",
+    "Lichtmischpult",
+    "Dimmer",
+  ],
+  sound: [
+    "Mischpult",
+    "Lautsprecher",
+    "Monitor",
+    "Mikrofon",
+    "Endstufe",
+  ],
+  network: [
+    "Switch",
+    "Router",
+    "Access Point",
+    "Netzwerk-Controller",
+    "Medienkonverter",
+  ],
+  video: [
+    "Kamera",
+    "Projektor",
+    "Bildmischer",
+    "Playback-System",
+    "Monitor",
+  ],
+  instruments: [
+    "Keyboard",
+    "Gitarre",
+    "Bass",
+    "Schlagzeug",
+    "Verstärker",
+  ],
+  cables: [
+    "Stromkabel",
+    "XLR-Kabel",
+    "Klinkenkabel",
+    "Multicore",
+    "DMX-Kabel",
+  ],
+  cases: [
+    "Flightcase",
+    "Rack",
+    "Tasche",
+    "Transportkoffer",
+    "Drawer",
+  ],
+  accessories: [
+    "Stativ",
+    "Adapter",
+    "Werkzeug",
+    "Ersatzteil",
+    "Verbrauchsmaterial",
+  ],
+} as const satisfies Record<TechnikInventoryCategory, readonly string[]>;


### PR DESCRIPTION
## Summary
- replace the Techniklager category panels with a single inventory table that can be filtered by search term and category
- update the add-item dialog to select a category and offer per-category type suggestions
- define reusable type option lists for each Technik inventory category

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d81503ef9c832d9cd66a715082b8f6