### PR TITLE
Move profile sidebar highlights next to checklist

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -765,6 +765,7 @@ function ProfileClientInner({
           createdAtLabel={createdAtLabel}
           memberSinceLabel={memberSinceLabel}
           percentComplete={percentComplete}
+          highlights={highlightTiles}
         />
         <div className="space-y-4">
           <ChecklistCard
@@ -772,13 +773,6 @@ function ProfileClientInner({
             activeTarget={activeChecklistTarget}
             onNavigate={(target) => setActiveTab(target)}
           />
-          {highlightTiles.length ? (
-            <div className="grid gap-4 sm:grid-cols-2">
-              {highlightTiles.map((tile) => (
-                <ProfileHighlightTile key={tile.id} {...tile} />
-              ))}
-            </div>
-          ) : null}
         </div>
       </div>
 
@@ -864,6 +858,7 @@ type ProfileOverviewCardProps = {
   createdAtLabel: string | null;
   memberSinceLabel: string | null;
   percentComplete: number;
+  highlights: HighlightTileConfig[];
 };
 
 function ProfileOverviewCard({
@@ -875,6 +870,7 @@ function ProfileOverviewCard({
   createdAtLabel,
   memberSinceLabel,
   percentComplete,
+  highlights,
 }: ProfileOverviewCardProps) {
   const email = user.email?.trim() ?? "";
   const show = onboarding?.show ?? null;
@@ -993,6 +989,15 @@ function ProfileOverviewCard({
           </div>
         ) : null}
       </CardContent>
+      {highlights.length ? (
+        <CardContent className="space-y-3 border-t border-border/50 bg-background/60">
+          <div className="space-y-3">
+            {highlights.map((tile) => (
+              <ProfileHighlightTile key={tile.id} {...tile} />
+            ))}
+          </div>
+        </CardContent>
+      ) : null}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- move the membership, onboarding focus, and team chat highlights into the profile sidebar beneath the member header
- keep the profile checklist column dedicated to the checklist by rendering highlight tiles inside the overview card

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d824f269f4832da36642a304764c36