### PR TITLE
Align hero container padding with layout container guidance

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -83,6 +83,10 @@ Weitere Layout-Konstanten:
 - `--layout-gutter`: responsive Außenabstände (mobile 1rem → Desktop 3–4rem)
 - `--header-height`: 4rem (mobile) / 5rem (≥768px)
 
+### Layout-Container
+
+- `.layout-container` steuert ausschließlich Breite und horizontale Außenabstände. Vertikale Polster fügst du je nach Kontext mit Tailwind-Utilities (`pt`, `pb`, `py`, `space-y` etc.) hinzu.
+
 ## Komponentenrichtlinien
 
 ### Mitgliederbereich: App Shell & Seitenaufbau

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -51,8 +51,8 @@ export function Hero({ images }: { images: string[] }) {
         className="absolute inset-0 z-10 opacity-[0.38] mix-blend-soft-light [background-image:radial-gradient(circle_at_center,rgba(255,255,255,0.12),rgba(255,255,255,0)_68%)]"
       />
 
-      <div className="hero-content relative z-20 flex h-full items-center justify-center px-6 pt-20 pb-14 sm:px-8 md:pb-24">
-        <div className="layout-container">
+      <div className="hero-content relative z-20 flex h-full items-center justify-center">
+        <div className="layout-container flex h-full items-center justify-center pt-20 pb-14 md:pb-24">
           <div
             className="mx-auto max-w-5xl text-center"
             style={{


### PR DESCRIPTION
## Summary
- remove redundant horizontal padding from the hero wrapper and keep spacing within the layout container
- document in the design handbook that the layout-container utility controls only horizontal gutters

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db8d91c7e0832da363e05c0fd223f1