### PR TITLE
Style onboarding dashboard refresh button

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
@@ -125,8 +125,8 @@ export function HeaderBar({
       {onRefresh ? (
         <Button
           type="button"
-          variant="ghost"
-          className="self-end text-sm text-muted-foreground hover:text-foreground"
+          variant="secondary"
+          className="self-end w-full border border-primary text-secondary-foreground hover:border-primary hover:text-secondary-foreground sm:w-auto"
           onClick={onRefresh}
           disabled={isRefreshing}
         >


### PR DESCRIPTION
## Summary
- style the onboarding dashboard refresh button to match the share button while highlighting it with an orange border

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dacdb5586c832d892517ec61fc8ca9