### PR TITLE
Enable editing of existing productions

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -15,7 +15,7 @@ import { X } from "lucide-react";
 import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 
 import { updateOnboardingSettingsAction, updateProductionTimelineAction } from "../actions";
-import { SetActiveProductionForm } from "../production-forms-client";
+import { SetActiveProductionForm, UpdateProductionDialog } from "../production-forms-client";
 
 function formatShowTitle(show: { title: string | null; year: number }) {
   if (show.title && show.title.trim()) return show.title;
@@ -66,6 +66,14 @@ export default async function ProduktionDetailPage({
     : null;
   const whatsappLink = getOnboardingWhatsAppLink(show.meta);
   const onboardingRedirect = `/mitglieder/produktionen/${show.id}`;
+  const updateDialogShow = {
+    id: show.id,
+    year: show.year,
+    title: show.title,
+    synopsis: show.synopsis,
+    dates: show.dates,
+    revealedAt: show.revealedAt ? show.revealedAt.toISOString() : null,
+  };
 
   return (
     <div className="space-y-10">
@@ -78,9 +86,20 @@ export default async function ProduktionDetailPage({
               <p className="max-w-2xl text-sm text-muted-foreground">{show.synopsis}</p>
             ) : null}
           </div>
-          <Button asChild variant="outline" size="sm">
-            <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <UpdateProductionDialog
+              show={updateDialogShow}
+              redirectPath={`/mitglieder/produktionen/${show.id}`}
+              trigger={
+                <Button variant="outline" size="sm">
+                  Produktion bearbeiten
+                </Button>
+              }
+            />
+            <Button asChild variant="outline" size="sm">
+              <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
+            </Button>
+          </div>
         </div>
       </section>
 

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -200,6 +200,56 @@ export async function createProductionAction(formData: FormData): Promise<Produc
   }
 }
 
+export async function updateProductionAction(formData: FormData): Promise<ProductionActionResult> {
+  try {
+    const session = await requireAuth();
+    const allowed = await hasPermission(session.user, "mitglieder.produktionen");
+    if (!allowed) {
+      throw new Error("Du hast keinen Zugriff auf die Produktionsplanung.");
+    }
+
+    const showId = readString(formData, "showId", { label: "Produktion" });
+    const year = readInt(formData, "year", { label: "Jahr", min: 1900, max: 2200 });
+    const title = readOptionalString(formData, "title", { label: "Titel", minLength: 2, maxLength: 160 });
+    const synopsis = readOptionalString(formData, "synopsis", { label: "Kurzbeschreibung", minLength: 2, maxLength: 600 });
+    const startDate = parseOptionalDate(formData, "startDate", "Startdatum");
+    const endDate = parseOptionalDate(formData, "endDate", "Enddatum");
+    const revealDate = parseOptionalDate(formData, "revealDate", "Premierenankündigung");
+    const redirectPath = readOptionalString(formData, "redirectPath");
+
+    if (endDate && !startDate) {
+      throw new Error("Bitte gib auch ein Startdatum an, wenn du ein Enddatum festlegst.");
+    }
+    if (startDate && endDate && endDate < startDate) {
+      throw new Error("Das Enddatum darf nicht vor dem Startdatum liegen.");
+    }
+
+    const formatDateOnly = (date: Date) => date.toISOString().slice(0, 10);
+
+    await prisma.show.update({
+      where: { id: showId },
+      data: {
+        year,
+        title: title ?? null,
+        synopsis: synopsis ?? null,
+        dates:
+          startDate && endDate
+            ? `${formatDateOnly(startDate)}/${formatDateOnly(endDate)}`
+            : startDate
+                ? formatDateOnly(startDate)
+                : Prisma.JsonNull,
+        revealedAt: revealDate ?? null,
+      },
+    });
+
+    revalidateShow(showId, redirectPath, true);
+    return actionSuccess("Produktion wurde aktualisiert.");
+  } catch (error) {
+    console.error("updateProductionAction", error);
+    return actionFailure(error, "Produktion konnte nicht aktualisiert werden.");
+  }
+}
+
 export async function updateProductionTimelineAction(formData: FormData): Promise<void> {
   const redirectPath = parseRedirectPath(formData);
   try {

--- a/src/app/(members)/mitglieder/produktionen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/page.tsx
@@ -14,6 +14,7 @@ import {
   ClearActiveProductionForm,
   CreateProductionDialog,
   SetActiveProductionForm,
+  UpdateProductionDialog,
 } from "./production-forms-client";
 
 function formatShowTitle(show: { title: string | null; year: number }) {
@@ -37,7 +38,7 @@ export default async function ProduktionenPage() {
   const [shows, activeProduction] = await Promise.all([
     prisma.show.findMany({
       orderBy: { year: "desc" },
-      select: { id: true, year: true, title: true, synopsis: true },
+      select: { id: true, year: true, title: true, synopsis: true, dates: true, revealedAt: true },
     }),
     getActiveProduction(session.user?.id),
   ]);
@@ -214,6 +215,22 @@ export default async function ProduktionenPage() {
                         showTitle={title}
                         redirectPath="/mitglieder/produktionen"
                         isActive={isActive}
+                      />
+                      <UpdateProductionDialog
+                        show={{
+                          id: show.id,
+                          year: show.year,
+                          title: show.title,
+                          synopsis: show.synopsis,
+                          dates: show.dates,
+                          revealedAt: show.revealedAt ? show.revealedAt.toISOString() : null,
+                        }}
+                        redirectPath="/mitglieder/produktionen"
+                        trigger={
+                          <Button size="sm" variant="ghost" className="flex-shrink-0">
+                            Bearbeiten
+                          </Button>
+                        }
                       />
                       <Button asChild size="sm" variant="outline" className="flex-shrink-0">
                         <Link href={`/mitglieder/produktionen/${show.id}`}>Details anzeigen</Link>

--- a/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
@@ -22,9 +22,76 @@ import {
   clearActiveProductionAction,
   createProductionAction,
   setActiveProductionAction,
+  updateProductionAction,
 } from "./actions";
 
 const INITIAL_ACTION_STATE: ProductionActionResult = { ok: true };
+
+function formatDateInput(value: string | Date | null | undefined): string {
+  if (!value) return "";
+  const source = value instanceof Date ? value : new Date(value);
+  if (!Number.isNaN(source.getTime())) {
+    return source.toISOString().slice(0, 10);
+  }
+  if (typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return value;
+  }
+  return "";
+}
+
+function extractDateRangeInput(raw: unknown): { start: string; end: string } {
+  const fromArray = (values: unknown[]): { start: string; end: string } => {
+    const normalized = values
+      .map((value) => {
+        if (value && typeof value === "object" && "date" in (value as Record<string, unknown>)) {
+          return formatDateInput((value as Record<string, unknown>).date as string | Date | null | undefined);
+        }
+        return formatDateInput(value as string | Date | null | undefined);
+      })
+      .filter((value): value is string => Boolean(value));
+    if (normalized.length === 0) {
+      return { start: "", end: "" };
+    }
+    const sorted = [...normalized].sort();
+    return { start: sorted[0], end: sorted[sorted.length - 1] };
+  };
+
+  if (!raw) {
+    return { start: "", end: "" };
+  }
+
+  if (Array.isArray(raw)) {
+    return fromArray(raw);
+  }
+
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      return { start: "", end: "" };
+    }
+    if (trimmed.includes("/")) {
+      const [start, end] = trimmed.split("/", 2);
+      return { start: formatDateInput(start), end: formatDateInput(end) };
+    }
+    return { start: formatDateInput(trimmed), end: "" };
+  }
+
+  if (raw instanceof Date) {
+    return { start: formatDateInput(raw), end: formatDateInput(raw) };
+  }
+
+  if (typeof raw === "object") {
+    const candidate = raw as Record<string, unknown>;
+    const startCandidate = candidate.start ?? candidate.begin ?? candidate.from ?? candidate.date;
+    const endCandidate = candidate.end ?? candidate.until ?? candidate.to ?? candidate.finish;
+    return {
+      start: formatDateInput(startCandidate as string | Date | null | undefined),
+      end: formatDateInput(endCandidate as string | Date | null | undefined),
+    };
+  }
+
+  return { start: "", end: "" };
+}
 
 type CreateProductionFormProps = {
   suggestedYear: number;
@@ -272,5 +339,159 @@ export function ClearActiveProductionForm({ redirectPath, className }: ClearActi
         </p>
       ) : null}
     </form>
+  );
+}
+
+type UpdateProductionFormProps = {
+  show: {
+    id: string;
+    year: number;
+    title: string | null;
+    synopsis: string | null;
+    dates: unknown;
+    revealedAt: string | Date | null;
+  };
+  redirectPath: string;
+  onSuccess?: () => void;
+};
+
+export function UpdateProductionForm({ show, redirectPath, onSuccess }: UpdateProductionFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const action = useCallback(
+    async (_state: ProductionActionResult, formData: FormData) => {
+      return updateProductionAction(formData);
+    },
+    [],
+  );
+  const [state, formAction, isPending] = useActionState(action, INITIAL_ACTION_STATE);
+  const isInitialRender = useRef(true);
+
+  const { start: startDate, end: endDate } = extractDateRangeInput(show.dates);
+  const revealDate = formatDateInput(show.revealedAt);
+
+  useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+    if (!state.ok) {
+      toast.error(state.error);
+      return;
+    }
+    const message = state.message ?? "Produktion wurde aktualisiert.";
+    toast.success(message);
+    onSuccess?.();
+    formRef.current?.reset();
+  }, [state, onSuccess]);
+
+  return (
+    <form ref={formRef} action={formAction} className="grid gap-6">
+      <input type="hidden" name="showId" value={show.id} />
+      <input type="hidden" name="redirectPath" value={redirectPath} />
+      <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 sm:grid-cols-2">
+        <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Basisdaten
+        </legend>
+        <div className="space-y-1">
+          <label className="text-sm font-medium" htmlFor={`year-${show.id}`}>
+            Jahr
+          </label>
+          <Input
+            id={`year-${show.id}`}
+            type="number"
+            name="year"
+            min={1900}
+            max={2200}
+            defaultValue={show.year}
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-sm font-medium" htmlFor={`title-${show.id}`}>
+            Titel
+          </label>
+          <Input id={`title-${show.id}`} name="title" defaultValue={show.title ?? ""} maxLength={160} />
+        </div>
+        <div className="space-y-1 sm:col-span-2">
+          <label className="text-sm font-medium" htmlFor={`synopsis-${show.id}`}>
+            Kurzbeschreibung
+          </label>
+          <Textarea
+            id={`synopsis-${show.id}`}
+            name="synopsis"
+            rows={3}
+            maxLength={600}
+            defaultValue={show.synopsis ?? ""}
+            placeholder="Optionaler Teaser, Autor oder kurzes Motto."
+          />
+        </div>
+      </fieldset>
+
+      <details className="rounded-lg border border-border/60 bg-background/60 p-4 transition [&_summary::-webkit-details-marker]:hidden">
+        <summary className="flex cursor-pointer items-center justify-between text-sm font-semibold text-foreground">
+          <span>Timeline &amp; Kommunikation (optional)</span>
+          <span className="text-xs text-muted-foreground">Bereich öffnen</span>
+        </summary>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor={`startDate-${show.id}`}>
+              Startdatum
+            </label>
+            <Input id={`startDate-${show.id}`} type="date" name="startDate" defaultValue={startDate} />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor={`endDate-${show.id}`}>
+              Enddatum
+            </label>
+            <Input id={`endDate-${show.id}`} type="date" name="endDate" defaultValue={endDate} />
+          </div>
+          <div className="space-y-1 sm:col-span-2">
+            <label className="text-sm font-medium" htmlFor={`revealDate-${show.id}`}>
+              Premierenankündigung
+            </label>
+            <Input id={`revealDate-${show.id}`} type="date" name="revealDate" defaultValue={revealDate} />
+          </div>
+        </div>
+      </details>
+
+      <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col items-start gap-2 sm:items-end">
+          <Button type="submit" className="sm:w-auto" disabled={isPending}>
+            Produktion aktualisieren
+          </Button>
+          {!state.ok ? (
+            <p role="alert" aria-live="assertive" className="text-sm text-destructive">
+              {state.error}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </form>
+  );
+}
+
+type UpdateProductionDialogProps = {
+  show: UpdateProductionFormProps["show"];
+  redirectPath: string;
+  trigger?: ReactNode;
+};
+
+export function UpdateProductionDialog({ show, redirectPath, trigger }: UpdateProductionDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger ?? <Button>Produktion bearbeiten</Button>}</DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader className="space-y-2">
+          <DialogTitle>Produktion bearbeiten</DialogTitle>
+          <DialogDescription>
+            Aktualisiere Jahrgang, optionale Beschreibung sowie Zeitraum deiner Produktion. Änderungen werden
+            direkt im Workspace übernommen.
+          </DialogDescription>
+        </DialogHeader>
+        <UpdateProductionForm show={show} redirectPath={redirectPath} onSuccess={() => setOpen(false)} />
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
- add a dedicated server action for updating existing production metadata and revalidate the overview
- provide a client-side edit dialog with date parsing helpers and a prefilled update form
- surface edit entry points on the productions overview and detail header

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d92ce953cc832db1b1c53853df1b21