### PR TITLE
Clarify documentation for rehearsal analytics data requirements

### DIFF
--- a/docs/analytics-optimization.md
+++ b/docs/analytics-optimization.md
@@ -49,6 +49,7 @@ Die Heuristiken werden auf maximal sechs Empfehlungen begrenzt. Ergibt sich kein
 
 * Wird keine Datenbankverbindung hergestellt oder liefert keine der oben genannten Quellen Werte, bleiben die statischen Fallback-Einträge aktiv.
 * Sobald mindestens eine der Datenquellen Daten liefert, werden dynamische Insights berechnet. Reicht die Datenlage dennoch nicht für eine Empfehlung, greifen ebenfalls die Fallbacks.
+* Mock- oder Demo-Daten dienen ausschließlich als Notlösung für lokale Entwicklung oder Ausfallzeiten. In produktiven Umgebungen müssen die Statistiken vollständig aus den erfassten Messwerten generiert werden.
 
 ## Anpassung
 

--- a/docs/entwurf-und-analyse.md
+++ b/docs/entwurf-und-analyse.md
@@ -368,6 +368,9 @@ der Belastung.
 - Pro Szene: summierte Probenminuten, letzte Probe, Abdeckung pro Figur.
 
 - Pro Person: summierte Probenminuten/Frequenz im Zeitfenster.
+- Datenbasis: Alle Kennzahlen speisen sich aus den tatsächlich
+  protokollierten Nachbereitungsdaten. Statische Mockups oder
+  Platzhalterwerte sind nicht zulässig.
 
 - Exhaustion-Metrik:
 
@@ -375,8 +378,10 @@ der Belastung.
   oft/zu lange eingeplant ist.
 
 Akzeptanzkriterien: - Statistik aktualisiert sich nach Nachbereitung;
-Dashboard/Tooltip zeigt Kennzahlen. - Planungsansicht warnt bei
-Überschreitung definierter Richtwerte (konfigurierbar).
+Dashboard/Tooltip zeigt Kennzahlen aus persistierten Rehearsal-Logs. -
+Planungsansicht warnt bei Überschreitung definierter Richtwerte
+(konfigurierbar). - Mockup-Darstellungen gelten nur als Übergang, solange
+keine Datenbank angebunden ist, und müssen nach Go-Live entfernt werden.
 
 ## 6. Nicht-funktionale Anforderungen
 
@@ -1282,8 +1287,10 @@ korrekt - \[ \] Mehrfachbesetzungen/Understudy werden berücksichtigt
 - [ ] Reports: Minuten je Szene/Person, letzte Probe
 
 Akzeptanzkriterien - \[ \] Statistik aktualisiert sich nach
-Nachbereitung - \[ \] Planungssicht zeigt kumulierte Minuten und letzte
-Probe je Szene/Person
+Nachbereitung mit echten Persistenzdaten - \[ \] Planungssicht zeigt
+kumulierte Minuten und letzte Probe je Szene/Person - \[ \]
+Mockup-Daten werden höchstens für leere Zustände genutzt und verschwinden,
+sobald reale Statistiken verfügbar sind
 
 ### 11.5. Sprint 5 – Exhaustion & Planungswarnungen
 


### PR DESCRIPTION
## Summary
- clarify in the rehearsal analytics specification that statistics must source persisted rehearsal data and not rely on mockups
- reinforce that mock/demo analytics data are only temporary fallbacks and production environments must use real measurements

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dacd492158832da02a837301ff4759