### PR TITLE
Wrap production creation forms in dialogs

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
@@ -10,6 +10,15 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { ProductionWorkspaceHeader } from "@/components/production/workspace-header";
 import { ProductionWorkspaceEmptyState } from "@/components/production/workspace-empty-state";
 
@@ -170,63 +179,72 @@ export default async function ProduktionsBesetzungPage() {
         summaryActions={summaryActions}
       />
 
-      <Card>
-        <CardHeader className="space-y-2">
-          <CardTitle className="text-lg font-semibold">Neue Rolle anlegen</CardTitle>
-          <p className="text-sm text-muted-foreground">Füge Figuren hinzu und definiere Reihenfolge, Farbe sowie optionale Notizen.</p>
-        </CardHeader>
-        <CardContent>
-          <form action={createCharacterAction} method="post" className="grid gap-6">
-            <input type="hidden" name="showId" value={show.id} />
-            <input type="hidden" name="redirectPath" value={currentPath} />
-            <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 md:grid-cols-2">
-              <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Basisdaten
-              </legend>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Name</label>
-                <Input name="name" placeholder="z.B. Protagonist" minLength={2} maxLength={120} required />
+      <div className="flex justify-end">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button size="sm">Rolle anlegen</Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>Neue Rolle anlegen</DialogTitle>
+              <DialogDescription>
+                Füge Figuren hinzu und definiere Reihenfolge, Farbe sowie optionale Notizen.
+              </DialogDescription>
+            </DialogHeader>
+            <form action={createCharacterAction} method="post" className="grid gap-6">
+              <input type="hidden" name="showId" value={show.id} />
+              <input type="hidden" name="redirectPath" value={currentPath} />
+              <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 md:grid-cols-2">
+                <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Basisdaten
+                </legend>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Name</label>
+                  <Input name="name" placeholder="z.B. Protagonist" minLength={2} maxLength={120} required />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Kurzname</label>
+                  <Input name="shortName" placeholder="Kurzlabel" maxLength={40} />
+                </div>
+                <div className="space-y-1 md:col-span-2">
+                  <label className="text-sm font-medium">Beschreibung</label>
+                  <Textarea name="description" rows={2} maxLength={500} placeholder="Charakterbeschreibung" />
+                </div>
+              </fieldset>
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Farbe</label>
+                  <input
+                    type="color"
+                    name="color"
+                    defaultValue="#7c3aed"
+                    className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Sortierung</label>
+                  <Input type="number" name="order" min={0} max={9999} placeholder="0" />
+                </div>
               </div>
               <div className="space-y-1">
-                <label className="text-sm font-medium">Kurzname</label>
-                <Input name="shortName" placeholder="Kurzlabel" maxLength={40} />
+                <label className="text-sm font-medium">Notiz</label>
+                <Textarea name="notes" rows={2} maxLength={500} placeholder="Interne Notiz" />
               </div>
-              <div className="space-y-1 md:col-span-2">
-                <label className="text-sm font-medium">Beschreibung</label>
-                <Textarea name="description" rows={2} maxLength={500} placeholder="Charakterbeschreibung" />
-              </div>
-            </fieldset>
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Farbe</label>
-                <input
-                  type="color"
-                  name="color"
-                  defaultValue="#7c3aed"
-                  className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
-                />
-              </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Sortierung</label>
-                <Input type="number" name="order" min={0} max={9999} placeholder="0" />
-              </div>
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Notiz</label>
-              <Textarea name="notes" rows={2} maxLength={500} placeholder="Interne Notiz" />
-            </div>
-            <div>
-              <Button type="submit">Rolle speichern</Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
+              <DialogFooter className="pt-2 sm:justify-end">
+                <Button type="submit">Rolle speichern</Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <section className="grid gap-6 xl:grid-cols-2">
         {show.characters.length === 0 ? (
           <Card>
             <CardContent>
-              <p className="text-sm text-muted-foreground">Noch keine Rollen angelegt. Lege eine neue Rolle über das Formular oben an.</p>
+              <p className="text-sm text-muted-foreground">
+                Noch keine Rollen angelegt. Nutze den Button &bdquo;Rolle anlegen&ldquo;, um die erste Figur zu erstellen.
+              </p>
             </CardContent>
           </Card>
         ) : (

--- a/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
@@ -10,6 +10,15 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { ProductionWorkspaceHeader } from "@/components/production/workspace-header";
 import { ProductionWorkspaceEmptyState } from "@/components/production/workspace-empty-state";
 
@@ -130,59 +139,64 @@ export default async function ProduktionsGewerkePage() {
         summaryActions={summaryActions}
       />
 
-      <Card>
-        <CardHeader className="space-y-2">
-          <CardTitle className="text-lg font-semibold">Neues Gewerk anlegen</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Definiere Verantwortungsbereiche mit Farben, Beschreibungen und optionalem Slug für eine bessere Orientierung.
-          </p>
-        </CardHeader>
-        <CardContent>
-          <form action={createDepartmentAction} className="grid gap-6">
-            <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
-            <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 sm:grid-cols-2">
-              <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Basisdaten
-              </legend>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Name</label>
-                <Input name="name" placeholder="z.B. Maske" required minLength={2} maxLength={80} />
-              </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Slug (optional)</label>
-                <Input name="slug" placeholder="maske" maxLength={80} />
-              </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Farbe</label>
-                <input
-                  type="color"
-                  name="color"
-                  defaultValue="#9333ea"
-                  className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
-                />
-              </div>
-              <div className="space-y-1 sm:col-span-2">
-                <span className="text-sm font-medium">Beitritt</span>
-                <label className="flex items-center gap-2 text-sm text-muted-foreground">
+      <div className="flex justify-end">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button size="sm">Gewerk anlegen</Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>Neues Gewerk anlegen</DialogTitle>
+              <DialogDescription>
+                Definiere Verantwortungsbereiche mit Farben, Beschreibungen und optionalem Slug für eine bessere Orientierung.
+              </DialogDescription>
+            </DialogHeader>
+            <form action={createDepartmentAction} className="grid gap-6">
+              <input type="hidden" name="redirectPath" value="/mitglieder/produktionen/gewerke" />
+              <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 sm:grid-cols-2">
+                <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Basisdaten
+                </legend>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Name</label>
+                  <Input name="name" placeholder="z.B. Maske" required minLength={2} maxLength={80} />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Slug (optional)</label>
+                  <Input name="slug" placeholder="maske" maxLength={80} />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Farbe</label>
                   <input
-                    type="checkbox"
-                    name="requiresApproval"
-                    className="h-4 w-4 rounded border border-border"
+                    type="color"
+                    name="color"
+                    defaultValue="#9333ea"
+                    className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
                   />
-                  Leitung muss neue Mitglieder bestätigen, bevor sie beitreten.
-                </label>
+                </div>
+                <div className="space-y-1 sm:col-span-2">
+                  <span className="text-sm font-medium">Beitritt</span>
+                  <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      name="requiresApproval"
+                      className="h-4 w-4 rounded border border-border"
+                    />
+                    Leitung muss neue Mitglieder bestätigen, bevor sie beitreten.
+                  </label>
+                </div>
+              </fieldset>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Beschreibung</label>
+                <Textarea name="description" rows={2} maxLength={2000} placeholder="Kurzbeschreibung für das Gewerk" />
               </div>
-            </fieldset>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Beschreibung</label>
-              <Textarea name="description" rows={2} maxLength={2000} placeholder="Kurzbeschreibung für das Gewerk" />
-            </div>
-            <div>
-              <Button type="submit">Gewerk speichern</Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
+              <DialogFooter className="pt-2 sm:justify-end">
+                <Button type="submit">Gewerk speichern</Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <div className="grid gap-6 xl:grid-cols-2">
         {departments.map((department) => {

--- a/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
@@ -10,6 +10,15 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { ProductionWorkspaceHeader } from "@/components/production/workspace-header";
 import { ProductionWorkspaceEmptyState } from "@/components/production/workspace-empty-state";
 
@@ -201,70 +210,79 @@ export default async function ProduktionsSzenenPage() {
         summaryActions={summaryActions}
       />
 
-      <Card>
-        <CardHeader className="space-y-2">
-          <CardTitle className="text-lg font-semibold">Neue Szene anlegen</CardTitle>
-          <p className="text-sm text-muted-foreground">Erfasse Orte, Tageszeiten, Reihenfolgen und Notizen, um den Szenenplan aktuell zu halten.</p>
-        </CardHeader>
-        <CardContent>
-          <form action={createSceneAction} method="post" className="grid gap-6">
-            <input type="hidden" name="showId" value={show.id} />
-            <input type="hidden" name="redirectPath" value={currentPath} />
-            <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 md:grid-cols-3">
-              <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Basisdaten
-              </legend>
+      <div className="flex justify-end">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button size="sm">Szene anlegen</Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>Neue Szene anlegen</DialogTitle>
+              <DialogDescription>
+                Erfasse Orte, Tageszeiten, Reihenfolgen und Notizen, um den Szenenplan aktuell zu halten.
+              </DialogDescription>
+            </DialogHeader>
+            <form action={createSceneAction} method="post" className="grid gap-6">
+              <input type="hidden" name="showId" value={show.id} />
+              <input type="hidden" name="redirectPath" value={currentPath} />
+              <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 md:grid-cols-3">
+                <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Basisdaten
+                </legend>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Nummer</label>
+                  <Input name="identifier" maxLength={40} placeholder="z.B. 1" />
+                </div>
+                <div className="space-y-1 md:col-span-2">
+                  <label className="text-sm font-medium">Titel</label>
+                  <Input name="title" maxLength={160} placeholder="z.B. Ankunft im Park" />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Ort</label>
+                  <Input name="location" maxLength={120} />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Tageszeit</label>
+                  <Input name="timeOfDay" maxLength={60} />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Slug</label>
+                  <Input name="slug" maxLength={80} placeholder="szene-1" />
+                </div>
+              </fieldset>
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Reihenfolge</label>
+                  <Input type="number" name="sequence" min={0} max={9999} />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Dauer (Minuten)</label>
+                  <Input type="number" name="duration" min={0} max={600} />
+                </div>
+              </div>
               <div className="space-y-1">
-                <label className="text-sm font-medium">Nummer</label>
-                <Input name="identifier" maxLength={40} placeholder="z.B. 1" />
-              </div>
-              <div className="space-y-1 md:col-span-2">
-                <label className="text-sm font-medium">Titel</label>
-                <Input name="title" maxLength={160} placeholder="z.B. Ankunft im Park" />
+                <label className="text-sm font-medium">Zusammenfassung</label>
+                <Textarea name="summary" rows={2} maxLength={600} />
               </div>
               <div className="space-y-1">
-                <label className="text-sm font-medium">Ort</label>
-                <Input name="location" maxLength={120} />
+                <label className="text-sm font-medium">Notizen</label>
+                <Textarea name="notes" rows={2} maxLength={400} />
               </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Tageszeit</label>
-                <Input name="timeOfDay" maxLength={60} />
-              </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Slug</label>
-                <Input name="slug" maxLength={80} placeholder="szene-1" />
-              </div>
-            </fieldset>
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Reihenfolge</label>
-                <Input type="number" name="sequence" min={0} max={9999} />
-              </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Dauer (Minuten)</label>
-                <Input type="number" name="duration" min={0} max={600} />
-              </div>
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Zusammenfassung</label>
-              <Textarea name="summary" rows={2} maxLength={600} />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium">Notizen</label>
-              <Textarea name="notes" rows={2} maxLength={400} />
-            </div>
-            <div>
-              <Button type="submit">Szene speichern</Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
+              <DialogFooter className="pt-2 sm:justify-end">
+                <Button type="submit">Szene speichern</Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <section className="space-y-6">
         {show.scenes.length === 0 ? (
           <Card>
             <CardContent>
-              <p className="text-sm text-muted-foreground">Noch keine Szenen erfasst. Lege eine Szene über das Formular oben an.</p>
+              <p className="text-sm text-muted-foreground">
+                Noch keine Szenen erfasst. Nutze den Button &bdquo;Szene anlegen&ldquo;, um den Ablaufplan zu starten.
+              </p>
             </CardContent>
           </Card>
         ) : (


### PR DESCRIPTION
## Summary
- replace the inline creation forms on the production Gewerke, Rollen und Szenen views with modal dialogs that open from explicit action buttons
- adjust the empty-state messaging to reference the new entry points

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d939803c88832dbb3e4b3ac6ed6a0d