### PR TITLE
Fix hero viewport height handling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,10 +108,22 @@
 
   body {
     @apply bg-background text-foreground;
-    min-height: 100dvh;
+    min-height: 100vh;
     font-feature-settings: "kern" 1, "liga" 1;
     font-family: var(--font-body);
     letter-spacing: var(--tracking-normal);
+  }
+
+  @supports (min-height: 100svh) {
+    body {
+      min-height: 100svh;
+    }
+  }
+
+  @supports (min-height: 100dvh) {
+    body {
+      min-height: 100dvh;
+    }
   }
 }
 
@@ -119,9 +131,21 @@
   .app-shell {
     position: relative;
     isolation: isolate;
-    min-height: 100dvh;
+    min-height: 100vh;
     display: grid;
     grid-template-rows: auto 1fr auto;
+  }
+
+  @supports (min-height: 100svh) {
+    .app-shell {
+      min-height: 100svh;
+    }
+  }
+
+  @supports (min-height: 100dvh) {
+    .app-shell {
+      min-height: 100dvh;
+    }
   }
 
   .layout-container {

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -19,7 +19,9 @@ export function Hero({ images }: { images: string[] }) {
   const rotateImages = images.length > 0 ? images.slice(0, 5) : ["https://picsum.photos/id/1069/1600/900"];
 
   return (
-    <section className="hero-section relative h-screen min-h-[100dvh] w-full overflow-hidden sm:min-h-[90vh] lg:min-h-[100vh]">
+    <section
+      className="hero-section relative min-h-[100vh] supports-[min-height:100svh]:min-h-[100svh] supports-[min-height:100dvh]:min-h-[100dvh] w-full overflow-hidden sm:min-h-[90vh] sm:supports-[min-height:100svh]:min-h-[90svh] sm:supports-[min-height:100dvh]:min-h-[90dvh] lg:min-h-[100vh] lg:supports-[min-height:100svh]:min-h-[100svh] lg:supports-[min-height:100dvh]:min-h-[100dvh]"
+    >
       <div
         className="absolute inset-0 z-0 h-full w-full overflow-hidden"
         style={{


### PR DESCRIPTION
## Summary
- replace the hero section height stack with dynamic viewport unit utilities to prevent overlay controls from hiding calls-to-action
- add @supports-based fallbacks so body and shell heights gracefully degrade when svh/dvh units are unsupported

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db8d7d5a30832d840329ffd8066025