### PR TITLE
Rename calendar labels to remove possessive phrasing

### DIFF
--- a/src/app/(members)/mitglieder/kalender/page.tsx
+++ b/src/app/(members)/mitglieder/kalender/page.tsx
@@ -266,7 +266,7 @@ export default async function MitgliederKalenderPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Mein Kalender"
+        title="Kalender"
         description="Plane deinen Vereinsalltag wie im Google Kalender: persönliche Proben, Gewerke-Termine und Sperrungen auf einen Blick."
         breadcrumbs={breadcrumbs}
       />

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -145,7 +145,7 @@ const QUICK_ACTION_LINKS = [
   },
   {
     href: "/mitglieder/kalender",
-    label: "Mein Kalender",
+    label: "Kalender",
     icon: CalendarRange,
     permissionKey: "mitglieder.meine-proben",
   },

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -444,7 +444,7 @@ export const membersNavigation = [
     items: [
       {
         href: "/mitglieder/kalender",
-        label: "Mein Kalender",
+        label: "Kalender",
         permissionKey: "mitglieder.meine-proben",
         icon: PersonalCalendarIcon,
       },


### PR DESCRIPTION
## Summary
- rename the members navigation entry from "Mein Kalender" to "Kalender"
- update the members dashboard quick action label to use the new wording
- adjust the calendar page header title to drop the possessive phrasing

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d9adf71a88832da0eeb18c5cde0d37