### PR TITLE
Fix server analytics timestamp hydration

### DIFF
--- a/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
@@ -40,7 +40,11 @@ const percentPreciseFormat = new Intl.NumberFormat("de-DE", {
   maximumFractionDigits: 1,
 });
 const percentChangeFormat = new Intl.NumberFormat("de-DE", { minimumFractionDigits: 1, maximumFractionDigits: 1 });
-const dateTimeFormat = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" });
+const dateTimeFormat = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "Europe/Berlin",
+});
 const uptimeFormat = new Intl.NumberFormat("de-DE", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
 const ANIMATION_DURATION_MS = 450;


### PR DESCRIPTION
## Summary
- ensure server analytics timestamps format in a fixed Europe/Berlin timezone to avoid hydration mismatches

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d927178e90832d9afd24c06e632507