### PR TITLE
Refine analytics overview metrics and timeline legend

### DIFF
--- a/src/app/(members)/mitglieder/server-analytics/overview-metrics.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/overview-metrics.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { tv } from "tailwind-variants";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const overviewMetricStyles = tv({
+  slots: {
+    card: "group min-h-[184px] border border-border/70 bg-background/95 shadow-sm transition-colors [--metric-accent:var(--chart-1)]",
+    header: "flex items-start justify-between gap-3",
+    headerContent: "flex items-center gap-3",
+    icon: "flex h-10 w-10 items-center justify-center rounded-xl border border-[color:var(--metric-accent)]/40 bg-[color:var(--metric-accent)]/12 text-[color:var(--metric-accent)]",
+    title: "text-sm font-semibold text-foreground",
+    subtitle: "text-xs text-muted-foreground/80 line-clamp-2",
+    value: "text-3xl font-semibold tracking-tight text-foreground",
+    description: "text-xs text-muted-foreground line-clamp-2",
+  },
+  variants: {
+    tone: {
+      emerald: {
+        card: "[--metric-accent:var(--chart-2)]",
+      },
+      sky: {
+        card: "[--metric-accent:var(--chart-4)]",
+      },
+      amber: {
+        card: "[--metric-accent:var(--chart-3)]",
+      },
+      violet: {
+        card: "[--metric-accent:var(--chart-5)]",
+      },
+      rose: {
+        card: "[--metric-accent:var(--chart-1)]",
+      },
+      indigo: {
+        card: "[--metric-accent:var(--primary)]",
+      },
+      slate: {
+        card: "[--metric-accent:var(--muted-foreground)]",
+      },
+    },
+  },
+  defaultVariants: {
+    tone: "slate",
+  },
+});
+
+export type OverviewMetricTone =
+  | "emerald"
+  | "sky"
+  | "amber"
+  | "violet"
+  | "rose"
+  | "indigo"
+  | "slate";
+
+export type OverviewMetricDefinition = {
+  id: string;
+  label: string;
+  value: string;
+  description: string;
+  icon: LucideIcon;
+  tone?: OverviewMetricTone;
+  secondary?: string;
+};
+
+type OverviewMetricsProps = {
+  metrics: OverviewMetricDefinition[];
+  renderBadge?: () => ReactNode;
+};
+
+export function OverviewMetrics({ metrics, renderBadge }: OverviewMetricsProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {metrics.map((metric) => {
+        const styles = overviewMetricStyles({ tone: metric.tone });
+
+        return (
+          <Card key={metric.id} className={styles.card()}>
+            <CardHeader className="pb-3">
+              <div className={styles.header()}>
+                <div className={styles.headerContent()}>
+                  <span className={styles.icon()} aria-hidden>
+                    <metric.icon className="h-5 w-5" aria-hidden />
+                  </span>
+                  <div className="flex min-w-0 flex-col">
+                    <CardTitle className={styles.title()}>{metric.label}</CardTitle>
+                    {metric.secondary ? (
+                      <p className={styles.subtitle()}>{metric.secondary}</p>
+                    ) : null}
+                  </div>
+                </div>
+                {renderBadge ? <span className="shrink-0">{renderBadge()}</span> : null}
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <p className={styles.value()}>{metric.value}</p>
+              <p className={styles.description()}>{metric.description}</p>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 
+import { Activity, AlertTriangle, HardDrive, Radio, ShieldCheck, Timer, Users } from "lucide-react";
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -28,6 +30,7 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
 import { resetServerAnalyticsAction, updateServerLogStatusAction } from "./actions";
+import { OverviewMetrics, type OverviewMetricDefinition } from "./overview-metrics";
 
 const numberFormat = new Intl.NumberFormat("de-DE");
 const decimalFormat = new Intl.NumberFormat("de-DE", { minimumFractionDigits: 1, maximumFractionDigits: 1 });
@@ -347,6 +350,65 @@ export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: S
   const showMockDataBadge = displayAnalytics.isDemoData;
   const renderMockDataBadge = () => (showMockDataBadge ? <MockDataBadge /> : null);
 
+  const overviewMetrics: OverviewMetricDefinition[] = [
+    {
+      id: "uptime",
+      label: "Verfügbarkeit",
+      value: `${uptimeFormat.format(displayAnalytics.summary.uptimePercentage)} %`,
+      description: "letzte 30 Tage",
+      icon: ShieldCheck,
+      tone: "emerald",
+    },
+    {
+      id: "requests",
+      label: "Anfragen (24h)",
+      value: numberFormat.format(displayAnalytics.summary.requestsLast24h),
+      description: "über alle Systeme hinweg",
+      icon: Activity,
+      tone: "violet",
+    },
+    {
+      id: "response-time",
+      label: "Ø Antwortzeit",
+      value: formatMs(displayAnalytics.summary.averageResponseTimeMs),
+      description: `95. Perzentil liegt bei ${formatMs(displayAnalytics.summary.averageResponseTimeMs * 1.6)}`,
+      icon: Timer,
+      tone: "sky",
+    },
+    {
+      id: "concurrent-users",
+      label: "Peak gleichzeitiger Nutzer",
+      value: numberFormat.format(displayAnalytics.summary.peakConcurrentUsers),
+      description: "innerhalb der letzten 24 Stunden",
+      icon: Users,
+      tone: "indigo",
+    },
+    {
+      id: "cache-hit",
+      label: "Cache-Hit-Rate",
+      value: percentPreciseFormat.format(displayAnalytics.summary.cacheHitRate),
+      description: "Edge- und Anwendungscache kombiniert",
+      icon: HardDrive,
+      tone: "amber",
+    },
+    {
+      id: "realtime-events",
+      label: "Realtime-Ereignisse (24h)",
+      value: numberFormat.format(displayAnalytics.summary.realtimeEventsLast24h),
+      description: "Socket.io Updates und Live-Sync",
+      icon: Radio,
+      tone: "rose",
+    },
+    {
+      id: "error-rate",
+      label: "Fehlerquote",
+      value: percentPreciseFormat.format(displayAnalytics.summary.errorRate),
+      description: "5xx/4xx im Verhältnis zu allen Requests",
+      icon: AlertTriangle,
+      tone: "slate",
+    },
+  ];
+
   const connectionDotClass = useMemo(() => {
     switch (connectionStatus) {
       case "connected":
@@ -558,92 +620,7 @@ export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: S
         </div>
 
         <TabsContent value="overview" className="space-y-6">
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <Card className="border border-border/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              Verfügbarkeit
-              {renderMockDataBadge()}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold">{uptimeFormat.format(displayAnalytics.summary.uptimePercentage)} %</p>
-            <p className="text-xs text-muted-foreground">letzte 30 Tage</p>
-          </CardContent>
-        </Card>
-        <Card className="border border-border/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              Anfragen (24h)
-              {renderMockDataBadge()}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold">{numberFormat.format(displayAnalytics.summary.requestsLast24h)}</p>
-            <p className="text-xs text-muted-foreground">über alle Systeme hinweg</p>
-          </CardContent>
-        </Card>
-        <Card className="border border-border/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              Ø Antwortzeit
-              {renderMockDataBadge()}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold">{formatMs(displayAnalytics.summary.averageResponseTimeMs)}</p>
-            <p className="text-xs text-muted-foreground">95. Perzentil liegt bei {formatMs(displayAnalytics.summary.averageResponseTimeMs * 1.6)}</p>
-          </CardContent>
-        </Card>
-        <Card className="border border-border/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              Peak gleichzeitiger Nutzer
-              {renderMockDataBadge()}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold">{numberFormat.format(displayAnalytics.summary.peakConcurrentUsers)}</p>
-            <p className="text-xs text-muted-foreground">innerhalb der letzten 24 Stunden</p>
-          </CardContent>
-        </Card>
-        <Card className="border border-border/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              Cache-Hit-Rate
-              {renderMockDataBadge()}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold">{percentPreciseFormat.format(displayAnalytics.summary.cacheHitRate)}</p>
-            <p className="text-xs text-muted-foreground">Edge- und Anwendungscache kombiniert</p>
-          </CardContent>
-        </Card>
-        <Card className="border border-border/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              Realtime-Ereignisse (24h)
-              {renderMockDataBadge()}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold">{numberFormat.format(displayAnalytics.summary.realtimeEventsLast24h)}</p>
-            <p className="text-xs text-muted-foreground">Socket.io Updates und Live-Sync</p>
-          </CardContent>
-        </Card>
-        <Card className="border border-border/70">
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              Fehlerquote
-              {renderMockDataBadge()}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-3xl font-semibold">{percentPreciseFormat.format(displayAnalytics.summary.errorRate)}</p>
-            <p className="text-xs text-muted-foreground">5xx/4xx im Verhältnis zu allen Requests</p>
-          </CardContent>
-        </Card>
-      </div>
+          <OverviewMetrics metrics={overviewMetrics} renderBadge={renderMockDataBadge} />
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Card className="border border-border/70">

--- a/src/app/(members)/mitglieder/sperrliste/overview/mobile-timeline.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/mobile-timeline.tsx
@@ -32,42 +32,25 @@ import {
   timelineStatusStyles,
   type TimelineStatus,
 } from './desktop-timeline';
+import {
+  timelineToneStyles,
+  type TimelineTone,
+} from './timeline-legend';
 import type {
   BlockOverviewSummary,
   PreparedMember,
   VisibleDayInfo,
 } from './useBlockOverviewData';
 
-const toneStyles = {
-  blocked: {
-    bullet: 'bg-destructive',
-    text: 'text-destructive/90',
-  },
-  limited: {
-    bullet: 'bg-amber-500',
-    text: 'text-amber-700 dark:text-amber-200',
-  },
-  preferred: {
-    bullet: 'bg-emerald-500',
-    text: 'text-emerald-600 dark:text-emerald-200',
-  },
-  holiday: {
-    bullet: 'bg-sky-500',
-    text: 'text-sky-700 dark:text-sky-200',
-  },
-} satisfies Record<
-  'blocked' | 'limited' | 'preferred' | 'holiday',
-  { bullet: string; text: string }
->;
-
 type ReasonPreviewProps = {
   reason: string;
   label: string;
-  tone: keyof typeof toneStyles;
+  tone: TimelineTone;
 };
 
 function ReasonPreview({ reason, label, tone }: ReasonPreviewProps) {
   const [open, setOpen] = React.useState(false);
+  const toneClasses = timelineToneStyles({ tone });
 
   const handleOpen = React.useCallback(
     (event: React.MouseEvent | React.KeyboardEvent) => {
@@ -93,24 +76,27 @@ function ReasonPreview({ reason, label, tone }: ReasonPreviewProps) {
             tabIndex={0}
             onClick={handleOpen}
             onKeyDown={handleOpen}
-            className={cn(
-              'group flex w-full cursor-pointer items-start gap-2 rounded-md px-1 py-0.5 text-left text-[11px] leading-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-              toneStyles[tone].text,
-            )}
-          >
-            <span
-              aria-hidden
               className={cn(
-                'mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full transition-colors',
-                toneStyles[tone].bullet,
+                'group flex w-full cursor-pointer items-start gap-2 rounded-md px-1 py-0.5 text-left text-[11px] leading-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                toneClasses.text(),
               )}
-            />
-            <span className="line-clamp-2 flex-1 text-[11px] leading-4">
-              {reason}
-            </span>
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  'mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full transition-colors',
+                  toneClasses.bullet(),
+                )}
+              />
+              <span className="line-clamp-2 flex-1 text-[11px] leading-4">
+                {reason}
+              </span>
             <Info
               aria-hidden
-              className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground"
+              className={cn(
+                'mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground',
+                toneClasses.text(),
+              )}
             />
           </span>
         </TooltipTrigger>

--- a/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
@@ -2,7 +2,6 @@
 import { ChevronLeft, ChevronRight, Sparkles } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
 import type { HolidayRange } from '@/types/holidays';
 
 import type { BlockedDay } from '../block-calendar';
@@ -14,11 +13,16 @@ import {
 } from './useBlockOverviewData';
 import { DesktopTimeline } from './desktop-timeline';
 import { MobileTimeline } from './mobile-timeline';
+import {
+  timelineLegendItems,
+  timelineToneStyles,
+  type TimelineTone,
+} from './timeline-legend';
 
 type LegendItemProps = {
   label: string;
   description: string;
-  className?: string;
+  tone: TimelineTone;
 };
 
 type OverviewShellProps = {
@@ -52,21 +56,15 @@ type OverviewShellProps = {
   formatCreatedAtLabel: (createdAt?: string | null) => string | null;
 };
 
-function LegendItem({ label, description, className }: LegendItemProps) {
+function LegendItem({ label, description, tone }: LegendItemProps) {
+  const styles = timelineToneStyles({ tone });
+
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-border/60 bg-card/80 px-3 py-2 shadow-sm">
-      <span
-        aria-hidden
-        className={cn(
-          'h-8 w-8 shrink-0 rounded-md border border-border/60 bg-muted',
-          className,
-        )}
-      />
+    <div className={styles.legendContainer()}>
+      <span aria-hidden className={styles.legendSwatch()} />
       <div className="flex flex-col">
-        <span className="text-xs font-semibold uppercase tracking-wide text-foreground/90">
-          {label}
-        </span>
-        <span className="text-[11px] leading-5 text-muted-foreground/80">{description}</span>
+        <span className={styles.legendLabel()}>{label}</span>
+        <span className={styles.legendDescription()}>{description}</span>
       </div>
     </div>
   );
@@ -153,16 +151,18 @@ export function OverviewShell({
           </div>
           <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
             <div className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">Gesperrte Tage</div>
-            <div className="mt-1 flex items-baseline gap-2 text-lg font-semibold sm:text-xl">
+            <div className="mt-1 flex flex-col gap-1 text-lg font-semibold sm:text-xl">
               <span>{totalBlockedDays}</span>
-              <span className="text-[11px] font-medium text-slate-300/80">({upcomingBlockedDays} bevorstehend)</span>
+              <span className="text-[11px] font-medium text-slate-300/80 line-clamp-1">
+                {upcomingBlockedDays} bevorstehend
+              </span>
             </div>
           </div>
           <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
             <div className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">Ferien in der Ansicht</div>
-            <div className="mt-1 flex items-baseline gap-2 text-lg font-semibold sm:text-xl">
+            <div className="mt-1 flex flex-col gap-1 text-lg font-semibold sm:text-xl">
               <span>{holidaysInRangeCount}</span>
-              <span className="text-[11px] font-medium text-slate-300/80">
+              <span className="text-[11px] font-medium text-slate-300/80 line-clamp-2">
                 {busiestMember ? `Top-Sperren: ${busiestMember.name} (${busiestMember.total})` : 'Keine Häufungen'}
               </span>
             </div>
@@ -176,26 +176,9 @@ export function OverviewShell({
             Klicke oder tippe auf rot markierte Sperrtage, um Hintergründe und Ferieninfos zu lesen. Gesperrte Tage erscheinen kompakt in Rot, eingeschränkte Slots schimmern in bernsteinfarbenen Tönen, bevorzugte Slots erscheinen in frischem Grün, freie bleiben dezent – so erkennst du Engpässe auf einen Blick. {preferredDescription} {exceptionDescription} Weitere Tage blenden wir nur ein, wenn Mitglieder sie ausdrücklich als bevorzugt markieren.
           </p>
           <div className="flex flex-wrap items-center gap-3">
-            <LegendItem
-              label="Gesperrt"
-              description="Eingetragene Abwesenheiten – Details per Klick"
-              className="border-destructive/60 bg-transparent"
-            />
-            <LegendItem
-              label="Eingeschränkt"
-              description="Teilnahme nur in bestimmten Zeitfenstern"
-              className="border-amber-300/60 bg-amber-200/40 text-amber-900 dark:border-amber-400/60 dark:bg-amber-500/20 dark:text-amber-100"
-            />
-            <LegendItem
-              label="Ferien"
-              description="Automatische Kalenderdaten"
-              className="border-sky-400/60 bg-sky-500/15 text-sky-700 dark:text-sky-200"
-            />
-            <LegendItem
-              label="Frei"
-              description="Keine Konflikte gemeldet"
-              className="border-border/60 bg-muted/40 text-muted-foreground"
-            />
+            {timelineLegendItems.map((item) => (
+              <LegendItem key={item.id} {...item} />
+            ))}
           </div>
         </div>
       </div>

--- a/src/app/(members)/mitglieder/sperrliste/overview/timeline-legend.ts
+++ b/src/app/(members)/mitglieder/sperrliste/overview/timeline-legend.ts
@@ -1,0 +1,93 @@
+import { tv } from "tailwind-variants";
+
+export type TimelineTone = "blocked" | "limited" | "holiday" | "free" | "preferred";
+
+export type TimelineLegendItem = {
+  id: string;
+  label: string;
+  description: string;
+  tone: Exclude<TimelineTone, "preferred">;
+};
+
+export const timelineLegendItems: readonly TimelineLegendItem[] = [
+  {
+    id: "blocked",
+    tone: "blocked",
+    label: "Gesperrt",
+    description: "Eingetragene Abwesenheiten – Details per Klick",
+  },
+  {
+    id: "limited",
+    tone: "limited",
+    label: "Eingeschränkt",
+    description: "Teilnahme nur in bestimmten Zeitfenstern",
+  },
+  {
+    id: "holiday",
+    tone: "holiday",
+    label: "Ferien",
+    description: "Automatische Kalenderdaten",
+  },
+  {
+    id: "free",
+    tone: "free",
+    label: "Frei",
+    description: "Keine Konflikte gemeldet",
+  },
+] as const;
+
+export const timelineToneStyles = tv({
+  slots: {
+    legendContainer:
+      "flex items-center gap-2 rounded-lg border border-border/60 bg-card/90 px-3 py-2 shadow-sm transition-colors",
+    legendSwatch: "h-8 w-8 shrink-0 rounded-md border border-border/60 bg-muted/60 transition-colors",
+    legendLabel: "text-xs font-semibold uppercase tracking-wide text-foreground/90",
+    legendDescription: "text-[11px] leading-5 text-muted-foreground/80",
+    bullet: "h-1.5 w-1.5 shrink-0 rounded-full transition-colors",
+    text: "transition-colors",
+  },
+  variants: {
+    tone: {
+      blocked: {
+        legendContainer: "border-destructive/60 bg-destructive/10 text-destructive/90",
+        legendSwatch: "border-destructive/70 bg-destructive/60",
+        legendLabel: "text-destructive",
+        legendDescription: "text-destructive/80",
+        bullet: "bg-destructive",
+        text: "text-destructive/90",
+      },
+      limited: {
+        legendContainer: "border-amber-400/60 bg-amber-200/30 text-amber-900 dark:text-amber-100",
+        legendSwatch: "border-amber-400/60 bg-amber-300/70 dark:bg-amber-400/60",
+        legendLabel: "text-amber-900 dark:text-amber-100",
+        legendDescription: "text-amber-900/80 dark:text-amber-100/80",
+        bullet: "bg-amber-500",
+        text: "text-amber-800 dark:text-amber-100",
+      },
+      holiday: {
+        legendContainer: "border-sky-400/60 bg-sky-300/20 text-sky-800 dark:text-sky-200",
+        legendSwatch: "border-sky-400/60 bg-sky-400/60",
+        legendLabel: "text-sky-800 dark:text-sky-200",
+        legendDescription: "text-sky-700/80 dark:text-sky-200/80",
+        bullet: "bg-sky-500",
+        text: "text-sky-700 dark:text-sky-200",
+      },
+      preferred: {
+        legendContainer: "border-emerald-400/60 bg-emerald-300/20 text-emerald-800 dark:text-emerald-200",
+        legendSwatch: "border-emerald-400/60 bg-emerald-400/60",
+        legendLabel: "text-emerald-800 dark:text-emerald-200",
+        legendDescription: "text-emerald-700/80 dark:text-emerald-200/80",
+        bullet: "bg-emerald-500",
+        text: "text-emerald-700 dark:text-emerald-200",
+      },
+      free: {
+        legendContainer: "border-border/60 bg-muted/40 text-muted-foreground",
+        legendSwatch: "border-border/60 bg-muted/70",
+        legendLabel: "text-foreground/80",
+        legendDescription: "text-muted-foreground/80",
+        bullet: "bg-muted-foreground/70",
+        text: "text-muted-foreground",
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- extract the server analytics overview cards into a reusable component with consistent icon, tone and sizing rules
- map the overview metrics from shared definitions so the content screen renders the new component with the proper tokens
- centralize the timeline legend variants and clamp dynamic text to stabilize the member overview across breakpoints

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d8d4d5b724832dbce07ef11ce3cf50