### PR TITLE
Add owner-only reset for server analytics

### DIFF
--- a/src/app/(members)/mitglieder/server-analytics/actions.ts
+++ b/src/app/(members)/mitglieder/server-analytics/actions.ts
@@ -9,6 +9,9 @@ import {
   type LoadedServerLog,
   type ServerLogStatus,
 } from "@/lib/analytics/load-server-logs";
+import { collectServerAnalytics } from "@/lib/server-analytics";
+import { resetAnalyticsMetadataCache } from "@/lib/server-analytics-data";
+import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 
@@ -24,6 +27,30 @@ export type UpdateServerLogStatusInput = z.infer<typeof updateStatusSchema>;
 export type UpdateServerLogStatusResult =
   | { success: true; log: LoadedServerLog }
   | { success: false; error: string };
+
+function hasOwnerRole(user: { role?: string | null; roles?: unknown } | null | undefined): boolean {
+  if (!user) {
+    return false;
+  }
+
+  if (user.role === "owner") {
+    return true;
+  }
+
+  if (Array.isArray(user.roles)) {
+    return user.roles.some((role) => {
+      if (typeof role === "string") {
+        return role === "owner";
+      }
+      if (role && typeof role === "object" && "role" in role) {
+        return (role as { role?: string }).role === "owner";
+      }
+      return false;
+    });
+  }
+
+  return false;
+}
 
 export async function updateServerLogStatusAction(
   input: UpdateServerLogStatusInput,
@@ -58,4 +85,52 @@ export async function reloadCriticalServerLogs(): Promise<LoadedServerLog[]> {
   }
 
   return loadLatestCriticalServerLogs({ limit: 25 });
+}
+
+type ResetServerAnalyticsError = "not_authorized" | "no_database" | "reset_failed";
+
+export type ResetServerAnalyticsResult =
+  | { success: true; analytics: Awaited<ReturnType<typeof collectServerAnalytics>> }
+  | { success: false; error: ResetServerAnalyticsError };
+
+export async function resetServerAnalyticsAction(): Promise<ResetServerAnalyticsResult> {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.analytics");
+  if (!allowed || !hasOwnerRole(session.user)) {
+    return { success: false, error: "not_authorized" };
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return { success: false, error: "no_database" };
+  }
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      await tx.analyticsHttpRequest.deleteMany();
+      await tx.analyticsUptimeHeartbeat.deleteMany();
+      await tx.analyticsRealtimeEvent.deleteMany();
+      await tx.analyticsHttpSummary.deleteMany();
+      await tx.analyticsHttpPeakHour.deleteMany();
+      await tx.analyticsPageMetric.deleteMany();
+      await tx.analyticsDeviceMetric.deleteMany();
+      await tx.analyticsSessionInsight.deleteMany();
+      await tx.analyticsTrafficSource.deleteMany();
+      await tx.analyticsRealtimeSummary.deleteMany();
+      await tx.analyticsSessionSummary.deleteMany();
+      await tx.analyticsServerLog.deleteMany();
+      await tx.analyticsPageView.deleteMany();
+      await tx.analyticsDeviceSnapshot.deleteMany();
+      await tx.analyticsTrafficAttribution.deleteMany();
+      await tx.analyticsSession.deleteMany();
+    });
+
+    resetAnalyticsMetadataCache();
+    revalidatePath("/mitglieder/server-analytics");
+
+    const analytics = await collectServerAnalytics();
+    return { success: true, analytics };
+  } catch (error) {
+    console.error("[server-analytics] Failed to reset analytics data", error);
+    return { success: false, error: "reset_failed" };
+  }
 }

--- a/src/app/(members)/mitglieder/server-analytics/page.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/page.tsx
@@ -11,7 +11,10 @@ export default async function ServerAnalyticsPage() {
     return <div className="text-sm text-red-600">Kein Zugriff auf die Server-Statistiken</div>;
   }
 
+  const user = session.user!;
+  const roles = Array.isArray(user.roles) ? user.roles : [];
+  const isOwner = user.role === "owner" || roles.includes("owner");
   const analytics = await collectServerAnalytics();
 
-  return <ServerAnalyticsContent initialAnalytics={analytics} />;
+  return <ServerAnalyticsContent initialAnalytics={analytics} canReset={isOwner} />;
 }


### PR DESCRIPTION
## Summary
- add a server action that clears all persisted analytics tables and returns a fresh snapshot
- restrict the reset feature to owners and surface it behind a confirmation dialog in the UI
- pass the owner capability from the page component so the button only renders for qualified users

## Testing
- `pnpm lint`
- `pnpm test`
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68d825ec1cf0832d98f4eb5a3e063323