### PR TITLE
Treat finance as supplemental member role

### DIFF
--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -44,6 +44,15 @@ function combineName(firstName, lastName) {
   return parts.length ? parts.join(" ") : null;
 }
 
+const ROLE_SORT_ORDER = ["member", "cast", "tech", "board", "finance", "admin", "owner"];
+const ROLE_ORDER = new Map(ROLE_SORT_ORDER.map((role, index) => [role, index]));
+
+function sortRoles(roles) {
+  return [...new Set(roles)].sort(
+    (a, b) => (ROLE_ORDER.get(a) ?? 0) - (ROLE_ORDER.get(b) ?? 0),
+  );
+}
+
 async function main() {
   const defaultThemeId = "default-website-theme";
   const themeTokens = JSON.parse(JSON.stringify(designTokens));
@@ -154,48 +163,52 @@ async function main() {
     },
   });
 
-  const emails = [
-    "member@example.com",
-    "cast@example.com",
-    "tech@example.com",
-    "board@example.com",
-    "finance@example.com",
-    "admin@example.com",
-    "owner@example.com",
+  const seedUsers = [
+    { email: "member@example.com", primaryRole: "member", supplementalRoles: [] },
+    { email: "cast@example.com", primaryRole: "cast", supplementalRoles: [] },
+    { email: "tech@example.com", primaryRole: "tech", supplementalRoles: [] },
+    { email: "board@example.com", primaryRole: "board", supplementalRoles: [] },
+    { email: "finance@example.com", primaryRole: "member", supplementalRoles: ["finance"] },
+    { email: "admin@example.com", primaryRole: "admin", supplementalRoles: [] },
+    { email: "owner@example.com", primaryRole: "owner", supplementalRoles: [] },
   ];
-  const roles = ["member", "cast", "tech", "board", "finance", "admin", "owner"];
+  const emails = seedUsers.map((entry) => entry.email);
   const defaultPasswordHash = await bcrypt.hash("password", 10);
 
-  for (let i = 0; i < emails.length; i++) {
-    const friendlyName = emails[i].split("@")[0] ?? "";
+  for (const entry of seedUsers) {
+    const friendlyName = entry.email.split("@")[0] ?? "";
     const normalizedName = friendlyName.replace(/[._-]+/g, " ");
     const { firstName, lastName } = splitFullName(normalizedName);
     const displayName = combineName(firstName, lastName);
+    const combinedRoles = sortRoles([entry.primaryRole, ...(entry.supplementalRoles ?? [])]);
 
     await prisma.user.upsert({
-      where: { email: emails[i] },
+      where: { email: entry.email },
       update: {
         firstName,
         lastName,
         name: displayName,
         passwordHash: defaultPasswordHash,
+        role: entry.primaryRole,
       },
       create: {
-        email: emails[i],
+        email: entry.email,
         firstName,
         lastName,
         name: displayName,
-        role: roles[i],
+        role: entry.primaryRole,
         passwordHash: defaultPasswordHash,
       },
     });
-    const userRecord = await prisma.user.findUnique({ where: { email: emails[i] } });
+    const userRecord = await prisma.user.findUnique({ where: { email: entry.email } });
     if (userRecord) {
-      await prisma.userRole.upsert({
-        where: { userId_role: { userId: userRecord.id, role: roles[i] } },
-        update: {},
-        create: { userId: userRecord.id, role: roles[i] },
-      });
+      await prisma.userRole.deleteMany({ where: { userId: userRecord.id } });
+      if (combinedRoles.length) {
+        await prisma.userRole.createMany({
+          data: combinedRoles.map((role) => ({ userId: userRecord.id, role })),
+          skipDuplicates: true,
+        });
+      }
     }
   }
 

--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -86,6 +86,7 @@ const CHECKLIST_TARGET_LABELS: Record<ProfileChecklistTarget, string> = {
   masse: "Maße",
   interessen: "Interessen",
   freigaben: "Freigaben",
+  onboarding: "Onboarding",
 };
 const CHECKLIST_TARGETS: ProfileChecklistTarget[] = [
   "stammdaten",
@@ -93,6 +94,7 @@ const CHECKLIST_TARGETS: ProfileChecklistTarget[] = [
   "masse",
   "interessen",
   "freigaben",
+  "onboarding",
 ];
 
 const ONBOARDING_FOCUS_LABELS: Record<OnboardingFocus, string> = {

--- a/src/app/api/members/roles/route.ts
+++ b/src/app/api/members/roles/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth, ROLES } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
-import { sortRoles, type Role } from "@/lib/roles";
+import {
+  filterPrimaryRoles,
+  filterSupplementalRoles,
+  getHighestPrimaryRole,
+  hasPrimaryRole,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
 import { Prisma } from "@prisma/client";
 import { hasPermission } from "@/lib/permissions";
 
@@ -30,11 +37,14 @@ export async function PUT(request: NextRequest) {
     (role): role is Role => typeof role === "string" && (ROLES as readonly string[]).includes(role),
   );
 
-  if (provided.length === 0) {
-    return NextResponse.json({ error: "Mindestens eine Rolle erforderlich" }, { status: 400 });
+  if (!hasPrimaryRole(provided)) {
+    return NextResponse.json({ error: "Mindestens eine Kernrolle erforderlich" }, { status: 400 });
   }
 
-  const orderedRoles = sortRoles(provided);
+  const orderedRoles = sortRoles([
+    ...filterPrimaryRoles(provided),
+    ...filterSupplementalRoles(provided),
+  ]);
 
   // Guard: Admins cannot assign or remove the owner role
   const actorRoles = new Set(session.user?.roles ?? (session.user?.role ? [session.user.role] : []));
@@ -72,7 +82,7 @@ export async function PUT(request: NextRequest) {
   }
 
   // Keep legacy primary role field for compatibility (highest role)
-  const primaryRole = orderedRoles[orderedRoles.length - 1];
+  const primaryRole = getHighestPrimaryRole(orderedRoles);
 
   try {
     const updated = await prisma.user.update({

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth, ROLES } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
-import { sortRoles, type Role } from "@/lib/roles";
+import {
+  DEFAULT_PRIMARY_ROLE,
+  filterPrimaryRoles,
+  filterSupplementalRoles,
+  getHighestPrimaryRole,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
 import { hashPassword } from "@/lib/password";
 import { Prisma } from "@prisma/client";
 import { hasPermission } from "@/lib/permissions";
@@ -102,7 +109,12 @@ export async function POST(request: NextRequest) {
   const filteredRoles = Array.from(new Set(requestedRoles)).filter(
     (role): role is Role => typeof role === "string" && (ROLES as readonly string[]).includes(role),
   );
-  const roles = sortRoles(filteredRoles.length > 0 ? filteredRoles : ["member"]);
+  const primaryRoles = filterPrimaryRoles(filteredRoles);
+  const supplementalRoles = filterSupplementalRoles(filteredRoles);
+  const roles = sortRoles([
+    ...(primaryRoles.length ? primaryRoles : [DEFAULT_PRIMARY_ROLE]),
+    ...supplementalRoles,
+  ]);
 
   // Only owners may assign the owner role
   const actorRoles = new Set(session.user?.roles ?? (session.user?.role ? [session.user.role] : []));
@@ -111,7 +123,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Keep legacy primary role field for compatibility (highest role)
-  const primaryRole = roles[roles.length - 1];
+  const primaryRole = getHighestPrimaryRole(roles);
 
   try {
     const user = await prisma.user.create({

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -4,7 +4,15 @@ import { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 import { isInviteUsable } from "@/lib/member-invites";
-import { sortRoles, ROLES, type Role } from "@/lib/roles";
+import {
+  DEFAULT_PRIMARY_ROLE,
+  ROLES,
+  filterPrimaryRoles,
+  filterSupplementalRoles,
+  getHighestPrimaryRole,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
 import { hashPassword } from "@/lib/password";
 import { combineNameParts } from "@/lib/names";
 import { MAX_INTERESTS_PER_USER } from "@/data/profile";
@@ -312,8 +320,13 @@ export async function POST(request: NextRequest) {
   }
 
   const rolesFromInvite = invite.roles?.filter((role): role is Role => (ROLES as readonly string[]).includes(role)) ?? [];
-  const roles = sortRoles(rolesFromInvite.length ? rolesFromInvite : ["member"]);
-  const primaryRole = roles[roles.length - 1];
+  const primaryRoles = filterPrimaryRoles(rolesFromInvite);
+  const supplementalRoles = filterSupplementalRoles(rolesFromInvite);
+  const roles = sortRoles([
+    ...(primaryRoles.length ? primaryRoles : [DEFAULT_PRIMARY_ROLE]),
+    ...supplementalRoles,
+  ]);
+  const primaryRole = getHighestPrimaryRole(roles);
 
   const storedPayload = {
     firstName,

--- a/src/components/members/add-member-card.tsx
+++ b/src/components/members/add-member-card.tsx
@@ -2,7 +2,17 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { describeRoles, ROLE_LABELS, ROLES, sortRoles, type Role } from "@/lib/roles";
+import {
+  DEFAULT_PRIMARY_ROLE,
+  PRIMARY_ROLES,
+  SUPPLEMENTAL_ROLES,
+  describeRoles,
+  hasPrimaryRole,
+  isPrimaryRole,
+  ROLE_LABELS,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import {
@@ -23,15 +33,31 @@ export function AddMemberModal() {
   const [lastName, setLastName] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [roles, setRoles] = useState<Role[]>(["member"]);
+  const [roles, setRoles] = useState<Role[]>([DEFAULT_PRIMARY_ROLE]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const toggleRole = (role: Role) => {
     setError(null);
     setRoles((prev) => {
-      const next = prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role];
-      return sortRoles(next.length ? next : ["member"]);
+      const nextSet = new Set(prev);
+      if (nextSet.has(role)) {
+        nextSet.delete(role);
+      } else {
+        nextSet.add(role);
+      }
+
+      const nextRoles = sortRoles(Array.from(nextSet));
+      if (!hasPrimaryRole(nextRoles)) {
+        if (isPrimaryRole(role) && !nextSet.has(role)) {
+          // Prevent removing the final primary role without replacement
+          nextSet.add(role);
+        } else {
+          nextSet.add(DEFAULT_PRIMARY_ROLE);
+        }
+      }
+
+      return sortRoles(Array.from(nextSet));
     });
   };
 
@@ -41,7 +67,7 @@ export function AddMemberModal() {
     setLastName("");
     setPassword("");
     setConfirmPassword("");
-    setRoles(["member"]);
+    setRoles([DEFAULT_PRIMARY_ROLE]);
     setError(null);
   };
 
@@ -180,33 +206,65 @@ export function AddMemberModal() {
               </label>
             </div>
 
-            <div className="space-y-2">
-              <span className="text-sm font-medium">Rollen</span>
-              <div className="grid gap-2 sm:grid-cols-2">
-                {ROLES.map((role) => {
-                  const active = roles.includes(role);
-                  return (
-                    <label
-                      key={role}
-                      className={`flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition ${
-                        active
-                          ? "border-primary bg-primary/10 text-primary"
-                          : "border-border hover:bg-accent/30"
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        className="h-4 w-4 rounded border-border text-primary focus-visible:outline-none"
-                        checked={active}
-                        onChange={() => toggleRole(role)}
-                      />
-                      <span>{ROLE_LABELS[role] ?? role}</span>
-                    </label>
-                  );
-                })}
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <span className="text-sm font-medium">Kernrollen</span>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {PRIMARY_ROLES.map((role) => {
+                    const active = roles.includes(role);
+                    return (
+                      <label
+                        key={role}
+                        className={`flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition ${
+                          active
+                            ? "border-primary bg-primary/10 text-primary"
+                            : "border-border hover:bg-accent/30"
+                        }`}
+                      >
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 rounded border-border text-primary focus-visible:outline-none"
+                          checked={active}
+                          onChange={() => toggleRole(role)}
+                        />
+                        <span>{ROLE_LABELS[role] ?? role}</span>
+                      </label>
+                    );
+                  })}
+                </div>
               </div>
+
+              {SUPPLEMENTAL_ROLES.length ? (
+                <div className="space-y-2">
+                  <span className="text-sm font-medium">Zusätzliche Berechtigungen</span>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {SUPPLEMENTAL_ROLES.map((role) => {
+                      const active = roles.includes(role);
+                      return (
+                        <label
+                          key={role}
+                          className={`flex cursor-pointer items-center gap-2 rounded-md border px-3 py-2 text-sm transition ${
+                            active
+                              ? "border-primary bg-primary/10 text-primary"
+                              : "border-border hover:bg-accent/30"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-border text-primary focus-visible:outline-none"
+                            checked={active}
+                            onChange={() => toggleRole(role)}
+                          />
+                          <span>{ROLE_LABELS[role] ?? role}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
+
               <p className="text-xs text-muted-foreground">
-                Zugewiesene Rollen: {describeRoles(roles)}
+                Zugewiesene Rollen: {describeRoles(sortRoles(roles))}
               </p>
             </div>
 

--- a/src/components/members/role-manager.tsx
+++ b/src/components/members/role-manager.tsx
@@ -3,7 +3,14 @@ import { useEffect, useMemo, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { EditIcon } from "@/components/ui/icons";
-import { ROLE_BADGE_VARIANTS, ROLE_LABELS, sortRoles, type Role } from "@/lib/roles";
+import {
+  DEFAULT_PRIMARY_ROLE,
+  ROLE_BADGE_VARIANTS,
+  ROLE_LABELS,
+  hasPrimaryRole,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
 import { toast } from "sonner";
 import { UserEditModal } from "@/components/members/user-edit-modal";
 import { RolePicker } from "@/components/members/role-picker";
@@ -40,7 +47,13 @@ export function RoleManager({
     name?: string | null;
   }) => void;
 }) {
-  const initialSorted = useMemo(() => sortRoles(initialRoles), [initialRoles]);
+  const initialSorted = useMemo(() => {
+    const sorted = sortRoles(initialRoles);
+    if (hasPrimaryRole(sorted)) {
+      return sorted;
+    }
+    return sortRoles([...sorted, DEFAULT_PRIMARY_ROLE]);
+  }, [initialRoles]);
   const [selected, setSelected] = useState<Role[]>(initialSorted);
   const [saved, setSaved] = useState<Role[]>(initialSorted);
   const [selectedCustomIds, setSelectedCustomIds] = useState<string[]>([...initialCustomRoleIds]);
@@ -55,8 +68,11 @@ export function RoleManager({
 
   useEffect(() => {
     const sorted = sortRoles(initialRoles);
-    setSelected(sorted);
-    setSaved(sorted);
+    const normalized = hasPrimaryRole(sorted)
+      ? sorted
+      : sortRoles([...sorted, DEFAULT_PRIMARY_ROLE]);
+    setSelected(normalized);
+    setSaved(normalized);
   }, [initialRoles]);
 
   useEffect(() => {
@@ -86,8 +102,8 @@ export function RoleManager({
   const dirty = useMemo(() => selected.join("|") !== saved.join("|") || selectedCustomIds.join("|") !== savedCustomIds.join("|"), [selected, saved, selectedCustomIds, savedCustomIds]);
 
   const handleSave = async () => {
-    if (selected.length === 0) {
-      setError("Mindestens eine Rolle muss ausgewählt sein.");
+    if (!hasPrimaryRole(selected)) {
+      setError("Mindestens eine Kernrolle muss ausgewählt sein.");
       return;
     }
 
@@ -199,8 +215,11 @@ export function RoleManager({
               // prevent empty selection and enforce owner guard
               const nextSet = new Set<Role>(next);
               if (!canEditOwner) nextSet.delete("owner");
-              if (nextSet.size === 0) return; // keep at least one role
-              const arr = sortRoles(Array.from(nextSet));
+              const normalized = Array.from(nextSet);
+              if (!hasPrimaryRole(normalized)) {
+                return;
+              }
+              const arr = sortRoles(normalized);
               setSelected(arr);
               setError(null);
             }}

--- a/src/components/members/role-picker.tsx
+++ b/src/components/members/role-picker.tsx
@@ -1,8 +1,18 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ROLE_BADGE_VARIANTS, ROLE_LABELS, ROLES, type Role } from "@/lib/roles";
+import {
+  DEFAULT_PRIMARY_ROLE,
+  PRIMARY_ROLES,
+  SUPPLEMENTAL_ROLES,
+  hasPrimaryRole,
+  isPrimaryRole,
+  ROLE_BADGE_VARIANTS,
+  ROLE_LABELS,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
 
 export function RolePicker({
   value,
@@ -32,17 +42,33 @@ export function RolePicker({
   }, [open]);
 
   const selected = useMemo(() => new Set(value), [value]);
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return ROLES;
-    return ROLES.filter((r) => (ROLE_LABELS[r] ?? r).toLowerCase().includes(q));
-  }, [query]);
+  const filterRoles = useCallback(
+    (roles: readonly Role[]) => {
+      const q = query.trim().toLowerCase();
+      if (!q) return roles;
+      return roles.filter((role) => (ROLE_LABELS[role] ?? role).toLowerCase().includes(q));
+    },
+    [query],
+  );
+
+  const filteredPrimary = useMemo(() => filterRoles(PRIMARY_ROLES), [filterRoles]);
+  const filteredSupplemental = useMemo(
+    () => filterRoles(SUPPLEMENTAL_ROLES),
+    [filterRoles],
+  );
 
   const toggle = (role: Role) => {
     if (role === "owner" && !canEditOwner) return;
     const isActive = selected.has(role);
-    const next = isActive ? value.filter((r) => r !== role) : [...value, role];
-    onChange(next);
+    let next = isActive ? value.filter((r) => r !== role) : [...value, role];
+    if (!hasPrimaryRole(next)) {
+      if (isPrimaryRole(role) && isActive) {
+        // Prevent removing the last primary role
+        return;
+      }
+      next = [...next, DEFAULT_PRIMARY_ROLE];
+    }
+    onChange(sortRoles(next));
   };
 
   return (
@@ -80,34 +106,76 @@ export function RolePicker({
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Rollen suchen…"
           />
-          <div className="mt-2 max-h-64 overflow-auto pr-1">
-            {filtered.map((role) => {
-              const active = selected.has(role);
-              const disabled = role === "owner" && !canEditOwner;
-              return (
-                <label
-                  key={role}
-                  className={`flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm hover:bg-accent/40 ${
-                    disabled ? "opacity-50 cursor-not-allowed" : ""
-                  }`}
-                >
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      className="h-4 w-4"
-                      checked={active}
-                      onChange={() => toggle(role)}
-                      disabled={disabled}
-                    />
-                    <span>{ROLE_LABELS[role] ?? role}</span>
-                  </div>
-                  <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${ROLE_BADGE_VARIANTS[role]}`}>
-                    {role}
-                  </span>
-                </label>
-              );
-            })}
-            {filtered.length === 0 && (
+          <div className="mt-2 max-h-64 overflow-auto pr-1 space-y-3">
+            {filteredPrimary.length > 0 && (
+              <div className="space-y-1">
+                <div className="px-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Kernrollen
+                </div>
+                {filteredPrimary.map((role) => {
+                  const active = selected.has(role);
+                  const disabled = role === "owner" && !canEditOwner;
+                  return (
+                    <label
+                      key={role}
+                      className={`flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm hover:bg-accent/40 ${
+                        disabled ? "cursor-not-allowed opacity-50" : ""
+                      }`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4"
+                          checked={active}
+                          onChange={() => toggle(role)}
+                          disabled={disabled}
+                        />
+                        <span>{ROLE_LABELS[role] ?? role}</span>
+                      </div>
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${ROLE_BADGE_VARIANTS[role]}`}
+                      >
+                        {role}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+
+            {filteredSupplemental.length > 0 && (
+              <div className="space-y-1">
+                <div className="px-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Zusätzliche Rollen
+                </div>
+                {filteredSupplemental.map((role) => {
+                  const active = selected.has(role);
+                  return (
+                    <label
+                      key={role}
+                      className="flex cursor-pointer items-center justify-between rounded-md px-2 py-1 text-sm hover:bg-accent/40"
+                    >
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4"
+                          checked={active}
+                          onChange={() => toggle(role)}
+                        />
+                        <span>{ROLE_LABELS[role] ?? role}</span>
+                      </div>
+                      <span
+                        className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs ${ROLE_BADGE_VARIANTS[role]}`}
+                      >
+                        {role}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+
+            {filteredPrimary.length === 0 && filteredSupplemental.length === 0 && (
               <div className="px-2 py-4 text-sm text-muted-foreground">Keine Treffer</div>
             )}
           </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,7 +8,7 @@ import type { JWT } from "next-auth/jwt";
 import EmailProvider from "next-auth/providers/email";
 import Credentials from "next-auth/providers/credentials";
 import type { CredentialInput } from "next-auth/providers/credentials";
-import { sortRoles, ROLES } from "@/lib/roles";
+import { getHighestPrimaryRole, sortRoles, ROLES } from "@/lib/roles";
 import { DEV_TEST_USER_EMAILS, DEV_TEST_USER_ROLE_MAP } from "@/lib/auth-dev-test-users";
 import { verifyPassword } from "@/lib/password";
 import { combineNameParts } from "@/lib/names";
@@ -227,6 +227,7 @@ const credentialsProvider = Credentials({
       user.role as Role,
       ...user.roles.map((r) => r.role as Role),
     ]);
+    const primaryRole = getHighestPrimaryRole(combinedRoles);
 
     return {
       id: user.id,
@@ -234,7 +235,7 @@ const credentialsProvider = Credentials({
       firstName: user.firstName ?? null,
       lastName: user.lastName ?? null,
       name: combineNameParts(user.firstName, user.lastName) ?? (user.name ?? null),
-      role: combinedRoles[combinedRoles.length - 1],
+      role: primaryRole,
       roles: combinedRoles,
       avatarSource: user.avatarSource,
       avatarImageUpdatedAt: user.avatarImageUpdatedAt,
@@ -285,7 +286,7 @@ export const authOptions = {
         if (!roles || roles.length === 0) return;
         const sorted = sortRoles(roles);
         mutableToken.roles = sorted;
-        mutableToken.role = sorted[sorted.length - 1];
+        mutableToken.role = getHighestPrimaryRole(sorted);
       };
 
       if (user && isRecord(user)) {

--- a/src/lib/auth/impersonation.ts
+++ b/src/lib/auth/impersonation.ts
@@ -3,7 +3,7 @@ import type { Session } from "next-auth";
 
 import { prisma } from "@/lib/prisma";
 import { combineNameParts } from "@/lib/names";
-import { sortRoles, type Role } from "@/lib/roles";
+import { getHighestPrimaryRole, sortRoles, type Role } from "@/lib/roles";
 
 const IMPERSONATION_COOKIE_NAME = "member_impersonation";
 
@@ -176,7 +176,7 @@ export async function applyImpersonation(
     target.role as Role,
     ...target.roles.map((entry) => entry.role as Role),
   ]);
-  const primaryRole = combinedRoles[combinedRoles.length - 1] ?? null;
+  const primaryRole = getHighestPrimaryRole(combinedRoles);
 
   const targetFullName =
     combineNameParts(target.firstName, target.lastName) ??

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import type { Role } from "@prisma/client";
+import { filterPrimaryRoles, getHighestPrimaryRole } from "@/lib/roles";
 
 const MEMBER_ROLES = new Set<Role>([
   "member",
@@ -25,8 +26,18 @@ function determineMembership(roles: Role[] | undefined) {
     return { isMember: false, membershipRole: null as string | null };
   }
 
-  const membershipRole = normalized[normalized.length - 1];
-  return { isMember: true, membershipRole };
+  const primaryRoles = filterPrimaryRoles(normalized);
+  if (primaryRoles.length > 0) {
+    const membershipRole = getHighestPrimaryRole(primaryRoles);
+    return { isMember: true, membershipRole };
+  }
+
+  if (normalized.includes("finance")) {
+    return { isMember: true, membershipRole: "finance" };
+  }
+
+  const fallback = normalized[normalized.length - 1] ?? null;
+  return { isMember: true, membershipRole: fallback };
 }
 
 function sanitizePath(path: string | null | undefined): string | null {

--- a/src/lib/dev-auth.ts
+++ b/src/lib/dev-auth.ts
@@ -1,7 +1,12 @@
 import type { AvatarSource } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { combineNameParts, splitFullName } from "@/lib/names";
-import type { Role } from "@/lib/roles";
+import {
+  DEFAULT_PRIMARY_ROLE,
+  isPrimaryRole,
+  sortRoles,
+  type Role,
+} from "@/lib/roles";
 
 export type DevTestUserProfile = {
   id: string;
@@ -22,27 +27,35 @@ export async function ensureDevTestUser(email: string, role: Role): Promise<DevT
   const { firstName: derivedFirstName, lastName: derivedLastName } = splitFullName(trimmedName);
   const combinedName = combineNameParts(derivedFirstName, derivedLastName) ?? (trimmedName || null);
 
+  const primaryRole = isPrimaryRole(role) ? role : DEFAULT_PRIMARY_ROLE;
+  const supplementalRoles = isPrimaryRole(role) ? [] : [role];
+  const allRoles = sortRoles([primaryRole, ...supplementalRoles]);
+
   const user = await prisma.user.upsert({
     where: { email: normalizedEmail },
     update: {
       firstName: derivedFirstName,
       lastName: derivedLastName,
       name: combinedName,
-      role,
+      role: primaryRole,
     },
     create: {
       email: normalizedEmail,
       firstName: derivedFirstName,
       lastName: derivedLastName,
       name: combinedName,
-      role,
+      role: primaryRole,
     },
   });
 
-  await prisma.userRole.upsert({
-    where: { userId_role: { userId: user.id, role } },
-    update: {},
-    create: { userId: user.id, role },
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      roles: {
+        deleteMany: {},
+        create: allRoles.map((entry) => ({ role: entry })),
+      },
+    },
   });
 
   return {
@@ -51,8 +64,8 @@ export async function ensureDevTestUser(email: string, role: Role): Promise<DevT
     firstName: user.firstName ?? null,
     lastName: user.lastName ?? null,
     name: combineNameParts(user.firstName, user.lastName) ?? (user.name ?? null),
-    role,
-    roles: [role],
+    role: primaryRole,
+    roles: allRoles,
     avatarSource: user.avatarSource,
     avatarImageUpdatedAt: user.avatarImageUpdatedAt,
   };

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,4 +1,8 @@
-export const ROLES = [
+export const PRIMARY_ROLES = ["member", "cast", "tech", "board", "admin", "owner"] as const;
+
+export const SUPPLEMENTAL_ROLES = ["finance"] as const;
+
+const ROLE_SORT_ORDER = [
   "member",
   "cast",
   "tech",
@@ -8,7 +12,53 @@ export const ROLES = [
   "owner",
 ] as const;
 
+export const ROLES = ROLE_SORT_ORDER;
+
+export type PrimaryRole = (typeof PRIMARY_ROLES)[number];
+export type SupplementalRole = (typeof SUPPLEMENTAL_ROLES)[number];
+
+export const DEFAULT_PRIMARY_ROLE: PrimaryRole = "member";
+
 export type Role = (typeof ROLES)[number];
+
+const ROLE_ORDER = new Map<Role, number>(ROLE_SORT_ORDER.map((role, index) => [role, index]));
+const PRIMARY_ROLE_ORDER = new Map<PrimaryRole, number>(
+  PRIMARY_ROLES.map((role, index) => [role, index]),
+);
+
+export function isPrimaryRole(role: Role): role is PrimaryRole {
+  return (PRIMARY_ROLE_ORDER as Map<Role, number>).has(role);
+}
+
+const SUPPLEMENTAL_ROLE_SET = new Set<Role>(SUPPLEMENTAL_ROLES);
+
+export function isSupplementalRole(role: Role): role is SupplementalRole {
+  return SUPPLEMENTAL_ROLE_SET.has(role);
+}
+
+export function filterPrimaryRoles(roles: Role[]): PrimaryRole[] {
+  return roles.filter((role): role is PrimaryRole => isPrimaryRole(role));
+}
+
+export function filterSupplementalRoles(roles: Role[]): SupplementalRole[] {
+  return roles.filter((role): role is SupplementalRole => isSupplementalRole(role));
+}
+
+export function hasPrimaryRole(roles: Role[]): boolean {
+  return roles.some((role) => isPrimaryRole(role));
+}
+
+export function getHighestPrimaryRole(roles: Role[]): PrimaryRole {
+  const primaries = filterPrimaryRoles(roles);
+  if (primaries.length === 0) {
+    return DEFAULT_PRIMARY_ROLE;
+  }
+  return primaries.reduce((highest, current) => {
+    const currentOrder = PRIMARY_ROLE_ORDER.get(current) ?? 0;
+    const highestOrder = PRIMARY_ROLE_ORDER.get(highest) ?? 0;
+    return currentOrder >= highestOrder ? current : highest;
+  });
+}
 
 export const ROLE_LABELS: Record<Role, string> = {
   member: "Mitglied",
@@ -41,8 +91,11 @@ export const ROLE_BADGE_VARIANTS: Record<Role, string> = {
 };
 
 export function sortRoles(roles: Role[]) {
-  const order = new Map<Role, number>(ROLES.map((role, index) => [role, index]));
-  return [...new Set(roles)].sort((a, b) => (order.get(a) ?? 0) - (order.get(b) ?? 0));
+  const unique = [...new Set(roles)];
+  if (!hasPrimaryRole(unique)) {
+    unique.push(DEFAULT_PRIMARY_ROLE);
+  }
+  return unique.sort((a, b) => (ROLE_ORDER.get(a) ?? 0) - (ROLE_ORDER.get(b) ?? 0));
 }
 
 export function describeRoles(roles: Role[]) {


### PR DESCRIPTION
## Summary
- separate primary vs supplemental member roles, treating finance as an add-on and updating seed data accordingly
- split role selection in member management UI to enforce at least one core role while still allowing finance as supplemental
- adjust API, auth, and session utilities to persist and surface the highest primary role alongside supplemental finance access

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d81ab4a174832d9cc91268e84b4961