### PR TITLE
Auto-select single production membership

### DIFF
--- a/src/app/api/member-invites/route.ts
+++ b/src/app/api/member-invites/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
+import { getActiveProductionId } from "@/lib/active-production";
 import { describeInvite, generateInviteToken, hashInviteToken, calculateInviteStatus } from "@/lib/member-invites";
 import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 import { onboardingPathForHash, onboardingPathForToken } from "@/lib/member-invite-links";
@@ -66,7 +67,19 @@ export async function GET() {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const [invites, productions] = await Promise.all([
+  const userId = session.user?.id ?? null;
+
+  const activeMembershipPromise = userId
+    ? prisma.productionMembership.findMany({
+        where: {
+          userId,
+          OR: [{ leftAt: null }, { leftAt: { gt: new Date() } }],
+        },
+        select: { showId: true },
+      })
+    : Promise.resolve<{ showId: string }[]>([]);
+
+  const [invites, productions, activeMemberships] = await Promise.all([
     prisma.memberInvite.findMany({
       orderBy: { createdAt: "desc" },
       include: {
@@ -82,6 +95,7 @@ export async function GET() {
       orderBy: { year: "desc" },
       select: { id: true, title: true, year: true, meta: true },
     }),
+    activeMembershipPromise,
   ]);
 
   const now = new Date();
@@ -131,7 +145,23 @@ export async function GET() {
     whatsappLink: getOnboardingWhatsAppLink(show.meta),
   }));
 
-  return NextResponse.json({ invites: formatted, productions: formattedProductions });
+  let defaultShowId = "";
+  if (activeMemberships.length === 1) {
+    defaultShowId = activeMemberships[0]?.showId ?? "";
+  } else if (userId) {
+    const activeProductionId = await getActiveProductionId(userId);
+    defaultShowId = activeProductionId ?? "";
+  }
+
+  if (defaultShowId && !formattedProductions.some((show) => show.id === defaultShowId)) {
+    defaultShowId = "";
+  }
+
+  return NextResponse.json({
+    invites: formatted,
+    productions: formattedProductions,
+    defaultShowId: defaultShowId || null,
+  });
 }
 
 export async function POST(request: NextRequest) {

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -113,6 +113,13 @@ type ProductionSummary = {
   whatsappLink: string | null;
 };
 
+function findValidShowId(productions: ProductionSummary[], candidateId: string) {
+  if (candidateId && productions.some((production) => production.id === candidateId)) {
+    return candidateId;
+  }
+  return productions[0]?.id ?? "";
+}
+
 type InviteSummary = {
   id: string;
   label: string | null;
@@ -196,6 +203,7 @@ type OnboardingSettingsDialogState = {
 export function MemberInviteManager() {
   const [invites, setInvites] = useState<InviteSummary[]>([]);
   const [productions, setProductions] = useState<ProductionSummary[]>([]);
+  const [preferredShowId, setPreferredShowId] = useState<string>("");
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -400,10 +408,21 @@ export function MemberInviteManager() {
         };
       });
       setInvites(normalizedInvites);
+      const defaultShowIdFromResponse =
+        typeof data?.defaultShowId === "string" ? data.defaultShowId : "";
+      const resolvedDefaultShowId = findValidShowId(productionsPayload, defaultShowIdFromResponse);
+      setPreferredShowId(resolvedDefaultShowId);
       setForm((prev) => {
-        if (prev.showId) return prev;
-        const defaultShowId = productionsPayload[0]?.id ?? "";
-        return { ...prev, showId: defaultShowId };
+        if (prev.showId && productionsPayload.some((production) => production.id === prev.showId)) {
+          return prev;
+        }
+        return { ...prev, showId: resolvedDefaultShowId };
+      });
+      setEditForm((prev) => {
+        if (prev.showId && productionsPayload.some((production) => production.id === prev.showId)) {
+          return prev;
+        }
+        return { ...prev, showId: resolvedDefaultShowId };
       });
       setFreshInvite((prev) => {
         if (!prev) return prev;
@@ -476,17 +495,33 @@ export function MemberInviteManager() {
     }
   }, []);
 
-  const resetForm = () => {
+  useEffect(() => {
+    setForm((prev) => {
+      const hasValidShow =
+        prev.showId && productions.some((production) => production.id === prev.showId);
+      if (hasValidShow) {
+        return prev;
+      }
+      const fallbackShowId = findValidShowId(productions, preferredShowId);
+      if (prev.showId === fallbackShowId) {
+        return prev;
+      }
+      return { ...prev, showId: fallbackShowId };
+    });
+  }, [productions, preferredShowId]);
+
+  const resetForm = useCallback(() => {
+    const fallbackShowId = findValidShowId(productions, preferredShowId);
     setForm({
       label: "",
       note: "",
       expiresAt: "",
       maxUses: "",
       roles: ["member"],
-      showId: productions[0]?.id ?? "",
+      showId: fallbackShowId,
     });
     setError(null);
-  };
+  }, [productions, preferredShowId]);
 
   const toggleRole = (role: Role) => {
     setForm((prev) => {
@@ -497,17 +532,18 @@ export function MemberInviteManager() {
     });
   };
 
-  const resetEditForm = () => {
+  const resetEditForm = useCallback(() => {
+    const fallbackShowId = findValidShowId(productions, preferredShowId);
     setEditForm({
       label: "",
       note: "",
       expiresAt: "",
       maxUses: "",
       roles: ["member"],
-      showId: productions[0]?.id ?? "",
+      showId: fallbackShowId,
     });
     setLockedRoles([]);
-  };
+  }, [productions, preferredShowId]);
 
   const closeEditModal = () => {
     if (updatingInviteId) return;
@@ -541,6 +577,10 @@ export function MemberInviteManager() {
     const dedupedLocked = Array.from(new Set(locked));
     const sanitizedEditable = normalizeRoles(editableRoles.length ? editableRoles : (["member"] as Role[]));
     setLockedRoles(dedupedLocked);
+    const resolvedShowId =
+      invite.showId && productions.some((production) => production.id === invite.showId)
+        ? invite.showId
+        : findValidShowId(productions, preferredShowId);
     setEditingInvite({
       ...invite,
       label: invite.label ?? null,
@@ -548,6 +588,7 @@ export function MemberInviteManager() {
       maxUses: typeof invite.maxUses === "number" ? invite.maxUses : null,
       expiresAt: invite.expiresAt ?? null,
       roles: normalizeRoles([...sanitizedEditable, ...dedupedLocked]),
+      showId: resolvedShowId,
     });
     setEditForm({
       label: invite.label ?? "",
@@ -557,7 +598,7 @@ export function MemberInviteManager() {
         ? String(invite.maxUses)
         : "",
       roles: sanitizedEditable,
-      showId: invite.showId ?? "",
+      showId: resolvedShowId,
     });
     setExpandedInviteId(invite.id);
     setEditModalOpen(true);


### PR DESCRIPTION
## Summary
- return a default production id from the member invites API based on the requester’s active memberships
- ensure the member invite manager reuses that preferred production for initial selection, resets, and edits so the only available production stays preselected

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d926b35700832d85fd27f013e9d05b