### PR TITLE
Adjust onboarding dashboard refresh button styling

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
@@ -125,8 +125,9 @@ export function HeaderBar({
       {onRefresh ? (
         <Button
           type="button"
-          variant="secondary"
-          className="self-end w-full border border-primary text-secondary-foreground hover:border-primary hover:text-secondary-foreground sm:w-auto"
+          variant="outline"
+          size="md"
+          className="w-full border-warning bg-transparent text-warning hover:border-warning/80 hover:bg-transparent hover:text-warning sm:w-auto lg:self-center"
           onClick={onRefresh}
           disabled={isRefreshing}
         >


### PR DESCRIPTION
## Summary
- restyle the onboarding dashboard refresh button with an outline appearance that uses the warning palette
- align the refresh button with the share control for consistent placement

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dad5c8e484832d818568524e9b9801