### PR TITLE
Show holidays by default in Sperrliste calendar

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -146,7 +146,7 @@ export function BlockCalendar({
   const [recentlyAdded, setRecentlyAdded] = useState<Set<string>>(new Set());
   const [recentlyRemoved, setRecentlyRemoved] = useState<Set<string>>(new Set());
   const [enterDir, setEnterDir] = useState<"left" | "right">("right");
-  const [showHolidays, setShowHolidays] = useState(false);
+  const [showHolidays, setShowHolidays] = useState(true);
 
   const dragIntentRef = useRef<SelectionIntent | null>(null);
   const draggingRef = useRef(false);
@@ -915,38 +915,32 @@ export function BlockCalendar({
     </div>
   ) : null;
 
-  const holidayToggle = (
-    <div className="space-y-2">
-      <button
-        type="button"
-        onClick={() => setShowHolidays((prev) => !prev)}
-        aria-pressed={showHolidays}
-        className={cn(
-          "flex w-full items-center justify-between rounded-lg border px-3 py-2 text-left text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500",
-          showHolidays
-            ? "border-sky-300 bg-sky-50 text-sky-900 hover:bg-sky-100 dark:border-sky-500/60 dark:bg-sky-500/20 dark:text-sky-50 dark:hover:bg-sky-500/30"
-            : "border-border/60 bg-background/80 text-muted-foreground hover:border-sky-200 hover:bg-muted/60 hover:text-foreground dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:bg-slate-900/60",
-        )}
-      >
-        <span className="flex items-center gap-2">
-          <CalendarDays className="h-4 w-4" aria-hidden />
-          <span>{showHolidays ? "Schulferien ausblenden" : "Schulferien anzeigen"}</span>
-        </span>
-        <span
-          className={cn(
-            "text-[10px] font-semibold uppercase tracking-wide",
-            showHolidays
-              ? "text-sky-800/80 dark:text-sky-100/80"
-              : "text-muted-foreground",
-          )}
-        >
-          Optional
-        </span>
-      </button>
-      <p className="text-xs leading-5 text-muted-foreground">
-        Blende die Schulferien bei Bedarf für deine persönliche Planung ein.
-      </p>
-    </div>
+  const holidayHeaderToggle = (
+    <label
+      className={cn(
+        "flex cursor-pointer select-none items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition",
+        showHolidays
+          ? "border-sky-300 bg-sky-50 text-sky-900 shadow-sm hover:bg-sky-100 dark:border-sky-500/60 dark:bg-sky-500/20 dark:text-sky-50 dark:hover:bg-sky-500/30"
+          : "border-border/60 bg-background/80 text-muted-foreground hover:border-sky-200 hover:text-foreground dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:bg-slate-900/60",
+      )}
+    >
+      <input
+        type="checkbox"
+        checked={showHolidays}
+        onChange={(event) => setShowHolidays(event.target.checked)}
+        className="h-4 w-4 accent-sky-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:accent-sky-400"
+      />
+      <span className="flex items-center gap-1.5">
+        <CalendarDays className="h-4 w-4" aria-hidden />
+        <span>Ferien anzeigen</span>
+      </span>
+    </label>
+  );
+
+  const holidayDescription = (
+    <p className="text-xs leading-5 text-muted-foreground">
+      Schulferien werden im Kalender hervorgehoben. Über das Kästchen oben kannst du sie bei Bedarf ausblenden.
+    </p>
   );
 
   const holidayPanel = !showHolidays
@@ -1139,22 +1133,25 @@ export function BlockCalendar({
         transitionDirection={enterDir}
         subtitle="Tippe auf einen Tag, um ihn zu sperren, einzuschränken oder als bevorzugt zu markieren."
         headerActions={
-          <Button
-            type="button"
-            variant={selectionMode ? "default" : "outline"}
-            size="sm"
-            onClick={handleToggleSelectionMode}
-            className="w-full sm:w-auto"
-          >
-            {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            {holidayHeaderToggle}
+            <Button
+              type="button"
+              variant={selectionMode ? "default" : "outline"}
+              size="sm"
+              onClick={handleToggleSelectionMode}
+              className="w-full sm:w-auto"
+            >
+              {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
+            </Button>
+          </div>
         }
         renderDay={renderCalendarDay}
         additionalContent={
           <>
             {rehearsalHint}
             {selectionPanel}
-            {holidayToggle}
+            {holidayDescription}
             {holidayPanel}
           </>
         }


### PR DESCRIPTION
## Summary
- show subscribed holidays in the Sperrliste calendar by default
- add a header checkbox to control the holiday overlay without hiding it by default
- surface a short description about the holiday layer above the calendar extras

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d844dc9528832d8e039c6af5646284