### PR TITLE
Refresh meal planning layouts for rehearsal week

### DIFF
--- a/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChefHat, Share2 } from "lucide-react";
+import { ChefHat, Grid3x3, ListChecks, Share2, type LucideIcon } from "lucide-react";
 
 import { PageHeader } from "@/components/members/page-header";
 import { ShoppingListBoard } from "@/components/members/shopping-list-board";
@@ -16,6 +16,23 @@ import {
   loadMealPlanningContext,
 } from "../essenplanung/meal-plan-context";
 import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+
+const DEFAULT_CATEGORY_LABEL = "Sonstiges";
+
+type Metric = {
+  label: string;
+  value: string;
+  hint: string;
+  icon: LucideIcon;
+  accent: string;
+};
+
+function formatCategoryLabel(value?: string | null) {
+  if (!value) return DEFAULT_CATEGORY_LABEL;
+  const trimmed = value.trim();
+  if (!trimmed) return DEFAULT_CATEGORY_LABEL;
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
 
 export const dynamic = "force-dynamic";
 
@@ -34,11 +51,15 @@ export default async function EinkaufslistePage() {
     session.user?.id,
   );
   const assignments: PlannerAssignments = {};
+  const uniqueDishIds = new Set<string>();
+  let filledSlots = 0;
   for (const day of plannerDays) {
     const dayAssignments: Record<string, string | null | undefined> = {};
     for (const slot of day.slots) {
       if (slot.dishId) {
         dayAssignments[slot.slot] = slot.dishId;
+        uniqueDishIds.add(slot.dishId);
+        filledSlots += 1;
       }
     }
     assignments[day.key] = dayAssignments;
@@ -50,12 +71,39 @@ export default async function EinkaufslistePage() {
     participantCount: defaultParticipantCount,
   });
   const hasGeneratedItems = shoppingList.length > 0;
+  const categoryCount = new Set(
+    shoppingList.map((item) => formatCategoryLabel(item.category)),
+  ).size;
   const breadcrumbs = [
     membersNavigationBreadcrumb("/mitglieder/endproben-woche/einkaufsliste"),
   ];
+  const numberFormatter = new Intl.NumberFormat("de-DE");
+  const metrics: Metric[] = [
+    {
+      label: "Menüs fixiert",
+      value: numberFormatter.format(uniqueDishIds.size),
+      hint: `${numberFormatter.format(filledSlots)} Slots gefüllt`,
+      icon: ChefHat,
+      accent: "border-primary/40 bg-primary/10 text-primary ring-primary/20",
+    },
+    {
+      label: "Artikel in Arbeit",
+      value: numberFormatter.format(shoppingList.length),
+      hint: hasGeneratedItems ? "Automatisch aggregiert" : "Wartet auf Rezepte",
+      icon: ListChecks,
+      accent: "border-sky-400/40 bg-sky-500/10 text-sky-500 ring-sky-500/20",
+    },
+    {
+      label: "Kategorien",
+      value: numberFormatter.format(categoryCount),
+      hint: categoryCount > 0 ? "Strukturierte Einkaufspfade" : "Noch keine Zuordnung",
+      icon: Grid3x3,
+      accent: "border-emerald-400/40 bg-emerald-500/10 text-emerald-500 ring-emerald-500/20",
+    },
+  ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8 lg:space-y-10">
       <PageHeader
         title="Einkaufsliste"
         description="Die automatisch aggregierten Mengen aus der Essensplanung – inklusive eigener Ergänzungen und optionalem Sharing-Link."
@@ -75,10 +123,54 @@ export default async function EinkaufslistePage() {
         }
       />
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,0.65fr)_minmax(0,0.35fr)] xl:items-start">
-        <div className="space-y-4">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.65fr)_minmax(0,0.35fr)] lg:items-start 2xl:gap-8">
+        <div className="space-y-6">
+          <Card className="relative overflow-hidden rounded-3xl border border-primary/30 bg-background/95 shadow-[0_24px_65px_rgba(59,130,246,0.14)]">
+            <div className="pointer-events-none absolute inset-0">
+              <div className="absolute -left-16 top-10 h-40 w-40 rounded-full bg-primary/15 blur-3xl" />
+              <div className="absolute -right-12 bottom-4 h-32 w-32 rounded-full bg-sky-500/15 blur-3xl" />
+            </div>
+            <CardHeader className="relative space-y-3">
+              <div className="flex items-center gap-2 text-primary">
+                <Share2 className="h-5 w-5" />
+                <CardTitle className="text-base font-semibold">Planungsüberblick</CardTitle>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Die Kennzahlen beziehen sich auf die aktuell hinterlegten Menüs und aggregierten Zutatenmengen. Aktualisiere die Essensplanung, um den Überblick in Echtzeit anzupassen.
+              </p>
+            </CardHeader>
+            <CardContent className="relative">
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {metrics.map((metric) => {
+                  const Icon = metric.icon;
+                  return (
+                    <div
+                      key={metric.label}
+                      className="relative overflow-hidden rounded-2xl border border-border/60 bg-background/95 p-4 shadow-sm ring-4 ring-transparent transition hover:border-primary/40 hover:ring-primary/10"
+                    >
+                      <div className="absolute -right-8 -top-8 h-20 w-20 rounded-full bg-primary/5 blur-2xl" aria-hidden />
+                      <div className="relative flex items-start gap-3">
+                        <div
+                          className={`flex h-10 w-10 items-center justify-center rounded-full border text-primary ring-4 ${metric.accent}`}
+                        >
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            {metric.label}
+                          </p>
+                          <p className="text-xl font-semibold text-foreground">{metric.value}</p>
+                          <p className="text-xs text-muted-foreground">{metric.hint}</p>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
           {!hasGeneratedItems ? (
-            <Card className="border border-dashed border-border/60 bg-background/80">
+            <Card className="rounded-3xl border border-dashed border-border/60 bg-background/80">
               <CardHeader className="space-y-2">
                 <div className="flex items-center gap-2 text-primary">
                   <ChefHat className="h-5 w-5" />
@@ -108,8 +200,8 @@ export default async function EinkaufslistePage() {
           ) : null}
           <ShoppingListBoard initialItems={shoppingList} />
         </div>
-        <div className="space-y-4">
-          <Card className="border border-border/60 bg-background/80">
+        <div className="space-y-6 lg:sticky lg:top-24">
+          <Card className="rounded-3xl border border-border/60 bg-background/80">
             <CardHeader>
               <CardTitle className="text-base font-semibold">Hinweis zu Kategorien</CardTitle>
             </CardHeader>

--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
@@ -144,7 +144,7 @@ export default async function EssensplanungPage() {
   );
 
   return (
-    <div className="space-y-8 xl:space-y-10">
+    <div className="space-y-8 lg:space-y-10">
       <PageHeader
         title="Essensplanung"
         description="Plane die Verpflegung der Endprobenwoche abgestimmt auf Ernährungsstile, Allergien und Portionen – inklusive eigener Rezeptideen."
@@ -152,9 +152,9 @@ export default async function EssensplanungPage() {
         quickActions={quickActions}
       />
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.68fr)_minmax(0,0.32fr)] xl:items-start">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.68fr)_minmax(0,0.32fr)] lg:items-start 2xl:gap-8">
         <div className="space-y-6">
-          <Card className="relative overflow-hidden border border-primary/30 bg-background/95 shadow-[0_30px_80px_rgba(59,130,246,0.15)]">
+          <Card className="relative overflow-hidden rounded-3xl border border-primary/30 bg-background/95 shadow-[0_30px_80px_rgba(59,130,246,0.15)]">
             <div className="pointer-events-none absolute inset-0">
               <div className="absolute -left-20 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-primary/20 blur-3xl" />
               <div className="absolute -right-12 top-10 h-48 w-48 rounded-full bg-sky-500/15 blur-3xl" />
@@ -192,7 +192,7 @@ export default async function EssensplanungPage() {
               </div>
             </CardHeader>
             <CardContent className="relative space-y-5">
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
                 {metrics.map((metric) => {
                   const Icon = metric.icon;
                   return (
@@ -257,7 +257,7 @@ export default async function EssensplanungPage() {
             </CardContent>
           </Card>
 
-          <Card className="relative overflow-hidden border border-border/70 bg-background/90 shadow-sm">
+          <Card className="relative overflow-hidden rounded-3xl border border-border/70 bg-background/90 shadow-sm">
             <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent" />
             <CardHeader className="relative space-y-3">
               <div className="flex items-center gap-2 text-primary">
@@ -305,8 +305,8 @@ export default async function EssensplanungPage() {
           </section>
         </div>
 
-        <div className="space-y-6">
-          <Card className="border border-border/70 bg-background/90 shadow-sm">
+        <div className="space-y-6 lg:sticky lg:top-24">
+          <Card className="rounded-3xl border border-border/70 bg-background/90 shadow-sm">
             <CardHeader className="space-y-3 pb-0">
               <div className="flex items-center gap-2 text-primary">
                 <Palette className="h-5 w-5" />
@@ -363,7 +363,7 @@ export default async function EssensplanungPage() {
             </CardContent>
           </Card>
 
-          <Card className="border border-border/70 bg-background/90 shadow-sm">
+          <Card className="rounded-3xl border border-border/70 bg-background/90 shadow-sm">
             <CardHeader className="space-y-3 pb-0">
               <div className="flex items-center gap-2 text-destructive">
                 <ShieldAlert className="h-5 w-5" />
@@ -424,7 +424,7 @@ export default async function EssensplanungPage() {
             </CardContent>
           </Card>
 
-          <Card className="border border-border/70 bg-background/90 shadow-sm">
+          <Card className="rounded-3xl border border-border/70 bg-background/90 shadow-sm">
             <CardHeader className="space-y-3 pb-0">
               <div className="flex items-center gap-2 text-primary">
                 <UserCheck className="h-5 w-5" />

--- a/src/app/(members)/mitglieder/endproben-woche/menueplan/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/menueplan/page.tsx
@@ -78,7 +78,7 @@ export default async function MenueplanPage() {
   const topAllergens = allergenSummaries.slice(0, 5);
 
   return (
-    <div className="space-y-8 xl:space-y-10">
+    <div className="space-y-8 lg:space-y-10">
       <PageHeader
         title="Menüplan"
         description="Frühstück, Mittag und Abendbrot der Endprobenwoche im Überblick – inklusive Fokus-Stilen, Highlights und kritischen Hinweisen."
@@ -104,9 +104,9 @@ export default async function MenueplanPage() {
         }
       />
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.68fr)_minmax(0,0.32fr)] xl:items-start">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.68fr)_minmax(0,0.32fr)] lg:items-start 2xl:gap-8">
         <div className="space-y-6">
-          <Card className="border border-border/70 bg-background/90 shadow-sm">
+          <Card className="rounded-3xl border border-border/70 bg-background/90 shadow-sm">
             <CardHeader className="space-y-3">
               <div className="flex items-center gap-2 text-primary">
                 <Sparkles className="h-5 w-5" />
@@ -146,7 +146,7 @@ export default async function MenueplanPage() {
           {mealPlan.map((day) => (
             <Card
               key={day.key}
-              className="relative overflow-hidden border border-border/70 bg-background/95 shadow-[0_18px_45px_rgba(15,23,42,0.18)]"
+              className="relative overflow-hidden rounded-3xl border border-border/70 bg-background/95 shadow-[0_18px_45px_rgba(15,23,42,0.18)]"
             >
               <div className="pointer-events-none absolute inset-0">
                 <div className="absolute -left-16 top-12 h-40 w-40 rounded-full bg-primary/15 blur-3xl" />
@@ -243,8 +243,8 @@ export default async function MenueplanPage() {
           ))}
         </div>
 
-        <div className="space-y-6">
-          <Card className="border border-border/70 bg-background/90 shadow-sm">
+        <div className="space-y-6 lg:sticky lg:top-24">
+          <Card className="rounded-3xl border border-border/70 bg-background/90 shadow-sm">
             <CardHeader className="space-y-3 pb-0">
               <div className="flex items-center gap-2 text-primary">
                 <ChefHat className="h-5 w-5" />
@@ -301,7 +301,7 @@ export default async function MenueplanPage() {
             </CardContent>
           </Card>
 
-          <Card className="border border-border/70 bg-background/90 shadow-sm">
+          <Card className="rounded-3xl border border-border/70 bg-background/90 shadow-sm">
             <CardHeader className="space-y-3 pb-0">
               <div className="flex items-center gap-2 text-destructive">
                 <ShieldAlert className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- polish the Essensplanung dashboard with rounded hero metrics, improved grid breakpoints, and sticky insights cards
- align the Menüplan overview styling with the refreshed Essensplanung layout for a consistent responsive experience
- add a metrics summary and updated responsive layout to the Einkaufsliste, including computed counts for dishes, items, and categories

## Testing
- pnpm lint
- pnpm test
- CI=1 FORCE_COLOR=0 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dacc4f16e8832da8ae498144adc3ca