### PR TITLE
Add visitor type breakdown to server analytics dashboard

### DIFF
--- a/src/app/(members)/mitglieder/server-analytics/__tests__/collect-server-analytics.test.ts
+++ b/src/app/(members)/mitglieder/server-analytics/__tests__/collect-server-analytics.test.ts
@@ -40,7 +40,7 @@ describe("collectServerAnalytics", () => {
   });
 
   it("overrides static metrics with aggregated database values", async () => {
-    const httpSummary: Partial<AnalyticsHttpSummary> = {
+    const httpSummary = {
       windowStart: new Date("2024-01-01T10:00:00.000Z"),
       windowEnd: new Date("2024-01-01T11:00:00.000Z"),
       totalRequests: 200,
@@ -59,6 +59,17 @@ describe("collectServerAnalytics", () => {
       apiAvgResponseMs: 160,
       apiErrorRate: 0.08,
       apiBackgroundJobs: 21,
+      botRequests: 30,
+      botAvgResponseMs: 180,
+      botBlockedRequests: 4,
+      guestRequests: 90,
+      guestAvgResponseMs: 95,
+    } as AnalyticsHttpSummary & {
+      botRequests: number;
+      botAvgResponseMs: number;
+      botBlockedRequests: number;
+      guestRequests: number;
+      guestAvgResponseMs: number;
     };
 
     const sessionSummary: Partial<AnalyticsSessionSummary> = {
@@ -67,6 +78,7 @@ describe("collectServerAnalytics", () => {
       peakConcurrentUsers: 5,
       membersRealtimeEvents: 12,
       membersAvgSessionDurationSeconds: 450,
+      guestAvgSessionDurationSeconds: 260,
     };
 
     const realtimeSummary: Partial<AnalyticsRealtimeSummary> = {
@@ -96,6 +108,13 @@ describe("collectServerAnalytics", () => {
     expect(analytics.requestBreakdown.members.realtimeEvents).toBe(12);
     expect(analytics.requestBreakdown.members.avgSessionDurationSeconds).toBe(450);
     expect(analytics.requestBreakdown.api.backgroundJobs).toBe(21);
+    const loggedOutSegment = analytics.visitorDistribution.find((segment) => segment.id === "logged-out");
+    expect(loggedOutSegment?.requests).toBe(90);
+    expect(loggedOutSegment?.avgSessionDurationSeconds).toBe(260);
+    const botSegment = analytics.visitorDistribution.find((segment) => segment.id === "bot");
+    expect(botSegment?.requests).toBe(30);
+    expect(botSegment?.avgResponseTimeMs).toBe(180);
+    expect(botSegment?.blockedRequests).toBe(4);
     expect(analytics.isDemoData).toBe(false);
   });
 

--- a/src/app/(members)/mitglieder/server-analytics/__tests__/server-analytics-content.test.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/__tests__/server-analytics-content.test.tsx
@@ -48,6 +48,33 @@ function createAnalytics(overrides: Partial<ServerAnalytics> = {}): ServerAnalyt
       members: { requests: 420, avgResponseTimeMs: 210, realtimeEvents: 80, avgSessionDurationSeconds: 360 },
       api: { requests: 180, avgResponseTimeMs: 240, backgroundJobs: 15, errorRate: 0.04 },
     },
+    visitorDistribution: [
+      {
+        id: "logged-out",
+        label: "Nicht eingeloggt",
+        requests: 600,
+        share: 0.48,
+        avgResponseTimeMs: 160,
+        avgSessionDurationSeconds: 300,
+      },
+      {
+        id: "logged-in",
+        label: "Eingeloggt",
+        requests: 420,
+        share: 0.34,
+        avgResponseTimeMs: 210,
+        avgSessionDurationSeconds: 360,
+        realtimeEvents: 80,
+      },
+      {
+        id: "bot",
+        label: "Bots & Crawler",
+        requests: 220,
+        share: 0.18,
+        avgResponseTimeMs: 320,
+        blockedRequests: 16,
+      },
+    ],
     peakHours: [],
     publicPages: [],
     memberPages: [],
@@ -126,5 +153,14 @@ describe("ServerAnalyticsContent", () => {
     render(<ServerAnalyticsContent initialAnalytics={analytics} />);
 
     expect(screen.queryByText("Demo")).not.toBeInTheDocument();
+  });
+
+  it("displays the visitor distribution", () => {
+    const analytics = createAnalytics();
+    render(<ServerAnalyticsContent initialAnalytics={analytics} />);
+
+    expect(screen.getByText("Nutzertypen & Traffic")).toBeInTheDocument();
+    expect(screen.getByText("Nicht eingeloggt")).toBeInTheDocument();
+    expect(screen.getByText("Bots & Crawler")).toBeInTheDocument();
   });
 });

--- a/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
@@ -45,6 +45,12 @@ const uptimeFormat = new Intl.NumberFormat("de-DE", { minimumFractionDigits: 2, 
 
 const ANIMATION_DURATION_MS = 450;
 
+const visitorSegmentAccentMap: Record<ServerAnalytics["visitorDistribution"][number]["id"], string> = {
+  "logged-in": "bg-indigo-500",
+  "logged-out": "bg-sky-500",
+  bot: "bg-amber-500",
+};
+
 const RESET_ERROR_MESSAGES: Record<string, string> = {
   not_authorized: "Du darfst diese Aktion nicht ausführen.",
   no_database: "Ohne Datenbankverbindung können keine Statistiken zurückgesetzt werden.",
@@ -621,6 +627,60 @@ export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: S
 
         <TabsContent value="overview" className="space-y-6">
           <OverviewMetrics metrics={overviewMetrics} renderBadge={renderMockDataBadge} />
+
+          <Card className="border border-border/70">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                Nutzertypen & Traffic
+                {renderMockDataBadge()}
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Aufschlüsselung nach Gästen, eingeloggten Mitgliedern und erkannten Bots innerhalb der letzten 24 Stunden.
+              </p>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-3">
+                {displayAnalytics.visitorDistribution.map((segment) => {
+                  const barWidth = `${Math.min(Math.max(segment.share * 100, 0), 100).toFixed(1)}%`;
+                  const accentClass = visitorSegmentAccentMap[segment.id] ?? "bg-primary/70";
+
+                  return (
+                    <div
+                      key={segment.id}
+                      className="space-y-2 rounded-md border border-border/60 bg-background/60 p-3"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0 space-y-1">
+                          <p className="text-sm font-semibold text-foreground">{segment.label}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Anteil {percentPreciseFormat.format(segment.share)}
+                          </p>
+                        </div>
+                        <div className="text-sm text-muted-foreground sm:text-right">
+                          <p className="text-lg font-semibold leading-none text-foreground">
+                            {numberFormat.format(segment.requests)} Requests
+                          </p>
+                          <p>Ø Antwortzeit {formatMs(segment.avgResponseTimeMs)}</p>
+                          {segment.avgSessionDurationSeconds ? (
+                            <p>Ø Sitzungsdauer {formatDuration(segment.avgSessionDurationSeconds)}</p>
+                          ) : null}
+                          {segment.realtimeEvents ? (
+                            <p>Realtime-Events {numberFormat.format(segment.realtimeEvents)}</p>
+                          ) : null}
+                          {segment.blockedRequests ? (
+                            <p>Geblockt {numberFormat.format(segment.blockedRequests)}</p>
+                          ) : null}
+                        </div>
+                      </div>
+                      <div className="h-2 w-full rounded-full bg-muted">
+                        <div className={cn("h-2 rounded-full", accentClass)} style={{ width: barWidth }} />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Card className="border border-border/70">

--- a/src/data/server-analytics-static.json
+++ b/src/data/server-analytics-static.json
@@ -51,6 +51,33 @@
       "errorRate": 0.006
     }
   },
+  "visitorDistribution": [
+    {
+      "id": "logged-out",
+      "label": "Nicht eingeloggt",
+      "requests": 7100,
+      "share": 0.368,
+      "avgResponseTimeMs": 172,
+      "avgSessionDurationSeconds": 268
+    },
+    {
+      "id": "logged-in",
+      "label": "Eingeloggt",
+      "requests": 8421,
+      "share": 0.437,
+      "avgResponseTimeMs": 214,
+      "avgSessionDurationSeconds": 486,
+      "realtimeEvents": 3920
+    },
+    {
+      "id": "bot",
+      "label": "Bots & Crawler",
+      "requests": 3763,
+      "share": 0.195,
+      "avgResponseTimeMs": 320,
+      "blockedRequests": 540
+    }
+  ],
   "peakHours": [
     { "range": "08:00 – 10:00", "requests": 1820, "share": 0.12 },
     { "range": "12:00 – 14:00", "requests": 2140, "share": 0.14 },

--- a/src/lib/server-analytics.ts
+++ b/src/lib/server-analytics.ts
@@ -69,6 +69,17 @@ export type RequestBreakdown = {
   };
 };
 
+export type VisitorDistributionSegment = {
+  id: "logged-in" | "logged-out" | "bot";
+  label: string;
+  requests: number;
+  share: number;
+  avgResponseTimeMs: number;
+  avgSessionDurationSeconds?: number;
+  realtimeEvents?: number;
+  blockedRequests?: number;
+};
+
 export type PeakHour = {
   range: string;
   requests: number;
@@ -127,6 +138,7 @@ export type ServerAnalytics = {
   summary: ServerSummary;
   resourceUsage: ServerResourceUsage[];
   requestBreakdown: RequestBreakdown;
+  visitorDistribution: VisitorDistributionSegment[];
   peakHours: PeakHour[];
   publicPages: PagePerformanceEntry[];
   memberPages: PagePerformanceEntry[];
@@ -148,6 +160,10 @@ function clonePageEntries(entries: PagePerformanceEntry[]): PagePerformanceEntry
 }
 
 function cloneDeviceStats(entries: DeviceStat[]): DeviceStat[] {
+  return entries.map((entry) => ({ ...entry }));
+}
+
+function cloneVisitorDistribution(entries: VisitorDistributionSegment[]): VisitorDistributionSegment[] {
   return entries.map((entry) => ({ ...entry }));
 }
 
@@ -354,6 +370,85 @@ function convertSessionInsightsFromDatabase(rows: AnalyticsSessionInsight[]): Se
     share: clamp(Number(row.share ?? 0), 0, 1),
     conversionRate: clamp(Number(row.conversionRate ?? 0), 0, 1),
   }));
+}
+
+function deriveVisitorDistribution(
+  base: VisitorDistributionSegment[],
+  summary: ServerSummary,
+  requestBreakdown: RequestBreakdown,
+  httpSummary: AnalyticsHttpSummary | null,
+  sessionSummary: AnalyticsSessionSummary | null,
+): VisitorDistributionSegment[] {
+  const segments = cloneVisitorDistribution(base);
+  const totalFallback = Math.max(0, summary.requestsLast24h);
+  const extendedHttp = (httpSummary ?? {}) as AnalyticsHttpSummary & {
+    botRequests?: number | null;
+    botAvgResponseMs?: number | null;
+    botBlockedRequests?: number | null;
+    guestRequests?: number | null;
+    guestAvgResponseMs?: number | null;
+  };
+  const extendedSession = (sessionSummary ?? {}) as AnalyticsSessionSummary & {
+    guestAvgSessionDurationSeconds?: number | null;
+  };
+
+  const loggedIn = segments.find((segment) => segment.id === "logged-in");
+  if (loggedIn) {
+    loggedIn.requests = Math.max(0, requestBreakdown.members.requests);
+    loggedIn.avgResponseTimeMs = Math.max(0, requestBreakdown.members.avgResponseTimeMs);
+    loggedIn.avgSessionDurationSeconds = Math.max(
+      0,
+      Math.round(Number(requestBreakdown.members.avgSessionDurationSeconds ?? 0)),
+    );
+    loggedIn.realtimeEvents = Math.max(0, requestBreakdown.members.realtimeEvents);
+  }
+
+  const loggedOut = segments.find((segment) => segment.id === "logged-out");
+  if (loggedOut) {
+    const guestRequests = Number.isFinite(extendedHttp.guestRequests ?? NaN)
+      ? Math.max(0, Math.round(Number(extendedHttp.guestRequests)))
+      : Math.max(0, requestBreakdown.frontend.requests);
+    loggedOut.requests = guestRequests;
+    const guestResponseMs = extendedHttp.guestAvgResponseMs;
+    loggedOut.avgResponseTimeMs = Number.isFinite(guestResponseMs ?? NaN)
+      ? Math.max(0, Math.round(Number(guestResponseMs)))
+      : Math.max(0, requestBreakdown.frontend.avgResponseTimeMs);
+    const guestDuration = extendedSession.guestAvgSessionDurationSeconds;
+    if (Number.isFinite(guestDuration ?? NaN)) {
+      loggedOut.avgSessionDurationSeconds = Math.max(0, Math.round(Number(guestDuration)));
+    }
+  }
+
+  const bots = segments.find((segment) => segment.id === "bot");
+  if (bots) {
+    const botRequests = Number.isFinite(extendedHttp.botRequests ?? NaN)
+      ? Math.max(0, Math.round(Number(extendedHttp.botRequests)))
+      : Math.max(0, bots.requests);
+    bots.requests = botRequests;
+    const botResponse = extendedHttp.botAvgResponseMs;
+    if (Number.isFinite(botResponse ?? NaN) && Number(botResponse) >= 0) {
+      bots.avgResponseTimeMs = Math.round(Number(botResponse));
+    }
+    const botBlocked = extendedHttp.botBlockedRequests;
+    if (Number.isFinite(botBlocked ?? NaN) && Number(botBlocked) >= 0) {
+      bots.blockedRequests = Math.round(Number(botBlocked));
+    }
+  }
+
+  const totalRequests = segments.reduce((total, segment) => total + Math.max(0, segment.requests), 0);
+  const denominator = totalRequests > 0 ? totalRequests : totalFallback;
+
+  if (denominator > 0) {
+    segments.forEach((segment) => {
+      segment.share = clamp(segment.requests / denominator, 0, 1);
+    });
+  } else {
+    segments.forEach((segment) => {
+      segment.share = 0;
+    });
+  }
+
+  return segments;
 }
 
 function convertTrafficSourcesFromDatabase(rows: AnalyticsTrafficSource[]): TrafficSource[] {
@@ -606,6 +701,7 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
     members: { ...STATIC_ANALYTICS.requestBreakdown.members },
     api: { ...STATIC_ANALYTICS.requestBreakdown.api },
   };
+  let visitorDistribution = cloneVisitorDistribution(STATIC_ANALYTICS.visitorDistribution);
   let peakHours: PeakHour[] = (STATIC_ANALYTICS.peakHours ?? []).map((entry) => ({ ...entry }));
   let trafficSources: TrafficSource[] = STATIC_ANALYTICS.trafficSources.map((entry) => ({ ...entry }));
   let sessionInsights: SessionInsight[] = STATIC_ANALYTICS.sessionInsights.map((entry) => ({ ...entry }));
@@ -758,6 +854,14 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
       markSegmentAsHydrated("sessionInsights");
     }
 
+    visitorDistribution = deriveVisitorDistribution(
+      visitorDistribution,
+      summary,
+      requestBreakdown,
+      latestHttpSummary,
+      sessionSummaryRow,
+    );
+
     if (Array.isArray(trafficSourceRows) && trafficSourceRows.length > 0) {
       trafficSources = convertTrafficSourcesFromDatabase(trafficSourceRows);
       markSegmentAsHydrated("trafficSources");
@@ -808,6 +912,7 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
     ...STATIC_ANALYTICS,
     summary,
     requestBreakdown,
+    visitorDistribution,
     peakHours,
     resourceUsage,
     deviceBreakdown,


### PR DESCRIPTION
## Summary
- extend server analytics types and static data with a visitor distribution segment for logged-in, logged-out and bot traffic
- derive visitor distribution from database overrides and surface it on the members server analytics dashboard
- update automated tests to cover the new visitor segmentation behaviour and rendering

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d8e11e0d00832db2984f5865f542fd