### PR TITLE
Add inventory sticker URLs and item overview page

### DIFF
--- a/src/app/(members)/mitglieder/inventar/[code]/page.tsx
+++ b/src/app/(members)/mitglieder/inventar/[code]/page.tsx
@@ -1,0 +1,262 @@
+import { notFound } from "next/navigation";
+
+import { PageHeader } from "@/components/members/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Text } from "@/components/ui/typography";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import { buildInventoryItemPath } from "@/lib/inventory/sticker-links";
+import { hasPermission } from "@/lib/permissions";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { cn } from "@/lib/utils";
+import {
+  TECH_CATEGORY_LABEL,
+  type TechnikInventoryCategory,
+} from "@/app/(members)/mitglieder/lagerverwaltung/technik/config";
+
+const NUMBER_FORMATTER = new Intl.NumberFormat("de-DE");
+const CURRENCY_FORMATTER = new Intl.NumberFormat("de-DE", {
+  style: "currency",
+  currency: "EUR",
+  minimumFractionDigits: 2,
+});
+const DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+const DATE_TIME_FORMATTER = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function formatCurrency(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return "–";
+  }
+
+  return CURRENCY_FORMATTER.format(value);
+}
+
+function formatDate(value: Date | null | undefined): string {
+  if (!value) {
+    return "–";
+  }
+
+  return DATE_FORMATTER.format(value);
+}
+
+function formatDateTime(value: Date | null | undefined): string {
+  if (!value) {
+    return "–";
+  }
+
+  return DATE_TIME_FORMATTER.format(value);
+}
+
+type PageProps = { params: Promise<{ code: string }> };
+
+export default async function InventoryItemPage({ params }: PageProps) {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.lager.technik");
+
+  if (!allowed) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-red-600">
+        Kein Zugriff auf diesen Lagerbereich.
+      </div>
+    );
+  }
+
+  const hasDatabase = Boolean(process.env.DATABASE_URL);
+  if (!hasDatabase) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-muted-foreground">
+        Keine Datenbankverbindung für das Inventar verfügbar.
+      </div>
+    );
+  }
+
+  const { code: rawCode } = await params;
+  const decoded = decodeURIComponent(Array.isArray(rawCode) ? rawCode[0] : rawCode);
+  const normalizedCode = decoded.trim();
+
+  if (!normalizedCode) {
+    notFound();
+  }
+
+  const item = await prisma.inventoryItem.findFirst({
+    where: {
+      OR: [{ sku: normalizedCode }, { id: normalizedCode }],
+    },
+    select: {
+      id: true,
+      sku: true,
+      name: true,
+      manufacturer: true,
+      itemType: true,
+      qty: true,
+      acquisitionCost: true,
+      totalValue: true,
+      purchaseDate: true,
+      location: true,
+      owner: true,
+      condition: true,
+      details: true,
+      category: true,
+      lastUsedAt: true,
+      lastInventoryAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!item) {
+    notFound();
+  }
+
+  const parentBreadcrumb =
+    membersNavigationBreadcrumb("/mitglieder/lagerverwaltung/technik") ??
+    ({ label: "Technik-Lager", href: "/mitglieder/lagerverwaltung/technik" } as const);
+  const currentBreadcrumb = {
+    label: item.name,
+    href: buildInventoryItemPath(item.sku),
+  } as const;
+
+  const category = item.category as TechnikInventoryCategory;
+  const categoryLabel = TECH_CATEGORY_LABEL[category] ?? category;
+  const condition = item.condition?.trim() ?? null;
+  const owner = item.owner?.trim() ?? null;
+  const location = item.location?.trim() ?? null;
+  const descriptionParts = [item.itemType?.trim(), item.manufacturer?.trim()].filter(Boolean);
+  const description = descriptionParts.length
+    ? descriptionParts.join(" • ")
+    : "Inventarposten im Technik-Lager";
+
+  const detailEntries = [
+    { label: "Inventarnummer", value: item.sku, mono: true },
+    { label: "Kategorie", value: categoryLabel },
+    { label: "Gerätetyp", value: item.itemType?.trim() ?? "–" },
+    { label: "Hersteller", value: item.manufacturer?.trim() ?? "–" },
+    { label: "Bestand", value: NUMBER_FORMATTER.format(item.qty) },
+    { label: "Anschaffungskosten (Stück)", value: formatCurrency(item.acquisitionCost) },
+    { label: "Gesamtwert", value: formatCurrency(item.totalValue) },
+    { label: "Anschaffungsdatum", value: formatDate(item.purchaseDate) },
+  ];
+
+  const statusEntries = [
+    { label: "Standort", value: location ?? "–" },
+    { label: "Verantwortlich", value: owner ?? "–" },
+    { label: "Zustand", value: condition ?? "–" },
+    { label: "Zuletzt verwendet", value: formatDateTime(item.lastUsedAt) },
+    { label: "Letzte Inventur", value: formatDateTime(item.lastInventoryAt) },
+  ];
+
+  const timelineEntries = [
+    { label: "Datenbank-ID", value: item.id, mono: true },
+    { label: "Erstellt am", value: formatDateTime(item.createdAt) },
+    { label: "Zuletzt aktualisiert", value: formatDateTime(item.updatedAt) },
+  ];
+
+  const breadcrumb = [parentBreadcrumb, currentBreadcrumb];
+
+  return (
+    <div className="space-y-6 pb-12">
+      <PageHeader
+        title={item.name}
+        description={description}
+        breadcrumbs={breadcrumb}
+        status={
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="font-mono">
+              Nr. {item.sku}
+            </Badge>
+            <Badge variant={item.qty > 0 ? "success" : "destructive"}>
+              Bestand {NUMBER_FORMATTER.format(item.qty)}
+            </Badge>
+            <Badge variant="secondary">{categoryLabel}</Badge>
+            {condition ? <Badge variant="info">{condition}</Badge> : null}
+          </div>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Stammdaten</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid gap-4 sm:grid-cols-2">
+                {detailEntries.map((entry) => (
+                  <div key={entry.label} className="space-y-1">
+                    <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                      {entry.label}
+                    </dt>
+                    <dd className={cn("text-sm text-foreground", entry.mono ? "font-mono" : undefined)}>
+                      {entry.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Status & Standort</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid gap-4 sm:grid-cols-2">
+                {statusEntries.map((entry) => (
+                  <div key={entry.label} className="space-y-1">
+                    <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                      {entry.label}
+                    </dt>
+                    <dd className="text-sm text-foreground">{entry.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Beschreibung & Notizen</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {item.details?.trim() ? (
+                <Text className="whitespace-pre-wrap text-sm text-foreground">
+                  {item.details.trim()}
+                </Text>
+              ) : (
+                <Text variant="caption" tone="muted">
+                  Keine zusätzlichen Notizen hinterlegt.
+                </Text>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Verlauf</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <dl className="grid gap-4">
+                {timelineEntries.map((entry) => (
+                  <div key={entry.label} className="space-y-1">
+                    <dt className="text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                      {entry.label}
+                    </dt>
+                    <dd className={cn("text-sm text-foreground", entry.mono ? "font-mono" : undefined)}>
+                      {entry.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -86,6 +86,7 @@ const CHECKLIST_TARGET_LABELS: Record<ProfileChecklistTarget, string> = {
   masse: "Maße",
   interessen: "Interessen",
   freigaben: "Freigaben",
+  onboarding: "Onboarding",
 };
 const CHECKLIST_TARGETS: ProfileChecklistTarget[] = [
   "stammdaten",
@@ -93,6 +94,7 @@ const CHECKLIST_TARGETS: ProfileChecklistTarget[] = [
   "masse",
   "interessen",
   "freigaben",
+  "onboarding",
 ];
 
 const ONBOARDING_FOCUS_LABELS: Record<OnboardingFocus, string> = {

--- a/src/lib/inventory/sticker-links.ts
+++ b/src/lib/inventory/sticker-links.ts
@@ -1,0 +1,148 @@
+export const INVENTORY_ITEM_ROUTE_PREFIX = "/mitglieder/inventar" as const;
+
+function normalizeCode(code: string): string {
+  return code.trim();
+}
+
+function ensureLeadingSlash(path: string): string {
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+export function buildInventoryItemPath(code: string): string {
+  const normalized = normalizeCode(code);
+  const encoded = encodeURIComponent(normalized);
+  return `${INVENTORY_ITEM_ROUTE_PREFIX}/${encoded}`;
+}
+
+function resolveBaseOrigin(explicitOrigin?: string | null): string | null {
+  if (explicitOrigin && explicitOrigin.trim().length > 0) {
+    return explicitOrigin.trim();
+  }
+
+  const envBase = process.env.NEXT_PUBLIC_BASE_URL;
+  if (envBase && envBase.trim().length > 0) {
+    return envBase.trim();
+  }
+
+  return null;
+}
+
+export function buildInventoryItemUrl(code: string, origin?: string | null): string {
+  const path = buildInventoryItemPath(code);
+  const resolvedOrigin = resolveBaseOrigin(origin);
+
+  if (!resolvedOrigin) {
+    return path;
+  }
+
+  try {
+    return new URL(path, resolvedOrigin).toString();
+  } catch {
+    const sanitizedOrigin = resolvedOrigin.replace(/\/+$/, "");
+    const normalizedPath = ensureLeadingSlash(path);
+    return `${sanitizedOrigin}${normalizedPath}`;
+  }
+}
+
+function extractCodeFromPath(pathname: string): string | null {
+  if (!pathname) {
+    return null;
+  }
+
+  const normalized = pathname.replace(/\/+$/, "");
+  const segments = normalized.split("/").filter(Boolean);
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const next = segments[index + 1];
+    if (segment === "mitglieder" && next === "inventar") {
+      const codeSegment = segments[index + 2];
+      if (codeSegment) {
+        try {
+          return decodeURIComponent(codeSegment);
+        } catch {
+          return codeSegment;
+        }
+      }
+    }
+    if (segment === "inventar") {
+      const codeSegment = segments[index + 1];
+      if (codeSegment) {
+        try {
+          return decodeURIComponent(codeSegment);
+        } catch {
+          return codeSegment;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export interface InventoryStickerDetails {
+  code: string;
+  path: string;
+}
+
+export function parseInventoryStickerInput(input: string): InventoryStickerDetails {
+  const trimmed = input.trim();
+
+  if (!trimmed) {
+    return { code: "", path: buildInventoryItemPath("") };
+  }
+
+  const candidates: Array<() => string | null> = [
+    () => {
+      try {
+        const url = new URL(trimmed);
+        return (
+          extractCodeFromPath(url.pathname) ||
+          url.searchParams.get("code") ||
+          url.searchParams.get("sku")
+        );
+      } catch {
+        return null;
+      }
+    },
+    () => {
+      if (trimmed.startsWith("/")) {
+        return extractCodeFromPath(trimmed);
+      }
+      return null;
+    },
+  ];
+
+  for (const getCandidate of candidates) {
+    const candidate = getCandidate();
+    if (candidate && candidate.trim().length > 0) {
+      const normalized = normalizeCode(candidate);
+      return { code: normalized, path: buildInventoryItemPath(normalized) };
+    }
+  }
+
+  const normalized = normalizeCode(trimmed);
+  return { code: normalized, path: buildInventoryItemPath(normalized) };
+}
+
+export function formatInventoryLinkLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const host = url.host;
+    const pathname = url.pathname.replace(/\/+$/, "");
+    return pathname ? `${host}${pathname}` : host;
+  } catch {
+    if (trimmed.startsWith("http://")) {
+      return trimmed.slice("http://".length);
+    }
+    if (trimmed.startsWith("https://")) {
+      return trimmed.slice("https://".length);
+    }
+    return trimmed.startsWith("/") ? trimmed.slice(1) : trimmed;
+  }
+}


### PR DESCRIPTION
## Summary
- add helper utilities for inventory sticker URLs and parsing and show the link/number in the sticker preview
- expose a new inventory item overview route that surfaces key metadata when a sticker link is opened
- update the scanner flow to understand sticker URLs, surface the item overview link after scans, and align checklist labels

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d818a463f8832d8ba97b3e2b608088