### PR TITLE
feat(analytics): capture dwell time and load metrics

### DIFF
--- a/prisma/migrations/20251215090000_analytics_page_time/migration.sql
+++ b/prisma/migrations/20251215090000_analytics_page_time/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "public"."AnalyticsPageView"
+  ADD COLUMN "timeOnPageMs" INTEGER;
+
+ALTER TABLE "public"."analytics_page_metrics"
+  ADD COLUMN "avg_time_on_page" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1453,6 +1453,7 @@ model AnalyticsPageView {
   deviceHint String?
   lcpMs      Float?
   loadTimeMs Float?
+  timeOnPageMs Int?
   weight     Int      @default(1)
   createdAt  DateTime @default(now())
   analyticsSessionId String?
@@ -1498,6 +1499,7 @@ model AnalyticsPageMetric {
   scope      String?
   avgLoadMs  Float    @map("avg_load")
   lcpMs      Float?   @map("lcp")
+  avgTimeOnPageSeconds Float? @map("avg_time_on_page")
   weight     Int      @default(0)
   generatedAt DateTime @default(now())
 

--- a/scripts/cron/aggregate-page-metrics.ts
+++ b/scripts/cron/aggregate-page-metrics.ts
@@ -39,6 +39,7 @@ async function main() {
       deviceHint: true,
       loadTimeMs: true,
       lcpMs: true,
+      timeOnPageMs: true,
       weight: true,
     },
   });
@@ -56,6 +57,7 @@ async function main() {
           scope: page.scope,
           avgLoadMs: page.avgLoadMs,
           lcpMs: page.lcpMs,
+          avgTimeOnPageSeconds: page.avgTimeOnPageSeconds,
           weight: page.weight,
         })),
       });

--- a/src/app/api/analytics/web-vitals/__tests__/route.test.ts
+++ b/src/app/api/analytics/web-vitals/__tests__/route.test.ts
@@ -59,6 +59,7 @@ describe("web vitals analytics route", () => {
         metrics: {
           loadTime: 2_240.6,
           lcp: 1_480.2,
+          timeOnPage: 90_123.4,
         },
         device: {
           userAgent: "Mozilla/5.0",
@@ -98,6 +99,7 @@ describe("web vitals analytics route", () => {
           scope: "public",
           loadTimeMs: 2241,
           lcpMs: 1480,
+          timeOnPageMs: 90123,
           weight: 3,
         }),
       }),
@@ -182,5 +184,25 @@ describe("web vitals analytics route", () => {
     expect(upsertPageMock).not.toHaveBeenCalled();
     expect(upsertDeviceMock).not.toHaveBeenCalled();
     expect(upsertTrafficMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts payload with only time on page metric", async () => {
+    const response = await POST(
+      createRequest({
+        sessionId: "metric-999",
+        path: "/galerie",
+        metrics: { timeOnPage: 45_000 },
+        device: { userAgent: "Test", deviceHint: "Desktop" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(upsertPageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          timeOnPageMs: 45000,
+        }),
+      }),
+    );
   });
 });

--- a/src/app/api/analytics/web-vitals/route.ts
+++ b/src/app/api/analytics/web-vitals/route.ts
@@ -44,11 +44,13 @@ const metricsSchema = z
   .object({
     loadTime: z.number().nonnegative().max(900_000).optional().nullable(),
     lcp: z.number().nonnegative().max(900_000).optional().nullable(),
+    timeOnPage: z.number().nonnegative().max(86_400_000).optional().nullable(),
   })
   .refine((value) => {
     const hasLoad = typeof value.loadTime === "number" && value.loadTime > 0;
     const hasLcp = typeof value.lcp === "number" && value.lcp > 0;
-    return hasLoad || hasLcp;
+    const hasTimeOnPage = typeof value.timeOnPage === "number" && value.timeOnPage > 0;
+    return hasLoad || hasLcp || hasTimeOnPage;
   }, "At least one metric must be provided");
 
 const trafficSchema = z
@@ -147,6 +149,17 @@ function normalizeDurationMs(value: number | null | undefined): number | null {
     return null;
   }
   return clamp(rounded, 0, 900_000);
