### PR TITLE
Fix sidebar scroll constraints on tablets

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -410,7 +410,7 @@ const Sidebar = React.forwardRef<
       return (
         <div
           className={cn(
-            "flex h-full w-[var(--sidebar-width)] flex-col bg-sidebar text-sidebar-foreground",
+            "flex h-full min-h-0 w-[var(--sidebar-width)] flex-col bg-sidebar text-sidebar-foreground",
             className,
           )}
           ref={assignStaticContainerRef}
@@ -450,7 +450,10 @@ const Sidebar = React.forwardRef<
               <SheetTitle>Sidebar</SheetTitle>
               <SheetDescription>Displays the mobile sidebar.</SheetDescription>
             </SheetHeader>
-            <div ref={contentRef} className="flex h-full w-full flex-col">
+            <div
+              ref={contentRef}
+              className="flex h-full min-h-0 w-full flex-col"
+            >
               {children}
             </div>
           </SheetContent>
@@ -495,7 +498,7 @@ const Sidebar = React.forwardRef<
           <div
             ref={contentRef}
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            className="flex h-full min-h-0 w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
           >
             {children}
           </div>


### PR DESCRIPTION
## Summary
- allow the sidebar containers to shrink properly so their scroll areas work on tablet-sized viewports
- apply the same fix to the mobile sheet sidebar to keep the behavior consistent across breakpoints

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d8d819e304832d9d8f6c69a3fbddf6