### PR TITLE
Add modal workflow for creating productions

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -12,7 +12,7 @@ import { ProductionWorkspaceHeader } from "@/components/production/workspace-hea
 
 import {
   ClearActiveProductionForm,
-  CreateProductionForm,
+  CreateProductionDialog,
   SetActiveProductionForm,
 } from "./production-forms-client";
 
@@ -104,14 +104,9 @@ export default async function ProduktionenPage() {
   ) : null;
 
   const headerActions = (
-    <>
-      <Button asChild variant="outline" size="sm">
-        <Link href="#produktionen">Produktion auswählen</Link>
-      </Button>
-      <Button asChild size="sm">
-        <Link href="#produktion-anlegen">Neue Produktion anlegen</Link>
-      </Button>
-    </>
+    <Button asChild variant="outline" size="sm">
+      <Link href="#produktionen">Produktion auswählen</Link>
+    </Button>
   );
 
   return (
@@ -166,33 +161,25 @@ export default async function ProduktionenPage() {
               Setze eine Produktion als aktiv, um Rollen, Szenen und Breakdown-Aufgaben gezielt zu bearbeiten.
             </p>
           </div>
-          {shows.length > 0 ? (
-            <Badge variant="outline">
-              {shows.length} Eintr
-              {shows.length === 1 ? "ag" : "äge"}
-            </Badge>
-          ) : null}
-        </div>
-
-        <Card id="produktion-anlegen" className="border-dashed border-primary/50 bg-primary/5">
-          <CardHeader className="space-y-2">
-            <CardTitle className="text-base font-semibold text-primary">Neue Produktion anlegen</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Erfasse Jahrgang, optionale Beschreibung und starte direkt in den modernen Gewerke-, Rollen- und Szenen-Workflows.
-            </p>
-          </CardHeader>
-          <CardContent>
-            <CreateProductionForm
+          <div className="flex flex-wrap items-center gap-2">
+            {shows.length > 0 ? (
+              <Badge variant="outline">
+                {shows.length} Eintr
+                {shows.length === 1 ? "ag" : "äge"}
+              </Badge>
+            ) : null}
+            <CreateProductionDialog
               redirectPath="/mitglieder/produktionen"
               suggestedYear={suggestedYear}
               shouldSetActiveByDefault={shouldSetActiveByDefault}
+              trigger={<Button size="sm">Neue Produktion anlegen</Button>}
             />
-          </CardContent>
-        </Card>
+          </div>
+        </div>
 
         {shows.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            Noch keine Produktionen angelegt. Nutze das Formular, um deine erste Produktion anzulegen.
+            Noch keine Produktionen angelegt. Nutze den Button „Neue Produktion anlegen“, um deine erste Produktion einzurichten.
           </p>
         ) : (
           <ul className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useActionState, useCallback, useEffect, useRef } from "react";
+import { useActionState, useCallback, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 import type { ProductionActionResult } from "./actions";
@@ -21,12 +30,14 @@ type CreateProductionFormProps = {
   suggestedYear: number;
   shouldSetActiveByDefault: boolean;
   redirectPath: string;
+  onSuccess?: () => void;
 };
 
 export function CreateProductionForm({
   suggestedYear,
   shouldSetActiveByDefault,
   redirectPath,
+  onSuccess,
 }: CreateProductionFormProps) {
   const formRef = useRef<HTMLFormElement>(null);
   const action = useCallback(
@@ -49,8 +60,9 @@ export function CreateProductionForm({
     }
     const message = state.message ?? "Produktion wurde erstellt.";
     toast.success(message);
+    onSuccess?.();
     formRef.current?.reset();
-  }, [state]);
+  }, [state, onSuccess]);
 
   return (
     <form ref={formRef} action={formAction} className="grid gap-6">
@@ -125,6 +137,45 @@ export function CreateProductionForm({
         </div>
       </div>
     </form>
+  );
+}
+
+type CreateProductionDialogProps = {
+  suggestedYear: number;
+  shouldSetActiveByDefault: boolean;
+  redirectPath: string;
+  trigger?: ReactNode;
+};
+
+export function CreateProductionDialog({
+  suggestedYear,
+  shouldSetActiveByDefault,
+  redirectPath,
+  trigger,
+}: CreateProductionDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger ?? <Button>Neue Produktion anlegen</Button>}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader className="space-y-2">
+          <DialogTitle>Neue Produktion anlegen</DialogTitle>
+          <DialogDescription>
+            Erfasse Jahrgang, optionale Beschreibung und starte direkt in den modernen
+            Gewerke-, Rollen- und Szenen-Workflows.
+          </DialogDescription>
+        </DialogHeader>
+        <CreateProductionForm
+          redirectPath={redirectPath}
+          suggestedYear={suggestedYear}
+          shouldSetActiveByDefault={shouldSetActiveByDefault}
+          onSuccess={() => setOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace the production creation card on the overview with a modal trigger button
- add a reusable `CreateProductionDialog` and allow the existing form to notify about successful submissions

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d9263c9c18832da59c0be77dcf389d