### PR TITLE
Add personal calendar view to members area

### DIFF
--- a/src/app/(members)/mitglieder/kalender/calendar-client.tsx
+++ b/src/app/(members)/mitglieder/kalender/calendar-client.tsx
@@ -1,0 +1,794 @@
+"use client";
+
+import { Fragment, useEffect, useMemo, useState } from "react";
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  differenceInMinutes,
+  eachDayOfInterval,
+  endOfDay,
+  endOfWeek,
+  format,
+  formatISO,
+  isAfter,
+  isBefore,
+  isSameDay,
+  isWithinInterval,
+  parseISO,
+  setHours,
+  setMinutes,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+} from "date-fns";
+import { de } from "date-fns/locale/de";
+import { ChevronLeft, ChevronRight, MapPin } from "lucide-react";
+
+import { MonthCalendar, type CalendarDay } from "@/components/calendar/month-calendar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { cn } from "@/lib/utils";
+
+import {
+  type MemberCalendarEvent,
+  type MemberCalendarSource,
+  type MemberCalendarSummaryItem,
+} from "./types";
+
+interface CalendarClientProps {
+  initialDate: string;
+  calendars: MemberCalendarSource[];
+  events: MemberCalendarEvent[];
+  summary: MemberCalendarSummaryItem[];
+}
+
+type CalendarView = "day" | "week" | "month" | "agenda";
+
+type CalendarEventWithDates = MemberCalendarEvent & {
+  startDate: Date;
+  endDate: Date;
+};
+
+type PositionedCalendarEvent = CalendarEventWithDates & {
+  layout: {
+    column: number;
+    columns: number;
+  };
+};
+
+type DayBucket = {
+  date: Date;
+  events: PositionedCalendarEvent[];
+  allDay: CalendarEventWithDates[];
+};
+
+const HOURS = Array.from({ length: 24 }, (_, index) => index);
+const WEEKDAY_LABELS = [
+  "Montag",
+  "Dienstag",
+  "Mittwoch",
+  "Donnerstag",
+  "Freitag",
+  "Samstag",
+  "Sonntag",
+];
+
+const AGENDA_RANGE_DAYS = 60;
+
+function computeEventLayouts(events: CalendarEventWithDates[]) {
+  const sorted = [...events].sort(
+    (a, b) => a.startDate.getTime() - b.startDate.getTime(),
+  );
+  type ActiveEntry = { event: CalendarEventWithDates; column: number; groupId: number };
+  const active: ActiveEntry[] = [];
+  const layout = new Map<
+    string,
+    { column: number; columns: number; groupId: number }
+  >();
+  let groupCounter = 0;
+
+  for (const event of sorted) {
+    for (let index = active.length - 1; index >= 0; index -= 1) {
+      const candidate = active[index];
+      if (candidate.event.endDate <= event.startDate) {
+        active.splice(index, 1);
+      }
+    }
+
+    const overlapping = active.filter((entry) =>
+      isBefore(entry.event.startDate, event.endDate) &&
+      isAfter(entry.event.endDate, event.startDate),
+    );
+
+    const groupId = overlapping.length ? overlapping[0].groupId : groupCounter++;
+    const usedColumns = new Set(overlapping.map((entry) => entry.column));
+    let column = 0;
+    while (usedColumns.has(column)) {
+      column += 1;
+    }
+
+    layout.set(event.id, { column, columns: column + 1, groupId });
+    active.push({ event, column, groupId });
+  }
+
+  const groupColumns = new Map<number, number>();
+  for (const entry of layout.values()) {
+    groupColumns.set(
+      entry.groupId,
+      Math.max(groupColumns.get(entry.groupId) ?? 0, entry.column + 1),
+    );
+  }
+
+  const normalized = new Map<string, { column: number; columns: number }>();
+  for (const [eventId, entry] of layout.entries()) {
+    normalized.set(eventId, {
+      column: entry.column,
+      columns: Math.max(groupColumns.get(entry.groupId) ?? entry.columns, 1),
+    });
+  }
+
+  return normalized;
+}
+
+export function CalendarClient({ initialDate, calendars, events, summary }: CalendarClientProps) {
+  const parsedInitialDate = useMemo(() => parseISO(initialDate), [initialDate]);
+  const [currentDate, setCurrentDate] = useState<Date>(parsedInitialDate);
+  const [currentMonth, setCurrentMonth] = useState<Date>(startOfMonth(parsedInitialDate));
+  const [view, setView] = useState<CalendarView>("week");
+  const [activeCalendarIds, setActiveCalendarIds] = useState<string[]>(() =>
+    calendars.map((item) => item.id),
+  );
+
+  const isTablet = useMediaQuery("(min-width: 768px)");
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
+
+  useEffect(() => {
+    if (!isTablet) {
+      setView((previous) => (previous === "month" ? "week" : previous));
+    }
+  }, [isTablet]);
+
+  useEffect(() => {
+    if (isDesktop) {
+      setView((previous) => (previous === "agenda" ? "week" : previous));
+    }
+  }, [isDesktop]);
+
+  const calendarMap = useMemo(() => {
+    const map = new Map<string, MemberCalendarSource>();
+    for (const source of calendars) {
+      map.set(source.id, source);
+    }
+    return map;
+  }, [calendars]);
+
+  const parsedEvents = useMemo<CalendarEventWithDates[]>(() => {
+    return events
+      .map((event) => {
+        const startDate = parseISO(event.start);
+        const endDate = event.end ? parseISO(event.end) : startDate;
+        return {
+          ...event,
+          startDate,
+          endDate,
+        } satisfies CalendarEventWithDates;
+      })
+      .sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
+  }, [events]);
+
+  const activeEvents = useMemo(() => {
+    return parsedEvents.filter((event) => activeCalendarIds.includes(event.calendarId));
+  }, [parsedEvents, activeCalendarIds]);
+
+  const eventsByDay = useMemo(() => {
+    const map = new Map<string, CalendarEventWithDates[]>();
+    for (const event of activeEvents) {
+      const start = startOfDay(event.startDate);
+      const end = startOfDay(event.endDate);
+      const days = eachDayOfInterval({ start, end });
+      for (const day of days) {
+        const key = formatISO(day, { representation: "date" });
+        if (!map.has(key)) {
+          map.set(key, []);
+        }
+        map.get(key)!.push(event);
+      }
+    }
+    return map;
+  }, [activeEvents]);
+
+  const selectedDayKey = useMemo(
+    () => formatISO(startOfDay(currentDate), { representation: "date" }),
+    [currentDate],
+  );
+
+  const rangeLabel = useMemo(() => {
+    if (view === "day") {
+      return format(currentDate, "EEEE, d. MMMM yyyy", { locale: de });
+    }
+    if (view === "week") {
+      const start = startOfWeek(currentDate, { weekStartsOn: 1 });
+      const end = endOfWeek(currentDate, { weekStartsOn: 1 });
+      const sameMonth = start.getMonth() === end.getMonth();
+      const monthPart = sameMonth
+        ? format(start, "MMMM yyyy", { locale: de })
+        : `${format(start, "MMMM", { locale: de })} – ${format(end, "MMMM yyyy", { locale: de })}`;
+      return `${format(start, "d.", { locale: de })} – ${format(end, "d.", { locale: de })} ${monthPart}`;
+    }
+    if (view === "month") {
+      return format(currentMonth, "MMMM yyyy", { locale: de });
+    }
+    const start = startOfDay(currentDate);
+    const end = addDays(start, AGENDA_RANGE_DAYS);
+    return `${format(start, "d. MMM", { locale: de })} – ${format(end, "d. MMM yyyy", { locale: de })}`;
+  }, [currentDate, currentMonth, view]);
+
+  const agendaEvents = useMemo(() => {
+    if (view !== "agenda") return [] as CalendarEventWithDates[];
+    const start = startOfDay(currentDate);
+    const end = addDays(start, AGENDA_RANGE_DAYS);
+    return activeEvents.filter((event) =>
+      isWithinInterval(event.startDate, { start, end }) ||
+      isWithinInterval(event.endDate, { start, end }),
+    );
+  }, [activeEvents, currentDate, view]);
+
+  const upcomingEvents = useMemo(() => {
+    const now = new Date();
+    return activeEvents
+      .filter((event) => isAfter(event.endDate, now))
+      .slice(0, 20);
+  }, [activeEvents]);
+
+  const handleNavigate = (direction: "previous" | "next") => {
+    const factor = direction === "next" ? 1 : -1;
+    if (view === "day") {
+      setCurrentDate((prev) => addDays(prev, factor));
+    } else if (view === "week") {
+      setCurrentDate((prev) => addWeeks(prev, factor));
+    } else if (view === "month") {
+      setCurrentDate((prev) => addMonths(prev, factor));
+      setCurrentMonth((prev) => addMonths(prev, factor));
+    } else {
+      setCurrentDate((prev) => addWeeks(prev, factor));
+    }
+  };
+
+  const handleToday = () => {
+    const today = new Date();
+    setCurrentDate(today);
+    setCurrentMonth(startOfMonth(today));
+  };
+
+  const toggleCalendar = (calendarId: string) => {
+    setActiveCalendarIds((prev) => {
+      if (prev.includes(calendarId)) {
+        return prev.filter((id) => id !== calendarId);
+      }
+      return [...prev, calendarId];
+    });
+  };
+
+  const handleViewChange = (nextView: CalendarView) => {
+    setView(nextView);
+    if (nextView === "month") {
+      setCurrentMonth(startOfMonth(currentDate));
+    }
+  };
+
+  const renderDayCell = (day: CalendarDay) => {
+    const key = formatISO(day.date, { representation: "date" });
+    const dayEvents = eventsByDay.get(key) ?? [];
+    const hasEvents = dayEvents.length > 0;
+    const isSelected = key === selectedDayKey;
+    const eventSummary = hasEvents
+      ? `${dayEvents.length} Termin${dayEvents.length === 1 ? "" : "e"}`
+      : "Keine Termine";
+
+    return {
+      onClick: () => {
+        setCurrentDate(day.date);
+        setCurrentMonth(startOfMonth(day.date));
+        if (!isTablet) {
+          setView("day");
+        }
+      },
+      className: cn(
+        "relative transition",
+        hasEvents && "border-primary/40 bg-primary/10",
+        isSelected && "border-primary bg-primary/15 shadow-[0_12px_30px_rgba(129,140,248,0.25)]",
+      ),
+      "aria-label": `${format(day.date, "EEEE, d. MMMM yyyy", { locale: de })}. ${eventSummary}.`,
+      content: (
+        <div className="flex h-full flex-col justify-between gap-1 text-xs">
+          <div className="flex items-start justify-between">
+            <span className="font-medium text-foreground">{format(day.date, "d.")}</span>
+            {!day.isCurrentMonth ? (
+              <span className="text-[10px] text-muted-foreground">{format(day.date, "MMM", { locale: de })}</span>
+            ) : null}
+          </div>
+          <div className="flex flex-col gap-1">
+            {dayEvents.slice(0, 3).map((event) => {
+              const source = calendarMap.get(event.calendarId);
+              const accentColor = source?.color ?? null;
+              return (
+                <div
+                  key={`${event.id}-${event.calendarId}`}
+                  className={cn(
+                    "flex items-center gap-2 rounded-full border px-2 py-1 text-[10px] font-medium",
+                    accentColor ? "border-transparent" : "border-primary/30 bg-primary/10 text-primary",
+                  )}
+                  style={
+                    accentColor
+                      ? {
+                          borderColor: `${accentColor}55`,
+                          backgroundColor: `${accentColor}1A`,
+                          color: accentColor,
+                        }
+                      : undefined
+                  }
+                >
+                  <span
+                    className={cn("h-1.5 w-1.5 rounded-full", !accentColor && "bg-primary")}
+                    style={accentColor ? { backgroundColor: accentColor } : undefined}
+                  />
+                  <span className="truncate">{event.title}</span>
+                </div>
+              );
+            })}
+            {dayEvents.length > 3 ? (
+              <span className="text-[10px] text-muted-foreground">+{dayEvents.length - 3} weitere</span>
+            ) : null}
+          </div>
+        </div>
+      ),
+    };
+  };
+
+  const bucketsForWeek = useMemo(() => {
+    if (view !== "week" && view !== "day") return [] as DayBucket[];
+    const weekStart =
+      view === "day"
+        ? startOfDay(currentDate)
+        : startOfWeek(currentDate, { weekStartsOn: 1 });
+    const days =
+      view === "day"
+        ? [weekStart]
+        : eachDayOfInterval({
+            start: weekStart,
+            end: addDays(weekStart, 6),
+          });
+    return days.map((day) => {
+      const key = formatISO(day, { representation: "date" });
+      const dayEvents = (eventsByDay.get(key) ?? []).filter((event) =>
+        isSameDay(event.startDate, day) ||
+        isWithinInterval(day, { start: startOfDay(event.startDate), end: endOfDay(event.endDate) }),
+      );
+      const allDay = dayEvents.filter((event) => event.allDay);
+      const timed = dayEvents.filter((event) => !event.allDay);
+      const sorted = timed.sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
+      const layoutMap = computeEventLayouts(sorted);
+      return {
+        date: day,
+        events: sorted.map((event) => ({
+          ...event,
+          layout: layoutMap.get(event.id) ?? { column: 0, columns: 1 },
+        })),
+        allDay,
+      } satisfies DayBucket;
+    });
+  }, [currentDate, eventsByDay, view]);
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+        <div className="hidden flex-col gap-6 lg:flex">
+          <Card className="rounded-3xl border border-border/60 bg-card/70 shadow-sm">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold">Monatsübersicht</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Tippe auf ein Datum, um in die Tages- oder Wochenansicht zu wechseln.
+              </p>
+            </CardHeader>
+            <CardContent>
+              <MonthCalendar
+                month={currentMonth}
+                onMonthChange={(next) => {
+                  setCurrentMonth(next);
+                  setCurrentDate(next);
+                }}
+                renderDay={renderDayCell}
+                showWeekNumbers={false}
+                weekStartsOn={1}
+                className="rounded-2xl border border-border/60"
+                contentClassName="p-2"
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-3xl border border-border/60 bg-card/70 shadow-sm">
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">Meine Kalender</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Blende einzelne Quellen aus, um dich auf bestimmte Termine zu konzentrieren.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {calendars.map((calendar) => {
+                const isActive = activeCalendarIds.includes(calendar.id);
+                return (
+                  <button
+                    key={calendar.id}
+                    type="button"
+                    onClick={() => toggleCalendar(calendar.id)}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-2xl border px-3 py-2 text-left text-sm transition",
+                      isActive
+                        ? "border-transparent bg-primary/10 text-foreground"
+                        : "border-border/70 bg-background/70 text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <span
+                      className="h-3 w-3 rounded-full"
+                      style={{ backgroundColor: calendar.color }}
+                      aria-hidden
+                    />
+                    <span className="flex-1">
+                      <span className="block font-medium">{calendar.label}</span>
+                      {calendar.secondaryLabel ? (
+                        <span className="text-xs text-muted-foreground/80">{calendar.secondaryLabel}</span>
+                      ) : null}
+                    </span>
+                    <Badge variant={isActive ? "default" : "outline"} className="rounded-full px-2 py-0 text-[10px]">
+                      {isActive ? "Aktiv" : "Aus"}
+                    </Badge>
+                  </button>
+                );
+              })}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="icon" onClick={() => handleNavigate("previous")}
+                  aria-label="Zurück">
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button variant="outline" onClick={handleToday} className="px-4">
+                  Heute
+                </Button>
+                <Button variant="outline" size="icon" onClick={() => handleNavigate("next")} aria-label="Vor">
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+              <div>
+                <p className="text-lg font-semibold text-foreground">{rangeLabel}</p>
+                <p className="text-sm text-muted-foreground">
+                  {view === "week"
+                    ? `Kalenderwoche ${format(currentDate, "I", { locale: de })}`
+                    : view === "day"
+                      ? format(currentDate, "EEEE", { locale: de })
+                      : view === "month"
+                        ? `Monat ${format(currentMonth, "MMMM", { locale: de })}`
+                        : `${agendaEvents.length} Termine in der Liste`}
+                </p>
+              </div>
+            </div>
+
+            <Tabs value={view} onValueChange={(value) => handleViewChange(value as CalendarView)} className="w-full md:w-auto">
+              <TabsList className="grid w-full grid-cols-4">
+                <TabsTrigger value="day">Tag</TabsTrigger>
+                <TabsTrigger value="week">Woche</TabsTrigger>
+                <TabsTrigger value="month" disabled={!isTablet}>
+                  Monat
+                </TabsTrigger>
+                <TabsTrigger value="agenda">Agenda</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+
+          <Card className="rounded-3xl border border-border/60 bg-card/80 shadow-sm">
+            <CardContent className="p-0">
+              {view === "month" ? (
+                <div className="p-4">
+                  <MonthCalendar
+                    month={currentMonth}
+                    onMonthChange={(next) => {
+                      setCurrentMonth(next);
+                      setCurrentDate(next);
+                    }}
+                    renderDay={renderDayCell}
+                    showWeekNumbers
+                    weekStartsOn={1}
+                    className="rounded-2xl border border-border/60"
+                    contentClassName="p-2"
+                  />
+                </div>
+              ) : null}
+
+              {view === "week" || view === "day" ? (
+                <div className="overflow-x-auto">
+                  <div className="min-w-[720px]">
+                    <WeekGrid buckets={bucketsForWeek} calendarMap={calendarMap} view={view} />
+                  </div>
+                </div>
+              ) : null}
+
+              {view === "agenda" ? (
+                <div className="divide-y divide-border/60">
+                  {agendaEvents.length ? (
+                    agendaEvents.map((event) => (
+                      <AgendaRow key={event.id} event={event} source={calendarMap.get(event.calendarId)} />
+                    ))
+                  ) : (
+                    <p className="p-6 text-sm text-muted-foreground">
+                      Für den ausgewählten Zeitraum sind keine Termine geplant.
+                    </p>
+                  )}
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card className="rounded-3xl border border-border/60 bg-card/70 shadow-sm lg:col-span-2">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base font-semibold">Bevorstehende Termine</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Die nächsten persönlichen Ereignisse aus allen aktiven Kalendern.
+            </p>
+          </CardHeader>
+          <CardContent className="divide-y divide-border/60">
+            {upcomingEvents.length ? (
+              upcomingEvents.map((event) => (
+                <AgendaRow key={`upcoming-${event.id}`} event={event} source={calendarMap.get(event.calendarId)} />
+              ))
+            ) : (
+              <p className="py-6 text-sm text-muted-foreground">Keine anstehenden Termine gefunden.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="rounded-3xl border border-border/60 bg-card/70 shadow-sm">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base font-semibold">Kalenderstatistiken</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Überblick über deine Aktivitäten in den letzten Monaten.
+            </p>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {summary.length ? (
+              summary.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-border/60 bg-background/70 px-3 py-2">
+                  <p className="text-sm font-semibold text-foreground">{item.label}</p>
+                  <p className="text-lg font-bold text-primary">{item.value}</p>
+                  {item.hint ? (
+                    <p className="text-xs text-muted-foreground">{item.hint}</p>
+                  ) : null}
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">Keine Statistiken verfügbar.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}
+
+interface WeekGridProps {
+  buckets: DayBucket[];
+  calendarMap: Map<string, MemberCalendarSource>;
+  view: CalendarView;
+}
+
+function WeekGrid({ buckets, calendarMap, view }: WeekGridProps) {
+  if (!buckets.length) {
+    return <p className="p-6 text-sm text-muted-foreground">Keine Termine in diesem Zeitraum.</p>;
+  }
+
+  const showWeekdays = view === "week";
+
+  return (
+    <div className="grid" style={{ gridTemplateColumns: `64px repeat(${buckets.length}, minmax(0, 1fr))` }}>
+      <div className="border-b border-border/60 bg-muted/30" />
+      {buckets.map((bucket, index) => (
+        <div key={formatISO(bucket.date, { representation: "date" })} className="border-b border-border/60 bg-muted/30 p-2">
+          <div className="flex flex-col">
+            {showWeekdays ? (
+              <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {WEEKDAY_LABELS[index] ?? format(bucket.date, "EEEE", { locale: de })}
+              </span>
+            ) : null}
+            <span className="text-lg font-semibold">
+              {format(bucket.date, "d.")}
+              <span className="ml-1 text-xs text-muted-foreground">{format(bucket.date, "MMM", { locale: de })}</span>
+            </span>
+          </div>
+        </div>
+      ))}
+
+      <div className="border-r border-border/60 bg-muted/20" />
+      {buckets.map((bucket) => (
+        <div key={`all-day-${bucket.date.toISOString()}`} className="border-r border-border/60 bg-muted/20 p-2">
+          {bucket.allDay.length ? (
+            <div className="space-y-2">
+              {bucket.allDay.map((event) => (
+                <InlineEvent key={event.id} event={event} source={calendarMap.get(event.calendarId)} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">Keine Ganztagesereignisse</p>
+          )}
+        </div>
+      ))}
+
+      {HOURS.map((hour) => (
+        <Fragment key={`hour-${hour}`}>
+          <div className="border-t border-border/60 px-2 py-4 text-right text-xs text-muted-foreground">
+            {format(setMinutes(setHours(new Date(), hour), 0), "HH:mm")}
+          </div>
+          {buckets.map((bucket) => (
+            <div key={`${bucket.date.toISOString()}-${hour}`} className="relative border-t border-border/60">
+              <HourCell hour={hour} bucket={bucket} calendarMap={calendarMap} />
+            </div>
+          ))}
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+interface HourCellProps {
+  hour: number;
+  bucket: DayBucket;
+  calendarMap: Map<string, MemberCalendarSource>;
+}
+
+function HourCell({ hour, bucket, calendarMap }: HourCellProps) {
+  if (!bucket.events.length) return null;
+  const dayStart = startOfDay(bucket.date);
+
+  const eventsStartingThisHour = bucket.events.filter((event) => {
+    const startsSameDay = isSameDay(event.startDate, bucket.date);
+    if (startsSameDay) {
+      return event.startDate.getHours() === hour;
+    }
+    return hour === 0 && event.startDate < dayStart;
+  });
+
+  return (
+    <>
+      {eventsStartingThisHour.map((event) => (
+        <TimedEvent
+          key={event.id}
+          event={event}
+          dayStart={dayStart}
+          calendarMap={calendarMap}
+        />
+      ))}
+    </>
+  );
+}
+
+interface TimedEventProps {
+  event: PositionedCalendarEvent;
+  dayStart: Date;
+  calendarMap: Map<string, MemberCalendarSource>;
+}
+
+function TimedEvent({ event, dayStart, calendarMap }: TimedEventProps) {
+  const width = 100 / event.layout.columns;
+  const left = event.layout.column * width;
+
+  const rawStart = differenceInMinutes(event.startDate, dayStart);
+  const rawEnd = differenceInMinutes(event.endDate, dayStart);
+  const startMinutes = Math.max(0, rawStart);
+  const endMinutes = Math.min(24 * 60, Math.max(rawEnd, startMinutes + 15));
+  const durationMinutes = Math.max(30, endMinutes - startMinutes);
+  const top = (startMinutes / (24 * 60)) * 100;
+  const height = (durationMinutes / (24 * 60)) * 100;
+
+  const source = calendarMap.get(event.calendarId);
+  const accentColor = source?.color ?? undefined;
+
+  return (
+    <div
+      className="absolute z-10 overflow-hidden rounded-xl border bg-background/90 p-2 text-xs shadow-md"
+      style={{
+        top: `${top}%`,
+        left: `${left}%`,
+        width: `${width}%`,
+        height: `${height}%`,
+        borderColor: accentColor,
+      }}
+    >
+      <p
+        className="line-clamp-2 font-semibold"
+        style={accentColor ? { color: accentColor } : undefined}
+      >
+        {event.title}
+      </p>
+      <p className="text-[11px] text-muted-foreground">
+        {format(event.startDate, "HH:mm", { locale: de })} – {format(event.endDate, "HH:mm", { locale: de })}
+      </p>
+      {event.location ? (
+        <p className="mt-1 flex items-center gap-1 text-[11px] text-muted-foreground">
+          <MapPin className="h-3 w-3" /> {event.location}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface InlineEventProps {
+  event: CalendarEventWithDates;
+  source?: MemberCalendarSource;
+}
+
+function InlineEvent({ event, source }: InlineEventProps) {
+  const accentColor = source?.color ?? null;
+  return (
+    <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-background/80 px-3 py-2 text-xs">
+      <span
+        className={cn("h-2 w-2 rounded-full", !accentColor && "bg-primary")}
+        style={accentColor ? { backgroundColor: accentColor } : undefined}
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium text-foreground">{event.title}</p>
+        <p className="text-[11px] text-muted-foreground">
+          Ganztägig{source ? ` • ${source.label}` : ""}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface AgendaRowProps {
+  event: CalendarEventWithDates;
+  source?: MemberCalendarSource;
+}
+
+function AgendaRow({ event, source }: AgendaRowProps) {
+  return (
+    <div className="flex flex-col gap-1 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-3">
+        <span
+          className="h-3 w-3 rounded-full"
+          style={{ backgroundColor: source?.color ?? "var(--primary)" }}
+          aria-hidden
+        />
+        <div>
+          <p className="text-sm font-semibold text-foreground">{event.title}</p>
+          <p className="text-xs text-muted-foreground">
+            {event.allDay
+              ? "Ganztägig"
+              : `${format(event.startDate, "EEE, d. MMM · HH:mm", { locale: de })} – ${format(event.endDate, "HH:mm", {
+                  locale: de,
+                })}`}
+            {event.location ? ` · ${event.location}` : ""}
+          </p>
+          {source ? (
+            <p className="text-xs text-muted-foreground/80">{source.label}</p>
+          ) : null}
+        </div>
+      </div>
+      {event.metadata?.attendanceStatus ? (
+        <Badge variant="outline" className="w-fit">
+          Status: {event.metadata.attendanceStatus}
+        </Badge>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/kalender/page.tsx
+++ b/src/app/(members)/mitglieder/kalender/page.tsx
@@ -1,0 +1,282 @@
+import { notFound } from "next/navigation";
+import { addMonths, subMonths, startOfDay } from "date-fns";
+
+import { PageHeader } from "@/components/members/page-header";
+import { prisma } from "@/lib/prisma";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+
+import { CalendarClient } from "./calendar-client";
+import type {
+  MemberCalendarEvent,
+  MemberCalendarSource,
+  MemberCalendarSummaryItem,
+} from "./types";
+
+const DEFAULT_REHEARSAL_COLOR = "#6366F1";
+const DEFAULT_BLOCKED_COLOR = "#F97316";
+const FALLBACK_DEPARTMENT_COLORS = [
+  "#0EA5E9",
+  "#8B5CF6",
+  "#10B981",
+  "#F97316",
+  "#F59E0B",
+];
+const CALENDAR_LOOKBACK_MONTHS = 3;
+const CALENDAR_LOOKAHEAD_MONTHS = 6;
+
+const ATTENDANCE_LABELS: Record<string, string> = {
+  yes: "Zusage",
+  no: "Absage",
+  maybe: "Unentschieden",
+  emergency: "Notfall",
+};
+
+function formatAttendance(value: string | null | undefined) {
+  if (!value) return null;
+  return ATTENDANCE_LABELS[value] ?? value;
+}
+
+export const dynamic = "force-dynamic";
+
+export default async function MitgliederKalenderPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.meine-proben");
+  if (!allowed) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        Kein Zugriff auf den persönlichen Kalender.
+      </div>
+    );
+  }
+
+  const userId = session.user?.id;
+  if (!userId) {
+    notFound();
+  }
+
+  const now = new Date();
+  const rangeStart = startOfDay(subMonths(now, CALENDAR_LOOKBACK_MONTHS));
+  const rangeEnd = startOfDay(addMonths(now, CALENDAR_LOOKAHEAD_MONTHS));
+
+  const memberships = await prisma.departmentMembership.findMany({
+    where: { userId },
+    include: {
+      department: { select: { id: true, name: true, color: true } },
+    },
+  });
+
+  const departmentIds = memberships.map((entry) => entry.departmentId);
+
+  const departmentEvents = departmentIds.length
+    ? await prisma.departmentEvent.findMany({
+        where: {
+          departmentId: { in: departmentIds },
+          start: { gte: rangeStart, lte: rangeEnd },
+        },
+        include: {
+          department: { select: { id: true, name: true, color: true } },
+        },
+        orderBy: { start: "asc" },
+      })
+    : [];
+
+  const [rehearsals, blockedDays] = await Promise.all([
+    prisma.rehearsal.findMany({
+      where: {
+        status: { not: "DRAFT" },
+        start: { gte: rangeStart, lte: rangeEnd },
+        OR: [
+          { attendance: { some: { userId } } },
+          { invitees: { some: { userId } } },
+        ],
+      },
+      include: {
+        attendance: {
+          where: { userId },
+          select: { status: true },
+        },
+      },
+      orderBy: { start: "asc" },
+    }),
+    prisma.blockedDay.findMany({
+      where: {
+        userId,
+        date: { gte: rangeStart, lte: rangeEnd },
+      },
+      orderBy: { date: "asc" },
+    }),
+  ]);
+
+  const calendarSources: MemberCalendarSource[] = [];
+  const calendarEvents: MemberCalendarEvent[] = [];
+
+  calendarSources.push({
+    id: "rehearsals",
+    label: "Meine Proben",
+    color: DEFAULT_REHEARSAL_COLOR,
+    type: "rehearsal",
+    secondaryLabel: "Einladungen & Teilnahmen",
+  });
+
+  for (const rehearsal of rehearsals) {
+    const attendanceStatus = rehearsal.attendance.at(0)?.status ?? null;
+    const normalizedEnd = rehearsal.end ?? rehearsal.start;
+    calendarEvents.push({
+      id: `rehearsal-${rehearsal.id}`,
+      calendarId: "rehearsals",
+      title: rehearsal.title,
+      start: rehearsal.start.toISOString(),
+      end: normalizedEnd.toISOString(),
+      allDay: false,
+      location: rehearsal.location,
+      description: rehearsal.description ?? null,
+      metadata: attendanceStatus
+        ? { attendanceStatus: formatAttendance(attendanceStatus) }
+        : undefined,
+    });
+  }
+
+  const departmentColorMap = new Map<string, string>();
+  let fallbackIndex = 0;
+  for (const membership of memberships) {
+    const existing = departmentColorMap.get(membership.departmentId);
+    if (!existing) {
+      const color =
+        membership.department?.color ??
+        FALLBACK_DEPARTMENT_COLORS[fallbackIndex % FALLBACK_DEPARTMENT_COLORS.length];
+      departmentColorMap.set(membership.departmentId, color);
+      fallbackIndex += 1;
+    }
+  }
+
+  const handledDepartments = new Set<string>();
+  for (const membership of memberships) {
+    if (handledDepartments.has(membership.departmentId)) continue;
+    handledDepartments.add(membership.departmentId);
+    const department = membership.department;
+    const color = departmentColorMap.get(membership.departmentId) ?? FALLBACK_DEPARTMENT_COLORS[0];
+    calendarSources.push({
+      id: `department:${membership.departmentId}`,
+      label: department?.name ?? "Gewerk",
+      color,
+      type: "department",
+      secondaryLabel: "Gewerk-Termine",
+    });
+  }
+
+  for (const event of departmentEvents) {
+    const calendarId = `department:${event.departmentId}`;
+    const color = departmentColorMap.get(event.departmentId);
+    if (color && !calendarSources.some((source) => source.id === calendarId)) {
+      calendarSources.push({
+        id: calendarId,
+        label: event.department?.name ?? "Gewerk",
+        color,
+        type: "department",
+        secondaryLabel: "Gewerk-Termine",
+      });
+    }
+    const end = event.end ?? event.start;
+    calendarEvents.push({
+      id: `department-event-${event.id}`,
+      calendarId,
+      title: event.title,
+      start: event.start.toISOString(),
+      end: end.toISOString(),
+      allDay: false,
+      location: event.location,
+      description: event.description ?? null,
+      metadata: {
+        departmentName: event.department?.name ?? null,
+      },
+    });
+  }
+
+  calendarSources.push({
+    id: "blocked",
+    label: "Meine Abwesenheiten",
+    color: DEFAULT_BLOCKED_COLOR,
+    type: "personal",
+    secondaryLabel: "Sperrungen & Urlaube",
+  });
+
+  for (const blocked of blockedDays) {
+    calendarEvents.push({
+      id: `blocked-${blocked.id}`,
+      calendarId: "blocked",
+      title: blocked.reason ? `Blockiert: ${blocked.reason}` : "Blockierter Tag",
+      start: blocked.date.toISOString(),
+      end: blocked.date.toISOString(),
+      allDay: true,
+      description: blocked.reason ?? null,
+    });
+  }
+
+  const upcoming = [...calendarEvents]
+    .filter((event) => {
+      const start = new Date(event.start);
+      return start >= now;
+    })
+    .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+
+  const nextEvent = upcoming.at(0) ?? null;
+
+  const summary: MemberCalendarSummaryItem[] = [
+    {
+      id: "rehearsal-count",
+      label: "Proben im Zeitraum",
+      value: String(rehearsals.length),
+      hint: "Eigene Einladungen und zugesagte Termine",
+    },
+    {
+      id: "department-count",
+      label: "Gewerk-Termine",
+      value: String(departmentEvents.length),
+      hint:
+        departmentColorMap.size === 1
+          ? "1 aktives Gewerk"
+          : `${departmentColorMap.size} aktive Gewerke`,
+    },
+    {
+      id: "blocked-count",
+      label: "Abwesenheiten",
+      value: String(blockedDays.length),
+      hint: "Eingetragene Sperrungen im Zeitraum",
+    },
+  ];
+
+  if (nextEvent) {
+    const source = calendarSources.find((entry) => entry.id === nextEvent.calendarId);
+    const dateFormatter = new Intl.DateTimeFormat("de-DE", {
+      dateStyle: "full",
+      timeStyle: nextEvent.allDay ? undefined : "short",
+    });
+    summary.push({
+      id: "next-event",
+      label: "Nächster Termin",
+      value: dateFormatter.format(new Date(nextEvent.start)),
+      hint: source ? source.label : undefined,
+    });
+  }
+
+  const breadcrumbs = [membersNavigationBreadcrumb("/mitglieder/kalender")].filter(Boolean);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Mein Kalender"
+        description="Plane deinen Vereinsalltag wie im Google Kalender: persönliche Proben, Gewerke-Termine und Sperrungen auf einen Blick."
+        breadcrumbs={breadcrumbs}
+      />
+
+      <CalendarClient
+        initialDate={now.toISOString()}
+        calendars={calendarSources}
+        events={calendarEvents}
+        summary={summary}
+      />
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/kalender/types.ts
+++ b/src/app/(members)/mitglieder/kalender/types.ts
@@ -1,0 +1,36 @@
+export type MemberCalendarSourceType =
+  | "rehearsal"
+  | "department"
+  | "personal";
+
+export interface MemberCalendarSource {
+  id: string;
+  label: string;
+  color: string;
+  type: MemberCalendarSourceType;
+  description?: string | null;
+  secondaryLabel?: string | null;
+}
+
+export interface MemberCalendarEvent {
+  id: string;
+  calendarId: string;
+  title: string;
+  start: string;
+  end: string | null;
+  allDay?: boolean;
+  location?: string | null;
+  description?: string | null;
+  metadata?: {
+    attendanceStatus?: string | null;
+    departmentName?: string | null;
+    sourceId?: string | null;
+  };
+}
+
+export interface MemberCalendarSummaryItem {
+  id: string;
+  label: string;
+  value: string;
+  hint?: string | null;
+}

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -144,6 +144,12 @@ const QUICK_ACTION_LINKS = [
     permissionKey: "mitglieder.profil",
   },
   {
+    href: "/mitglieder/kalender",
+    label: "Mein Kalender",
+    icon: CalendarRange,
+    permissionKey: "mitglieder.meine-proben",
+  },
+  {
     href: "/mitglieder/meine-proben",
     label: "Meine Proben",
     icon: CalendarCheck,

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -139,6 +139,16 @@ const RehearsalsIcon = createMembersNavIcon(
   </>,
 );
 
+const PersonalCalendarIcon = createMembersNavIcon(
+  <>
+    <rect x="3" y="4" width="18" height="17" rx="2" />
+    <path d="M8 2v4" />
+    <path d="M16 2v4" />
+    <path d="M3 10h18" />
+    <rect x="8" y="13" width="8" height="6" rx="1.5" />
+  </>,
+);
+
 const DepartmentsIcon = createMembersNavIcon(
   <>
     <rect x="5" y="4" width="14" height="16" rx="2" />
@@ -432,6 +442,12 @@ export const membersNavigation = [
     id: "assignments",
     label: "Proben & Gewerke",
     items: [
+      {
+        href: "/mitglieder/kalender",
+        label: "Mein Kalender",
+        permissionKey: "mitglieder.meine-proben",
+        icon: PersonalCalendarIcon,
+      },
       {
         href: "/mitglieder/meine-proben",
         label: "Meine Proben",


### PR DESCRIPTION
## Summary
- add personal calendar route that aggregates rehearsals, department events, and blocked days for the authenticated member
- build responsive calendar UI with month/week/day/agenda views and configurable source filters
- surface the new calendar in members navigation and dashboard quick actions

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d92ca3b618832dbad3fde619015066