### PR TITLE
Add document management and multi-assignee support for Gewerke

### DIFF
--- a/prisma/migrations/20250301000000_department_task_documents/migration.sql
+++ b/prisma/migrations/20250301000000_department_task_documents/migration.sql
@@ -1,0 +1,47 @@
+-- CreateTable
+CREATE TABLE "public"."DepartmentTaskAssignment" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DepartmentTaskAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."DepartmentDocument" (
+    "id" TEXT NOT NULL,
+    "departmentId" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "data" BYTEA NOT NULL,
+    "uploadedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "DepartmentDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DepartmentTaskAssignment_taskId_userId_key" ON "public"."DepartmentTaskAssignment"("taskId", "userId");
+
+-- CreateIndex
+CREATE INDEX "DepartmentTaskAssignment_userId_idx" ON "public"."DepartmentTaskAssignment"("userId");
+
+-- CreateIndex
+CREATE INDEX "DepartmentDocument_departmentId_createdAt_idx" ON "public"."DepartmentDocument"("departmentId", "createdAt");
+
+-- Copy existing single assignments
+INSERT INTO "public"."DepartmentTaskAssignment" ("id", "taskId", "userId", "createdAt")
+SELECT md5("DepartmentTask"."id" || ':' || "DepartmentTask"."assigneeId" || ':' || now()::text), "DepartmentTask"."id", "DepartmentTask"."assigneeId", COALESCE("DepartmentTask"."updatedAt", CURRENT_TIMESTAMP)
+FROM "public"."DepartmentTask"
+WHERE "DepartmentTask"."assigneeId" IS NOT NULL;
+
+-- Drop old foreign key and column
+ALTER TABLE "public"."DepartmentTask" DROP CONSTRAINT IF EXISTS "DepartmentTask_assigneeId_fkey";
+DROP INDEX IF EXISTS "DepartmentTask_assigneeId_idx";
+ALTER TABLE "public"."DepartmentTask" DROP COLUMN IF EXISTS "assigneeId";
+
+-- Add foreign keys for new tables
+ALTER TABLE "public"."DepartmentTaskAssignment" ADD CONSTRAINT "DepartmentTaskAssignment_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "public"."DepartmentTask"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."DepartmentTaskAssignment" ADD CONSTRAINT "DepartmentTaskAssignment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."DepartmentDocument" ADD CONSTRAINT "DepartmentDocument_departmentId_fkey" FOREIGN KEY ("departmentId") REFERENCES "public"."Department"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."DepartmentDocument" ADD CONSTRAINT "DepartmentDocument_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -300,10 +300,11 @@ model User {
   rehearsalInvites       RehearsalInvitee[]
   photoConsent           PhotoConsent?
   approvedPhotoConsents  PhotoConsent[] @relation("PhotoConsentApprover")
-  departmentMemberships  DepartmentMembership[]
-  departmentTasksAssigned DepartmentTask[] @relation("DepartmentTaskAssignee")
-  departmentTasksCreated  DepartmentTask[] @relation("DepartmentTaskCreator")
-  departmentEventsCreated DepartmentEvent[]
+  departmentMemberships        DepartmentMembership[]
+  departmentTaskAssignments    DepartmentTaskAssignment[]
+  departmentTasksCreated       DepartmentTask[] @relation("DepartmentTaskCreator")
+  departmentEventsCreated      DepartmentEvent[]
+  departmentDocumentsUploaded  DepartmentDocument[]
   characterCastings      CharacterCasting[]
   breakdownAssignments   SceneBreakdownItem[] @relation("BreakdownAssignee")
   inviteLinksCreated     MemberInvite[]       @relation("MemberInvitesCreated")
@@ -429,6 +430,7 @@ model Department {
   tasks        DepartmentTask[]
   permissions  DepartmentPermission[]
   events       DepartmentEvent[]
+  documents    DepartmentDocument[]
 }
 
 model DepartmentMembership {
@@ -453,17 +455,27 @@ model DepartmentTask {
   description   String?
   status        TaskStatus @default(todo)
   dueAt         DateTime?
-  assigneeId    String?
   createdById   String
   createdAt     DateTime   @default(now())
   updatedAt     DateTime   @updatedAt
   department    Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
-  assignee      User?      @relation("DepartmentTaskAssignee", fields: [assigneeId], references: [id], onDelete: SetNull)
   creator       User       @relation("DepartmentTaskCreator", fields: [createdById], references: [id], onDelete: Cascade)
+  assignments   DepartmentTaskAssignment[]
 
   @@index([departmentId, status])
-  @@index([assigneeId])
   @@index([createdAt])
+}
+
+model DepartmentTaskAssignment {
+  id        String   @id @default(cuid())
+  taskId    String
+  userId    String
+  createdAt DateTime @default(now())
+  task      DepartmentTask @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([taskId, userId])
+  @@index([userId])
 }
 
 model DepartmentPermission {
@@ -491,6 +503,21 @@ model DepartmentEvent {
   createdBy     User       @relation(fields: [createdById], references: [id], onDelete: Cascade)
 
   @@index([departmentId, start])
+}
+
+model DepartmentDocument {
+  id            String     @id @default(cuid())
+  departmentId  String
+  fileName      String
+  mimeType      String
+  fileSize      Int
+  data          Bytes
+  uploadedById  String?
+  createdAt     DateTime   @default(now())
+  department    Department @relation(fields: [departmentId], references: [id], onDelete: Cascade)
+  uploadedBy    User?      @relation(fields: [uploadedById], references: [id], onDelete: SetNull)
+
+  @@index([departmentId, createdAt])
 }
 
 model Character {

--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -74,13 +74,17 @@ export default async function GewerkDetailPage({ params }: PageProps) {
           },
           tasks: {
             include: {
-              assignee: {
-                select: {
-                  id: true,
-                  name: true,
-                  email: true,
-                  firstName: true,
-                  lastName: true,
+              assignments: {
+                include: {
+                  user: {
+                    select: {
+                      id: true,
+                      name: true,
+                      email: true,
+                      firstName: true,
+                      lastName: true,
+                    },
+                  },
                 },
               },
             },
@@ -99,6 +103,20 @@ export default async function GewerkDetailPage({ params }: PageProps) {
               },
             },
             orderBy: { start: "asc" },
+          },
+          documents: {
+            include: {
+              uploadedBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  firstName: true,
+                  lastName: true,
+                },
+              },
+            },
+            orderBy: { createdAt: "desc" },
           },
         },
       },
@@ -251,6 +269,10 @@ export default async function GewerkDetailPage({ params }: PageProps) {
     membership.department.description ??
     "Alle Aufgaben, Termine und Teamkontakte dieses Gewerks im Fokus.";
 
+  const refreshPath = membership.department.slug
+    ? `/mitglieder/meine-gewerke/${encodeURIComponent(membership.department.slug)}`
+    : "/mitglieder/meine-gewerke";
+
   const hero = (
     <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-background/70 p-6 shadow-[0_28px_90px_-50px_rgba(99,102,241,0.8)] sm:p-10">
       <div aria-hidden className="pointer-events-none absolute inset-0">
@@ -348,6 +370,7 @@ export default async function GewerkDetailPage({ params }: PageProps) {
         planningWindowLabel={planningWindowLabel}
         now={now}
         measurementsByUser={departmentMeasurementsByUser}
+        refreshPath={refreshPath}
       />
     </div>
   );

--- a/src/app/(members)/mitglieder/meine-gewerke/department-card.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/department-card.tsx
@@ -32,6 +32,7 @@ import {
   isCastDepartmentUser,
 } from "./utils";
 import { CreateDepartmentEventButton } from "./department-event-create-button";
+import { DepartmentDocumentsSection } from "./department-documents-section";
 
 export type DepartmentMeasurementEntry = {
   id: string;
@@ -56,6 +57,7 @@ type DepartmentCardProps = {
   teamLinkHref?: string;
   teamLinkLabel?: string;
   measurementsByUser?: DepartmentMeasurementsByUser;
+  refreshPath: string;
 };
 
 export function DepartmentCard({
@@ -70,6 +72,7 @@ export function DepartmentCard({
   teamLinkHref,
   teamLinkLabel = "Team öffnen",
   measurementsByUser,
+  refreshPath,
 }: DepartmentCardProps) {
   const { department } = membership;
   const isEnsembleDepartment = department.slug?.toLowerCase() === "ensemble";
@@ -106,6 +109,9 @@ export function DepartmentCard({
   );
   const blockedDatesCount = countBlockedDays(memberIdsForDepartment, blockedByUser);
   const canManageEvents = membership.role === "lead" && Boolean(department.slug);
+  const canManageDocuments = membership.role === "lead" || membership.role === "deputy";
+  const canSeePlanning = membership.role === "lead";
+  const documents = department.documents ?? [];
 
   const blockedMembersDetailed = sortedMembers
     .map((member) => {
@@ -245,109 +251,126 @@ export function DepartmentCard({
             </ul>
           </section>
 
-          <section className="space-y-4 rounded-2xl border border-border/60 bg-background/80 p-4 shadow-inner">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <h3 className="text-sm font-semibold text-foreground">Terminvorschläge</h3>
-              <div className="flex items-center gap-2">
-                <Badge variant="muted" size="sm">
-                  {blockedDatesCount} blockierte Tage
-                </Badge>
-                {canManageEvents ? (
-                  <CreateDepartmentEventButton
-                    departmentId={department.id}
-                    departmentSlug={department.slug!}
-                    triggerProps={{
-                      size: "xs",
-                      className:
-                        "px-3 text-xs shadow-[0_12px_30px_-32px_rgba(99,102,241,0.7)] hover:from-primary/85 hover:via-primary/75 hover:to-primary/85",
-                    }}
-                  />
-                ) : null}
-              </div>
-            </div>
-            {meetingSuggestions.length ? (
-              <ul className="grid gap-3 sm:grid-cols-2">
-                {meetingSuggestions.map((suggestion) => (
-                  <li
-                    key={suggestion.key}
-                    className="group flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-background/90 p-3 transition hover:border-primary/50"
-                  >
-                    <div className="flex items-center gap-3">
-                      <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                        <CalendarDays aria-hidden className="h-5 w-5" />
-                      </span>
-                      <div className="space-y-1">
-                        <p className="text-sm font-medium text-foreground">{suggestion.label}</p>
-                        <p className="text-xs text-muted-foreground">Frei für alle Mitglieder</p>
-                      </div>
-                    </div>
-                    <div className="flex flex-col items-end gap-2">
-                      <Badge variant="outline" size="sm" className="rounded-full border-primary/40 text-primary">
-                        {suggestion.shortLabel}
+          <div className="space-y-4">
+            <section className="space-y-4 rounded-2xl border border-border/60 bg-background/80 p-4 shadow-inner">
+              {canSeePlanning ? (
+                <>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold text-foreground">Terminvorschläge</h3>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="muted" size="sm">
+                        {blockedDatesCount} blockierte Tage
                       </Badge>
                       {canManageEvents ? (
                         <CreateDepartmentEventButton
                           departmentId={department.id}
                           departmentSlug={department.slug!}
-                          defaultValues={{
-                            date: suggestion.key,
-                            title: `${department.name} · Treffen`,
-                          }}
-                          dialogDescription={`Übernimm ${suggestion.label} als Startpunkt und passe Zeiten oder Details nach Bedarf an.`}
                           triggerProps={{
-                            label: "Übernehmen",
                             size: "xs",
                             className:
-                              "px-3 text-xs shadow-[0_10px_26px_-34px_rgba(99,102,241,0.65)] hover:from-primary/85 hover:via-primary/75 hover:to-primary/85",
+                              "px-3 text-xs shadow-[0_12px_30px_-32px_rgba(99,102,241,0.7)] hover:from-primary/85 hover:via-primary/75 hover:to-primary/85",
                           }}
                         />
                       ) : null}
                     </div>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                Aktuell gibt es keinen Termin ohne Sperrlisten-Konflikte. Prüfe deine Sperrtage und die deines Teams.
-              </p>
-            )}
-            {blockedMembersDetailed.length ? (
-              <div className="space-y-2 rounded-xl border border-dashed border-amber-400/40 bg-amber-500/5 p-3 text-xs">
-                <div className="flex items-center gap-2 text-foreground">
-                  <span className="flex h-7 w-7 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
-                    <BellRing aria-hidden className="h-4 w-4" />
-                  </span>
-                  <p className="text-sm font-semibold">Abmeldungen im Planungsfenster</p>
-                </div>
-                <ul className="space-y-1">
-                  {blockedMembersDetailed.map((entry) => (
-                    <li key={entry.id} className="flex items-center justify-between gap-2">
-                      <span className="font-medium text-foreground">{entry.name}</span>
-                      <span className="text-muted-foreground">
-                        {entry.formattedDates.join(", ")}
-                        {entry.remaining > 0 ? ` (+${entry.remaining} weitere)` : ""}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-                <p className="text-[11px] text-muted-foreground/80">
-                  Grundlage: Aktualisierte Sperrlisten seit dem Freeze bis {planningWindowLabel}.
+                  </div>
+                  {meetingSuggestions.length ? (
+                    <ul className="grid gap-3 sm:grid-cols-2">
+                      {meetingSuggestions.map((suggestion) => (
+                        <li
+                          key={suggestion.key}
+                          className="group flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-background/90 p-3 transition hover:border-primary/50"
+                        >
+                          <div className="flex items-center gap-3">
+                            <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                              <CalendarDays aria-hidden className="h-5 w-5" />
+                            </span>
+                            <div className="space-y-1">
+                              <p className="text-sm font-medium text-foreground">{suggestion.label}</p>
+                              <p className="text-xs text-muted-foreground">Frei für alle Mitglieder</p>
+                            </div>
+                          </div>
+                          <div className="flex flex-col items-end gap-2">
+                            <Badge variant="outline" size="sm" className="rounded-full border-primary/40 text-primary">
+                              {suggestion.shortLabel}
+                            </Badge>
+                            {canManageEvents ? (
+                              <CreateDepartmentEventButton
+                                departmentId={department.id}
+                                departmentSlug={department.slug!}
+                                defaultValues={{
+                                  date: suggestion.key,
+                                  title: `${department.name} · Treffen`,
+                                }}
+                                dialogDescription={`Übernimm ${suggestion.label} als Startpunkt und passe Zeiten oder Details nach Bedarf an.`}
+                                triggerProps={{
+                                  label: "Übernehmen",
+                                  size: "xs",
+                                  className:
+                                    "px-3 text-xs shadow-[0_10px_26px_-34px_rgba(99,102,241,0.65)] hover:from-primary/85 hover:via-primary/75 hover:to-primary/85",
+                                }}
+                              />
+                            ) : null}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      Aktuell gibt es keinen Termin ohne Sperrlisten-Konflikte. Prüfe deine Sperrtage und die deines Teams.
+                    </p>
+                  )}
+                  {blockedMembersDetailed.length ? (
+                    <div className="space-y-2 rounded-xl border border-dashed border-amber-400/40 bg-amber-500/5 p-3 text-xs">
+                      <div className="flex items-center gap-2 text-foreground">
+                        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
+                          <BellRing aria-hidden className="h-4 w-4" />
+                        </span>
+                        <p className="text-sm font-semibold">Abmeldungen im Planungsfenster</p>
+                      </div>
+                      <ul className="space-y-1">
+                        {blockedMembersDetailed.map((entry) => (
+                          <li key={entry.id} className="flex items-center justify-between gap-2">
+                            <span className="font-medium text-foreground">{entry.name}</span>
+                            <span className="text-muted-foreground">
+                              {entry.formattedDates.join(", ")}
+                              {entry.remaining > 0 ? ` (+${entry.remaining} weitere)` : ""}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                      <p className="text-[11px] text-muted-foreground/80">
+                        Grundlage: Aktualisierte Sperrlisten seit dem Freeze bis {planningWindowLabel}.
+                      </p>
+                    </div>
+                  ) : null}
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+                    <span>
+                      Fenster: {freezeUntilLabel} – {planningWindowLabel}
+                    </span>
+                    <Link
+                      href="/mitglieder/sperrliste"
+                      className="inline-flex items-center gap-1 font-semibold text-primary transition hover:text-primary/80"
+                    >
+                      <CalendarDays aria-hidden className="h-4 w-4" />
+                      Sperrliste öffnen
+                    </Link>
+                  </div>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Terminvorschläge stehen ausschließlich der Leitung zur Verfügung.
                 </p>
-              </div>
-            ) : null}
-            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-              <span>
-                Fenster: {freezeUntilLabel} – {planningWindowLabel}
-              </span>
-              <Link
-                href="/mitglieder/sperrliste"
-                className="inline-flex items-center gap-1 font-semibold text-primary transition hover:text-primary/80"
-              >
-                <CalendarDays aria-hidden className="h-4 w-4" />
-                Sperrliste öffnen
-              </Link>
-            </div>
-          </section>
+              )}
+            </section>
+            <DepartmentDocumentsSection
+              documents={documents}
+              departmentId={department.id}
+              canManage={canManageDocuments}
+              userId={userId}
+              refreshPath={refreshPath}
+            />
+          </div>
         </div>
 
         {isCostumeDepartment && measurementsForDepartment ? (
@@ -444,7 +467,9 @@ export function DepartmentCard({
             <ul className="mt-4 grid gap-3 md:grid-cols-2">
               {activeTasks.map((task) => {
                 const dueMeta = task.dueAt ? getDueMeta(task.dueAt, now) : null;
-                const assigneeName = task.assignee ? formatUserName(task.assignee) : null;
+                const assigneeNames = task.assignments
+                  .map((assignment) => formatUserName(assignment.user))
+                  .filter(Boolean);
                 return (
                   <li
                     key={task.id}
@@ -454,7 +479,7 @@ export function DepartmentCard({
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                           <span className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-background/80 px-2.5 py-0.5">
-                            Zuständig: {assigneeName ?? "Noch keine Zuordnung"}
+                            Zuständig: {assigneeNames.length ? assigneeNames.join(", ") : "Noch keine Zuordnung"}
                           </span>
                           {dueMeta ? (
                             <span
@@ -507,14 +532,16 @@ export function DepartmentCard({
               <ul className="mt-4 space-y-3 text-sm">
                 {completedTasks.map((task) => {
                   const dueMeta = task.dueAt ? getDueMeta(task.dueAt, now) : null;
-                  const assigneeName = task.assignee ? formatUserName(task.assignee) : null;
+                  const assigneeNames = task.assignments
+                    .map((assignment) => formatUserName(assignment.user))
+                    .filter(Boolean);
                   return (
                     <li key={task.id} className="rounded-xl border border-border/60 bg-background/90 p-3">
                       <div className="flex items-start justify-between gap-3">
                         <div className="space-y-1">
                           <p className="font-medium text-foreground">{task.title}</p>
                           <p className="text-xs text-muted-foreground">
-                            Zuständig: {assigneeName ?? "Noch offen"}
+                            Zuständig: {assigneeNames.length ? assigneeNames.join(", ") : "Noch offen"}
                           </p>
                           {dueMeta ? (
                             <p className="text-xs text-muted-foreground">Fällig war {dueMeta.absolute}</p>

--- a/src/app/(members)/mitglieder/meine-gewerke/department-documents-actions.ts
+++ b/src/app/(members)/mitglieder/meine-gewerke/department-documents-actions.ts
@@ -1,0 +1,206 @@
+"use server";
+
+import { Buffer } from "node:buffer";
+
+import { revalidatePath } from "next/cache";
+import { DepartmentMembershipRole } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+
+type ReadOptions = {
+  minLength?: number;
+  maxLength?: number;
+  label?: string;
+};
+
+function isString(value: FormDataEntryValue | null | undefined): value is string {
+  return typeof value === "string";
+}
+
+function readString(formData: FormData, key: string, options?: ReadOptions): string {
+  const raw = formData.get(key);
+  if (!isString(raw)) {
+    throw new Error(`${options?.label ?? key} fehlt.`);
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error(`${options?.label ?? key} fehlt.`);
+  }
+  if (options?.minLength && trimmed.length < options.minLength) {
+    throw new Error(
+      `${options?.label ?? key} muss mindestens ${options.minLength} Zeichen enthalten.`,
+    );
+  }
+  if (options?.maxLength && trimmed.length > options.maxLength) {
+    throw new Error(
+      `${options?.label ?? key} darf höchstens ${options.maxLength} Zeichen enthalten.`,
+    );
+  }
+  return trimmed;
+}
+
+function readOptionalString(formData: FormData, key: string, options?: ReadOptions) {
+  const raw = formData.get(key);
+  if (!isString(raw)) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  if (options?.minLength && trimmed.length < options.minLength) {
+    throw new Error(
+      `${options?.label ?? key} muss mindestens ${options.minLength} Zeichen enthalten.`,
+    );
+  }
+  if (options?.maxLength && trimmed.length > options.maxLength) {
+    throw new Error(
+      `${options?.label ?? key} darf höchstens ${options.maxLength} Zeichen enthalten.`,
+    );
+  }
+  return trimmed;
+}
+
+const MAX_DOCUMENT_SIZE_BYTES = 15 * 1024 * 1024;
+const ALLOWED_MIME_PREFIXES = ["image/", "application/pdf", "application/msword", "application/vnd."];
+
+function sanitizeFileName(name: string | undefined | null) {
+  const fallback = "dokument";
+  if (!name) return fallback;
+  const trimmed = name.trim();
+  if (!trimmed) return fallback;
+  if (trimmed.length > 160) {
+    return trimmed.slice(0, 160);
+  }
+  return trimmed;
+}
+
+function ensureAllowedType(file: File) {
+  if (!file.type) return false;
+  return ALLOWED_MIME_PREFIXES.some((prefix) => file.type.startsWith(prefix));
+}
+
+export async function uploadDepartmentDocumentAction(formData: FormData) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+  if (!userId) {
+    throw new Error("Nicht autorisiert.");
+  }
+
+  const departmentId = readString(formData, "departmentId", { label: "Gewerk" });
+  const redirectPath = readOptionalString(formData, "redirectPath", { label: "Seite" }) ??
+    "/mitglieder/meine-gewerke";
+
+  const files = formData
+    .getAll("files")
+    .filter((entry): entry is File => entry instanceof File && entry.size > 0);
+
+  if (!files.length) {
+    throw new Error("Bitte wähle mindestens eine Datei aus.");
+  }
+
+  const canManageByPermission = await hasPermission(session.user, "mitglieder.produktionen");
+  let canManage = canManageByPermission;
+  if (!canManage) {
+    const membership = await prisma.departmentMembership.findFirst({
+      where: { departmentId, userId },
+      select: { role: true },
+    });
+    canManage = Boolean(
+      membership &&
+        (membership.role === DepartmentMembershipRole.lead ||
+          membership.role === DepartmentMembershipRole.deputy),
+    );
+  }
+  if (!canManage) {
+    throw new Error("Keine Berechtigung zum Hochladen.");
+  }
+
+  const errors: string[] = [];
+  const payloads: { file: File; buffer: Buffer }[] = [];
+
+  for (const file of files) {
+    if (file.size > MAX_DOCUMENT_SIZE_BYTES) {
+      errors.push(
+        `${file.name || "Datei"}: Datei ist zu groß (maximal ${Math.floor(
+          MAX_DOCUMENT_SIZE_BYTES / (1024 * 1024),
+        )} MB).`,
+      );
+      continue;
+    }
+
+    if (!ensureAllowedType(file)) {
+      errors.push(`${file.name || "Datei"}: Dateityp wird nicht unterstützt.`);
+      continue;
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    payloads.push({ file, buffer });
+  }
+
+  if (!payloads.length) {
+    throw new Error(errors.join(" ") || "Keine gültigen Dateien ausgewählt.");
+  }
+
+  await prisma.$transaction(async (tx) => {
+    for (const { file, buffer } of payloads) {
+      await tx.departmentDocument.create({
+        data: {
+          departmentId,
+          fileName: sanitizeFileName(file.name),
+          mimeType: file.type || "application/octet-stream",
+          fileSize: buffer.length,
+          data: buffer,
+          uploadedById: userId,
+        },
+      });
+    }
+  });
+
+  revalidatePath(redirectPath);
+}
+
+export async function deleteDepartmentDocumentAction(formData: FormData) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+  if (!userId) {
+    throw new Error("Nicht autorisiert.");
+  }
+
+  const documentId = readString(formData, "documentId", { label: "Dokument" });
+  const redirectPath = readOptionalString(formData, "redirectPath", { label: "Seite" }) ??
+    "/mitglieder/meine-gewerke";
+
+  const document = await prisma.departmentDocument.findUnique({
+    where: { id: documentId },
+    select: {
+      id: true,
+      departmentId: true,
+      uploadedById: true,
+    },
+  });
+
+  if (!document) {
+    throw new Error("Dokument wurde nicht gefunden.");
+  }
+
+  const canManageByPermission = await hasPermission(session.user, "mitglieder.produktionen");
+  let canManage = canManageByPermission;
+  if (!canManage) {
+    const membership = await prisma.departmentMembership.findFirst({
+      where: { departmentId: document.departmentId, userId },
+      select: { role: true },
+    });
+    canManage = Boolean(
+      membership &&
+        (membership.role === DepartmentMembershipRole.lead ||
+          membership.role === DepartmentMembershipRole.deputy),
+    );
+  }
+  const isOwner = document.uploadedById === userId;
+  if (!canManage && !isOwner) {
+    throw new Error("Keine Berechtigung zum Löschen.");
+  }
+
+  await prisma.departmentDocument.delete({ where: { id: documentId } });
+
+  revalidatePath(redirectPath);
+}

--- a/src/app/(members)/mitglieder/meine-gewerke/department-documents-section.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/department-documents-section.tsx
@@ -1,0 +1,145 @@
+import { formatDistanceToNow } from "date-fns";
+import { de } from "date-fns/locale/de";
+import { FileText, Image as ImageIcon, Upload, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { formatFileLibraryFileSize } from "@/lib/file-library";
+import { getUserDisplayName } from "@/lib/names";
+
+import {
+  deleteDepartmentDocumentAction,
+  uploadDepartmentDocumentAction,
+} from "./department-documents-actions";
+
+type DocumentEntry = {
+  id: string;
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+  createdAt: Date;
+  uploadedById: string | null;
+  uploadedBy: {
+    id: string | null;
+    name: string | null;
+    email: string | null;
+    firstName?: string | null;
+    lastName?: string | null;
+  } | null;
+};
+
+type DepartmentDocumentsSectionProps = {
+  documents: DocumentEntry[];
+  departmentId: string;
+  canManage: boolean;
+  userId: string;
+  refreshPath: string;
+};
+
+function resolveIcon(mimeType: string) {
+  if (mimeType.startsWith("image/")) {
+    return ImageIcon;
+  }
+  return FileText;
+}
+
+export function DepartmentDocumentsSection({
+  documents,
+  departmentId,
+  canManage,
+  userId,
+  refreshPath,
+}: DepartmentDocumentsSectionProps) {
+  const hasDocuments = documents.length > 0;
+  return (
+    <section className="space-y-4 rounded-2xl border border-border/60 bg-background/80 p-4 shadow-inner">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Dokumente &amp; Fotos</h3>
+          <p className="text-xs text-muted-foreground">
+            Teile Pläne, Fotos oder Unterlagen zentral in deinem Gewerk.
+          </p>
+        </div>
+        <Badge variant="muted" size="sm">
+          {documents.length} Datei{documents.length === 1 ? "" : "en"}
+        </Badge>
+      </div>
+
+      {canManage ? (
+        <form
+          action={uploadDepartmentDocumentAction}
+          encType="multipart/form-data"
+          className="flex flex-col gap-2 rounded-xl border border-dashed border-border/60 bg-background/70 p-3"
+        >
+          <input type="hidden" name="departmentId" value={departmentId} />
+          <input type="hidden" name="redirectPath" value={refreshPath} />
+          <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Dateien hochladen (Bilder oder PDFs, max. 15&nbsp;MB)
+          </label>
+          <Input type="file" name="files" multiple accept="image/*,application/pdf,application/msword,application/vnd.*" />
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-[11px] text-muted-foreground">
+              Unterstützt Bilder (JPG, PNG, WebP) sowie PDF- und Office-Dokumente.
+            </p>
+            <Button type="submit" size="sm" className="gap-2">
+              <Upload aria-hidden className="h-4 w-4" />
+              <span>Hochladen</span>
+            </Button>
+          </div>
+        </form>
+      ) : null}
+
+      {hasDocuments ? (
+        <ul className="space-y-3">
+          {documents.map((doc) => {
+            const Icon = resolveIcon(doc.mimeType);
+            const uploadedLabel = doc.uploadedBy
+              ? getUserDisplayName(doc.uploadedBy, "Unbekannt")
+              : "Unbekannt";
+            const canDelete = canManage || doc.uploadedById === userId;
+            const downloadHref = `/api/departments/${departmentId}/documents/${doc.id}`;
+            return (
+              <li
+                key={doc.id}
+                className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background/85 p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="flex items-start gap-3">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                    <Icon aria-hidden className="h-5 w-5" />
+                  </span>
+                  <div className="space-y-1">
+                    <a
+                      href={downloadHref}
+                      className="text-sm font-medium text-foreground underline-offset-2 hover:underline"
+                    >
+                      {doc.fileName}
+                    </a>
+                    <p className="text-xs text-muted-foreground">
+                      {formatFileLibraryFileSize(doc.fileSize)} · hochgeladen von {uploadedLabel} ·{' '}
+                      {formatDistanceToNow(doc.createdAt, { addSuffix: true, locale: de })}
+                    </p>
+                  </div>
+                </div>
+                {canDelete ? (
+                  <form action={deleteDepartmentDocumentAction} className="flex justify-end">
+                    <input type="hidden" name="documentId" value={doc.id} />
+                    <input type="hidden" name="redirectPath" value={refreshPath} />
+                    <Button type="submit" variant="ghost" size="sm" className="text-destructive hover:text-destructive">
+                      <X aria-hidden className="mr-2 h-4 w-4" />
+                      Entfernen
+                    </Button>
+                  </form>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Noch keine Dateien hinterlegt. {canManage ? "Lege los und stelle deinem Team wichtige Unterlagen bereit." : "Bitte wende dich an die Leitung, um Unterlagen zu teilen."}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -77,13 +77,17 @@ export default async function MeineGewerkePage() {
           },
           tasks: {
             include: {
-              assignee: {
-                select: {
-                  id: true,
-                  name: true,
-                  email: true,
-                  firstName: true,
-                  lastName: true,
+              assignments: {
+                include: {
+                  user: {
+                    select: {
+                      id: true,
+                      name: true,
+                      email: true,
+                      firstName: true,
+                      lastName: true,
+                    },
+                  },
                 },
               },
             },
@@ -102,6 +106,20 @@ export default async function MeineGewerkePage() {
               },
             },
             orderBy: { start: "asc" },
+          },
+          documents: {
+            include: {
+              uploadedBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  firstName: true,
+                  lastName: true,
+                },
+              },
+            },
+            orderBy: { createdAt: "desc" },
           },
         },
       },
@@ -473,6 +491,7 @@ export default async function MeineGewerkePage() {
               teamLinkHref={teamLinkHref}
               teamLinkLabel={teamLinkLabel}
               measurementsByUser={costumeMeasurementsByUser}
+              refreshPath="/mitglieder/meine-gewerke"
             />
           );
         })}

--- a/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
@@ -71,13 +71,17 @@ export default async function DepartmentTodosPage() {
           },
           tasks: {
             include: {
-              assignee: {
-                select: {
-                  id: true,
-                  name: true,
-                  email: true,
-                  firstName: true,
-                  lastName: true,
+              assignments: {
+                include: {
+                  user: {
+                    select: {
+                      id: true,
+                      name: true,
+                      email: true,
+                      firstName: true,
+                      lastName: true,
+                    },
+                  },
                 },
               },
             },
@@ -119,7 +123,8 @@ export default async function DepartmentTodosPage() {
   for (const membership of memberships) {
     for (const task of membership.department.tasks) {
       totalStatusCounts[task.status] += 1;
-      if (task.assigneeId === userId) {
+      const isAssignedToMe = task.assignments.some((assignment) => assignment.userId === userId);
+      if (isAssignedToMe) {
         if (task.status === "done") {
           myCompletedAssignments.push({ task, department: membership.department });
         } else {
@@ -383,7 +388,9 @@ export default async function DepartmentTodosPage() {
           const leadership = membership.department.memberships.filter((entry) =>
             entry.role === "lead" || entry.role === "deputy",
           );
-          const myTasks = membership.department.tasks.filter((task) => task.assigneeId === userId);
+          const myTasks = membership.department.tasks.filter((task) =>
+            task.assignments.some((assignment) => assignment.userId === userId),
+          );
           const myOpenTasks = myTasks.filter((task) => task.status !== "done");
           const myDoneTasks = myTasks.filter((task) => task.status === "done");
           const openCount = membership.department.tasks.filter((task) => task.status !== "done").length;

--- a/src/app/(members)/mitglieder/meine-gewerke/utils.ts
+++ b/src/app/(members)/mitglieder/meine-gewerke/utils.ts
@@ -151,13 +151,17 @@ export type DepartmentMembershipWithDepartment = Prisma.DepartmentMembershipGetP
         };
         tasks: {
           include: {
-            assignee: {
-              select: {
-                id: true;
-                name: true;
-                email: true;
-                firstName: true;
-                lastName: true;
+            assignments: {
+              include: {
+                user: {
+                  select: {
+                    id: true;
+                    name: true;
+                    email: true;
+                    firstName: true;
+                    lastName: true;
+                  };
+                };
               };
             };
           };
@@ -178,10 +182,26 @@ export type DepartmentMembershipWithDepartment = Prisma.DepartmentMembershipGetP
             start: "asc";
           };
         };
+        documents: {
+          include: {
+            uploadedBy: {
+              select: {
+                id: true;
+                name: true;
+                email: true;
+                firstName: true;
+                lastName: true;
+              };
+            };
+          };
+          orderBy: {
+            createdAt: "desc";
+          };
+        };
       };
     };
   };
-}>; 
+}>;
 
 export type DepartmentMemberUser = DepartmentMembershipWithDepartment["department"]["memberships"][number]["user"];
 

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -470,7 +470,7 @@ export default async function MemberProfileAdminPage({ params }: PageProps) {
       },
     }),
     prisma.departmentTask.findMany({
-      where: { assigneeId: decodedId },
+      where: { assignments: { some: { userId: decodedId } } },
       select: {
         id: true,
         title: true,

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -792,32 +792,46 @@ export async function createDepartmentTaskAction(formData: FormData): Promise<vo
     const status =
       parseEnumValue(TaskStatus, formData.get("status"), "Status", { optional: true }) ??
       TaskStatus.todo;
-    const assigneeId = readOptionalString(formData, "assigneeId", {
-      label: "Zuständiges Mitglied",
-      maxLength: 200,
-    });
+    const assigneeIds = Array.from(
+      new Set(
+        formData
+          .getAll("assigneeIds")
+          .filter((value): value is string => typeof value === "string")
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0),
+      ),
+    );
     const dueAt = parseOptionalDate(formData, "dueAt", "Fällig bis");
 
-    if (assigneeId) {
-      const membership = await prisma.departmentMembership.findFirst({
-        where: { departmentId, userId: assigneeId },
-        select: { id: true },
+    if (assigneeIds.length) {
+      const validAssignments = await prisma.departmentMembership.count({
+        where: { departmentId, userId: { in: assigneeIds } },
       });
-      if (!membership) {
-        throw new Error("Das gewählte Mitglied gehört nicht zu diesem Gewerk.");
+      if (validAssignments !== assigneeIds.length) {
+        throw new Error("Mindestens eine ausgewählte Person gehört nicht zu diesem Gewerk.");
       }
     }
 
-    await prisma.departmentTask.create({
-      data: {
-        departmentId,
-        title,
-        description: description ?? null,
-        status,
-        dueAt: dueAt ?? null,
-        assigneeId: assigneeId ?? null,
-        createdById: userId,
-      },
+    await prisma.$transaction(async (tx) => {
+      const created = await tx.departmentTask.create({
+        data: {
+          departmentId,
+          title,
+          description: description ?? null,
+          status,
+          dueAt: dueAt ?? null,
+          createdById: userId,
+        },
+      });
+
+      if (assigneeIds.length) {
+        await tx.departmentTaskAssignment.createMany({
+          data: assigneeIds.map((assignmentId) => ({
+            taskId: created.id,
+            userId: assignmentId,
+          })),
+        });
+      }
     });
 
     revalidateDepartments(redirectPath);
@@ -850,31 +864,44 @@ export async function updateDepartmentTaskAction(formData: FormData): Promise<vo
     const status =
       parseEnumValue(TaskStatus, formData.get("status"), "Status", { optional: true }) ??
       task.status;
-    const assigneeId = readOptionalString(formData, "assigneeId", {
-      label: "Zuständiges Mitglied",
-      maxLength: 200,
-    });
+    const assigneeIds = Array.from(
+      new Set(
+        formData
+          .getAll("assigneeIds")
+          .filter((value): value is string => typeof value === "string")
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0),
+      ),
+    );
     const dueAt = parseOptionalDate(formData, "dueAt", "Fällig bis");
 
-    if (assigneeId) {
-      const membership = await prisma.departmentMembership.findFirst({
-        where: { departmentId: task.departmentId, userId: assigneeId },
-        select: { id: true },
+    if (assigneeIds.length) {
+      const validAssignments = await prisma.departmentMembership.count({
+        where: { departmentId: task.departmentId, userId: { in: assigneeIds } },
       });
-      if (!membership) {
-        throw new Error("Das gewählte Mitglied gehört nicht zu diesem Gewerk.");
+      if (validAssignments !== assigneeIds.length) {
+        throw new Error("Mindestens eine ausgewählte Person gehört nicht zu diesem Gewerk.");
       }
     }
 
-    await prisma.departmentTask.update({
-      where: { id: taskId },
-      data: {
-        title,
-        description: description ?? null,
-        status,
-        dueAt: dueAt ?? null,
-        assigneeId: assigneeId ?? null,
-      },
+    await prisma.$transaction(async (tx) => {
+      await tx.departmentTask.update({
+        where: { id: taskId },
+        data: {
+          title,
+          description: description ?? null,
+          status,
+          dueAt: dueAt ?? null,
+        },
+      });
+
+      await tx.departmentTaskAssignment.deleteMany({ where: { taskId } });
+
+      if (assigneeIds.length) {
+        await tx.departmentTaskAssignment.createMany({
+          data: assigneeIds.map((assignmentId) => ({ taskId, userId: assignmentId })),
+        });
+      }
     });
 
     revalidateDepartments(redirectPath);

--- a/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { DepartmentDocumentsSection } from "@/app/(members)/mitglieder/meine-gewerke/department-documents-section";
 
 import {
   DATE_KEY_FORMAT,
@@ -66,10 +67,22 @@ async function loadDepartmentWithRelations(id: string) {
       },
       tasks: {
         include: {
-          assignee: { select: { id: true, name: true, email: true } },
+          assignments: {
+            include: {
+              user: { select: { id: true, name: true, email: true } },
+            },
+          },
           creator: { select: { id: true, name: true, email: true } },
         },
         orderBy: { createdAt: "asc" },
+      },
+      documents: {
+        include: {
+          uploadedBy: {
+            select: { id: true, name: true, email: true, firstName: true, lastName: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
       },
     },
   });
@@ -132,6 +145,14 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
   const meetingSuggestions = findMeetingSuggestions(memberIds, planningStart, planningEnd, blockedByUser);
   const blockedDatesCount = countBlockedDays(memberIds, blockedByUser);
   const hasMembers = memberIds.length > 0;
+  const documents = department.documents ?? [];
+  const viewerId = session.user?.id;
+  const viewerMembership = viewerId
+    ? department.memberships.find((membership) => membership.userId === viewerId)
+    : undefined;
+  const canSeePlanning = viewerMembership?.role === "lead";
+  const canManageDocuments =
+    viewerMembership?.role === "lead" || viewerMembership?.role === "deputy" || allowed;
 
   const sortedMembers = [...department.memberships].sort((a, b) =>
     formatUserName(a.user).localeCompare(formatUserName(b.user), "de", { sensitivity: "base" }),
@@ -281,7 +302,9 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
             {activeTasks.length ? (
               <ul className="space-y-3">
                 {activeTasks.map((task) => {
-                  const assigneeName = task.assignee ? formatUserName(task.assignee) : null;
+                  const assigneeNames = task.assignments
+                    .map((assignment) => formatUserName(assignment.user))
+                    .filter(Boolean);
                   const creatorName = task.creator ? formatUserName(task.creator) : "System";
                   const dueMeta = task.dueAt ? getDueMeta(task.dueAt, now) : null;
                   const dueDateValue = task.dueAt ? format(task.dueAt, DATE_KEY_FORMAT) : "";
@@ -309,7 +332,9 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
                               </span>
                             ) : null}
                             <span className="inline-flex items-center gap-1 rounded-full border border-border/50 px-2 py-0.5">
-                              {assigneeName ? `Zuständig: ${assigneeName}` : "Noch keine Zuordnung"}
+                              {assigneeNames.length
+                                ? `Zuständig: ${assigneeNames.join(", ")}`
+                                : "Noch keine Zuordnung"}
                             </span>
                           </div>
                           <p className="text-base font-medium leading-snug text-foreground">{task.title}</p>
@@ -360,16 +385,23 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
                           </div>
                           <div className="space-y-1">
                             <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                              Zuständiges Mitglied
+                              Zuständige Mitglieder
                             </label>
-                            <select name="assigneeId" defaultValue={task.assignee?.id ?? ""} className={selectClassName}>
-                              <option value="">Noch offen</option>
+                            <select
+                              name="assigneeIds"
+                              multiple
+                              defaultValue={task.assignments.map((assignment) => assignment.userId)}
+                              className={cn(selectClassName, "min-h-[140px]")}
+                            >
                               {department.memberships.map((membership) => (
                                 <option key={membership.user.id} value={membership.user.id}>
                                   {formatUserName(membership.user)}
                                 </option>
                               ))}
                             </select>
+                            <p className="text-[11px] text-muted-foreground">
+                              Halte Strg (Windows) oder ⌘ (Mac), um mehrere Personen auszuwählen.
+                            </p>
                           </div>
                           <div className="md:col-span-2 flex justify-end">
                             <Button type="submit" variant="outline" size="sm">
@@ -457,15 +489,24 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
                   <Input type="date" name="dueAt" />
                 </div>
                 <div className="space-y-1 md:col-span-2">
-                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Zuständiges Mitglied</label>
-                  <select name="assigneeId" className={selectClassName} defaultValue="">
-                    <option value="">Noch offen</option>
+                  <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Zuständige Mitglieder
+                  </label>
+                  <select
+                    name="assigneeIds"
+                    multiple
+                    className={cn(selectClassName, "min-h-[140px]")}
+                    defaultValue={[]}
+                  >
                     {department.memberships.map((membership) => (
                       <option key={membership.user.id} value={membership.user.id}>
                         {formatUserName(membership.user)}
                       </option>
                     ))}
                   </select>
+                  <p className="text-[11px] text-muted-foreground">
+                    Halte Strg (Windows) oder ⌘ (Mac), um mehrere Personen auszuwählen.
+                  </p>
                 </div>
                 <div className="md:col-span-2 flex justify-end">
                   <Button type="submit" size="sm">
@@ -488,7 +529,7 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
                 </p>
               </div>
               <Badge variant="outline" size="sm" className="rounded-full border-primary/40 text-primary">
-                {meetingSuggestions.length} Vorschläge
+                {canSeePlanning ? `${meetingSuggestions.length} Vorschläge` : "Nur Leitung"}
               </Badge>
             </div>
           </CardHeader>
@@ -497,7 +538,7 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
               <p className="text-sm text-muted-foreground">
                 Füge Teammitglieder hinzu, um gemeinsame Termine zu planen.
               </p>
-            ) : (
+            ) : canSeePlanning ? (
               <>
                 <div className={`${subtleSurfaceClassName} flex items-center justify-between gap-3 border-border/50 bg-background/85 px-4 py-3`}>
                   <div>
@@ -517,11 +558,22 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
                   </Button>
                 </div>
                 {renderSuggestions(meetingSuggestions, department.memberships.length)}
+                <p className="text-xs text-muted-foreground">
+                  Fenster: {freezeUntilLabel} – {planningWindowLabel}
+                </p>
               </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Terminvorschläge stehen ausschließlich der Leitung zur Verfügung.
+              </p>
             )}
-            <p className="text-xs text-muted-foreground">
-              Fenster: {freezeUntilLabel} – {planningWindowLabel}
-            </p>
+            <DepartmentDocumentsSection
+              documents={documents}
+              departmentId={department.id}
+              canManage={canManageDocuments}
+              userId={session.user?.id ?? ""}
+              refreshPath={detailPath}
+            />
           </CardContent>
         </Card>
       </div>

--- a/src/app/api/departments/[departmentId]/documents/[documentId]/route.ts
+++ b/src/app/api/departments/[departmentId]/documents/[documentId]/route.ts
@@ -1,0 +1,63 @@
+import { Buffer } from "node:buffer";
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ departmentId: string; documentId: string }> },
+) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const { departmentId, documentId } = await context.params;
+  if (!departmentId || !documentId) {
+    return NextResponse.json({ error: "Ungültige Anfrage" }, { status: 400 });
+  }
+
+  const document = await prisma.departmentDocument.findFirst({
+    where: { id: documentId, departmentId },
+    select: {
+      id: true,
+      fileName: true,
+      mimeType: true,
+      fileSize: true,
+      data: true,
+      departmentId: true,
+    },
+  });
+
+  if (!document) {
+    return NextResponse.json({ error: "Dokument nicht gefunden" }, { status: 404 });
+  }
+
+  const [hasGlobalAccess, membership] = await Promise.all([
+    hasPermission(session.user, "mitglieder.produktionen"),
+    prisma.departmentMembership.findFirst({
+      where: { departmentId, userId },
+      select: { id: true },
+    }),
+  ]);
+
+  if (!hasGlobalAccess && !membership) {
+    return NextResponse.json({ error: "Kein Zugriff auf dieses Dokument" }, { status: 403 });
+  }
+
+  const safeName = document.fileName.replace(/"/g, "'");
+  const encodedName = encodeURIComponent(document.fileName);
+
+  const fileBuffer = Buffer.from(document.data);
+
+  return new NextResponse(fileBuffer, {
+    headers: {
+      "Content-Type": document.mimeType,
+      "Content-Length": document.fileSize.toString(),
+      "Content-Disposition": `attachment; filename="${safeName}"; filename*=UTF-8''${encodedName}`,
+    },
+  });
+}

--- a/src/app/api/members/[id]/usage/route.ts
+++ b/src/app/api/members/[id]/usage/route.ts
@@ -91,7 +91,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     prisma.characterCasting.count({ where: { userId: id } }),
     prisma.sceneBreakdownItem.count({ where: { assignedToId: id } }),
     prisma.task.count({ where: { assigneeId: id } }),
-    prisma.departmentTask.count({ where: { assigneeId: id } }),
+    prisma.departmentTaskAssignment.count({ where: { userId: id } }),
     prisma.departmentTask.count({ where: { createdById: id } }),
     prisma.rehearsalInvitee.count({ where: { userId: id } }),
     prisma.rehearsalAttendance.count({ where: { userId: id } }),


### PR DESCRIPTION
## Summary
- replace the single assignee column on department tasks with the DepartmentTaskAssignment join table and add DepartmentDocument storage, including backfill and Prisma schema updates
- update member and production views to respect department lead visibility for planning widgets while supporting multiple task assignees and rendering document sections
- introduce server actions and an authenticated download route for uploading, listing, and removing department documents with role-based permissions

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dacb601058832d9d795c1859caa16e