+}
+
+function normalizeTimeOnPageMs(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  const rounded = Math.round(value);
+  if (rounded <= 0) {
+    return null;
+  }
+  return clamp(rounded, 0, 86_400_000);
 }
 
 function sanitizeDeviceHint(value: string | null | undefined): string | null {
@@ -258,6 +271,7 @@ export async function POST(request: NextRequest) {
   const scope = inferScope(path, parsed.scope ?? null);
   const loadTimeMs = normalizeDurationMs(parsed.metrics.loadTime);
   const lcpMs = normalizeDurationMs(parsed.metrics.lcp);
+  const timeOnPageMs = normalizeTimeOnPageMs(parsed.metrics.timeOnPage);
   const weight = clamp(Math.round(parsed.weight ?? 1), 1, 10_000);
   const now = new Date();
   const analyticsSessionId = sanitizeAnalyticsSessionId(parsed.analyticsSessionId ?? null);
@@ -271,6 +285,7 @@ export async function POST(request: NextRequest) {
     deviceHint: sanitizeDeviceHint(parsed.device.deviceHint),
     lcpMs,
     loadTimeMs,
+    timeOnPageMs,
     weight,
     createdAt: now,
     analyticsSessionId,
@@ -313,6 +328,7 @@ export async function POST(request: NextRequest) {
           deviceHint: pageViewData.deviceHint,
           lcpMs: pageViewData.lcpMs,
           loadTimeMs: pageViewData.loadTimeMs,
+          timeOnPageMs: pageViewData.timeOnPageMs,
           weight: pageViewData.weight,
           analyticsSessionId: pageViewData.analyticsSessionId,
         },

--- a/src/app/reportWebVitals.ts
+++ b/src/app/reportWebVitals.ts
@@ -44,6 +44,11 @@ type WebVitalsContext = {
   device: DeviceHints;
   navigation: NavigationInsights;
   updatedAt: number;
+  startedAt: number;
+  metricId?: string;
+  timeOnPageReported?: boolean;
+  timeOnPageHandlerAttached?: boolean;
+  timeOnPageCleanup?: (() => void) | null;
 };
 
 declare global {
@@ -56,6 +61,7 @@ type PendingMetrics = {
   id: string;
   loadTimeMs?: number | null;
   lcpMs?: number | null;
+  timeOnPageMs?: number | null;
   timeoutId?: number;
   reported?: boolean;
 };
@@ -67,6 +73,7 @@ const LOAD_METRIC_NAMES = new Set([
   "TTFB",
   "FCP",
 ]);
+const MAX_TIME_ON_PAGE_MS = 86_400_000;
 
 function ensureContext(): WebVitalsContext | null {
   if (typeof window === "undefined") {
@@ -80,6 +87,40 @@ function normalizeDuration(value: number | null | undefined): number | null {
     return null;
   }
   return Math.round(value);
+}
+
+function normalizeTimeOnPageDuration(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  const rounded = Math.round(value);
+  if (rounded <= 0) {
+    return null;
+  }
+  if (rounded > MAX_TIME_ON_PAGE_MS) {
+    return MAX_TIME_ON_PAGE_MS;
+  }
+  return rounded;
+}
+
+function generateSessionId(fallback?: string): string {
+  if (typeof fallback === "string" && fallback.trim()) {
+    return fallback;
+  }
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const random = Math.random().toString(16).slice(2);
+  return `${Date.now()}-${random}`;
+}
+
+function getOrCreateSessionId(context: WebVitalsContext, fallback?: string): string {
+  if (context.metricId && typeof context.metricId === "string" && context.metricId.trim()) {
+    return context.metricId;
+  }
+  const sessionId = generateSessionId(fallback);
+  context.metricId = sessionId;
+  return sessionId;
 }
 
 function extractTrafficAttribution(context: WebVitalsContext) {
@@ -125,6 +166,7 @@ async function transmitMetrics(
   context: WebVitalsContext,
   loadTimeMs: number | null,
   lcpMs: number | null,
+  timeOnPageMs: number | null,
 ) {
   const traffic = extractTrafficAttribution(context);
 
@@ -137,6 +179,7 @@ async function transmitMetrics(
     metrics: {
       loadTime: loadTimeMs,
       lcp: lcpMs,
+      timeOnPage: timeOnPageMs,
     },
     device: {
       ...context.device,
@@ -174,6 +217,69 @@ async function transmitMetrics(
   }
 }
 
+function sendTimeOnPageMetric(context: WebVitalsContext, sessionId?: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (context.timeOnPageReported) {
+    return;
+  }
+
+  const resolvedSessionId = getOrCreateSessionId(context, sessionId);
+  const now = Date.now();
+  const startedAt = Number.isFinite(context.startedAt) ? context.startedAt : now;
+  const durationMs = Math.max(0, now - startedAt);
+  const normalized = normalizeTimeOnPageDuration(durationMs);
+  if (normalized === null) {
+    return;
+  }
+
+  context.timeOnPageReported = true;
+  const cleanup = context.timeOnPageCleanup;
+  context.timeOnPageCleanup = null;
+  context.timeOnPageHandlerAttached = false;
+
+  void transmitMetrics(resolvedSessionId, context, null, null, normalized).catch(() => {
+    // Swallow errors to avoid blocking unload.
+  });
+
+  if (typeof cleanup === "function") {
+    cleanup();
+  }
+}
+
+function ensureTimeOnPageTracking(context: WebVitalsContext, sessionId: string) {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return;
+  }
+  if (context.timeOnPageHandlerAttached) {
+    return;
+  }
+
+  context.timeOnPageHandlerAttached = true;
+  context.startedAt = Number.isFinite(context.startedAt) ? context.startedAt : Date.now();
+
+  const visibilityHandler = () => {
+    if (document.visibilityState === "hidden") {
+      sendTimeOnPageMetric(context, sessionId);
+    }
+  };
+
+  const unloadHandler = () => {
+    sendTimeOnPageMetric(context, sessionId);
+  };
+
+  document.addEventListener("visibilitychange", visibilityHandler);
+  window.addEventListener("pagehide", unloadHandler);
+  window.addEventListener("beforeunload", unloadHandler);
+
+  context.timeOnPageCleanup = () => {
+    document.removeEventListener("visibilitychange", visibilityHandler);
+    window.removeEventListener("pagehide", unloadHandler);
+    window.removeEventListener("beforeunload", unloadHandler);
+  };
+}
+
 function finalizeMetric(metricId: string) {
   const entry = pending.get(metricId);
   if (!entry) {
@@ -196,18 +302,23 @@ function attemptSend(metricId: string) {
     return;
   }
 
+  const sessionId = getOrCreateSessionId(context, metricId);
+  ensureTimeOnPageTracking(context, sessionId);
+
   const normalizedLoad =
     entry.loadTimeMs !== null && entry.loadTimeMs !== undefined
       ? normalizeDuration(entry.loadTimeMs)
       : normalizeDuration(context.navigation.loadTimeMs);
   const normalizedLcp = normalizeDuration(entry.lcpMs ?? undefined);
 
-  if (normalizedLoad === null && normalizedLcp === null) {
+  const normalizedTimeOnPage = normalizeTimeOnPageDuration(entry.timeOnPageMs);
+
+  if (normalizedLoad === null && normalizedLcp === null && normalizedTimeOnPage === null) {
     return;
   }
 
   entry.reported = true;
-  void transmitMetrics(metricId, context, normalizedLoad, normalizedLcp);
+  void transmitMetrics(sessionId, context, normalizedLoad, normalizedLcp, normalizedTimeOnPage);
   finalizeMetric(metricId);
 }
 
@@ -237,6 +348,22 @@ function storeMetric(metric: NextWebVitalsMetric) {
   pending.set(metric.id, existing);
   scheduleFallback(metric.id);
   attemptSend(metric.id);
+}
+
+export function flushWebVitals() {
+  const context = ensureContext();
+  if (!context) {
+    return;
+  }
+
+  try {
+    const sessionId = getOrCreateSessionId(context);
+    sendTimeOnPageMetric(context, sessionId);
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.debug("[analytics] Failed to flush web vitals", error);
+    }
+  }
 }
 
 export function reportWebVitals(metric: NextWebVitalsMetric) {

--- a/src/hooks/useWebVitals.ts
+++ b/src/hooks/useWebVitals.ts
@@ -3,6 +3,8 @@
 import { useEffect, useMemo } from "react";
 import { usePathname } from "next/navigation";
 
+import { flushWebVitals } from "@/app/reportWebVitals";
+
 type WebVitalsScope = "public" | "members" | null;
 
 type DeviceConnection = {
@@ -47,6 +49,11 @@ type WebVitalsContext = {
   device: DeviceHints;
   navigation: NavigationInsights;
   updatedAt: number;
+  startedAt: number;
+  metricId?: string;
+  timeOnPageReported?: boolean;
+  timeOnPageHandlerAttached?: boolean;
+  timeOnPageCleanup?: (() => void) | null;
 };
 
 declare global {
@@ -60,6 +67,17 @@ export type UseWebVitalsOptions = {
   weight?: number;
   analyticsSessionId?: string | null;
 };
+
+function generateMetricId(seed?: string) {
+  const sanitizedSeed = typeof seed === "string" && seed ? seed.replace(/[^a-zA-Z0-9_-]/g, "-") : null;
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    const id = crypto.randomUUID();
+    return sanitizedSeed ? `${sanitizedSeed}-${id}` : id;
+  }
+  const random = Math.random().toString(16).slice(2);
+  const timestamp = Date.now();
+  return sanitizedSeed ? `${sanitizedSeed}-${timestamp}-${random}` : `${timestamp}-${random}`;
+}
 
 function normalizePath(pathname: string | null): string {
   if (!pathname) {
@@ -323,10 +341,20 @@ export function useWebVitals(options?: UseWebVitalsOptions) {
   }, [options?.weight]);
 
   const analyticsSessionId = options?.analyticsSessionId ?? null;
+  const metricId = useMemo(() => generateMetricId(normalizedPath), [normalizedPath]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
+    }
+
+    const previous = window.__APP_WEB_VITALS__;
+    if (previous?.timeOnPageCleanup) {
+      try {
+        previous.timeOnPageCleanup();
+      } catch {
+        // ignore cleanup errors
+      }
     }
 
     const context: WebVitalsContext = {
@@ -337,6 +365,11 @@ export function useWebVitals(options?: UseWebVitalsOptions) {
       device: collectDeviceHints(),
       navigation: collectNavigationInsights(),
       updatedAt: Date.now(),
+      startedAt: Date.now(),
+      metricId,
+      timeOnPageReported: false,
+      timeOnPageHandlerAttached: false,
+      timeOnPageCleanup: null,
     };
 
     window.__APP_WEB_VITALS__ = context;
@@ -351,8 +384,30 @@ export function useWebVitals(options?: UseWebVitalsOptions) {
     window.addEventListener("resize", handleVisibilityChange);
 
     return () => {
+      try {
+        if (window.__APP_WEB_VITALS__ === context) {
+          flushWebVitals();
+        }
+      } catch (error) {
+        if (process.env.NODE_ENV !== "production") {
+          console.debug("[analytics] Failed to flush web vitals on cleanup", error);
+        }
+      }
+
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       window.removeEventListener("resize", handleVisibilityChange);
+
+      if (window.__APP_WEB_VITALS__ === context) {
+        window.__APP_WEB_VITALS__ = undefined;
+      }
+
+      if (context.timeOnPageCleanup) {
+        try {
+          context.timeOnPageCleanup();
+        } catch {
+          // ignore cleanup issues
+        }
+      }
     };
-  }, [normalizedPath, scope, weight, analyticsSessionId]);
+  }, [normalizedPath, scope, weight, analyticsSessionId, metricId]);
 }

--- a/src/lib/analytics/__tests__/aggregate-page-metrics.test.ts
+++ b/src/lib/analytics/__tests__/aggregate-page-metrics.test.ts
@@ -10,6 +10,7 @@ describe("aggregatePageMetrics", () => {
         scope: "public",
         loadTimeMs: 1_200,
         lcpMs: 900,
+        timeOnPageMs: 95_000,
         weight: 2,
         deviceHint: "Desktop",
       },
@@ -18,6 +19,7 @@ describe("aggregatePageMetrics", () => {
         scope: "Public",
         loadTimeMs: 1_500,
         lcpMs: null,
+        timeOnPageMs: 110_000,
         weight: 1,
         deviceHint: "desktop",
       },
@@ -26,6 +28,7 @@ describe("aggregatePageMetrics", () => {
         scope: null,
         loadTimeMs: 820,
         lcpMs: 640,
+        timeOnPageMs: 160_000,
         weight: 3,
         deviceHint: "iPhone",
       },
@@ -34,6 +37,7 @@ describe("aggregatePageMetrics", () => {
         scope: "members",
         loadTimeMs: 780,
         lcpMs: 610,
+        timeOnPageMs: 140_000,
         weight: 1,
         deviceHint: "iphone",
       },
@@ -53,6 +57,7 @@ describe("aggregatePageMetrics", () => {
         scope: "members",
         avgLoadMs: 810,
         lcpMs: 633,
+        avgTimeOnPageSeconds: 155,
         weight: 4,
       },
       {
@@ -60,6 +65,7 @@ describe("aggregatePageMetrics", () => {
         scope: "public",
         avgLoadMs: 1300,
         lcpMs: 900,
+        avgTimeOnPageSeconds: 100,
         weight: 3,
       },
     ]);
@@ -82,7 +88,7 @@ describe("aggregatePageMetrics", () => {
   it("ignores entries without metrics", () => {
     const result = aggregatePageMetrics([
       { path: "/foo", scope: "public", loadTimeMs: null, lcpMs: null, weight: 3 },
-      { path: "/bar", scope: "public", weight: 2 },
+      { path: "/bar", scope: "public", weight: 2, timeOnPageMs: null },
     ]);
 
     expect(result.pages).toEqual([]);

--- a/src/lib/analytics/aggregate-page-metrics.ts
+++ b/src/lib/analytics/aggregate-page-metrics.ts
@@ -4,6 +4,7 @@ export type RawPageView = {
   deviceHint?: string | null;
   loadTimeMs?: number | null;
   lcpMs?: number | null;
+  timeOnPageMs?: number | null;
   weight?: number | null;
 };
 
@@ -12,6 +13,7 @@ export type AggregatedPageMetric = {
   scope: "public" | "members" | null;
   avgLoadMs: number;
   lcpMs: number | null;
+  avgTimeOnPageSeconds: number | null;
   weight: number;
 };
 
@@ -29,6 +31,8 @@ type PageBucket = {
   loadWeight: number;
   lcpSum: number;
   lcpWeight: number;
+  timeOnPageSum: number;
+  timeOnPageWeight: number;
   totalWeight: number;
 };
 
@@ -128,7 +132,7 @@ function normalizeDeviceKey(raw: string | null | undefined): string {
   return value.replace(/\s+/g, "_");
 }
 
-function normalizeDuration(value: number | null | undefined): number | null {
+function normalizeDuration(value: number | null | undefined, max = 900_000): number | null {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return null;
   }
@@ -136,7 +140,7 @@ function normalizeDuration(value: number | null | undefined): number | null {
   if (rounded <= 0) {
     return null;
   }
-  return Math.min(rounded, 900_000);
+  return Math.min(rounded, max);
 }
 
 function normalizeWeight(value: number | null | undefined): number {
@@ -165,7 +169,8 @@ export function aggregatePageMetrics(rawPageViews: RawPageView[]) {
 
     const loadTime = normalizeDuration(view.loadTimeMs);
     const lcp = normalizeDuration(view.lcpMs);
-    if (loadTime === null && lcp === null) {
+    const timeOnPage = normalizeDuration(view.timeOnPageMs, 86_400_000);
+    if (loadTime === null && lcp === null && timeOnPage === null) {
       continue;
     }
 
@@ -184,6 +189,8 @@ export function aggregatePageMetrics(rawPageViews: RawPageView[]) {
         loadWeight: 0,
         lcpSum: 0,
         lcpWeight: 0,
+        timeOnPageSum: 0,
+        timeOnPageWeight: 0,
         totalWeight: 0,
       });
     }
@@ -198,6 +205,10 @@ export function aggregatePageMetrics(rawPageViews: RawPageView[]) {
     if (lcp !== null) {
       pageBucket.lcpSum += lcp * weight;
       pageBucket.lcpWeight += weight;
+    }
+    if (timeOnPage !== null) {
+      pageBucket.timeOnPageSum += timeOnPage * weight;
+      pageBucket.timeOnPageWeight += weight;
     }
 
     const deviceKey = normalizeDeviceKey(view.deviceHint ?? null);
@@ -226,11 +237,15 @@ export function aggregatePageMetrics(rawPageViews: RawPageView[]) {
     }
     const avgLoad = bucket.loadWeight > 0 ? bucket.loadSum / bucket.loadWeight : 0;
     const avgLcp = bucket.lcpWeight > 0 ? bucket.lcpSum / bucket.lcpWeight : null;
+    const avgTimeOnPageMs =
+      bucket.timeOnPageWeight > 0 ? bucket.timeOnPageSum / bucket.timeOnPageWeight : null;
     pages.push({
       path: bucket.path,
       scope: bucket.scope,
       avgLoadMs: Math.max(0, Math.round(avgLoad)),
       lcpMs: avgLcp !== null ? Math.max(0, Math.round(avgLcp)) : null,
+      avgTimeOnPageSeconds:
+        avgTimeOnPageMs !== null ? Math.max(0, Math.round(avgTimeOnPageMs / 1000)) : null,
       weight: bucket.totalWeight,
     });
   }

--- a/src/lib/server-analytics-data.d.ts
+++ b/src/lib/server-analytics-data.d.ts
@@ -4,6 +4,7 @@ export type PagePerformanceMetricOverride = {
   path: string;
   avgPageLoadMs: number;
   lcpMs?: number | null;
+  avgTimeOnPageSeconds?: number | null;
   scope?: "public" | "members" | null;
   weight?: number;
 };

--- a/src/lib/server-analytics-data.js
+++ b/src/lib/server-analytics-data.js
@@ -70,6 +70,18 @@ const SCOPE_PATTERNS = [
   "scope",
 ];
 const LCP_PATTERNS = ["lcp", "largest", "hero"];
+const DWELL_PATTERNS = [
+  "time_on_page",
+  "time-on-page",
+  "time_spent",
+  "timespent",
+  "verweildauer",
+  "dwell",
+  "avg_time",
+  "avg_duration",
+  "time_per",
+  "duration",
+];
 const COUNT_PATTERNS = [
   "session",
   "visit",
@@ -185,7 +197,10 @@ function findColumn(table, patterns, exclude = new Set()) {
   return null;
 }
 
-function computeScore(table, { keywords = [], hasShare = false, hasScope = false, hasLcp = false, hasCount = false } = {}) {
+function computeScore(
+  table,
+  { keywords = [], hasShare = false, hasScope = false, hasLcp = false, hasCount = false, hasTimeOnPage = false } = {},
+) {
   let score = 0;
   const name = table.tableLower;
   const schema = table.schemaLower;
@@ -207,6 +222,7 @@ function computeScore(table, { keywords = [], hasShare = false, hasScope = false
   if (hasScope) score += 0.5;
   if (hasLcp) score += 0.5;
   if (hasCount) score += 0.5;
+  if (hasTimeOnPage) score += 0.5;
   score += table.columns.length * 0.02;
 
   return score;
@@ -288,6 +304,9 @@ async function resolvePageTable(prisma) {
       const lcpColumn = findColumn(table, LCP_PATTERNS, exclude);
       if (lcpColumn) exclude.add(lcpColumn.original);
 
+      const timeOnPageColumn = findColumn(table, DWELL_PATTERNS, exclude);
+      if (timeOnPageColumn) exclude.add(timeOnPageColumn.original);
+
       let countColumn = findColumn(table, COUNT_PATTERNS, exclude);
       if (countColumn && countColumn.original === loadColumn.original) {
         countColumn = null;
@@ -298,6 +317,7 @@ async function resolvePageTable(prisma) {
         hasScope: Boolean(scopeColumn),
         hasLcp: Boolean(lcpColumn),
         hasCount: Boolean(countColumn),
+        hasTimeOnPage: Boolean(timeOnPageColumn),
       });
 
       if (score > bestScore) {
@@ -310,6 +330,7 @@ async function resolvePageTable(prisma) {
             load: loadColumn.original,
             scope: scopeColumn ? scopeColumn.original : null,
             lcp: lcpColumn ? lcpColumn.original : null,
+            timeOnPage: timeOnPageColumn ? timeOnPageColumn.original : null,
             count: countColumn ? countColumn.original : null,
           },
         };
@@ -544,7 +565,7 @@ async function loadDeviceMetricsFromDedicatedView(prisma) {
 async function loadPageMetricsFromDedicatedView(prisma) {
   try {
     const rows = await prisma.$queryRawUnsafe(
-      "SELECT path, scope, avg_load, lcp, weight FROM analytics_page_metrics",
+      "SELECT path, scope, avg_load, lcp, avg_time_on_page, weight FROM analytics_page_metrics",
     );
     if (!Array.isArray(rows)) {
       return [];
@@ -568,11 +589,19 @@ async function loadPageMetricsFromDedicatedView(prisma) {
       const scope = normalizeScope(row?.scope ?? row?.SCOPE ?? null, normalizedPath);
       const lcpMsRaw = normalizeDurationToMs(row?.lcp ?? row?.LCP ?? row?.largest_contentful_paint);
       const weight = Math.max(0, Math.round(toNumber(row?.weight ?? row?.WEIGHT ?? row?.samples)));
+      const avgTimeOnPageSecondsRaw = toNumber(
+        row?.avg_time_on_page ?? row?.AVG_TIME_ON_PAGE ?? row?.avg_time_on_page_seconds,
+      );
+      const avgTimeOnPageSeconds =
+        Number.isFinite(avgTimeOnPageSecondsRaw) && avgTimeOnPageSecondsRaw > 0
+          ? Math.max(0, Math.round(avgTimeOnPageSecondsRaw))
+          : null;
 
       metrics.push({
         path: normalizedPath,
         avgPageLoadMs: Math.max(0, Math.round(avgLoadMs)),
         lcpMs: lcpMsRaw > 0 ? Math.max(0, Math.round(lcpMsRaw)) : null,
+        avgTimeOnPageSeconds,
         scope,
         weight: weight > 0 ? weight : undefined,
       });
@@ -705,6 +734,9 @@ export async function loadPagePerformanceMetrics() {
   if (match.columns.lcp) {
     selectParts.push(`${quoteIdentifier(match.columns.lcp)} AS lcp`);
   }
+  if (match.columns.timeOnPage) {
+    selectParts.push(`${quoteIdentifier(match.columns.timeOnPage)} AS time_on_page`);
+  }
   if (match.columns.count) {
     selectParts.push(`${quoteIdentifier(match.columns.count)} AS weight`);
   }
@@ -756,6 +788,8 @@ export async function loadPagePerformanceMetrics() {
         totalLoad: 0,
         totalLcp: 0,
         lcpWeight: 0,
+        totalTimeOnPageSeconds: 0,
+        timeOnPageWeight: 0,
       });
     }
 
@@ -766,6 +800,21 @@ export async function loadPagePerformanceMetrics() {
       bucket.totalLcp += lcpMs * weight;
       bucket.lcpWeight += weight;
     }
+
+    let timeOnPageSeconds = null;
+    if (match.columns.timeOnPage) {
+      const parsedTime = normalizeDurationToMs(
+        row.time_on_page ?? row.TIME_ON_PAGE ?? row.avg_time_on_page ?? row.timeOnPage,
+      );
+      if (Number.isFinite(parsedTime) && parsedTime > 0) {
+        timeOnPageSeconds = parsedTime / 1000;
+      }
+    }
+
+    if (timeOnPageSeconds !== null) {
+      bucket.totalTimeOnPageSeconds += timeOnPageSeconds * weight;
+      bucket.timeOnPageWeight += weight;
+    }
   }
 
   const result = [];
@@ -774,10 +823,16 @@ export async function loadPagePerformanceMetrics() {
     if (!Number.isFinite(bucket.totalWeight) || bucket.totalWeight <= 0) continue;
     const avgLoad = bucket.totalLoad / bucket.totalWeight;
     const avgLcp = bucket.lcpWeight > 0 ? bucket.totalLcp / bucket.lcpWeight : null;
+    const avgTimeOnPageSeconds =
+      bucket.timeOnPageWeight > 0
+        ? bucket.totalTimeOnPageSeconds / bucket.timeOnPageWeight
+        : null;
     result.push({
       path: bucket.path,
       avgPageLoadMs: Math.max(0, Math.round(avgLoad)),
       lcpMs: avgLcp !== null ? Math.max(0, Math.round(avgLcp)) : null,
+      avgTimeOnPageSeconds:
+        avgTimeOnPageSeconds !== null ? Math.max(0, Math.round(avgTimeOnPageSeconds)) : null,
       scope: bucket.scope,
       weight: bucket.totalWeight,
     });
@@ -874,6 +929,10 @@ export function applyPagePerformanceMetrics(baseEntries, overrides, scope) {
           entry.lcpMs === null || entry.lcpMs === undefined
             ? null
             : Math.max(0, Math.round(Number(entry.lcpMs))),
+        avgTimeOnPageSeconds:
+          entry.avgTimeOnPageSeconds === null || entry.avgTimeOnPageSeconds === undefined
+            ? null
+            : Math.max(0, Math.round(Number(entry.avgTimeOnPageSeconds))),
       });
     }
   }
@@ -900,6 +959,13 @@ export function applyPagePerformanceMetrics(baseEntries, overrides, scope) {
     }
     if (override.lcpMs !== null && override.lcpMs !== undefined && Number.isFinite(override.lcpMs)) {
       updates.lcpMs = override.lcpMs;
+    }
+    if (
+      override.avgTimeOnPageSeconds !== null &&
+      override.avgTimeOnPageSeconds !== undefined &&
+      Number.isFinite(override.avgTimeOnPageSeconds)
+    ) {
+      updates.avgTimeOnPageSeconds = override.avgTimeOnPageSeconds;
     }
 
     result.push({ ...entry, ...updates });

--- a/src/lib/server-analytics.ts
+++ b/src/lib/server-analytics.ts
@@ -187,7 +187,10 @@ function buildAggregatedPageEntries(
       title: base?.title ?? metric.path,
       views,
       uniqueVisitors: base?.uniqueVisitors ?? views,
-      avgTimeOnPageSeconds: base?.avgTimeOnPageSeconds ?? 0,
+      avgTimeOnPageSeconds:
+        metric.avgTimeOnPageSeconds !== null && metric.avgTimeOnPageSeconds !== undefined
+          ? metric.avgTimeOnPageSeconds
+          : base?.avgTimeOnPageSeconds ?? 0,
       loadTimeMs: metric.avgPageLoadMs,
       lcpMs: metric.lcpMs ?? base?.lcpMs ?? 0,
       bounceRate: base?.bounceRate ?? 0,


### PR DESCRIPTION
## Summary
- add time-on-page fields to analytics Prisma schema and cron aggregation so dwell time can be persisted【F:prisma/schema.prisma†L1447-L1509】【F:scripts/cron/aggregate-page-metrics.ts†L29-L75】【F:prisma/migrations/20251215090000_analytics_page_time/migration.sql†L1-L5】
- extend web vitals ingestion, aggregation helpers, and server analytics to process the new dwell-time metric alongside load metrics【F:src/app/api/analytics/web-vitals/route.ts†L44-L333】【F:src/lib/analytics/aggregate-page-metrics.ts†L4-L243】【F:src/lib/server-analytics-data.js†L565-L910】【F:src/lib/server-analytics.ts†L187-L193】
- enhance client-side metric collection to send time-on-page beacons and updated tests to cover the new metric handling【F:src/app/reportWebVitals.ts†L39-L322】【F:src/hooks/useWebVitals.ts†L63-L385】【F:src/app/api/analytics/web-vitals/__tests__/route.test.ts†L52-L207】【F:src/lib/analytics/__tests__/aggregate-page-metrics.test.ts†L6-L95】

## Testing
- pnpm lint【209f27†L1-L3】
- pnpm test【f0f952†L1-L26】
- CI=1 pnpm build【4d76f5†L1-L85】

------
https://chatgpt.com/codex/tasks/task_e_68d8d6eff81c832d8e185c35a5193f4f