### PR TITLE
Respect Sperrliste freeze settings for block entries

### DIFF
--- a/src/app/api/block-days/__tests__/route.test.ts
+++ b/src/app/api/block-days/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+import type { NextRequest } from "next/server";
+import { BlockedDayKind } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ResolvedSperrlisteSettings } from "@/lib/sperrliste-settings";
+import { POST } from "../route";
+
+const {
+  createMock,
+  requireAuthMock,
+  hasPermissionMock,
+  readSettingsMock,
+  resolveSettingsMock,
+} = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  requireAuthMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
+  readSettingsMock: vi.fn(),
+  resolveSettingsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    blockedDay: {
+      create: createMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/rbac", () => ({
+  requireAuth: requireAuthMock,
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  hasPermission: hasPermissionMock,
+}));
+
+vi.mock("@/lib/sperrliste-settings", () => ({
+  DEFAULT_FREEZE_DAYS: 7,
+  readSperrlisteSettings: readSettingsMock,
+  resolveSperrlisteSettings: resolveSettingsMock,
+}));
+
+const createSettings = (freezeDays: number): ResolvedSperrlisteSettings => ({
+  id: "default",
+  freezeDays,
+  preferredWeekdays: [],
+  exceptionWeekdays: [],
+  holidaySource: { mode: "default", url: null, effectiveUrl: null },
+  holidayStatus: { status: "unknown", message: null, checkedAt: null },
+  updatedAt: null,
+  cacheKey: `default|${freezeDays}`,
+});
+
+describe("block days route", () => {
+  const createRequest = (body: unknown) => ({
+    json: async () => body,
+  }) as NextRequest;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-10T12:00:00.000Z"));
+
+    requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+    hasPermissionMock.mockResolvedValue(true);
+    readSettingsMock.mockResolvedValue(null);
+    resolveSettingsMock.mockReturnValue(createSettings(7));
+    createMock.mockResolvedValue({
+      id: "blocked-1",
+      date: new Date("2025-01-21T00:00:00.000Z"),
+      reason: null,
+      kind: BlockedDayKind.BLOCKED,
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects block days within the configured freeze window", async () => {
+    resolveSettingsMock.mockReturnValue(createSettings(10));
+
+    const response = await POST(
+      createRequest({
+        date: "2025-01-15",
+        reason: "Urlaub",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+
+    const payload = await response.json();
+    expect(payload.error).toContain("20. Januar 2025");
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("allows block days after the freeze window", async () => {
+    resolveSettingsMock.mockReturnValue(createSettings(10));
+
+    const response = await POST(
+      createRequest({
+        date: "2025-01-21",
+        reason: "Urlaub",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "blocked-1",
+      date: "2025-01-21",
+      reason: null,
+      kind: BlockedDayKind.BLOCKED,
+      createdAt: "2025-01-01T00:00:00.000Z",
+    });
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not enforce a freeze when configured with zero days", async () => {
+    resolveSettingsMock.mockReturnValue(createSettings(0));
+    createMock.mockResolvedValue({
+      id: "blocked-2",
+      date: new Date("2025-01-11T00:00:00.000Z"),
+      reason: null,
+      kind: BlockedDayKind.BLOCKED,
+      createdAt: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    const response = await POST(
+      createRequest({
+        date: "2025-01-11",
+        reason: null,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      id: "blocked-2",
+      date: "2025-01-11",
+      reason: null,
+      kind: BlockedDayKind.BLOCKED,
+      createdAt: "2025-01-01T00:00:00.000Z",
+    });
+  });
+});

--- a/src/app/api/block-days/route.ts
+++ b/src/app/api/block-days/route.ts
@@ -5,6 +5,11 @@ import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { z } from "zod";
 import {
+  DEFAULT_FREEZE_DAYS,
+  readSperrlisteSettings,
+  resolveSperrlisteSettings,
+} from "@/lib/sperrliste-settings";
+import {
   isoDate,
   normaliseReason,
   toDateOnly,
@@ -42,6 +47,32 @@ export async function GET() {
   return NextResponse.json(entries.map(toResponse));
 }
 
+async function resolveFreezeDays() {
+  try {
+    const record = await readSperrlisteSettings();
+    const resolved = resolveSperrlisteSettings(record);
+    return Number.isFinite(resolved.freezeDays)
+      ? Math.max(0, Math.floor(resolved.freezeDays))
+      : DEFAULT_FREEZE_DAYS;
+  } catch (error) {
+    console.error("[block-days:freeze]", error);
+    return DEFAULT_FREEZE_DAYS;
+  }
+}
+
+function formatFreezeDate(date: Date) {
+  try {
+    return new Intl.DateTimeFormat("de-DE", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    }).format(date);
+  } catch {
+    return date.toISOString().slice(0, 10);
+  }
+}
+
 export async function POST(request: Request) {
   const session = await requireAuth();
   const userId = (session.user as SessionUser)?.id;
@@ -75,19 +106,25 @@ export async function POST(request: Request) {
 
   const kind = payload.kind ?? BlockedDayKind.BLOCKED;
 
-  // Planning window: no blocks within next 7 days including today
   if (kind === BlockedDayKind.BLOCKED) {
     try {
-      const todayKey = new Date().toISOString().slice(0, 10);
-      const today = toDateOnly(todayKey);
-      const cutoff = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
-      if (blockDate.getTime() < cutoff.getTime()) {
-        return NextResponse.json(
-          { error: "Aus Planungsgründen können Sperrtermine erst ab einer Woche im Voraus eingetragen werden." },
-          { status: 400 }
-        );
+      const freezeDays = await resolveFreezeDays();
+      if (freezeDays > 0) {
+        const todayKey = new Date().toISOString().slice(0, 10);
+        const today = toDateOnly(todayKey);
+        const cutoff = new Date(today.getTime() + freezeDays * 24 * 60 * 60 * 1000);
+        if (blockDate.getTime() < cutoff.getTime()) {
+          return NextResponse.json(
+            {
+              error: `Aus Planungsgründen können Sperrtermine erst ab ${formatFreezeDate(cutoff)} eingetragen werden.`,
+            },
+            { status: 400 }
+          );
+        }
       }
-    } catch {}
+    } catch (error) {
+      console.error("[block-days:freeze-check]", error);
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary
- use the configured Sperrliste freezeDays in the block-days POST handler instead of a hard-coded week
- surface a localized cutoff date in the validation error and guard against settings lookup failures
- cover the freeze window logic with new unit tests for the block-days route

## Testing
- pnpm vitest run src/app/api/block-days/__tests__/route.test.ts
- pnpm lint
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dab1c3bbf4832db4e7599bb939846f