### PR TITLE
Refactor onboarding background form handling

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -53,10 +53,11 @@ import {
   type DietaryStrictnessOption,
   type DietaryStyleOption,
 } from "@/data/dietary-preferences";
-import { BACKGROUND_TAGS, findMatchingBackgroundTag, normalizeBackgroundLabel } from "@/data/onboarding-backgrounds";
+import { BACKGROUND_TAGS, normalizeBackgroundLabel } from "@/data/onboarding-backgrounds";
 import { MAX_INTERESTS_PER_USER } from "@/data/profile";
 import { ALLERGY_LEVEL_STYLES } from "@/data/allergy-styles";
 import { UserAvatar } from "@/components/user-avatar";
+import { useOnboardingBackgroundData } from "@/components/onboarding/use-onboarding-background-data";
 import {
   buildProfileChecklist,
   type ProfileChecklistTarget,
@@ -97,6 +98,8 @@ const ONBOARDING_FOCUS_LABELS: Record<OnboardingFocus, string> = {
   tech: "Gewerke",
   both: "Schauspiel & Gewerke",
 };
+
+const PROFILE_ONBOARDING_BACKGROUND_SUGGESTIONS = ["Schule", "Ausbildung", "Beruf"] as const;
 
 const PAYOUT_METHOD_OPTIONS: Array<{ value: PayoutMethod; label: string }> = [
   { value: "BANK_TRANSFER", label: "Banküberweisung" },
@@ -2422,8 +2425,10 @@ export function OnboardingSection({
   const [formState, setFormState] = useState<OnboardingFormState>(initialForm);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [backgroundSuggestions, setBackgroundSuggestions] = useState<string[]>(() => ["Schule", "Ausbildung", "Beruf"]);
-  const [classSuggestions, setClassSuggestions] = useState<string[]>([]);
+  const { backgroundSuggestions, classSuggestions, activeTag, requiresClass } =
+    useOnboardingBackgroundData(formState.background, {
+      initialSuggestions: PROFILE_ONBOARDING_BACKGROUND_SUGGESTIONS,
+    });
   const [whatsappSubmitting, setWhatsappSubmitting] = useState(false);
   const whatsappVisitedLabel = useMemo(() => formatDate(whatsappVisitedAt), [whatsappVisitedAt]);
 
@@ -2431,75 +2436,6 @@ export function OnboardingSection({
     setFormState(initialForm);
   }, [initialForm]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const loadBackgrounds = async () => {
-      try {
-        const response = await fetch("/api/onboarding/backgrounds", { cache: "no-store" });
-        const data = await response.json().catch(() => null);
-        if (cancelled || !Array.isArray(data?.backgrounds)) return;
-        setBackgroundSuggestions((prev) => {
-          const seen = new Set(prev.map((entry) => entry.toLowerCase()));
-          const merged = [...prev];
-          for (const raw of data.backgrounds as unknown[]) {
-            let label: string | null = null;
-            if (typeof raw === "string") label = raw;
-            else if (raw && typeof raw === "object" && typeof (raw as { name?: unknown }).name === "string") {
-              label = (raw as { name: string }).name;
-            }
-            if (!label) continue;
-            const trimmed = label.trim();
-            if (!trimmed) continue;
-            const key = trimmed.toLowerCase();
-            if (seen.has(key)) continue;
-            seen.add(key);
-            merged.push(trimmed);
-          }
-          return merged;
-        });
-      } catch {
-        // ignore optional suggestions errors
-      }
-    };
-    void loadBackgrounds();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const activeTag = useMemo(() => findMatchingBackgroundTag(formState.background), [formState.background]);
-  const requiresClass = activeTag?.requiresClass ?? false;
-
-  useEffect(() => {
-    if (!requiresClass) {
-      setClassSuggestions([]);
-      return;
-    }
-    let cancelled = false;
-    const loadClasses = async () => {
-      try {
-        const response = await fetch("/api/onboarding/background-classes", { cache: "no-store" });
-        const data = await response.json().catch(() => null);
-        if (cancelled || !Array.isArray(data?.classes)) return;
-        const entries = (data.classes as unknown[])
-          .map<string | null>((entry: unknown) => {
-            if (typeof entry === "string") return entry.trim();
-            if (entry && typeof entry === "object" && typeof (entry as { name?: unknown }).name === "string") {
-              return (entry as { name: string }).name.trim();
-            }
-            return null;
-          })
-          .filter((value): value is string => Boolean(value));
-        setClassSuggestions(Array.from(new Set(entries)));
-      } catch {
-        setClassSuggestions([]);
-      }
-    };
-    void loadClasses();
-    return () => {
-      cancelled = true;
-    };
-  }, [requiresClass]);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -33,11 +33,8 @@ import {
   type DietaryStyleOption,
 } from "@/data/dietary-preferences";
 import { ALLERGY_LEVEL_STYLES } from "@/data/allergy-styles";
-import {
-  BACKGROUND_TAGS,
-  findMatchingBackgroundTag,
-  normalizeBackgroundLabel,
-} from "@/data/onboarding-backgrounds";
+import { BACKGROUND_TAGS, normalizeBackgroundLabel } from "@/data/onboarding-backgrounds";
+import { useOnboardingBackgroundData } from "@/components/onboarding/use-onboarding-background-data";
 
 const allergyLevelLabels: Record<AllergyLevel, string> = {
   MILD: "Leicht (Unbehagen)",
@@ -316,15 +313,18 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
   const [signatureDataUrl, setSignatureDataUrl] = useState<string | null>(null);
   const [availableInterests, setAvailableInterests] = useState<InterestSuggestion[]>([]);
   const [interestsLoading, setInterestsLoading] = useState(false);
-  const [backgroundSuggestions, setBackgroundSuggestions] = useState<string[]>(
-    () => [...BASE_BACKGROUND_SUGGESTIONS],
-  );
-  const [backgroundClassSuggestions, setBackgroundClassSuggestions] = useState<string[]>([]);
+  const [form, setForm] = useState(() => createInitialFormState(variant));
+  const {
+    backgroundSuggestions,
+    classSuggestions: backgroundClassSuggestions,
+    activeTag: activeBackgroundTag,
+    requiresClass: requiresBackgroundClass,
+  } = useOnboardingBackgroundData(form.background, {
+    initialSuggestions: BASE_BACKGROUND_SUGGESTIONS,
+  });
   const [customCrewDraft, setCustomCrewDraft] = useState({ title: "", description: "" });
   const [customCrewError, setCustomCrewError] = useState<string | null>(null);
   const [whatsappVisitTracked, setWhatsappVisitTracked] = useState(false);
-
-  const [form, setForm] = useState(() => createInitialFormState(variant));
 
   useEffect(() => {
     if (!isRegieVariant) {
@@ -387,51 +387,8 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
     };
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    const loadBackgrounds = async () => {
-      try {
-        const response = await fetch("/api/onboarding/backgrounds", { cache: "no-store" });
-        const data = await response.json().catch(() => null);
-        if (cancelled || !Array.isArray(data?.backgrounds)) return;
-        setBackgroundSuggestions((prev) => {
-          const seen = new Set(prev.map((entry) => entry.toLowerCase()));
-          const merged = [...prev];
-          for (const rawEntry of data.backgrounds as unknown[]) {
-            let label: string | null = null;
-            if (typeof rawEntry === "string") {
-              label = rawEntry;
-            } else if (rawEntry && typeof rawEntry === "object") {
-              const record = rawEntry as { name?: unknown };
-              label = typeof record.name === "string" ? record.name : null;
-            }
-            if (!label) continue;
-            const trimmed = label.trim();
-            if (!trimmed) continue;
-            const key = trimmed.toLowerCase();
-            if (seen.has(key)) continue;
-            seen.add(key);
-            merged.push(trimmed);
-          }
-          return merged;
-        });
-      } catch {
-        // ignore optional background suggestions errors
-      }
-    };
-    void loadBackgrounds();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   const age = useMemo(() => calculateAge(form.dateOfBirth || null), [form.dateOfBirth]);
   const isMinor = age !== null && age < 18;
-  const activeBackgroundTag = useMemo(
-    () => findMatchingBackgroundTag(form.background),
-    [form.background],
-  );
-  const requiresBackgroundClass = activeBackgroundTag?.requiresClass ?? false;
   const backgroundTagValueKeys = useMemo(
     () => new Set(BACKGROUND_TAGS.map((tag) => normalizeBackgroundLabel(tag.value))),
     [],
@@ -458,46 +415,6 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
       return { ...prev, backgroundClass: "" };
     });
   }, [form.backgroundClass, requiresBackgroundClass]);
-
-  useEffect(() => {
-    if (!requiresBackgroundClass) {
-      setBackgroundClassSuggestions([]);
-      return;
-    }
-    let cancelled = false;
-    const loadBackgroundClasses = async () => {
-      try {
-        const response = await fetch("/api/onboarding/background-classes", { cache: "no-store" });
-        const data = await response.json().catch(() => null);
-        if (cancelled || !Array.isArray(data?.classes)) return;
-        const entries = data.classes
-          .map((entry: unknown): string | null => {
-            if (typeof entry === "string") {
-              return entry.trim();
-            }
-            if (entry && typeof entry === "object") {
-              const record = entry as { name?: unknown };
-              if (typeof record.name === "string") {
-                return record.name.trim();
-              }
-            }
-            return null;
-          })
-          .filter((value: string | null): value is string => Boolean(value && value.length > 0));
-        const unique = Array.from(new Set<string>(entries));
-        if (cancelled) return;
-        setBackgroundClassSuggestions(unique);
-      } catch {
-        if (!cancelled) {
-          setBackgroundClassSuggestions([]);
-        }
-      }
-    };
-    void loadBackgroundClasses();
-    return () => {
-      cancelled = true;
-    };
-  }, [requiresBackgroundClass]);
 
   const genderLabel = useMemo(() => {
     if (form.genderOption === "custom") {

--- a/src/components/onboarding/use-onboarding-background-data.ts
+++ b/src/components/onboarding/use-onboarding-background-data.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  findMatchingBackgroundTag,
+  normalizeBackgroundLabel,
+  type BackgroundTag,
+} from "@/data/onboarding-backgrounds";
+
+type UseOnboardingBackgroundDataOptions = {
+  initialSuggestions?: readonly string[] | string[];
+};
+
+function sanitizeSuggestions(input: UseOnboardingBackgroundDataOptions["initialSuggestions"]) {
+  if (!input) {
+    return ["Schule", "Ausbildung", "Beruf"];
+  }
+  const seen = new Set<string>();
+  const entries: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    const key = normalizeBackgroundLabel(trimmed) || trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    entries.push(trimmed);
+  }
+  return entries.length ? entries : ["Schule", "Ausbildung", "Beruf"];
+}
+
+export function useOnboardingBackgroundData(
+  background: string,
+  options?: UseOnboardingBackgroundDataOptions,
+): {
+  backgroundSuggestions: string[];
+  classSuggestions: string[];
+  activeTag: BackgroundTag | null;
+  requiresClass: boolean;
+} {
+  const baseSuggestions = useMemo(() => sanitizeSuggestions(options?.initialSuggestions), [options?.initialSuggestions]);
+  const [backgroundSuggestions, setBackgroundSuggestions] = useState<string[]>(baseSuggestions);
+  const [classSuggestions, setClassSuggestions] = useState<string[]>([]);
+
+  const activeTag = useMemo(() => findMatchingBackgroundTag(background), [background]);
+  const requiresClass = activeTag?.requiresClass ?? false;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadBackgrounds = async () => {
+      try {
+        const response = await fetch("/api/onboarding/backgrounds", { cache: "no-store" });
+        const data = await response.json().catch(() => null);
+        if (cancelled || !Array.isArray(data?.backgrounds)) return;
+        setBackgroundSuggestions((prev) => {
+          const seen = new Set(prev.map((entry) => normalizeBackgroundLabel(entry) || entry.toLowerCase()));
+          const merged = [...prev];
+          for (const raw of data.backgrounds as unknown[]) {
+            let label: string | null = null;
+            if (typeof raw === "string") {
+              label = raw;
+            } else if (raw && typeof raw === "object" && typeof (raw as { name?: unknown }).name === "string") {
+              label = (raw as { name: string }).name;
+            }
+            if (!label) continue;
+            const trimmed = label.trim();
+            if (!trimmed) continue;
+            const key = normalizeBackgroundLabel(trimmed) || trimmed.toLowerCase();
+            if (seen.has(key)) continue;
+            seen.add(key);
+            merged.push(trimmed);
+          }
+          return merged;
+        });
+      } catch {
+        // optional suggestions, ignore errors
+      }
+    };
+
+    void loadBackgrounds();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    // keep suggestions in sync with option changes
+    setBackgroundSuggestions((prev) => {
+      const seen = new Set(baseSuggestions.map((entry) => normalizeBackgroundLabel(entry) || entry.toLowerCase()));
+      const merged = [...baseSuggestions];
+      for (const entry of prev) {
+        const key = normalizeBackgroundLabel(entry) || entry.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        merged.push(entry);
+      }
+      return merged;
+    });
+  }, [baseSuggestions]);
+
+  useEffect(() => {
+    if (!requiresClass) {
+      setClassSuggestions([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadClasses = async () => {
+      try {
+        const response = await fetch("/api/onboarding/background-classes", { cache: "no-store" });
+        const data = await response.json().catch(() => null);
+        if (cancelled || !Array.isArray(data?.classes)) return;
+        const entries = (data.classes as unknown[])
+          .map((entry): string | null => {
+            if (typeof entry === "string") return entry.trim();
+            if (entry && typeof entry === "object" && typeof (entry as { name?: unknown }).name === "string") {
+              return (entry as { name: string }).name.trim();
+            }
+            return null;
+          })
+          .filter((value): value is string => Boolean(value));
+        const unique = Array.from(new Set(entries));
+        if (!cancelled) setClassSuggestions(unique);
+      } catch {
+        if (!cancelled) setClassSuggestions([]);
+      }
+    };
+
+    void loadClasses();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [requiresClass, activeTag?.value]);
+
+  return { backgroundSuggestions, classSuggestions, activeTag, requiresClass };
+}


### PR DESCRIPTION
## Summary
- extract a reusable `useOnboardingBackgroundData` hook so onboarding flows share the same background and class suggestion logic
- update the onboarding wizard to consume the shared hook and drop its duplicated fetch effects
- switch the profile onboarding section to reuse the shared hook and common background suggestions

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db8a8b9474832d9b58dff75bf6ef57