### PR TITLE
feat: support final rehearsal week end date

### DIFF
--- a/prisma/migrations/20250315000000_add_final_rehearsal_week_end/migration.sql
+++ b/prisma/migrations/20250315000000_add_final_rehearsal_week_end/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "Show"
+ADD COLUMN "finalRehearsalWeekEnd" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -378,6 +378,7 @@ model Show {
   posterUrl  String?
   revealedAt DateTime?
   finalRehearsalWeekStart DateTime?
+  finalRehearsalWeekEnd   DateTime?
   meta       Json?
   clues      Clue[]
   rehearsals Rehearsal[]

--- a/src/app/(members)/mitglieder/endproben-woche/actions.ts
+++ b/src/app/(members)/mitglieder/endproben-woche/actions.ts
@@ -7,6 +7,8 @@ import { hasPermission } from "@/lib/permissions";
 
 import { FINAL_WEEK_MANAGE_PERMISSION_KEY } from "./constants";
 
+const DAY_IN_MS = 86_400_000;
+
 type ReadOptions = {
   label?: string;
   minLength?: number;
@@ -124,12 +126,17 @@ async function ensureAssigneeExists(assigneeId: string): Promise<void> {
   }
 }
 
-function assertWithinFinalWeek(date: Date, weekStart: Date) {
+function assertWithinFinalWeek(date: Date, weekStart: Date, weekEnd?: Date | null) {
   const normalizedStart = normalizeDateOnly(weekStart);
-  const normalizedEnd = new Date(normalizedStart.getTime() + 6 * 86_400_000);
+  const normalizedEnd = weekEnd
+    ? normalizeDateOnly(weekEnd)
+    : new Date(normalizedStart.getTime() + 6 * DAY_IN_MS);
+  const effectiveEnd = normalizedEnd.getTime() >= normalizedStart.getTime()
+    ? normalizedEnd
+    : new Date(normalizedStart.getTime() + 6 * DAY_IN_MS);
   const dateIso = toDateIso(date);
   const startIso = toDateIso(normalizedStart);
-  const endIso = toDateIso(normalizedEnd);
+  const endIso = toDateIso(effectiveEnd);
   if (dateIso < startIso || dateIso > endIso) {
     throw new Error("Der Dienst muss innerhalb der definierten Endprobenwoche liegen.");
   }
@@ -169,7 +176,7 @@ export async function createFinalRehearsalDutyAction(formData: FormData): Promis
 
     const show = await prisma.show.findUnique({
       where: { id: showId },
-      select: { finalRehearsalWeekStart: true },
+      select: { finalRehearsalWeekStart: true, finalRehearsalWeekEnd: true },
     });
     if (!show) {
       throw new Error("Produktion wurde nicht gefunden.");
@@ -178,7 +185,7 @@ export async function createFinalRehearsalDutyAction(formData: FormData): Promis
       throw new Error("Für diese Produktion ist noch kein Start der Endprobenwoche hinterlegt.");
     }
 
-    assertWithinFinalWeek(date, show.finalRehearsalWeekStart);
+    assertWithinFinalWeek(date, show.finalRehearsalWeekStart, show.finalRehearsalWeekEnd);
 
     if (assigneeId) {
       await ensureAssigneeExists(assigneeId);

--- a/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
@@ -33,6 +33,8 @@ const selectClassName =
 const collapsibleClassName =
   "group rounded-lg border border-border/60 bg-background/70 p-4 shadow-sm transition [&_summary::-webkit-details-marker]:hidden";
 
+const DAY_IN_MS = 86_400_000;
+
 const dutyInclude = {
   assignee: { select: { id: true, firstName: true, lastName: true, name: true, email: true } },
   createdBy: { select: { id: true, firstName: true, lastName: true, name: true, email: true } },
@@ -75,10 +77,24 @@ function toDateIso(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
-function createWeekDays(start: Date): WeekDay[] {
+function createWeekDays(start: Date, end?: Date | null): WeekDay[] {
+  const normalizedStart = normalizeDateOnly(start);
+  const normalizedEnd = end
+    ? normalizeDateOnly(end)
+    : new Date(normalizedStart.getTime() + 6 * DAY_IN_MS);
+  const effectiveEnd = normalizedEnd.getTime() >= normalizedStart.getTime()
+    ? normalizedEnd
+    : normalizedStart;
+
+  const maxDays = 31;
+  const totalDays = Math.min(
+    maxDays,
+    Math.floor((effectiveEnd.getTime() - normalizedStart.getTime()) / DAY_IN_MS) + 1,
+  );
+
   const days: WeekDay[] = [];
-  for (let index = 0; index < 7; index += 1) {
-    const date = new Date(start.getTime() + index * 86_400_000);
+  for (let index = 0; index < totalDays; index += 1) {
+    const date = new Date(normalizedStart.getTime() + index * DAY_IN_MS);
     days.push({ iso: toDateIso(date), date, label: dayLabelFormatter.format(date) });
   }
   return days;
@@ -239,17 +255,35 @@ export default async function FinalRehearsalDutyPlanPage() {
     activeProductionId
       ? prisma.show.findUnique({
           where: { id: activeProductionId },
-          select: { id: true, title: true, year: true, finalRehearsalWeekStart: true },
+          select: {
+            id: true,
+            title: true,
+            year: true,
+            finalRehearsalWeekStart: true,
+            finalRehearsalWeekEnd: true,
+          },
         })
       : Promise.resolve(null),
     prisma.show.findFirst({
       where: { finalRehearsalWeekStart: { not: null } },
       orderBy: { finalRehearsalWeekStart: "desc" },
-      select: { id: true, title: true, year: true, finalRehearsalWeekStart: true },
+      select: {
+        id: true,
+        title: true,
+        year: true,
+        finalRehearsalWeekStart: true,
+        finalRehearsalWeekEnd: true,
+      },
     }),
     prisma.show.findFirst({
       orderBy: { year: "desc" },
-      select: { id: true, title: true, year: true, finalRehearsalWeekStart: true },
+      select: {
+        id: true,
+        title: true,
+        year: true,
+        finalRehearsalWeekStart: true,
+        finalRehearsalWeekEnd: true,
+      },
     }),
   ]);
 
@@ -309,7 +343,10 @@ export default async function FinalRehearsalDutyPlanPage() {
   const finalWeekStart = show?.finalRehearsalWeekStart
     ? normalizeDateOnly(new Date(show.finalRehearsalWeekStart))
     : null;
-  const weekDays = finalWeekStart ? createWeekDays(finalWeekStart) : [];
+  const finalWeekEnd = show?.finalRehearsalWeekEnd
+    ? normalizeDateOnly(new Date(show.finalRehearsalWeekEnd))
+    : null;
+  const weekDays = finalWeekStart ? createWeekDays(finalWeekStart, finalWeekEnd) : [];
   const weekIsoSet = new Set(weekDays.map((day) => day.iso));
 
   const dutiesByDay = new Map<string, DutyWithRelations[]>();
@@ -331,10 +368,13 @@ export default async function FinalRehearsalDutyPlanPage() {
       : `Produktion ${show.year}`
     : null;
   const startLabel = finalWeekStart ? dateLabelFormatter.format(finalWeekStart) : null;
-  const rangeLabel = finalWeekStart
-    ? `${rangeLabelFormatter.format(finalWeekStart)} – ${rangeLabelFormatter.format(
-        new Date(finalWeekStart.getTime() + 6 * 86_400_000),
-      )}`
+  const effectiveRangeEnd = finalWeekStart
+    ? finalWeekEnd && finalWeekEnd.getTime() >= finalWeekStart.getTime()
+      ? finalWeekEnd
+      : new Date(finalWeekStart.getTime() + 6 * DAY_IN_MS)
+    : null;
+  const rangeLabel = finalWeekStart && effectiveRangeEnd
+    ? `${rangeLabelFormatter.format(finalWeekStart)} – ${rangeLabelFormatter.format(effectiveRangeEnd)}`
     : null;
   const breadcrumbs = [
     membersNavigationBreadcrumb("/mitglieder/endproben-woche/dienstplan"),
@@ -355,7 +395,7 @@ export default async function FinalRehearsalDutyPlanPage() {
           <CardContent className="space-y-4 text-sm text-muted-foreground">
             <p>
               Aktuell ist keine Produktion verfügbar. Lege in der Produktionsplanung eine Produktion an und
-              hinterlege den Start der Endprobenwoche, um den Dienstplan zu aktivieren.
+              hinterlege den Zeitraum der Endprobenwoche, um den Dienstplan zu aktivieren.
             </p>
             {canManage ? (
               <Button asChild>
@@ -383,13 +423,17 @@ export default async function FinalRehearsalDutyPlanPage() {
               <ClipboardList className="h-5 w-5 text-primary" />
               Überblick Endprobenwoche
             </CardTitle>
-            {startLabel ? (
+            {rangeLabel ? (
+              <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
+                Zeitraum {rangeLabel}
+              </Badge>
+            ) : startLabel ? (
               <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
                 Start {startLabel}
               </Badge>
             ) : (
               <Badge variant="outline" className="border-warning/60 bg-warning/10 text-warning">
-                Startdatum fehlt
+                Zeitraum fehlt
               </Badge>
             )}
           </div>
@@ -435,7 +479,7 @@ export default async function FinalRehearsalDutyPlanPage() {
             <div className="flex items-start gap-3 rounded-lg border border-warning/40 bg-warning/5 p-3 text-xs text-warning">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
               <div>
-                Hinterlege bei der Produktionserstellung im Bereich „Produktionen“ den Start der Endprobenwoche, um den
+                Hinterlege bei der Produktion im Bereich „Produktionen“ den Zeitraum der Endprobenwoche, um den
                 Dienstplan zeitlich einzuordnen.
               </div>
             </div>
@@ -566,17 +610,17 @@ export default async function FinalRehearsalDutyPlanPage() {
           <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-2 text-warning">
               <AlertTriangle className="h-5 w-5" />
-              <CardTitle className="text-lg font-semibold">Start der Endprobenwoche fehlt</CardTitle>
+              <CardTitle className="text-lg font-semibold">Zeitraum der Endprobenwoche fehlt</CardTitle>
             </div>
             {canManage ? (
               <Button asChild variant="outline" size="sm">
-                <Link href="/mitglieder/produktionen">Startdatum festlegen</Link>
+                <Link href="/mitglieder/produktionen">Zeitraum festlegen</Link>
               </Button>
             ) : null}
           </CardHeader>
           <CardContent className="text-sm text-muted-foreground">
             <p>
-              Hinterlege bei der Produktionserstellung im Bereich „Produktionen“ den Beginn der Endprobenwoche. Danach
+              Hinterlege bei der Produktion im Bereich „Produktionen“ den Beginn und das Ende der Endprobenwoche. Danach
               kannst du die Dienste pro Tag strukturieren und Verantwortliche zuweisen.
             </p>
           </CardContent>

--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/meal-plan-context.ts
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/meal-plan-context.ts
@@ -103,12 +103,15 @@ type MealPlanDay = {
 
 type BuildMealPlanArgs = {
   startDate: Date | null;
+  endDate: Date | null;
   styleSummaries: StyleSummary[];
   criticalAllergens: Set<string>;
   dishes: PlannerRecipe[];
 };
 
 export const DISH_LIBRARY: PlannerRecipe[] = [];
+
+const DAY_IN_MS = 86_400_000;
 
 
 function pickDishForStyle(
@@ -156,7 +159,7 @@ function pickDishForStyle(
   return dishes[0];
 }
 
-function buildMealPlan({ startDate, styleSummaries, criticalAllergens, dishes }: BuildMealPlanArgs): MealPlanDay[] {
+function buildMealPlan({ startDate, endDate, styleSummaries, criticalAllergens, dishes }: BuildMealPlanArgs): MealPlanDay[] {
   const focusList = styleSummaries.length
     ? styleSummaries
     : [
@@ -173,12 +176,19 @@ function buildMealPlan({ startDate, styleSummaries, criticalAllergens, dishes }:
         },
       ];
 
-  const dayCount = 5;
   const formatter = new Intl.DateTimeFormat("de-DE", { weekday: "long", day: "2-digit", month: "2-digit" });
+  const effectiveEnd = startDate
+    ? endDate && endDate.getTime() >= startDate.getTime()
+      ? endDate
+      : new Date(startDate.getTime() + 4 * DAY_IN_MS)
+    : null;
+  const dayCount = startDate && effectiveEnd
+    ? Math.min(14, Math.floor((effectiveEnd.getTime() - startDate.getTime()) / DAY_IN_MS) + 1)
+    : 5;
 
   if (dishes.length === 0) {
     return Array.from({ length: dayCount }, (_, dayIndex) => {
-      const date = startDate ? new Date(startDate.getTime() + dayIndex * 86_400_000) : null;
+      const date = startDate ? new Date(startDate.getTime() + dayIndex * DAY_IN_MS) : null;
       const label = date ? formatter.format(date) : `Tag ${dayIndex + 1}`;
 
       return {
@@ -193,7 +203,7 @@ function buildMealPlan({ startDate, styleSummaries, criticalAllergens, dishes }:
   const used = new Set<string>();
 
   return Array.from({ length: dayCount }, (_, dayIndex) => {
-    const date = startDate ? new Date(startDate.getTime() + dayIndex * 86_400_000) : null;
+    const date = startDate ? new Date(startDate.getTime() + dayIndex * DAY_IN_MS) : null;
     const label = date ? formatter.format(date) : `Tag ${dayIndex + 1}`;
     const entries = MEAL_SLOTS.map((slot, slotIndex) => {
       const focus = focusList[(dayIndex + slotIndex) % focusList.length];
@@ -219,7 +229,13 @@ function buildMealPlan({ startDate, styleSummaries, criticalAllergens, dishes }:
 
 
 export type MealPlanningContext = {
-  show: { id: string; title: string | null; year: number; finalRehearsalWeekStart: Date | null } | null;
+  show: {
+    id: string;
+    title: string | null;
+    year: number;
+    finalRehearsalWeekStart: Date | null;
+    finalRehearsalWeekEnd: Date | null;
+  } | null;
   participants: ParticipantDietProfile[];
   totalParticipants: number;
   strictParticipants: number;
@@ -249,7 +265,13 @@ export async function loadMealPlanningContext(userId?: string | null): Promise<M
     activeProductionId
       ? prisma.show.findUnique({
           where: { id: activeProductionId },
-          select: { id: true, title: true, year: true, finalRehearsalWeekStart: true },
+          select: {
+            id: true,
+            title: true,
+            year: true,
+            finalRehearsalWeekStart: true,
+            finalRehearsalWeekEnd: true,
+          },
         })
       : Promise.resolve(null),
     prisma.memberOnboardingProfile.findMany({
@@ -284,11 +306,23 @@ export async function loadMealPlanningContext(userId?: string | null): Promise<M
       (await prisma.show.findFirst({
         where: { finalRehearsalWeekStart: { not: null } },
         orderBy: { finalRehearsalWeekStart: "desc" },
-        select: { id: true, title: true, year: true, finalRehearsalWeekStart: true },
+        select: {
+          id: true,
+          title: true,
+          year: true,
+          finalRehearsalWeekStart: true,
+          finalRehearsalWeekEnd: true,
+        },
       })) ??
       (await prisma.show.findFirst({
         orderBy: { year: "desc" },
-        select: { id: true, title: true, year: true, finalRehearsalWeekStart: true },
+        select: {
+          id: true,
+          title: true,
+          year: true,
+          finalRehearsalWeekStart: true,
+          finalRehearsalWeekEnd: true,
+        },
       }));
   }
 
@@ -471,6 +505,7 @@ export async function loadMealPlanningContext(userId?: string | null): Promise<M
 
   const mealPlan = buildMealPlan({
     startDate: show?.finalRehearsalWeekStart ?? null,
+    endDate: show?.finalRehearsalWeekEnd ?? null,
     styleSummaries,
     criticalAllergens: criticalAllergensSet,
     dishes: DISH_LIBRARY,

--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
@@ -38,6 +38,8 @@ const ALLERGY_LEVEL_LABELS: Record<AllergyLevel, string> = {
   LETHAL: "Kritisch",
 };
 
+const DAY_IN_MS = 86_400_000;
+
 type Metric = {
   label: string;
   value: string;
@@ -77,9 +79,10 @@ export default async function EssensplanungPage() {
     ? new Intl.DateTimeFormat("de-DE", { dateStyle: "long" }).format(finalWeekStart)
     : null;
   const finalWeekCountdown = finalWeekStart
-    ? Math.max(0, Math.ceil((finalWeekStart.getTime() - Date.now()) / 86_400_000))
+    ? Math.max(0, Math.ceil((finalWeekStart.getTime() - Date.now()) / DAY_IN_MS))
     : null;
-  const finalWeekEnd = finalWeekStart ? new Date(finalWeekStart.getTime() + 6 * 86_400_000) : null;
+  const finalWeekEnd =
+    show?.finalRehearsalWeekEnd ?? (finalWeekStart ? new Date(finalWeekStart.getTime() + 6 * DAY_IN_MS) : null);
   const finalWeekRangeLabel = finalWeekStart && finalWeekEnd
     ? `${new Intl.DateTimeFormat("de-DE", { day: "2-digit", month: "2-digit" }).format(finalWeekStart)} – ${new Intl.DateTimeFormat("de-DE", { day: "2-digit", month: "2-digit" }).format(finalWeekEnd)}`
     : null;

--- a/src/app/(members)/mitglieder/endproben-woche/menueplan/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/menueplan/page.tsx
@@ -41,6 +41,8 @@ const ALLERGY_LEVEL_LABELS: Record<AllergyLevel, string> = {
 
 export const dynamic = "force-dynamic";
 
+const DAY_IN_MS = 86_400_000;
+
 export default async function MenueplanPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.essenplanung");
@@ -62,7 +64,8 @@ export default async function MenueplanPage() {
   } = await loadMealPlanningContext(session.user?.id);
 
   const finalWeekStart = show?.finalRehearsalWeekStart ?? null;
-  const finalWeekEnd = finalWeekStart ? new Date(finalWeekStart.getTime() + 6 * 86_400_000) : null;
+  const finalWeekEnd =
+    show?.finalRehearsalWeekEnd ?? (finalWeekStart ? new Date(finalWeekStart.getTime() + 6 * DAY_IN_MS) : null);
   const finalWeekRangeLabel = finalWeekStart && finalWeekEnd
     ? `${new Intl.DateTimeFormat("de-DE", { day: "2-digit", month: "2-digit" }).format(finalWeekStart)} – ${new Intl.DateTimeFormat("de-DE", { day: "2-digit", month: "2-digit" }).format(finalWeekEnd)}`
     : null;

--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -61,9 +61,22 @@ export default async function ProduktionDetailPage({
   const finalRehearsalWeekStartValue = show.finalRehearsalWeekStart
     ? show.finalRehearsalWeekStart.toISOString().slice(0, 10)
     : "";
+  const finalRehearsalWeekEndValue = show.finalRehearsalWeekEnd
+    ? show.finalRehearsalWeekEnd.toISOString().slice(0, 10)
+    : "";
   const finalRehearsalWeekStartLabel = show.finalRehearsalWeekStart
     ? new Intl.DateTimeFormat("de-DE", { dateStyle: "long" }).format(show.finalRehearsalWeekStart)
     : null;
+  const finalRehearsalWeekEndLabel = show.finalRehearsalWeekEnd
+    ? new Intl.DateTimeFormat("de-DE", { dateStyle: "long" }).format(show.finalRehearsalWeekEnd)
+    : null;
+  const finalRehearsalWeekRangeLabel = finalRehearsalWeekStartLabel && finalRehearsalWeekEndLabel
+    ? `Aktueller Zeitraum: ${finalRehearsalWeekStartLabel} – ${finalRehearsalWeekEndLabel}`
+    : finalRehearsalWeekStartLabel
+      ? `Aktueller Start: ${finalRehearsalWeekStartLabel}`
+      : finalRehearsalWeekEndLabel
+        ? `Aktuelles Ende: ${finalRehearsalWeekEndLabel}`
+        : null;
   const whatsappLink = getOnboardingWhatsAppLink(show.meta);
   const onboardingRedirect = `/mitglieder/produktionen/${show.id}`;
   const updateDialogShow = {
@@ -159,7 +172,7 @@ export default async function ProduktionDetailPage({
         <CardHeader className="space-y-2">
           <CardTitle className="text-lg font-semibold">Endprobenwoche</CardTitle>
           <p className="text-sm text-muted-foreground">
-            Hinterlege den Start der großen Endprobenwoche. Mitglieder sehen darauf basierend einen Countdown
+            Hinterlege den Zeitraum der großen Endprobenwoche. Mitglieder sehen darauf basierend einen Countdown
             im Dashboard.
           </p>
         </CardHeader>
@@ -180,10 +193,21 @@ export default async function ProduktionDetailPage({
                 />
               </div>
               <p className="text-xs text-muted-foreground">
-                {finalRehearsalWeekStartLabel
-                  ? `Aktueller Start: ${finalRehearsalWeekStartLabel}`
-                  : "Kein Datum hinterlegt."}
+                {finalRehearsalWeekRangeLabel ?? "Kein Zeitraum hinterlegt."}
               </p>
+            </div>
+            <div className="space-y-2 sm:max-w-xs">
+              <div className="space-y-1">
+                <label className="text-sm font-medium" htmlFor="finalRehearsalWeekEnd">
+                  Ende der Endprobenwoche
+                </label>
+                <Input
+                  id="finalRehearsalWeekEnd"
+                  type="date"
+                  name="finalRehearsalWeekEnd"
+                  defaultValue={finalRehearsalWeekEndValue}
+                />
+              </div>
             </div>
             <Button type="submit" className="sm:w-auto">
               Zeitplan aktualisieren

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -132,6 +132,24 @@ export async function createProductionAction(formData: FormData): Promise<Produc
       "finalRehearsalWeekStart",
       "Start der Endprobenwoche",
     );
+    const finalRehearsalWeekEnd = parseOptionalDate(
+      formData,
+      "finalRehearsalWeekEnd",
+      "Ende der Endprobenwoche",
+    );
+
+    if (finalRehearsalWeekEnd && !finalRehearsalWeekStart) {
+      throw new Error(
+        "Bitte gib auch ein Startdatum an, wenn du ein Enddatum für die Endprobenwoche festlegst.",
+      );
+    }
+    if (
+      finalRehearsalWeekStart &&
+      finalRehearsalWeekEnd &&
+      finalRehearsalWeekEnd.getTime() < finalRehearsalWeekStart.getTime()
+    ) {
+      throw new Error("Das Ende der Endprobenwoche darf nicht vor dem Start liegen.");
+    }
     const setActive = parseCheckbox(formData.get("setActive"));
     const redirectPath = readOptionalString(formData, "redirectPath");
 
@@ -157,6 +175,7 @@ export async function createProductionAction(formData: FormData): Promise<Produc
                 : Prisma.JsonNull,
         revealedAt: revealDate ?? null,
         finalRehearsalWeekStart: finalRehearsalWeekStart ?? null,
+        finalRehearsalWeekEnd: finalRehearsalWeekEnd ?? null,
       },
       select: { id: true },
     });
@@ -215,6 +234,16 @@ export async function updateProductionAction(formData: FormData): Promise<Produc
     const startDate = parseOptionalDate(formData, "startDate", "Startdatum");
     const endDate = parseOptionalDate(formData, "endDate", "Enddatum");
     const revealDate = parseOptionalDate(formData, "revealDate", "Premierenankündigung");
+    const finalRehearsalWeekStart = parseOptionalDate(
+      formData,
+      "finalRehearsalWeekStart",
+      "Start der Endprobenwoche",
+    );
+    const finalRehearsalWeekEnd = parseOptionalDate(
+      formData,
+      "finalRehearsalWeekEnd",
+      "Ende der Endprobenwoche",
+    );
     const redirectPath = readOptionalString(formData, "redirectPath");
 
     if (endDate && !startDate) {
@@ -239,6 +268,8 @@ export async function updateProductionAction(formData: FormData): Promise<Produc
                 ? formatDateOnly(startDate)
                 : Prisma.JsonNull,
         revealedAt: revealDate ?? null,
+        finalRehearsalWeekStart: finalRehearsalWeekStart ?? null,
+        finalRehearsalWeekEnd: finalRehearsalWeekEnd ?? null,
       },
     });
 
@@ -265,10 +296,31 @@ export async function updateProductionTimelineAction(formData: FormData): Promis
       "finalRehearsalWeekStart",
       "Start der Endprobenwoche",
     );
+    const finalRehearsalWeekEnd = parseOptionalDate(
+      formData,
+      "finalRehearsalWeekEnd",
+      "Ende der Endprobenwoche",
+    );
+
+    if (finalRehearsalWeekEnd && !finalRehearsalWeekStart) {
+      throw new Error(
+        "Bitte gib auch ein Startdatum an, wenn du ein Enddatum für die Endprobenwoche festlegst.",
+      );
+    }
+    if (
+      finalRehearsalWeekStart &&
+      finalRehearsalWeekEnd &&
+      finalRehearsalWeekEnd.getTime() < finalRehearsalWeekStart.getTime()
+    ) {
+      throw new Error("Das Ende der Endprobenwoche darf nicht vor dem Start liegen.");
+    }
 
     await prisma.show.update({
       where: { id: showId },
-      data: { finalRehearsalWeekStart: finalRehearsalWeekStart ?? null },
+      data: {
+        finalRehearsalWeekStart: finalRehearsalWeekStart ?? null,
+        finalRehearsalWeekEnd: finalRehearsalWeekEnd ?? null,
+      },
     });
 
     revalidateShow(showId, redirectPath, true);

--- a/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
@@ -171,9 +171,13 @@ export function CreateProductionForm({
             <label className="text-sm font-medium">Enddatum</label>
             <Input type="date" name="endDate" />
           </div>
-          <div className="space-y-1 sm:col-span-2">
+          <div className="space-y-1">
             <label className="text-sm font-medium">Beginn der Endprobenwoche</label>
             <Input type="date" name="finalRehearsalWeekStart" />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Ende der Endprobenwoche</label>
+            <Input type="date" name="finalRehearsalWeekEnd" />
           </div>
           <div className="space-y-1 sm:col-span-2">
             <label className="text-sm font-medium">Premierenankündigung</label>

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -50,7 +50,13 @@ export async function GET() {
     const activeProductionPromise = activeProductionId
       ? prisma.show.findUnique({
           where: { id: activeProductionId },
-          select: { id: true, title: true, year: true, finalRehearsalWeekStart: true },
+          select: {
+            id: true,
+            title: true,
+            year: true,
+            finalRehearsalWeekStart: true,
+            finalRehearsalWeekEnd: true,
+          },
         })
       : null;
 
@@ -233,6 +239,7 @@ export async function GET() {
           title: activeProduction.title,
           year: activeProduction.year,
           startDate: activeProduction.finalRehearsalWeekStart.toISOString(),
+          endDate: activeProduction.finalRehearsalWeekEnd?.toISOString() ?? null,
         }
       : null;
 

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -63,6 +63,7 @@ interface FinalRehearsalWeekInfo {
   title: string | null;
   year: number;
   startDate: Date;
+  endDate: Date | null;
 }
 
 const INITIAL_STATS: DashboardStats = {
@@ -92,6 +93,8 @@ type MetricItem = {
 
 const DASHBOARD_CARD_SURFACE =
   "rounded-3xl border border-border/60 bg-gradient-to-br from-background via-background/95 to-background shadow-lg shadow-primary/5 backdrop-blur";
+
+const DAY_IN_MS = 86_400_000;
 
 const DASHBOARD_CARD_ACCENT =
   "rounded-3xl border border-primary/45 bg-gradient-to-br from-primary/12 via-background/95 to-background shadow-xl shadow-primary/10 backdrop-blur";
@@ -290,6 +293,8 @@ function parseFinalRehearsalWeek(value: unknown): FinalRehearsalWeekInfo | null 
   const startDate = parseIsoDate(value.startDate);
   if (!startDate) return null;
 
+  const endDate = parseIsoDate(value.endDate);
+
   const title = typeof value.title === "string" && value.title.trim() ? value.title : null;
   const yearRaw = value.year;
   const year =
@@ -302,6 +307,7 @@ function parseFinalRehearsalWeek(value: unknown): FinalRehearsalWeekInfo | null 
     title,
     year,
     startDate,
+    endDate,
   };
 }
 
@@ -643,13 +649,26 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     const showLabel = finalRehearsalWeek.title
       ? finalRehearsalWeek.title
       : `Produktion ${finalRehearsalWeek.year}`;
-    const formattedDate = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(startDate);
+    const formatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+    const startDay = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+    const endDay = finalRehearsalWeek.endDate
+      ? new Date(
+          finalRehearsalWeek.endDate.getFullYear(),
+          finalRehearsalWeek.endDate.getMonth(),
+          finalRehearsalWeek.endDate.getDate(),
+        )
+      : null;
+    const formattedStart = formatter.format(startDay);
+    const formattedEnd = endDay ? formatter.format(endDay) : null;
+    const rangeHint = formattedEnd
+      ? `${showLabel} · ${formattedStart} – ${formattedEnd}`
+      : `${showLabel} · Start am ${formattedStart}`;
+    const effectiveEnd = endDay ?? new Date(startDay.getTime() + 6 * DAY_IN_MS);
 
     const now = new Date();
     const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    const startDay = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
     const diffMs = startDay.getTime() - today.getTime();
-    const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+    const diffDays = Math.round(diffMs / DAY_IN_MS);
 
     if (diffDays > 0) {
       let tone: "info" | "warning" | "destructive" = "info";
@@ -661,7 +680,7 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
       return {
         label: "Tage bis Endprobenwoche",
         value: diffDays,
-        hint: `${showLabel} · Start am ${formattedDate}`,
+        hint: rangeHint,
         tone,
       } as const;
     }
@@ -670,15 +689,24 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
       return {
         label: "Endprobenwoche",
         value: "Heute",
-        hint: `${showLabel} · Start am ${formattedDate}`,
+        hint: rangeHint,
+        tone: "warning" as const,
+      };
+    }
+
+    if (effectiveEnd.getTime() >= today.getTime()) {
+      return {
+        label: "Endprobenwoche",
+        value: "Läuft",
+        hint: rangeHint,
         tone: "warning" as const,
       };
     }
 
     return {
       label: "Endprobenwoche",
-      value: "Gestartet",
-      hint: `${showLabel} · Start am ${formattedDate}`,
+      value: "Abgeschlossen",
+      hint: rangeHint,
       tone: "positive" as const,
     };
   }, [finalRehearsalWeek]);

--- a/src/lib/active-production.ts
+++ b/src/lib/active-production.ts
@@ -14,6 +14,7 @@ type ActiveMembership = {
     title: string | null;
     year: number;
     finalRehearsalWeekStart: Date | null;
+    finalRehearsalWeekEnd: Date | null;
   };
 };
 
@@ -52,6 +53,7 @@ async function resolveFallbackActiveProductionId(userId: string | null | undefin
           title: true,
           year: true,
           finalRehearsalWeekStart: true,
+          finalRehearsalWeekEnd: true,
         },
       },
     },

--- a/src/lib/onboarding/dashboard-service.ts
+++ b/src/lib/onboarding/dashboard-service.ts
@@ -113,12 +113,13 @@ function deriveStatus(
   show: {
     revealedAt: Date | null;
     finalRehearsalWeekStart: Date | null;
+    finalRehearsalWeekEnd: Date | null;
   },
   range: DateRange,
 ): { status: OnboardingSummary["status"]; label: string } {
   const now = new Date();
   const start = range.start ?? show.revealedAt ?? null;
-  const end = range.end ?? show.finalRehearsalWeekStart ?? null;
+  const end = range.end ?? show.finalRehearsalWeekEnd ?? show.finalRehearsalWeekStart ?? null;
 
   if (!show.revealedAt || isAfter(now, show.revealedAt) === false) {
     return { status: "draft", label: "In Vorbereitung" };
@@ -355,6 +356,7 @@ async function computeOnboardingDashboardData(
       dates: true,
       revealedAt: true,
       finalRehearsalWeekStart: true,
+      finalRehearsalWeekEnd: true,
       meta: true,
       onboardingProfiles: {
         select: {


### PR DESCRIPTION
## Summary
- add a nullable `finalRehearsalWeekEnd` column and migration for shows
- expose start/end controls in production forms with validation and timeline updates
- update dashboard widgets and endproben-woche tools to honour the configured range

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68daccc4c7ec832da0884497ebe2af81