### PR TITLE
Fix duplicate keys in onboarding dashboard tabs

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
@@ -126,7 +126,7 @@ export function DashboardClient({
           {historyAvailable ? <TabsTrigger value="history">Historie</TabsTrigger> : null}
         </TabsList>
         <AnimatePresence mode="wait">
-          <TabsContent value="global" className="space-y-6">
+          <TabsContent key="global" value="global" className="space-y-6">
             <motion.div
               key={`${currentData.onboarding.id}-global`}
               initial={{ opacity: 0, y: 12 }}
@@ -137,7 +137,7 @@ export function DashboardClient({
               <GlobalOverviewTab data={currentData.global} participants={currentData.onboarding.participants} />
             </motion.div>
           </TabsContent>
-          <TabsContent value="allocation" className="space-y-6">
+          <TabsContent key="allocation" value="allocation" className="space-y-6">
             <motion.div
               key={`${currentData.onboarding.id}-allocation`}
               initial={{ opacity: 0, y: 12 }}
@@ -152,7 +152,7 @@ export function DashboardClient({
             </motion.div>
           </TabsContent>
           {historyAvailable ? (
-            <TabsContent value="history" className="space-y-6">
+            <TabsContent key="history" value="history" className="space-y-6">
               <motion.div
                 key={`${currentData.onboarding.id}-history`}
                 initial={{ opacity: 0, y: 12 }}


### PR DESCRIPTION
## Summary
- add explicit keys to each dashboard tab content so AnimatePresence no longer renders children with duplicate keys

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: missing dependencies d3-scale, d3-scale-chromatic, tippy.js/dist/tippy.css, react-wordcloud)*

------
https://chatgpt.com/codex/tasks/task_e_68d851f86d78832d92d01f2552aa4f09