### PR TITLE
Allow editing server analytics retention windows in UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,18 @@ REALTIME_SERVER_EVENT_PATH=/events
 CRON_SECRET=replace-with-cron-secret
 
 # ------------------------------------------------------------------------------
+# Server analytics retention & aggregation windows
+# Optional: werden beim ersten Start als Vorgabewerte verwendet und lassen sich
+# anschließend direkt im Mitgliederbereich auf der Analytics-Seite anpassen.
+# ------------------------------------------------------------------------------
+ANALYTICS_HTTP_WINDOW_MINUTES=1440
+ANALYTICS_HTTP_BUCKET_MINUTES=60
+ANALYTICS_SESSION_WINDOW_DAYS=30
+ANALYTICS_SESSION_RETENTION_DAYS=180
+ANALYTICS_PAGE_WINDOW_DAYS=14
+ANALYTICS_PAGE_RETENTION_DAYS=60
+
+# ------------------------------------------------------------------------------
 # Email delivery (choose one provider)
 # ------------------------------------------------------------------------------
 EMAIL_SERVER=smtp://user:pass@mail.example.com:587

--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ on [http://localhost:3000](http://localhost:3000).
 - `pnpm start:proxy` – emulate the Docker proxy setup locally.
 - `pnpm swatches:gen` / `pnpm design-system:tokens` – update color palettes and
   design tokens.
+- `pnpm ts-node scripts/cron/aggregate-http-metrics.ts` – aggregate raw HTTP
+  analytics into the summary tables.
+- `pnpm ts-node scripts/cron/aggregate-session-metrics.ts` – derive session,
+  traffic and realtime insights.
+- `pnpm ts-node scripts/cron/aggregate-page-metrics.ts` – compute page and device
+  performance metrics.
+
+### Server analytics aggregation
+
+The server analytics dashboard pulls its metrics from the aggregated tables in
+Postgres. A dedicated cron endpoint at `/api/cron/server-analytics` executes the
+entire pipeline (HTTP, session and page analytics). Protect the route by passing
+the `x-cron-secret` header with the value from `CRON_SECRET`. When the header is
+missing or invalid the request is rejected with `401`.
+
+Aggregation windows and retention policies are configurable via the environment
+variables `ANALYTICS_HTTP_WINDOW_MINUTES`, `ANALYTICS_HTTP_BUCKET_MINUTES`,
+`ANALYTICS_SESSION_WINDOW_DAYS`, `ANALYTICS_SESSION_RETENTION_DAYS`,
+`ANALYTICS_PAGE_WINDOW_DAYS` and `ANALYTICS_PAGE_RETENTION_DAYS`. These values
+act as initial defaults and can later be adjusted directly from the
+“Einstellungen” tab on the server analytics page. All scripts under
+`scripts/cron/*` use the shared pipeline logic, so the same configuration
+applies whether the job is triggered via the API route or a standalone task
+runner.
 
 ### Quality checks
 

--- a/prisma/migrations/20251220090000_analytics_settings/migration.sql
+++ b/prisma/migrations/20251220090000_analytics_settings/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "analytics_settings" (
+    "id" TEXT NOT NULL DEFAULT 'default',
+    "http_window_minutes" INTEGER NOT NULL DEFAULT 1440,
+    "http_bucket_minutes" INTEGER NOT NULL DEFAULT 60,
+    "session_window_days" INTEGER NOT NULL DEFAULT 30,
+    "session_retention_days" INTEGER NOT NULL DEFAULT 180,
+    "realtime_window_hours" INTEGER NOT NULL DEFAULT 24,
+    "page_window_days" INTEGER NOT NULL DEFAULT 14,
+    "page_retention_days" INTEGER NOT NULL DEFAULT 60,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "analytics_settings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTrigger
+CREATE TRIGGER "analytics_settings_set_updated_at"
+BEFORE UPDATE ON "analytics_settings"
+FOR EACH ROW
+EXECUTE FUNCTION "set_current_timestamp_updated_at"();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1403,6 +1403,21 @@ enum AnalyticsServerLogStatus {
   resolved
 }
 
+model AnalyticsSettings {
+  id                   String   @id @default("default")
+  httpWindowMinutes    Int      @default(1440)
+  httpBucketMinutes    Int      @default(60)
+  sessionWindowDays    Int      @default(30)
+  sessionRetentionDays Int      @default(180)
+  realtimeWindowHours  Int      @default(24)
+  pageWindowDays       Int      @default(14)
+  pageRetentionDays    Int      @default(60)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  @@map("analytics_settings")
+}
+
 model AnalyticsHttpRequest {
   id           String                @id @default(cuid())
   timestamp    DateTime              @default(now())

--- a/realtime-server/src/analytics.js
+++ b/realtime-server/src/analytics.js
@@ -1,6 +1,10 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import { setTimeout as wait } from 'node:timers/promises';
+import {
+  getDefaultServerAnalyticsSettings,
+  loadServerAnalyticsSettings,
+} from '../../src/lib/server-analytics-settings.js';
 const BASELINE_ANALYTICS = Object.freeze({
   summary: {
     uptimePercentage: 0,
@@ -67,6 +71,7 @@ const BASELINE_ANALYTICS = Object.freeze({
   sessionInsights: [],
   optimizationInsights: [],
   serverLogs: [],
+  settings: getDefaultServerAnalyticsSettings(),
 });
 
 const fallbackAnalyticsModule = {
@@ -424,6 +429,7 @@ export function createAnalyticsManager({
   async function collectAnalyticsSnapshot() {
     const base = baselineLoader();
     let resourceUsage = base.resourceUsage;
+    let settings = base.settings ?? getDefaultServerAnalyticsSettings();
     try {
       resourceUsage = await resourceUsageCollector({
         previousResourceUsage: state.previousResourceUsage,
@@ -432,6 +438,14 @@ export function createAnalyticsManager({
       });
     } catch (error) {
       logError('[Realtime] Verwende statische Ressourcenwerte für Server-Analytics', error);
+    }
+
+    if (getDatabaseUrl()) {
+      try {
+        settings = await loadServerAnalyticsSettings();
+      } catch (error) {
+        logError('[Realtime] Failed to load analytics settings', error);
+      }
     }
 
     const baseSummary = mergeOnlineStatsIntoSummary(
@@ -497,6 +511,7 @@ export function createAnalyticsManager({
       deviceBreakdown,
       publicPages,
       memberPages,
+      settings,
     };
   }
 

--- a/scripts/cron/aggregate-http-metrics.ts
+++ b/scripts/cron/aggregate-http-metrics.ts
@@ -1,89 +1,17 @@
 import { prisma } from "@/lib/prisma";
-import { aggregateHttpMetrics } from "@/lib/analytics/aggregate-http";
-
-const DEFAULT_WINDOW_MINUTES = 24 * 60;
-const DEFAULT_BUCKET_MINUTES = 60;
+import { runHttpAnalyticsAggregation } from "@/lib/analytics/server-analytics-pipeline";
 
 async function main() {
-  if (!process.env.DATABASE_URL) {
-    console.warn("[analytics] DATABASE_URL is not set. Skipping HTTP aggregation batch.");
-    return;
+  const result = await runHttpAnalyticsAggregation({ prisma });
+  if (result.status === "skipped") {
+    console.warn(
+      `[analytics] Skipping HTTP aggregation batch (${result.reason ?? "unknown reason"}).`,
+    );
+  } else {
+    console.info(
+      `[analytics] Aggregated HTTP metrics for ${result.data.requestCount} requests between ${result.data.windowStart.toISOString()} and ${result.data.windowEnd.toISOString()}.`,
+    );
   }
-
-  const now = new Date();
-  const windowMinutes = Number(process.env.ANALYTICS_HTTP_WINDOW_MINUTES ?? DEFAULT_WINDOW_MINUTES);
-  const bucketMinutes = Number(process.env.ANALYTICS_HTTP_BUCKET_MINUTES ?? DEFAULT_BUCKET_MINUTES);
-  const windowStart = new Date(now.getTime() - Math.max(windowMinutes, 5) * 60_000);
-
-  const [requests, heartbeats] = await Promise.all([
-    prisma.analyticsHttpRequest.findMany({
-      where: {
-        timestamp: {
-          gte: windowStart,
-          lte: now,
-        },
-      },
-      orderBy: { timestamp: "asc" },
-    }),
-    prisma.analyticsUptimeHeartbeat.findMany({
-      where: {
-        observedAt: {
-          gte: windowStart,
-          lte: now,
-        },
-      },
-    }),
-  ]);
-
-  const { summary, peakHours } = aggregateHttpMetrics({
-    requests,
-    heartbeats,
-    windowStart,
-    windowEnd: now,
-    bucketMinutes,
-  });
-
-  await prisma.$transaction(async (tx) => {
-    await tx.analyticsHttpSummary.deleteMany({});
-    await tx.analyticsHttpPeakHour.deleteMany({});
-
-    await tx.analyticsHttpSummary.create({
-      data: {
-        windowStart: summary.windowStart,
-        windowEnd: summary.windowEnd,
-        totalRequests: summary.totalRequests,
-        successfulRequests: summary.successfulRequests,
-        clientErrorRequests: summary.clientErrorRequests,
-        serverErrorRequests: summary.serverErrorRequests,
-        averageDurationMs: summary.averageDurationMs,
-        p95DurationMs: summary.p95DurationMs,
-        averagePayloadBytes: summary.averagePayloadBytes,
-        uptimePercentage: summary.uptimePercentage,
-        frontendRequests: summary.frontendRequests,
-        frontendAvgResponseMs: summary.frontendAvgResponseMs,
-        frontendAvgPayloadBytes: summary.frontendAvgPayloadBytes,
-        cacheHitRate: summary.cacheHitRate,
-        frontendCacheHitRate: summary.frontendCacheHitRate,
-        membersRequests: summary.membersRequests,
-        membersAvgResponseMs: summary.membersAvgResponseMs,
-        apiRequests: summary.apiRequests,
-        apiAvgResponseMs: summary.apiAvgResponseMs,
-        apiErrorRate: summary.apiErrorRate,
-        apiBackgroundJobs: summary.apiBackgroundJobs,
-      },
-    });
-
-    if (peakHours.length > 0) {
-      await tx.analyticsHttpPeakHour.createMany({
-        data: peakHours.map((entry) => ({
-          bucketStart: entry.bucketStart,
-          bucketEnd: entry.bucketEnd,
-          requests: entry.requests,
-          share: entry.share,
-        })),
-      });
-    }
-  });
 }
 
 void main()

--- a/scripts/cron/aggregate-page-metrics.ts
+++ b/scripts/cron/aggregate-page-metrics.ts
@@ -1,93 +1,17 @@
 import { prisma } from "@/lib/prisma";
-import { aggregatePageMetrics } from "@/lib/analytics/aggregate-page-metrics";
-
-const DEFAULT_WINDOW_DAYS = 14;
-const DEFAULT_RETENTION_DAYS = 60;
-
-function resolvePositiveInteger(value: unknown, fallback: number) {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return fallback;
-  }
-  return Math.round(parsed);
-}
+import { runPageAnalyticsAggregation } from "@/lib/analytics/server-analytics-pipeline";
 
 async function main() {
-  if (!process.env.DATABASE_URL) {
-    console.warn("[analytics] DATABASE_URL is not set. Skipping page metrics aggregation.");
-    return;
+  const result = await runPageAnalyticsAggregation({ prisma });
+  if (result.status === "skipped") {
+    console.warn(
+      `[analytics] Skipping page metrics aggregation (${result.reason ?? "unknown reason"}).`,
+    );
+  } else {
+    console.info(
+      `[analytics] Aggregated page metrics from ${result.data.pageViewCount} page view samples.`,
+    );
   }
-
-  const now = new Date();
-  const windowDays = resolvePositiveInteger(process.env.ANALYTICS_PAGE_WINDOW_DAYS, DEFAULT_WINDOW_DAYS);
-  const retentionDays = resolvePositiveInteger(
-    process.env.ANALYTICS_PAGE_RETENTION_DAYS,
-    DEFAULT_RETENTION_DAYS,
-  );
-  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
-
-  const pageViews = await prisma.analyticsPageView.findMany({
-    where: {
-      createdAt: {
-        gte: windowStart,
-        lte: now,
-      },
-    },
-    select: {
-      path: true,
-      scope: true,
-      deviceHint: true,
-      loadTimeMs: true,
-      lcpMs: true,
-      timeOnPageMs: true,
-      weight: true,
-    },
-  });
-
-  const { pages, devices } = aggregatePageMetrics(pageViews);
-
-  await prisma.$transaction(async (tx) => {
-    await tx.analyticsPageMetric.deleteMany({});
-    await tx.analyticsDeviceMetric.deleteMany({});
-
-    if (pages.length > 0) {
-      await tx.analyticsPageMetric.createMany({
-        data: pages.map((page) => ({
-          path: page.path,
-          scope: page.scope,
-          avgLoadMs: page.avgLoadMs,
-          lcpMs: page.lcpMs,
-          avgTimeOnPageSeconds: page.avgTimeOnPageSeconds,
-          weight: page.weight,
-        })),
-      });
-    }
-
-    if (devices.length > 0) {
-      await tx.analyticsDeviceMetric.createMany({
-        data: devices.map((device) => ({
-          device: device.device,
-          sessions: device.sessions,
-          avgLoadMs: device.avgLoadMs,
-          share: device.share,
-        })),
-      });
-    }
-
-    if (retentionDays > 0) {
-      const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
-      await tx.analyticsPageView.deleteMany({
-        where: {
-          createdAt: { lt: cutoff },
-        },
-      });
-      await tx.analyticsDeviceSnapshot.deleteMany({
-        where: {
-          createdAt: { lt: cutoff },
-        },
-      });
-    }
-  });
 }
 
 void main()

--- a/scripts/cron/aggregate-session-metrics.ts
+++ b/scripts/cron/aggregate-session-metrics.ts
@@ -1,168 +1,17 @@
 import { prisma } from "@/lib/prisma";
-import {
-  aggregateSessionMetrics,
-  type AnalyticsSessionLike,
-  type RealtimeEventLike,
-  type TrafficAttributionLike,
-} from "@/lib/analytics/aggregate-session-metrics";
-import type {
-  AnalyticsRealtimeEvent,
-  AnalyticsSession,
-  AnalyticsTrafficAttribution,
-} from "@prisma/client";
-
-const DEFAULT_SESSION_WINDOW_DAYS = 30;
-const DEFAULT_RETENTION_DAYS = 180;
-
-function resolvePositiveInteger(value: unknown, fallback: number): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return fallback;
-  }
-  return Math.round(parsed);
-}
-
-function transformSessions(sessions: AnalyticsSession[]): AnalyticsSessionLike[] {
-  return sessions.map((session) => ({
-    ...session,
-    startedAt: session.startedAt instanceof Date ? session.startedAt : new Date(session.startedAt),
-    lastSeenAt: session.lastSeenAt instanceof Date ? session.lastSeenAt : new Date(session.lastSeenAt),
-    pagePaths: Array.isArray(session.pagePaths) ? [...session.pagePaths] : [],
-  }));
-}
-
-function transformRealtimeEvents(events: AnalyticsRealtimeEvent[]): RealtimeEventLike[] {
-  return events.map((event) => ({
-    ...event,
-    occurredAt: event.occurredAt instanceof Date ? event.occurredAt : new Date(event.occurredAt),
-  }));
-}
+import { runSessionAnalyticsAggregation } from "@/lib/analytics/server-analytics-pipeline";
 
 async function main() {
-  if (!process.env.DATABASE_URL) {
-    console.warn("[analytics] DATABASE_URL is not set. Skipping session metrics aggregation.");
-    return;
+  const result = await runSessionAnalyticsAggregation({ prisma });
+  if (result.status === "skipped") {
+    console.warn(
+      `[analytics] Skipping session metrics aggregation (${result.reason ?? "unknown reason"}).`,
+    );
+  } else {
+    console.info(
+      `[analytics] Aggregated ${result.data.sessionCount} sessions, ${result.data.trafficAttributionCount} traffic entries and ${result.data.realtimeEventCount} realtime events.`,
+    );
   }
-
-  const now = new Date();
-  const windowDays = resolvePositiveInteger(
-    process.env.ANALYTICS_SESSION_WINDOW_DAYS,
-    DEFAULT_SESSION_WINDOW_DAYS,
-  );
-  const retentionDays = resolvePositiveInteger(
-    process.env.ANALYTICS_SESSION_RETENTION_DAYS,
-    DEFAULT_RETENTION_DAYS,
-  );
-  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
-  const realtimeWindowStart = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-
-  const [sessionsRaw, trafficRaw, realtimeEventsRaw] = await Promise.all([
-    prisma.analyticsSession.findMany({
-      where: {
-        startedAt: {
-          gte: windowStart,
-          lte: now,
-        },
-      },
-    }),
-    prisma.analyticsTrafficAttribution.findMany({
-      where: {
-        createdAt: {
-          gte: windowStart,
-          lte: now,
-        },
-      },
-    }),
-    prisma.analyticsRealtimeEvent.findMany({
-      where: {
-        occurredAt: {
-          gte: realtimeWindowStart,
-          lte: now,
-        },
-      },
-    }),
-  ]);
-
-  const sessions = transformSessions(sessionsRaw);
-  const traffic = trafficRaw as AnalyticsTrafficAttribution[] as TrafficAttributionLike[];
-  const realtimeEvents = transformRealtimeEvents(realtimeEventsRaw);
-
-  const result = aggregateSessionMetrics({
-    sessions,
-    traffic,
-    realtimeEvents,
-    now,
-  });
-
-  await prisma.$transaction(async (tx) => {
-    await tx.analyticsSessionInsight.deleteMany({});
-    await tx.analyticsTrafficSource.deleteMany({});
-    await tx.analyticsRealtimeSummary.deleteMany({});
-    await tx.analyticsSessionSummary.deleteMany({});
-
-    if (result.sessionInsights.length > 0) {
-      await tx.analyticsSessionInsight.createMany({
-        data: result.sessionInsights.map((insight) => ({
-          segment: insight.segment,
-          avgSessionDurationSeconds: insight.avgSessionDurationSeconds,
-          pagesPerSession: insight.pagesPerSession,
-          retentionRate: insight.retentionRate,
-          share: insight.share,
-          conversionRate: insight.conversionRate,
-        })),
-      });
-    }
-
-    if (result.trafficSources.length > 0) {
-      await tx.analyticsTrafficSource.createMany({
-        data: result.trafficSources.map((source) => ({
-          channel: source.channel,
-          sessions: source.sessions,
-          avgSessionDurationSeconds: source.avgSessionDurationSeconds,
-          conversionRate: source.conversionRate,
-          changePercent: source.changePercent,
-        })),
-      });
-    }
-
-    await tx.analyticsRealtimeSummary.create({
-      data: {
-        windowStart: result.realtimeSummary.windowStart,
-        windowEnd: result.realtimeSummary.windowEnd,
-        totalEvents: result.realtimeSummary.totalEvents,
-        eventCounts: result.realtimeSummary.eventCounts,
-      },
-    });
-
-    await tx.analyticsSessionSummary.create({
-      data: {
-        windowStart: result.sessionSummary.windowStart,
-        windowEnd: result.sessionSummary.windowEnd,
-        peakConcurrentUsers: result.sessionSummary.peakConcurrentUsers,
-        membersRealtimeEvents: result.sessionSummary.membersRealtimeEvents,
-        membersAvgSessionDurationSeconds: result.sessionSummary.membersAvgSessionDurationSeconds,
-      },
-    });
-
-    if (retentionDays > 0) {
-      const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
-      await tx.analyticsSession.deleteMany({
-        where: {
-          startedAt: { lt: cutoff },
-        },
-      });
-      await tx.analyticsTrafficAttribution.deleteMany({
-        where: {
-          createdAt: { lt: cutoff },
-        },
-      });
-      await tx.analyticsRealtimeEvent.deleteMany({
-        where: {
-          occurredAt: { lt: cutoff },
-        },
-      });
-    }
-  });
 }
 
 void main()

--- a/src/app/(members)/mitglieder/server-analytics/__tests__/collect-server-analytics.test.ts
+++ b/src/app/(members)/mitglieder/server-analytics/__tests__/collect-server-analytics.test.ts
@@ -4,7 +4,7 @@ import type { AnalyticsHttpSummary, AnalyticsRealtimeSummary, AnalyticsSessionSu
 
 import { collectServerAnalytics } from "@/lib/server-analytics";
 
-const { prismaMock } = vi.hoisted(() => ({
+const { prismaMock, loadSettingsMock } = vi.hoisted(() => ({
   prismaMock: {
     analyticsHttpSummary: { findFirst: vi.fn() },
     analyticsHttpPeakHour: { findMany: vi.fn() },
@@ -13,6 +13,7 @@ const { prismaMock } = vi.hoisted(() => ({
     analyticsTrafficSource: { findMany: vi.fn() },
     analyticsRealtimeSummary: { findFirst: vi.fn() },
   },
+  loadSettingsMock: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -28,6 +29,16 @@ vi.mock("@/lib/server-analytics-data", () => ({
   loadPagePerformanceMetrics: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock("@/lib/server-analytics-settings", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/server-analytics-settings")>(
+    "@/lib/server-analytics-settings",
+  );
+  return {
+    ...actual,
+    loadServerAnalyticsSettings: loadSettingsMock,
+  };
+});
+
 describe("collectServerAnalytics", () => {
   beforeEach(() => {
     prismaMock.analyticsHttpSummary.findFirst.mockReset();
@@ -36,10 +47,29 @@ describe("collectServerAnalytics", () => {
     prismaMock.analyticsSessionInsight.findMany.mockReset();
     prismaMock.analyticsTrafficSource.findMany.mockReset();
     prismaMock.analyticsRealtimeSummary.findFirst.mockReset();
+    loadSettingsMock.mockReset();
+    loadSettingsMock.mockResolvedValue({
+      httpWindowMinutes: 1440,
+      httpBucketMinutes: 60,
+      sessionWindowDays: 30,
+      sessionRetentionDays: 180,
+      realtimeWindowHours: 24,
+      pageWindowDays: 14,
+      pageRetentionDays: 60,
+    });
     process.env.DATABASE_URL = "postgres://test";
   });
 
   it("overrides static metrics with aggregated database values", async () => {
+    loadSettingsMock.mockResolvedValue({
+      httpWindowMinutes: 900,
+      httpBucketMinutes: 45,
+      sessionWindowDays: 21,
+      sessionRetentionDays: 120,
+      realtimeWindowHours: 18,
+      pageWindowDays: 10,
+      pageRetentionDays: 50,
+    });
     const httpSummary = {
       windowStart: new Date("2024-01-01T10:00:00.000Z"),
       windowEnd: new Date("2024-01-01T11:00:00.000Z"),
@@ -116,6 +146,15 @@ describe("collectServerAnalytics", () => {
     expect(botSegment?.avgResponseTimeMs).toBe(180);
     expect(botSegment?.blockedRequests).toBe(4);
     expect(analytics.isDemoData).toBe(false);
+    expect(analytics.settings).toEqual({
+      httpWindowMinutes: 900,
+      httpBucketMinutes: 45,
+      sessionWindowDays: 21,
+      sessionRetentionDays: 120,
+      realtimeWindowHours: 18,
+      pageWindowDays: 10,
+      pageRetentionDays: 50,
+    });
   });
 
   it("keeps the demo flag when no database connection is available", async () => {
@@ -127,5 +166,6 @@ describe("collectServerAnalytics", () => {
     expect(prismaMock.analyticsSessionSummary.findFirst).not.toHaveBeenCalled();
     expect(prismaMock.analyticsRealtimeSummary.findFirst).not.toHaveBeenCalled();
     expect(analytics.isDemoData).toBe(true);
+    expect(loadSettingsMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(members)/mitglieder/server-analytics/__tests__/server-analytics-content.test.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/__tests__/server-analytics-content.test.tsx
@@ -10,12 +10,14 @@ import type { ServerAnalytics } from "@/lib/server-analytics";
 
 import { ServerAnalyticsContent } from "../server-analytics-content";
 
-const { updateStatusMock } = vi.hoisted(() => ({
+const { updateStatusMock, updateSettingsMock } = vi.hoisted(() => ({
   updateStatusMock: vi.fn(),
+  updateSettingsMock: vi.fn(),
 }));
 
 vi.mock("../actions", () => ({
   updateServerLogStatusAction: updateStatusMock,
+  updateServerAnalyticsSettingsAction: updateSettingsMock,
 }));
 
 vi.mock("@/hooks/useRealtime", () => ({
@@ -31,6 +33,15 @@ function createAnalytics(overrides: Partial<ServerAnalytics> = {}): ServerAnalyt
   const analytics: ServerAnalytics = {
     generatedAt: now,
     isDemoData: false,
+    settings: {
+      httpWindowMinutes: 1440,
+      httpBucketMinutes: 60,
+      sessionWindowDays: 30,
+      sessionRetentionDays: 180,
+      realtimeWindowHours: 24,
+      pageWindowDays: 14,
+      pageRetentionDays: 60,
+    },
     summary: {
       uptimePercentage: 99.9,
       requestsLast24h: 1_200,
@@ -110,6 +121,7 @@ describe("ServerAnalyticsContent", () => {
   beforeEach(() => {
     (globalThis as typeof globalThis & { React?: typeof React }).React = React;
     vi.clearAllMocks();
+    updateSettingsMock.mockReset();
   });
 
   it("updates server log status via server action", async () => {
@@ -162,5 +174,48 @@ describe("ServerAnalyticsContent", () => {
     expect(screen.getByText("Nutzertypen & Traffic")).toBeInTheDocument();
     expect(screen.getByText("Nicht eingeloggt")).toBeInTheDocument();
     expect(screen.getByText("Bots & Crawler")).toBeInTheDocument();
+  });
+
+  it("updates analytics settings via server action", async () => {
+    const analytics = createAnalytics();
+    const user = userEvent.setup();
+    const updatedSettings = {
+      ...analytics.settings,
+      httpWindowMinutes: 720,
+    };
+    const updatedAnalytics = createAnalytics({
+      settings: updatedSettings,
+      generatedAt: new Date("2024-02-01T12:00:00.000Z").toISOString(),
+    });
+
+    updateSettingsMock.mockResolvedValueOnce({
+      success: true,
+      settings: updatedSettings,
+      analytics: updatedAnalytics,
+    });
+
+    render(<ServerAnalyticsContent initialAnalytics={analytics} canManageSettings />);
+
+    const settingsTab = await screen.findByRole("tab", { name: "Einstellungen" });
+    await user.click(settingsTab);
+
+    const httpInput = await screen.findByLabelText("Auswertungszeitraum (Minuten)");
+    await user.clear(httpInput);
+    await user.type(httpInput, "720");
+
+    const submitButton = await screen.findByRole("button", { name: "Einstellungen speichern" });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(updateSettingsMock).toHaveBeenCalledWith({
+        httpWindowMinutes: 720,
+        httpBucketMinutes: analytics.settings.httpBucketMinutes,
+        sessionWindowDays: analytics.settings.sessionWindowDays,
+        sessionRetentionDays: analytics.settings.sessionRetentionDays,
+        realtimeWindowHours: analytics.settings.realtimeWindowHours,
+        pageWindowDays: analytics.settings.pageWindowDays,
+        pageRetentionDays: analytics.settings.pageRetentionDays,
+      });
+    });
   });
 });

--- a/src/app/(members)/mitglieder/server-analytics/actions.ts
+++ b/src/app/(members)/mitglieder/server-analytics/actions.ts
@@ -11,6 +11,11 @@ import {
 } from "@/lib/analytics/load-server-logs";
 import { collectServerAnalytics } from "@/lib/server-analytics";
 import { resetAnalyticsMetadataCache } from "@/lib/server-analytics-data";
+import {
+  SERVER_ANALYTICS_SETTINGS_LIMITS,
+  saveServerAnalyticsSettings,
+  type ServerAnalyticsSettings,
+} from "@/lib/server-analytics-settings";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
@@ -22,11 +27,72 @@ const updateStatusSchema = z.object({
   status: statusSchema,
 });
 
+const settingsLimits = SERVER_ANALYTICS_SETTINGS_LIMITS;
+
+const updateSettingsSchema = z.object({
+  httpWindowMinutes: z
+    .coerce
+    .number()
+    .int()
+    .min(settingsLimits.httpWindowMinutes.min, "Mindestens 5 Minuten")
+    .max(settingsLimits.httpWindowMinutes.max, "Maximal 7 Tage"),
+  httpBucketMinutes: z
+    .coerce
+    .number()
+    .int()
+    .min(settingsLimits.httpBucketMinutes.min, "Mindestens 1 Minute")
+    .max(settingsLimits.httpBucketMinutes.max, "Maximal 24 Stunden"),
+  sessionWindowDays: z
+    .coerce
+    .number()
+    .int()
+    .min(settingsLimits.sessionWindowDays.min, "Mindestens 1 Tag")
+    .max(settingsLimits.sessionWindowDays.max, "Maximal 365 Tage"),
+  sessionRetentionDays: z
+    .coerce
+    .number()
+    .int()
+    .min(settingsLimits.sessionRetentionDays.min, "Mindestens 1 Tag")
+    .max(settingsLimits.sessionRetentionDays.max, "Maximal 365 Tage"),
+  realtimeWindowHours: z
+    .coerce
+    .number()
+    .int()
+    .min(settingsLimits.realtimeWindowHours.min, "Mindestens 1 Stunde")
+    .max(settingsLimits.realtimeWindowHours.max, "Maximal 168 Stunden"),
+  pageWindowDays: z
+    .coerce
+    .number()
+    .int()
+    .min(settingsLimits.pageWindowDays.min, "Mindestens 1 Tag")
+    .max(settingsLimits.pageWindowDays.max, "Maximal 365 Tage"),
+  pageRetentionDays: z
+    .coerce
+    .number()
+    .int()
+    .min(settingsLimits.pageRetentionDays.min, "Mindestens 1 Tag")
+    .max(settingsLimits.pageRetentionDays.max, "Maximal 365 Tage"),
+});
+
 export type UpdateServerLogStatusInput = z.infer<typeof updateStatusSchema>;
 
 export type UpdateServerLogStatusResult =
   | { success: true; log: LoadedServerLog }
   | { success: false; error: string };
+
+export type UpdateServerAnalyticsSettingsInput = z.infer<typeof updateSettingsSchema>;
+
+export type UpdateServerAnalyticsSettingsResult =
+  | {
+      success: true;
+      settings: ServerAnalyticsSettings;
+      analytics: Awaited<ReturnType<typeof collectServerAnalytics>>;
+    }
+  | {
+      success: false;
+      error: "not_authorized" | "no_database" | "validation_failed" | "update_failed";
+      fieldErrors?: Record<string, string[]>;
+    };
 
 function hasOwnerRole(user: { role?: string | null; roles?: unknown } | null | undefined): boolean {
   if (!user) {
@@ -92,6 +158,37 @@ type ResetServerAnalyticsError = "not_authorized" | "no_database" | "reset_faile
 export type ResetServerAnalyticsResult =
   | { success: true; analytics: Awaited<ReturnType<typeof collectServerAnalytics>> }
   | { success: false; error: ResetServerAnalyticsError };
+
+export async function updateServerAnalyticsSettingsAction(
+  input: UpdateServerAnalyticsSettingsInput,
+): Promise<UpdateServerAnalyticsSettingsResult> {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.analytics");
+  if (!allowed || !hasOwnerRole(session.user)) {
+    return { success: false, error: "not_authorized" };
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return { success: false, error: "no_database" };
+  }
+
+  const parsed = updateSettingsSchema.safeParse(input);
+  if (!parsed.success) {
+    const fieldErrors = parsed.error.flatten().fieldErrors;
+    return { success: false, error: "validation_failed", fieldErrors };
+  }
+
+  try {
+    const settings = await saveServerAnalyticsSettings(parsed.data, prisma);
+    resetAnalyticsMetadataCache();
+    revalidatePath("/mitglieder/server-analytics");
+    const analytics = await collectServerAnalytics();
+    return { success: true, settings, analytics };
+  } catch (error) {
+    console.error("[server-analytics] Failed to update analytics settings", error);
+    return { success: false, error: "update_failed" };
+  }
+}
 
 export async function resetServerAnalyticsAction(): Promise<ResetServerAnalyticsResult> {
   const session = await requireAuth();

--- a/src/app/(members)/mitglieder/server-analytics/page.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/page.tsx
@@ -4,6 +4,30 @@ import { requireAuth } from "@/lib/rbac";
 
 import { ServerAnalyticsContent } from "./server-analytics-content";
 
+function userHasOwnerRole(user: { role?: string | null; roles?: unknown } | null | undefined): boolean {
+  if (!user) {
+    return false;
+  }
+
+  if (user.role === "owner") {
+    return true;
+  }
+
+  if (Array.isArray(user.roles)) {
+    return user.roles.some((role) => {
+      if (typeof role === "string") {
+        return role === "owner";
+      }
+      if (role && typeof role === "object" && "role" in role) {
+        return (role as { role?: string | null }).role === "owner";
+      }
+      return false;
+    });
+  }
+
+  return false;
+}
+
 export default async function ServerAnalyticsPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.server.analytics");
@@ -12,9 +36,14 @@ export default async function ServerAnalyticsPage() {
   }
 
   const user = session.user!;
-  const roles = Array.isArray(user.roles) ? user.roles : [];
-  const isOwner = user.role === "owner" || roles.includes("owner");
+  const isOwner = userHasOwnerRole(user);
   const analytics = await collectServerAnalytics();
 
-  return <ServerAnalyticsContent initialAnalytics={analytics} canReset={isOwner} />;
+  return (
+    <ServerAnalyticsContent
+      initialAnalytics={analytics}
+      canReset={isOwner}
+      canManageSettings={isOwner}
+    />
+  );
 }

--- a/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type FormEvent,
+} from "react";
 
 import { Activity, AlertTriangle, HardDrive, Radio, ShieldCheck, Timer, Users } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogClose,
@@ -29,8 +39,14 @@ import type { ServerAnalyticsRealtimeEvent } from "@/lib/realtime/types";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
-import { resetServerAnalyticsAction, updateServerLogStatusAction } from "./actions";
+import {
+  resetServerAnalyticsAction,
+  updateServerAnalyticsSettingsAction,
+  updateServerLogStatusAction,
+  type UpdateServerAnalyticsSettingsInput,
+} from "./actions";
 import { OverviewMetrics, type OverviewMetricDefinition } from "./overview-metrics";
+import { SERVER_ANALYTICS_SETTINGS_LIMITS } from "@/lib/server-analytics-settings";
 
 const numberFormat = new Intl.NumberFormat("de-DE");
 const decimalFormat = new Intl.NumberFormat("de-DE", { minimumFractionDigits: 1, maximumFractionDigits: 1 });
@@ -290,12 +306,62 @@ const statusActionLabelMap: Record<ServerLogEvent["status"], string> = {
 
 const statusUpdateOrder: ServerLogEvent["status"][] = ["open", "monitoring", "resolved"];
 
+type SettingsFormState = {
+  httpWindowMinutes: string;
+  httpBucketMinutes: string;
+  sessionWindowDays: string;
+  sessionRetentionDays: string;
+  realtimeWindowHours: string;
+  pageWindowDays: string;
+  pageRetentionDays: string;
+};
+
+type SettingsFieldErrors = Partial<Record<keyof SettingsFormState, string[]>>;
+
+function toSettingsFormState(settings: ServerAnalytics["settings"]): SettingsFormState {
+  return {
+    httpWindowMinutes: String(settings.httpWindowMinutes ?? ""),
+    httpBucketMinutes: String(settings.httpBucketMinutes ?? ""),
+    sessionWindowDays: String(settings.sessionWindowDays ?? ""),
+    sessionRetentionDays: String(settings.sessionRetentionDays ?? ""),
+    realtimeWindowHours: String(settings.realtimeWindowHours ?? ""),
+    pageWindowDays: String(settings.pageWindowDays ?? ""),
+    pageRetentionDays: String(settings.pageRetentionDays ?? ""),
+  };
+}
+
+function parseSettingsFormState(form: SettingsFormState): UpdateServerAnalyticsSettingsInput {
+  const parse = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return Number.NaN;
+    }
+    const numeric = Number(trimmed);
+    return Number.isFinite(numeric) ? numeric : Number.NaN;
+  };
+
+  return {
+    httpWindowMinutes: parse(form.httpWindowMinutes),
+    httpBucketMinutes: parse(form.httpBucketMinutes),
+    sessionWindowDays: parse(form.sessionWindowDays),
+    sessionRetentionDays: parse(form.sessionRetentionDays),
+    realtimeWindowHours: parse(form.realtimeWindowHours),
+    pageWindowDays: parse(form.pageWindowDays),
+    pageRetentionDays: parse(form.pageRetentionDays),
+  };
+}
+
 type ServerAnalyticsContentProps = {
   initialAnalytics: ServerAnalytics;
   canReset?: boolean;
+  canManageSettings?: boolean;
 };
 
-export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: ServerAnalyticsContentProps) {
+export function ServerAnalyticsContent({
+  initialAnalytics,
+  canReset = false,
+  canManageSettings = false,
+}: ServerAnalyticsContentProps) {
   const { socket, isConnected, connectionStatus } = useRealtime();
   const [analytics, setAnalytics] = useState<ServerAnalytics>(initialAnalytics);
   const [generatedAt, setGeneratedAt] = useState<Date>(() => parseGeneratedAt(initialAnalytics.generatedAt));
@@ -303,15 +369,29 @@ export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: S
   const [pendingLogId, setPendingLogId] = useState<string | null>(null);
   const [isStatusUpdating, startStatusUpdate] = useTransition();
   const [isResetting, startResetTransition] = useTransition();
+  const [isSavingSettings, startSettingsSave] = useTransition();
   const [isResetDialogOpen, setResetDialogOpen] = useState(false);
   const [resetError, setResetError] = useState<string | null>(null);
+  const [settingsForm, setSettingsForm] = useState<SettingsFormState>(() =>
+    toSettingsFormState(initialAnalytics.settings),
+  );
+  const [settingsFieldErrors, setSettingsFieldErrors] = useState<SettingsFieldErrors>({});
+  const [settingsError, setSettingsError] = useState<string | null>(null);
   const displayAnalytics = useAnimatedAnalytics(analytics);
+  const settingsLimits = SERVER_ANALYTICS_SETTINGS_LIMITS;
 
   useEffect(() => {
     setAnalytics(initialAnalytics);
     setGeneratedAt(parseGeneratedAt(initialAnalytics.generatedAt));
     setHasLiveUpdate(false);
+    setSettingsForm(toSettingsFormState(initialAnalytics.settings));
+    setSettingsFieldErrors({});
+    setSettingsError(null);
   }, [initialAnalytics]);
+
+  useEffect(() => {
+    setSettingsForm(toSettingsFormState(analytics.settings));
+  }, [analytics.settings]);
 
   useEffect(() => {
     if (!socket) return;
@@ -341,6 +421,55 @@ export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: S
       socket.emit("get_server_analytics");
     }
   }, [socket, isConnected]);
+
+  const handleSettingsChange = useCallback((field: keyof SettingsFormState, value: string) => {
+    setSettingsForm((previous) => ({ ...previous, [field]: value }));
+    setSettingsFieldErrors((previous) => {
+      if (!previous[field]?.length) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[field];
+      return next;
+    });
+  }, []);
+
+  const handleSettingsSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setSettingsError(null);
+      setSettingsFieldErrors({});
+      const payload = parseSettingsFormState(settingsForm);
+
+      startSettingsSave(async () => {
+        const result = await updateServerAnalyticsSettingsAction(payload);
+        if (result.success) {
+          setAnalytics(result.analytics);
+          setGeneratedAt(parseGeneratedAt(result.analytics.generatedAt));
+          setSettingsForm(toSettingsFormState(result.settings));
+          setSettingsFieldErrors({});
+          setSettingsError(null);
+          toast.success("Analytics-Einstellungen gespeichert.");
+        } else if (result.error === "validation_failed" && result.fieldErrors) {
+          setSettingsFieldErrors(result.fieldErrors as SettingsFieldErrors);
+          toast.error("Bitte prüfe die markierten Felder.");
+        } else if (result.error === "no_database") {
+          const message = "Ohne Datenbankverbindung können die Einstellungen nicht gespeichert werden.";
+          setSettingsError(message);
+          toast.error(message);
+        } else if (result.error === "not_authorized") {
+          const message = "Du darfst diese Einstellungen nicht ändern.";
+          setSettingsError(message);
+          toast.error(message);
+        } else {
+          const message = "Einstellungen konnten nicht gespeichert werden. Bitte später erneut versuchen.";
+          setSettingsError(message);
+          toast.error(message);
+        }
+      });
+    },
+    [settingsForm, startSettingsSave],
+  );
 
   const lastUpdatedLabel = useMemo(() => dateTimeFormat.format(generatedAt), [generatedAt]);
 
@@ -621,6 +750,9 @@ export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: S
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <TabsList className="w-full sm:w-auto">
             <TabsTrigger value="overview">Kennzahlen</TabsTrigger>
+            {canManageSettings ? (
+              <TabsTrigger value="settings">Einstellungen</TabsTrigger>
+            ) : null}
             <TabsTrigger value="logs">Serverlogs</TabsTrigger>
           </TabsList>
           <div className="text-xs text-muted-foreground sm:text-right">
@@ -1013,6 +1145,209 @@ export function ServerAnalyticsContent({ initialAnalytics, canReset = false }: S
         </Card>
       </div>
         </TabsContent>
+
+        {canManageSettings ? (
+          <TabsContent value="settings" className="space-y-6">
+            <Card className="border border-border/70">
+              <CardHeader>
+                <CardTitle>Einstellungen für Messfenster &amp; Retention</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  Steuere, wie lange Requests, Sessions und Seitenaufrufe ausgewertet werden. Änderungen wirken sich auf die
+                  nächste Aggregation aus.
+                </p>
+              </CardHeader>
+              <CardContent>
+                <form className="space-y-6" onSubmit={handleSettingsSubmit}>
+                  <div className="grid gap-6 lg:grid-cols-2">
+                    <fieldset className="space-y-4">
+                      <legend className="text-sm font-semibold text-foreground">HTTP-Requests</legend>
+                      <div className="space-y-2">
+                        <Label htmlFor="httpWindowMinutes">Auswertungszeitraum (Minuten)</Label>
+                        <Input
+                          id="httpWindowMinutes"
+                          name="httpWindowMinutes"
+                          type="number"
+                          min={settingsLimits.httpWindowMinutes.min}
+                          max={settingsLimits.httpWindowMinutes.max}
+                          value={settingsForm.httpWindowMinutes}
+                          onChange={(event) => handleSettingsChange("httpWindowMinutes", event.target.value)}
+                          disabled={isSavingSettings}
+                          inputMode="numeric"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Zeitraum, über den Requests für die Kennzahlen berücksichtigt werden.
+                        </p>
+                        {settingsFieldErrors.httpWindowMinutes ? (
+                          <p className="text-xs text-destructive">
+                            {settingsFieldErrors.httpWindowMinutes.join(" ")}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="httpBucketMinutes">Bucket-Größe (Minuten)</Label>
+                        <Input
+                          id="httpBucketMinutes"
+                          name="httpBucketMinutes"
+                          type="number"
+                          min={settingsLimits.httpBucketMinutes.min}
+                          max={settingsLimits.httpBucketMinutes.max}
+                          value={settingsForm.httpBucketMinutes}
+                          onChange={(event) => handleSettingsChange("httpBucketMinutes", event.target.value)}
+                          disabled={isSavingSettings}
+                          inputMode="numeric"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Aggregationsintervall zur Ermittlung von Peak-Hours und Antwortzeiten.
+                        </p>
+                        {settingsFieldErrors.httpBucketMinutes ? (
+                          <p className="text-xs text-destructive">
+                            {settingsFieldErrors.httpBucketMinutes.join(" ")}
+                          </p>
+                        ) : null}
+                      </div>
+                    </fieldset>
+
+                    <fieldset className="space-y-4">
+                      <legend className="text-sm font-semibold text-foreground">Sessions &amp; Realtime</legend>
+                      <div className="space-y-2">
+                        <Label htmlFor="sessionWindowDays">Auswertungszeitraum Sessions (Tage)</Label>
+                        <Input
+                          id="sessionWindowDays"
+                          name="sessionWindowDays"
+                          type="number"
+                          min={settingsLimits.sessionWindowDays.min}
+                          max={settingsLimits.sessionWindowDays.max}
+                          value={settingsForm.sessionWindowDays}
+                          onChange={(event) => handleSettingsChange("sessionWindowDays", event.target.value)}
+                          disabled={isSavingSettings}
+                          inputMode="numeric"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Gibt an, wie viele Tage für die Session-Analyse herangezogen werden.
+                        </p>
+                        {settingsFieldErrors.sessionWindowDays ? (
+                          <p className="text-xs text-destructive">
+                            {settingsFieldErrors.sessionWindowDays.join(" ")}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="sessionRetentionDays">Retention Sessions (Tage)</Label>
+                        <Input
+                          id="sessionRetentionDays"
+                          name="sessionRetentionDays"
+                          type="number"
+                          min={settingsLimits.sessionRetentionDays.min}
+                          max={settingsLimits.sessionRetentionDays.max}
+                          value={settingsForm.sessionRetentionDays}
+                          onChange={(event) => handleSettingsChange("sessionRetentionDays", event.target.value)}
+                          disabled={isSavingSettings}
+                          inputMode="numeric"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Ab wann alte Sessions, Traffic-Attributions und Realtime-Events gelöscht werden.
+                        </p>
+                        {settingsFieldErrors.sessionRetentionDays ? (
+                          <p className="text-xs text-destructive">
+                            {settingsFieldErrors.sessionRetentionDays.join(" ")}
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="realtimeWindowHours">Realtime-Zeitraum (Stunden)</Label>
+                        <Input
+                          id="realtimeWindowHours"
+                          name="realtimeWindowHours"
+                          type="number"
+                          min={settingsLimits.realtimeWindowHours.min}
+                          max={settingsLimits.realtimeWindowHours.max}
+                          value={settingsForm.realtimeWindowHours}
+                          onChange={(event) => handleSettingsChange("realtimeWindowHours", event.target.value)}
+                          disabled={isSavingSettings}
+                          inputMode="numeric"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Zeitraum für Live-Events wie Websocket-Pings und Hintergrundjobs.
+                        </p>
+                        {settingsFieldErrors.realtimeWindowHours ? (
+                          <p className="text-xs text-destructive">
+                            {settingsFieldErrors.realtimeWindowHours.join(" ")}
+                          </p>
+                        ) : null}
+                      </div>
+                    </fieldset>
+
+                    <fieldset className="space-y-4 lg:col-span-2">
+                      <legend className="text-sm font-semibold text-foreground">Seiten-Performance</legend>
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="space-y-2">
+                          <Label htmlFor="pageWindowDays">Auswertungszeitraum Seiten (Tage)</Label>
+                          <Input
+                            id="pageWindowDays"
+                            name="pageWindowDays"
+                            type="number"
+                            min={settingsLimits.pageWindowDays.min}
+                            max={settingsLimits.pageWindowDays.max}
+                            value={settingsForm.pageWindowDays}
+                            onChange={(event) => handleSettingsChange("pageWindowDays", event.target.value)}
+                            disabled={isSavingSettings}
+                            inputMode="numeric"
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            Wie viele Tage Pageviews und Gerätewerte zur Analyse beitragen.
+                          </p>
+                          {settingsFieldErrors.pageWindowDays ? (
+                            <p className="text-xs text-destructive">
+                              {settingsFieldErrors.pageWindowDays.join(" ")}
+                            </p>
+                          ) : null}
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="pageRetentionDays">Retention Seiten (Tage)</Label>
+                          <Input
+                            id="pageRetentionDays"
+                            name="pageRetentionDays"
+                            type="number"
+                            min={settingsLimits.pageRetentionDays.min}
+                            max={settingsLimits.pageRetentionDays.max}
+                            value={settingsForm.pageRetentionDays}
+                            onChange={(event) => handleSettingsChange("pageRetentionDays", event.target.value)}
+                            disabled={isSavingSettings}
+                            inputMode="numeric"
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            Nach wie vielen Tagen Pageviews und Geräteschnappschüsse bereinigt werden.
+                          </p>
+                          {settingsFieldErrors.pageRetentionDays ? (
+                            <p className="text-xs text-destructive">
+                              {settingsFieldErrors.pageRetentionDays.join(" ")}
+                            </p>
+                          ) : null}
+                        </div>
+                      </div>
+                    </fieldset>
+                  </div>
+
+                  {settingsError ? (
+                    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                      {settingsError}
+                    </div>
+                  ) : null}
+
+                  <div className="flex items-center justify-end">
+                    <Button
+                      type="submit"
+                      disabled={isSavingSettings}
+                      data-state={isSavingSettings ? "loading" : undefined}
+                    >
+                      Einstellungen speichern
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        ) : null}
 
         <TabsContent value="logs" className="space-y-6">
           <div className="grid gap-4 md:grid-cols-3">

--- a/src/app/api/cron/server-analytics/route.ts
+++ b/src/app/api/cron/server-analytics/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+import { runServerAnalyticsAggregation } from "@/lib/analytics/server-analytics-pipeline";
+
+function isAuthorized(request: NextRequest): boolean {
+  const cronSecret = request.headers.get("x-cron-secret");
+  if (!cronSecret) {
+    return false;
+  }
+  if (!process.env.CRON_SECRET) {
+    console.warn("[analytics] CRON_SECRET is not configured – rejecting request");
+    return false;
+  }
+  return cronSecret === process.env.CRON_SECRET;
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const result = await runServerAnalyticsAggregation();
+    return NextResponse.json({ status: "ok", result });
+  } catch (error) {
+    console.error("[analytics] Failed to execute server analytics aggregation", error);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
+  }
+}
+
+export async function GET(request: NextRequest) {
+  return POST(request);
+}

--- a/src/lib/analytics/__tests__/server-analytics-pipeline.test.ts
+++ b/src/lib/analytics/__tests__/server-analytics-pipeline.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PrismaClient } from "@prisma/client";
+
+const aggregatorMocks = vi.hoisted(() => ({
+  aggregateHttpMetrics: vi.fn(),
+  aggregateSessionMetrics: vi.fn(),
+  aggregatePageMetrics: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/aggregate-http", () => ({
+  aggregateHttpMetrics: aggregatorMocks.aggregateHttpMetrics,
+}));
+
+vi.mock("@/lib/analytics/aggregate-session-metrics", () => ({
+  aggregateSessionMetrics: aggregatorMocks.aggregateSessionMetrics,
+}));
+
+vi.mock("@/lib/analytics/aggregate-page-metrics", () => ({
+  aggregatePageMetrics: aggregatorMocks.aggregatePageMetrics,
+}));
+
+import {
+  runHttpAnalyticsAggregation,
+  runServerAnalyticsAggregation,
+  runSessionAnalyticsAggregation,
+} from "@/lib/analytics/server-analytics-pipeline";
+
+describe("server analytics pipeline", () => {
+  beforeEach(() => {
+    aggregatorMocks.aggregateHttpMetrics.mockReset();
+    aggregatorMocks.aggregateSessionMetrics.mockReset();
+    aggregatorMocks.aggregatePageMetrics.mockReset();
+    process.env.DATABASE_URL = "postgres://test";
+  });
+
+  it("aggregates HTTP analytics and persists summaries", async () => {
+    const now = new Date("2024-01-01T01:00:00.000Z");
+    const requests = [
+      {
+        timestamp: new Date("2024-01-01T00:30:00.000Z"),
+        area: "public",
+        statusCode: 200,
+        durationMs: 120,
+        payloadBytes: 512,
+        route: "/",
+        method: "GET",
+      },
+    ];
+    const heartbeats: unknown[] = [];
+
+    const tx = {
+      analyticsHttpSummary: {
+        deleteMany: vi.fn().mockResolvedValue(undefined),
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+      analyticsHttpPeakHour: {
+        deleteMany: vi.fn().mockResolvedValue(undefined),
+        createMany: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    const prismaMock = {
+      analyticsHttpRequest: { findMany: vi.fn().mockResolvedValue(requests) },
+      analyticsUptimeHeartbeat: { findMany: vi.fn().mockResolvedValue(heartbeats) },
+      $transaction: vi.fn(async (callback: (tx: typeof tx) => Promise<void>) => {
+        await callback(tx);
+      }),
+    } as unknown as PrismaClient;
+
+    aggregatorMocks.aggregateHttpMetrics.mockReturnValue({
+      summary: {
+        windowStart: new Date("2024-01-01T00:00:00.000Z"),
+        windowEnd: now,
+        totalRequests: 1,
+        successfulRequests: 1,
+        clientErrorRequests: 0,
+        serverErrorRequests: 0,
+        averageDurationMs: 120,
+        p95DurationMs: 120,
+        averagePayloadBytes: 512,
+        uptimePercentage: 99,
+        frontendRequests: 1,
+        frontendAvgResponseMs: 120,
+        frontendAvgPayloadBytes: 512,
+        cacheHitRate: 0.5,
+        frontendCacheHitRate: 0.5,
+        membersRequests: 0,
+        membersAvgResponseMs: 0,
+        apiRequests: 0,
+        apiAvgResponseMs: 0,
+        apiErrorRate: 0,
+        apiBackgroundJobs: 0,
+      },
+      peakHours: [
+        {
+          bucketStart: new Date("2024-01-01T00:00:00.000Z"),
+          bucketEnd: new Date("2024-01-01T01:00:00.000Z"),
+          requests: 1,
+          share: 1,
+        },
+      ],
+    });
+
+    const result = await runHttpAnalyticsAggregation({
+      prisma: prismaMock,
+      now,
+      windowMinutes: 60,
+      bucketMinutes: 60,
+    });
+
+    expect(aggregatorMocks.aggregateHttpMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requests,
+        windowEnd: now,
+      }),
+    );
+    expect(tx.analyticsHttpSummary.deleteMany).toHaveBeenCalledOnce();
+    expect(tx.analyticsHttpSummary.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ totalRequests: 1 }),
+    });
+    expect(result.status).toBe("success");
+    if (result.status === "success") {
+      expect(result.data.requestCount).toBe(1);
+    }
+  });
+
+  it("aggregates session analytics and writes derived data", async () => {
+    const now = new Date("2024-01-02T00:00:00.000Z");
+    const sessions = [
+      {
+        id: "session-1",
+        userId: "user-1",
+        isMember: true,
+        membershipRole: "cast",
+        startedAt: new Date("2024-01-01T22:00:00.000Z"),
+        endedAt: null,
+        lastSeenAt: new Date("2024-01-01T23:00:00.000Z"),
+        durationSeconds: null,
+        pagePaths: ["/mitglieder"],
+      },
+    ];
+    const traffic = [
+      {
+        sessionId: "session-1",
+        analyticsSessionId: "session-1",
+        path: "/mitglieder",
+        referrer: null,
+        referrerDomain: null,
+        utmSource: null,
+        utmMedium: null,
+        utmCampaign: null,
+        utmTerm: null,
+        utmContent: null,
+      },
+    ];
+    const realtimeEvents = [
+      {
+        id: "event-1",
+        eventType: "ping",
+        occurredAt: new Date("2024-01-01T23:30:00.000Z"),
+      },
+    ];
+
+    const tx = {
+      analyticsSessionInsight: {
+        deleteMany: vi.fn().mockResolvedValue(undefined),
+        createMany: vi.fn().mockResolvedValue(undefined),
+      },
+      analyticsTrafficSource: {
+        deleteMany: vi.fn().mockResolvedValue(undefined),
+        createMany: vi.fn().mockResolvedValue(undefined),
+      },
+      analyticsRealtimeSummary: {
+        deleteMany: vi.fn().mockResolvedValue(undefined),
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+      analyticsSessionSummary: {
+        deleteMany: vi.fn().mockResolvedValue(undefined),
+        create: vi.fn().mockResolvedValue(undefined),
+      },
+      analyticsSession: { deleteMany: vi.fn().mockResolvedValue(undefined) },
+      analyticsTrafficAttribution: { deleteMany: vi.fn().mockResolvedValue(undefined) },
+      analyticsRealtimeEvent: { deleteMany: vi.fn().mockResolvedValue(undefined) },
+    };
+
+    const prismaMock = {
+      analyticsSession: { findMany: vi.fn().mockResolvedValue(sessions) },
+      analyticsTrafficAttribution: { findMany: vi.fn().mockResolvedValue(traffic) },
+      analyticsRealtimeEvent: { findMany: vi.fn().mockResolvedValue(realtimeEvents) },
+      $transaction: vi.fn(async (callback: (tx: typeof tx) => Promise<void>) => {
+        await callback(tx);
+      }),
+    } as unknown as PrismaClient;
+
+    aggregatorMocks.aggregateSessionMetrics.mockReturnValue({
+      sessionInsights: [
+        {
+          segment: "Mitglieder",
+          avgSessionDurationSeconds: 360,
+          pagesPerSession: 3,
+          retentionRate: 0.6,
+          share: 0.4,
+          conversionRate: 0.1,
+        },
+      ],
+      trafficSources: [
+        {
+          channel: "Direct",
+          sessions: 10,
+          avgSessionDurationSeconds: 200,
+          conversionRate: 0.1,
+          changePercent: 0.05,
+        },
+      ],
+      realtimeSummary: {
+        windowStart: new Date("2024-01-01T22:00:00.000Z"),
+        windowEnd: now,
+        totalEvents: 1,
+        eventCounts: { ping: 1 },
+      },
+      sessionSummary: {
+        windowStart: new Date("2024-01-01T22:00:00.000Z"),
+        windowEnd: now,
+        peakConcurrentUsers: 2,
+        membersRealtimeEvents: 1,
+        membersAvgSessionDurationSeconds: 420,
+      },
+    });
+
+    const settings = {
+      httpWindowMinutes: 1440,
+      httpBucketMinutes: 60,
+      sessionWindowDays: 30,
+      sessionRetentionDays: 180,
+      realtimeWindowHours: 24,
+      pageWindowDays: 14,
+      pageRetentionDays: 60,
+    };
+
+    const result = await runSessionAnalyticsAggregation({ prisma: prismaMock, now, settings });
+
+    expect(aggregatorMocks.aggregateSessionMetrics).toHaveBeenCalled();
+    expect(tx.analyticsSessionInsight.deleteMany).toHaveBeenCalledOnce();
+    expect(tx.analyticsSessionInsight.createMany).toHaveBeenCalled();
+    expect(tx.analyticsRealtimeSummary.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ totalEvents: 1 }),
+    });
+    expect(result.status).toBe("success");
+    if (result.status === "success") {
+      expect(result.data.sessionCount).toBe(1);
+      expect(result.data.realtimeEventCount).toBe(1);
+    }
+  });
+
+  it("skips aggregation gracefully when no database is configured", async () => {
+    delete process.env.DATABASE_URL;
+
+    const summary = await runServerAnalyticsAggregation();
+
+    expect(summary.http.status).toBe("skipped");
+    expect(summary.sessions.status).toBe("skipped");
+    expect(summary.pages.status).toBe("skipped");
+    expect(aggregatorMocks.aggregateHttpMetrics).not.toHaveBeenCalled();
+    expect(aggregatorMocks.aggregateSessionMetrics).not.toHaveBeenCalled();
+    expect(aggregatorMocks.aggregatePageMetrics).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/analytics/server-analytics-pipeline.ts
+++ b/src/lib/analytics/server-analytics-pipeline.ts
@@ -1,0 +1,622 @@
+import type {
+  AnalyticsRealtimeEvent,
+  AnalyticsSession,
+  AnalyticsTrafficAttribution,
+  PrismaClient,
+} from "@prisma/client";
+
+import { aggregateHttpMetrics } from "@/lib/analytics/aggregate-http";
+import {
+  aggregateSessionMetrics,
+  type AnalyticsSessionLike,
+  type RealtimeEventLike,
+  type TrafficAttributionLike,
+} from "@/lib/analytics/aggregate-session-metrics";
+import { aggregatePageMetrics } from "@/lib/analytics/aggregate-page-metrics";
+import {
+  DEFAULT_SERVER_ANALYTICS_SETTINGS,
+  loadServerAnalyticsSettings,
+  type ServerAnalyticsSettings,
+} from "@/lib/server-analytics-settings";
+import { prisma } from "@/lib/prisma";
+
+const DEFAULT_HTTP_WINDOW_MINUTES = DEFAULT_SERVER_ANALYTICS_SETTINGS.httpWindowMinutes;
+const DEFAULT_HTTP_BUCKET_MINUTES = DEFAULT_SERVER_ANALYTICS_SETTINGS.httpBucketMinutes;
+const DEFAULT_SESSION_WINDOW_DAYS = DEFAULT_SERVER_ANALYTICS_SETTINGS.sessionWindowDays;
+const DEFAULT_SESSION_RETENTION_DAYS = DEFAULT_SERVER_ANALYTICS_SETTINGS.sessionRetentionDays;
+const DEFAULT_REALTIME_WINDOW_HOURS = DEFAULT_SERVER_ANALYTICS_SETTINGS.realtimeWindowHours;
+const DEFAULT_PAGE_WINDOW_DAYS = DEFAULT_SERVER_ANALYTICS_SETTINGS.pageWindowDays;
+const DEFAULT_PAGE_RETENTION_DAYS = DEFAULT_SERVER_ANALYTICS_SETTINGS.pageRetentionDays;
+
+type AggregationResult<T> =
+  | { status: "skipped"; reason: string }
+  | { status: "success"; data: T };
+
+type HttpAggregationOptions = {
+  prisma?: PrismaClient;
+  now?: Date;
+  windowMinutes?: number;
+  bucketMinutes?: number;
+  settings?: ServerAnalyticsSettings;
+};
+
+type SessionAggregationOptions = {
+  prisma?: PrismaClient;
+  now?: Date;
+  windowDays?: number;
+  retentionDays?: number;
+  realtimeWindowHours?: number;
+  settings?: ServerAnalyticsSettings;
+};
+
+type PageAggregationOptions = {
+  prisma?: PrismaClient;
+  now?: Date;
+  windowDays?: number;
+  retentionDays?: number;
+  settings?: ServerAnalyticsSettings;
+};
+
+type ServerAnalyticsAggregationOptions = {
+  http?: HttpAggregationOptions;
+  sessions?: SessionAggregationOptions;
+  pages?: PageAggregationOptions;
+};
+
+function needsHttpSettings(options?: HttpAggregationOptions): boolean {
+  if (!options) {
+    return false;
+  }
+  const settings = options.settings;
+  if (options.windowMinutes === undefined && settings?.httpWindowMinutes === undefined) {
+    return true;
+  }
+  if (options.bucketMinutes === undefined && settings?.httpBucketMinutes === undefined) {
+    return true;
+  }
+  return false;
+}
+
+function needsSessionSettings(options?: SessionAggregationOptions): boolean {
+  if (!options) {
+    return false;
+  }
+  const settings = options.settings;
+  if (options.windowDays === undefined && settings?.sessionWindowDays === undefined) {
+    return true;
+  }
+  if (options.retentionDays === undefined && settings?.sessionRetentionDays === undefined) {
+    return true;
+  }
+  if (options.realtimeWindowHours === undefined && settings?.realtimeWindowHours === undefined) {
+    return true;
+  }
+  return false;
+}
+
+function needsPageSettings(options?: PageAggregationOptions): boolean {
+  if (!options) {
+    return false;
+  }
+  const settings = options.settings;
+  if (options.windowDays === undefined && settings?.pageWindowDays === undefined) {
+    return true;
+  }
+  if (options.retentionDays === undefined && settings?.pageRetentionDays === undefined) {
+    return true;
+  }
+  return false;
+}
+
+export type ServerAnalyticsAggregationSummary = {
+  http: AggregationResult<{
+    windowStart: Date;
+    windowEnd: Date;
+    requestCount: number;
+  }>;
+  sessions: AggregationResult<{
+    sessionCount: number;
+    trafficAttributionCount: number;
+    realtimeEventCount: number;
+  }>;
+  pages: AggregationResult<{
+    pageViewCount: number;
+  }>;
+};
+
+function getPrisma(client?: PrismaClient): PrismaClient {
+  return client ?? prisma;
+}
+
+function isDatabaseEnabled(): boolean {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+function resolvePositiveInteger(
+  value: unknown,
+  fallback: number,
+  { min }: { min?: number } = {},
+): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  const normalized = Math.round(parsed);
+  if (typeof min === "number" && normalized < min) {
+    return fallback;
+  }
+  if (normalized <= 0) {
+    return fallback;
+  }
+  return normalized;
+}
+
+function transformSessions(rows: AnalyticsSession[]): AnalyticsSessionLike[] {
+  return rows.map((session) => ({
+    ...session,
+    startedAt:
+      session.startedAt instanceof Date ? session.startedAt : new Date(session.startedAt),
+    lastSeenAt:
+      session.lastSeenAt instanceof Date ? session.lastSeenAt : new Date(session.lastSeenAt),
+    pagePaths: Array.isArray(session.pagePaths) ? [...session.pagePaths] : [],
+  }));
+}
+
+function transformRealtimeEvents(rows: AnalyticsRealtimeEvent[]): RealtimeEventLike[] {
+  return rows.map((event) => ({
+    ...event,
+    occurredAt:
+      event.occurredAt instanceof Date ? event.occurredAt : new Date(event.occurredAt),
+  }));
+}
+
+function toTrafficAttributionLike(
+  rows: AnalyticsTrafficAttribution[],
+): TrafficAttributionLike[] {
+  return rows.map((row) => ({
+    sessionId: row.sessionId,
+    analyticsSessionId: row.analyticsSessionId,
+    path: row.path,
+    referrer: row.referrer,
+    referrerDomain: row.referrerDomain,
+    utmSource: row.utmSource,
+    utmMedium: row.utmMedium,
+    utmCampaign: row.utmCampaign,
+    utmTerm: row.utmTerm,
+    utmContent: row.utmContent,
+  }));
+}
+
+export async function runHttpAnalyticsAggregation(
+  options: HttpAggregationOptions = {},
+): Promise<
+  AggregationResult<{
+    windowStart: Date;
+    windowEnd: Date;
+    requestCount: number;
+  }>
+> {
+  if (!isDatabaseEnabled()) {
+    return { status: "skipped", reason: "database_disabled" };
+  }
+
+  const client = getPrisma(options.prisma);
+  const now = options.now ?? new Date();
+  let settings = options.settings ?? null;
+
+  if (!settings && (options.windowMinutes === undefined || options.bucketMinutes === undefined)) {
+    try {
+      settings = await loadServerAnalyticsSettings(client);
+    } catch (error) {
+      console.error("[analytics] Failed to load server analytics settings for HTTP aggregation", error);
+    }
+  }
+
+  const windowMinutes = options.windowMinutes ??
+    settings?.httpWindowMinutes ??
+    resolvePositiveInteger(
+      process.env.ANALYTICS_HTTP_WINDOW_MINUTES,
+      DEFAULT_HTTP_WINDOW_MINUTES,
+      { min: 5 },
+    );
+  const bucketMinutes = options.bucketMinutes ??
+    settings?.httpBucketMinutes ??
+    resolvePositiveInteger(
+      process.env.ANALYTICS_HTTP_BUCKET_MINUTES,
+      DEFAULT_HTTP_BUCKET_MINUTES,
+      { min: 1 },
+    );
+  const windowStart = new Date(now.getTime() - Math.max(windowMinutes, 5) * 60_000);
+
+  const [requests, heartbeats] = await Promise.all([
+    client.analyticsHttpRequest.findMany({
+      where: {
+        timestamp: {
+          gte: windowStart,
+          lte: now,
+        },
+      },
+      orderBy: { timestamp: "asc" },
+    }),
+    client.analyticsUptimeHeartbeat.findMany({
+      where: {
+        observedAt: {
+          gte: windowStart,
+          lte: now,
+        },
+      },
+    }),
+  ]);
+
+  const { summary, peakHours } = aggregateHttpMetrics({
+    requests,
+    heartbeats,
+    windowStart,
+    windowEnd: now,
+    bucketMinutes,
+  });
+
+  await client.$transaction(async (tx) => {
+    await tx.analyticsHttpSummary.deleteMany({});
+    await tx.analyticsHttpPeakHour.deleteMany({});
+
+    await tx.analyticsHttpSummary.create({
+      data: {
+        windowStart: summary.windowStart,
+        windowEnd: summary.windowEnd,
+        totalRequests: summary.totalRequests,
+        successfulRequests: summary.successfulRequests,
+        clientErrorRequests: summary.clientErrorRequests,
+        serverErrorRequests: summary.serverErrorRequests,
+        averageDurationMs: summary.averageDurationMs,
+        p95DurationMs: summary.p95DurationMs,
+        averagePayloadBytes: summary.averagePayloadBytes,
+        uptimePercentage: summary.uptimePercentage,
+        frontendRequests: summary.frontendRequests,
+        frontendAvgResponseMs: summary.frontendAvgResponseMs,
+        frontendAvgPayloadBytes: summary.frontendAvgPayloadBytes,
+        cacheHitRate: summary.cacheHitRate,
+        frontendCacheHitRate: summary.frontendCacheHitRate,
+        membersRequests: summary.membersRequests,
+        membersAvgResponseMs: summary.membersAvgResponseMs,
+        apiRequests: summary.apiRequests,
+        apiAvgResponseMs: summary.apiAvgResponseMs,
+        apiErrorRate: summary.apiErrorRate,
+        apiBackgroundJobs: summary.apiBackgroundJobs,
+      },
+    });
+
+    if (peakHours.length > 0) {
+      await tx.analyticsHttpPeakHour.createMany({
+        data: peakHours.map((entry) => ({
+          bucketStart: entry.bucketStart,
+          bucketEnd: entry.bucketEnd,
+          requests: entry.requests,
+          share: entry.share,
+        })),
+      });
+    }
+  });
+
+  return {
+    status: "success",
+    data: {
+      windowStart,
+      windowEnd: now,
+      requestCount: requests.length,
+    },
+  };
+}
+
+export async function runSessionAnalyticsAggregation(
+  options: SessionAggregationOptions = {},
+): Promise<
+  AggregationResult<{
+    sessionCount: number;
+    trafficAttributionCount: number;
+    realtimeEventCount: number;
+  }>
+> {
+  if (!isDatabaseEnabled()) {
+    return { status: "skipped", reason: "database_disabled" };
+  }
+
+  const client = getPrisma(options.prisma);
+  const now = options.now ?? new Date();
+  let settings = options.settings ?? null;
+
+  if (
+    !settings &&
+    (options.windowDays === undefined ||
+      options.retentionDays === undefined ||
+      options.realtimeWindowHours === undefined)
+  ) {
+    try {
+      settings = await loadServerAnalyticsSettings(client);
+    } catch (error) {
+      console.error("[analytics] Failed to load server analytics settings for session aggregation", error);
+    }
+  }
+
+  const windowDays = options.windowDays ??
+    settings?.sessionWindowDays ??
+    resolvePositiveInteger(
+      process.env.ANALYTICS_SESSION_WINDOW_DAYS,
+      DEFAULT_SESSION_WINDOW_DAYS,
+    );
+  const retentionDays = options.retentionDays ??
+    settings?.sessionRetentionDays ??
+    resolvePositiveInteger(
+      process.env.ANALYTICS_SESSION_RETENTION_DAYS,
+      DEFAULT_SESSION_RETENTION_DAYS,
+    );
+  const realtimeWindowHours = options.realtimeWindowHours ??
+    settings?.realtimeWindowHours ??
+    DEFAULT_REALTIME_WINDOW_HOURS;
+
+  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  const realtimeWindowStart = new Date(now.getTime() - realtimeWindowHours * 60 * 60 * 1000);
+
+  const [sessionsRaw, trafficRaw, realtimeEventsRaw] = await Promise.all([
+    client.analyticsSession.findMany({
+      where: {
+        startedAt: {
+          gte: windowStart,
+          lte: now,
+        },
+      },
+    }),
+    client.analyticsTrafficAttribution.findMany({
+      where: {
+        createdAt: {
+          gte: windowStart,
+          lte: now,
+        },
+      },
+    }),
+    client.analyticsRealtimeEvent.findMany({
+      where: {
+        occurredAt: {
+          gte: realtimeWindowStart,
+          lte: now,
+        },
+      },
+    }),
+  ]);
+
+  const sessions = transformSessions(sessionsRaw as AnalyticsSession[]);
+  const traffic = toTrafficAttributionLike(trafficRaw as AnalyticsTrafficAttribution[]);
+  const realtimeEvents = transformRealtimeEvents(realtimeEventsRaw as AnalyticsRealtimeEvent[]);
+
+  const result = aggregateSessionMetrics({
+    sessions,
+    traffic,
+    realtimeEvents,
+    now,
+  });
+
+  await client.$transaction(async (tx) => {
+    await tx.analyticsSessionInsight.deleteMany({});
+    await tx.analyticsTrafficSource.deleteMany({});
+    await tx.analyticsRealtimeSummary.deleteMany({});
+    await tx.analyticsSessionSummary.deleteMany({});
+
+    if (result.sessionInsights.length > 0) {
+      await tx.analyticsSessionInsight.createMany({
+        data: result.sessionInsights.map((insight) => ({
+          segment: insight.segment,
+          avgSessionDurationSeconds: insight.avgSessionDurationSeconds,
+          pagesPerSession: insight.pagesPerSession,
+          retentionRate: insight.retentionRate,
+          share: insight.share,
+          conversionRate: insight.conversionRate,
+        })),
+      });
+    }
+
+    if (result.trafficSources.length > 0) {
+      await tx.analyticsTrafficSource.createMany({
+        data: result.trafficSources.map((source) => ({
+          channel: source.channel,
+          sessions: source.sessions,
+          avgSessionDurationSeconds: source.avgSessionDurationSeconds,
+          conversionRate: source.conversionRate,
+          changePercent: source.changePercent,
+        })),
+      });
+    }
+
+    await tx.analyticsRealtimeSummary.create({
+      data: {
+        windowStart: result.realtimeSummary.windowStart,
+        windowEnd: result.realtimeSummary.windowEnd,
+        totalEvents: result.realtimeSummary.totalEvents,
+        eventCounts: result.realtimeSummary.eventCounts,
+      },
+    });
+
+    await tx.analyticsSessionSummary.create({
+      data: {
+        windowStart: result.sessionSummary.windowStart,
+        windowEnd: result.sessionSummary.windowEnd,
+        peakConcurrentUsers: result.sessionSummary.peakConcurrentUsers,
+        membersRealtimeEvents: result.sessionSummary.membersRealtimeEvents,
+        membersAvgSessionDurationSeconds:
+          result.sessionSummary.membersAvgSessionDurationSeconds,
+      },
+    });
+
+    if (retentionDays > 0) {
+      const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+      await tx.analyticsSession.deleteMany({
+        where: {
+          startedAt: { lt: cutoff },
+        },
+      });
+      await tx.analyticsTrafficAttribution.deleteMany({
+        where: {
+          createdAt: { lt: cutoff },
+        },
+      });
+      await tx.analyticsRealtimeEvent.deleteMany({
+        where: {
+          occurredAt: { lt: cutoff },
+        },
+      });
+    }
+  });
+
+  return {
+    status: "success",
+    data: {
+      sessionCount: sessionsRaw.length,
+      trafficAttributionCount: trafficRaw.length,
+      realtimeEventCount: realtimeEventsRaw.length,
+    },
+  };
+}
+
+export async function runPageAnalyticsAggregation(
+  options: PageAggregationOptions = {},
+): Promise<AggregationResult<{ pageViewCount: number }>> {
+  if (!isDatabaseEnabled()) {
+    return { status: "skipped", reason: "database_disabled" };
+  }
+
+  const client = getPrisma(options.prisma);
+  const now = options.now ?? new Date();
+  let settings = options.settings ?? null;
+
+  if (!settings && (options.windowDays === undefined || options.retentionDays === undefined)) {
+    try {
+      settings = await loadServerAnalyticsSettings(client);
+    } catch (error) {
+      console.error("[analytics] Failed to load server analytics settings for page aggregation", error);
+    }
+  }
+
+  const windowDays = options.windowDays ??
+    settings?.pageWindowDays ??
+    resolvePositiveInteger(
+      process.env.ANALYTICS_PAGE_WINDOW_DAYS,
+      DEFAULT_PAGE_WINDOW_DAYS,
+    );
+  const retentionDays = options.retentionDays ??
+    settings?.pageRetentionDays ??
+    resolvePositiveInteger(
+      process.env.ANALYTICS_PAGE_RETENTION_DAYS,
+      DEFAULT_PAGE_RETENTION_DAYS,
+    );
+
+  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+
+  const pageViews = await client.analyticsPageView.findMany({
+    where: {
+      createdAt: {
+        gte: windowStart,
+        lte: now,
+      },
+    },
+    select: {
+      path: true,
+      scope: true,
+      deviceHint: true,
+      loadTimeMs: true,
+      lcpMs: true,
+      timeOnPageMs: true,
+      weight: true,
+    },
+  });
+
+  const { pages, devices } = aggregatePageMetrics(pageViews);
+
+  await client.$transaction(async (tx) => {
+    await tx.analyticsPageMetric.deleteMany({});
+    await tx.analyticsDeviceMetric.deleteMany({});
+
+    if (pages.length > 0) {
+      await tx.analyticsPageMetric.createMany({
+        data: pages.map((page) => ({
+          path: page.path,
+          scope: page.scope,
+          avgLoadMs: page.avgLoadMs,
+          lcpMs: page.lcpMs,
+          avgTimeOnPageSeconds: page.avgTimeOnPageSeconds,
+          weight: page.weight,
+        })),
+      });
+    }
+
+    if (devices.length > 0) {
+      await tx.analyticsDeviceMetric.createMany({
+        data: devices.map((device) => ({
+          device: device.device,
+          sessions: device.sessions,
+          avgLoadMs: device.avgLoadMs,
+          share: device.share,
+        })),
+      });
+    }
+
+    if (retentionDays > 0) {
+      const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+      await tx.analyticsPageView.deleteMany({
+        where: {
+          createdAt: { lt: cutoff },
+        },
+      });
+      await tx.analyticsDeviceSnapshot.deleteMany({
+        where: {
+          createdAt: { lt: cutoff },
+        },
+      });
+    }
+  });
+
+  return {
+    status: "success",
+    data: {
+      pageViewCount: pageViews.length,
+    },
+  };
+}
+
+export async function runServerAnalyticsAggregation(
+  options: ServerAnalyticsAggregationOptions = {},
+): Promise<ServerAnalyticsAggregationSummary> {
+  let sharedSettings: ServerAnalyticsSettings | null = null;
+
+  if (
+    isDatabaseEnabled() &&
+    (needsHttpSettings(options.http) || needsSessionSettings(options.sessions) || needsPageSettings(options.pages))
+  ) {
+    try {
+      const prismaCandidate = options.http?.prisma ?? options.sessions?.prisma ?? options.pages?.prisma;
+      sharedSettings = await loadServerAnalyticsSettings(getPrisma(prismaCandidate));
+    } catch (error) {
+      console.error("[analytics] Failed to load shared server analytics settings", error);
+      sharedSettings = null;
+    }
+  }
+
+  const [http, sessions, pages] = await Promise.all([
+    runHttpAnalyticsAggregation({
+      ...options.http,
+      settings: options.http?.settings ?? sharedSettings ?? undefined,
+    }),
+    runSessionAnalyticsAggregation({
+      ...options.sessions,
+      settings: options.sessions?.settings ?? sharedSettings ?? undefined,
+    }),
+    runPageAnalyticsAggregation({
+      ...options.pages,
+      settings: options.pages?.settings ?? sharedSettings ?? undefined,
+    }),
+  ]);
+
+  return {
+    http,
+    sessions,
+    pages,
+  };
+}

--- a/src/lib/server-analytics-settings.d.ts
+++ b/src/lib/server-analytics-settings.d.ts
@@ -1,0 +1,36 @@
+import type { PrismaClient } from "@prisma/client";
+
+export type ServerAnalyticsSettings = {
+  httpWindowMinutes: number;
+  httpBucketMinutes: number;
+  sessionWindowDays: number;
+  sessionRetentionDays: number;
+  realtimeWindowHours: number;
+  pageWindowDays: number;
+  pageRetentionDays: number;
+};
+
+export type ServerAnalyticsSettingsInput = Partial<ServerAnalyticsSettings>;
+
+export declare const DEFAULT_SERVER_ANALYTICS_SETTINGS: ServerAnalyticsSettings;
+export declare const SERVER_ANALYTICS_SETTINGS_LIMITS: {
+  httpWindowMinutes: { min: number; max: number };
+  httpBucketMinutes: { min: number; max: number };
+  sessionWindowDays: { min: number; max: number };
+  sessionRetentionDays: { min: number; max: number };
+  realtimeWindowHours: { min: number; max: number };
+  pageWindowDays: { min: number; max: number };
+  pageRetentionDays: { min: number; max: number };
+};
+
+export declare function getDefaultServerAnalyticsSettings(): ServerAnalyticsSettings;
+export declare function ensureServerAnalyticsSettings(
+  prisma?: PrismaClient,
+): Promise<ServerAnalyticsSettings>;
+export declare function loadServerAnalyticsSettings(
+  prisma?: PrismaClient,
+): Promise<ServerAnalyticsSettings>;
+export declare function saveServerAnalyticsSettings(
+  input: ServerAnalyticsSettingsInput,
+  prisma?: PrismaClient,
+): Promise<ServerAnalyticsSettings>;

--- a/src/lib/server-analytics-settings.js
+++ b/src/lib/server-analytics-settings.js
@@ -1,0 +1,176 @@
+import { PrismaClient } from "@prisma/client";
+
+const SETTINGS_ID = "default";
+const globalForAnalyticsSettings = globalThis;
+
+export const DEFAULT_SERVER_ANALYTICS_SETTINGS = Object.freeze({
+  httpWindowMinutes: 1440,
+  httpBucketMinutes: 60,
+  sessionWindowDays: 30,
+  sessionRetentionDays: 180,
+  realtimeWindowHours: 24,
+  pageWindowDays: 14,
+  pageRetentionDays: 60,
+});
+
+export const SERVER_ANALYTICS_SETTINGS_LIMITS = Object.freeze({
+  httpWindowMinutes: { min: 5, max: 10080 },
+  httpBucketMinutes: { min: 1, max: 1440 },
+  sessionWindowDays: { min: 1, max: 365 },
+  sessionRetentionDays: { min: 1, max: 365 },
+  realtimeWindowHours: { min: 1, max: 168 },
+  pageWindowDays: { min: 1, max: 365 },
+  pageRetentionDays: { min: 1, max: 365 },
+});
+
+function cloneDefaultSettings() {
+  return JSON.parse(JSON.stringify(DEFAULT_SERVER_ANALYTICS_SETTINGS));
+}
+
+function getAnalyticsPrisma(client) {
+  if (client) {
+    return client;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return null;
+  }
+
+  const globalKey = Symbol.for("__analytics_settings_prisma");
+  if (!globalForAnalyticsSettings[globalKey]) {
+    globalForAnalyticsSettings[globalKey] = new PrismaClient({
+      log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+    });
+  }
+
+  return globalForAnalyticsSettings[globalKey];
+}
+
+function isTableMissingError(error) {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  if (error.code === "P2021") {
+    return true;
+  }
+
+  const cause = error.meta?.cause;
+  if (typeof cause === "string" && cause.includes("does not exist")) {
+    return true;
+  }
+
+  const sqlCode = error.code?.code ?? error.code;
+  if (typeof sqlCode === "string" && sqlCode.toUpperCase() === "42P01") {
+    return true;
+  }
+
+  return false;
+}
+
+function normaliseSetting(value, key) {
+  const defaults = DEFAULT_SERVER_ANALYTICS_SETTINGS;
+  const limits = SERVER_ANALYTICS_SETTINGS_LIMITS[key] ?? {};
+  const fallback = defaults[key];
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  let normalised = Math.round(numeric);
+  if (typeof limits.min === "number" && normalised < limits.min) {
+    normalised = limits.min;
+  }
+  if (typeof limits.max === "number" && normalised > limits.max) {
+    normalised = limits.max;
+  }
+  return normalised;
+}
+
+function normaliseSettings(record) {
+  const defaults = cloneDefaultSettings();
+  if (!record || typeof record !== "object") {
+    return defaults;
+  }
+
+  return {
+    httpWindowMinutes: normaliseSetting(record.httpWindowMinutes, "httpWindowMinutes"),
+    httpBucketMinutes: normaliseSetting(record.httpBucketMinutes, "httpBucketMinutes"),
+    sessionWindowDays: normaliseSetting(record.sessionWindowDays, "sessionWindowDays"),
+    sessionRetentionDays: normaliseSetting(record.sessionRetentionDays, "sessionRetentionDays"),
+    realtimeWindowHours: normaliseSetting(record.realtimeWindowHours, "realtimeWindowHours"),
+    pageWindowDays: normaliseSetting(record.pageWindowDays, "pageWindowDays"),
+    pageRetentionDays: normaliseSetting(record.pageRetentionDays, "pageRetentionDays"),
+  };
+}
+
+function buildUpdatePayload(input) {
+  if (!input || typeof input !== "object") {
+    return {};
+  }
+
+  const update = {};
+  for (const key of Object.keys(SERVER_ANALYTICS_SETTINGS_LIMITS)) {
+    if (Object.prototype.hasOwnProperty.call(input, key)) {
+      update[key] = normaliseSetting(input[key], key);
+    }
+  }
+
+  return update;
+}
+
+export function getDefaultServerAnalyticsSettings() {
+  return cloneDefaultSettings();
+}
+
+export async function ensureServerAnalyticsSettings(prisma) {
+  return saveServerAnalyticsSettings({}, prisma);
+}
+
+export async function loadServerAnalyticsSettings(prisma) {
+  const client = getAnalyticsPrisma(prisma);
+  if (!client) {
+    return cloneDefaultSettings();
+  }
+
+  try {
+    const record = await client.analyticsSettings.findUnique({ where: { id: SETTINGS_ID } });
+    if (!record) {
+      const created = await client.analyticsSettings.create({
+        data: { id: SETTINGS_ID, ...cloneDefaultSettings() },
+      });
+      return normaliseSettings(created);
+    }
+
+    return normaliseSettings(record);
+  } catch (error) {
+    if (isTableMissingError(error)) {
+      return cloneDefaultSettings();
+    }
+    throw error;
+  }
+}
+
+export async function saveServerAnalyticsSettings(input = {}, prisma) {
+  const client = getAnalyticsPrisma(prisma);
+  if (!client) {
+    return cloneDefaultSettings();
+  }
+
+  const update = buildUpdatePayload(input);
+  const create = { id: SETTINGS_ID, ...cloneDefaultSettings(), ...update };
+
+  try {
+    const record = await client.analyticsSettings.upsert({
+      where: { id: SETTINGS_ID },
+      create,
+      update,
+    });
+    return normaliseSettings(record);
+  } catch (error) {
+    if (isTableMissingError(error)) {
+      return cloneDefaultSettings();
+    }
+    throw error;
+  }
+}

--- a/src/lib/server-analytics.ts
+++ b/src/lib/server-analytics.ts
@@ -16,6 +16,11 @@ import type { LoadedServerLog } from "@/lib/analytics/load-server-logs";
 import { loadLatestCriticalServerLogs } from "@/lib/analytics/load-server-logs";
 import { loadDeviceBreakdownFromDatabase, loadPagePerformanceMetrics } from "@/lib/server-analytics-data";
 import type { PagePerformanceMetricOverride } from "@/lib/server-analytics-data";
+import {
+  DEFAULT_SERVER_ANALYTICS_SETTINGS,
+  loadServerAnalyticsSettings,
+  type ServerAnalyticsSettings,
+} from "@/lib/server-analytics-settings";
 import { prisma } from "@/lib/prisma";
 
 export type OptimizationImpact = "Hoch" | "Mittel" | "Niedrig";
@@ -134,6 +139,7 @@ export type OptimizationInsight = {
 export type ServerAnalytics = {
   generatedAt: string;
   isDemoData: boolean;
+  settings: ServerAnalyticsSettings;
   summary: ServerSummary;
   resourceUsage: ServerResourceUsage[];
   requestBreakdown: RequestBreakdown;
@@ -210,6 +216,7 @@ const DEFAULT_VISITOR_DISTRIBUTION: VisitorDistributionSegment[] = [
 ];
 
 const DEFAULT_ANALYTICS: StaticAnalyticsData = {
+  settings: DEFAULT_SERVER_ANALYTICS_SETTINGS,
   summary: DEFAULT_SUMMARY,
   resourceUsage: [],
   requestBreakdown: DEFAULT_REQUEST_BREAKDOWN,
@@ -762,6 +769,7 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
   let deviceBreakdown = cloneDeviceStats(DEFAULT_ANALYTICS.deviceBreakdown);
   let publicPages = clonePageEntries(DEFAULT_ANALYTICS.publicPages);
   let memberPages = clonePageEntries(DEFAULT_ANALYTICS.memberPages);
+  let settings: ServerAnalyticsSettings = { ...DEFAULT_ANALYTICS.settings };
   let serverLogs: LoadedServerLog[] = (DEFAULT_ANALYTICS.serverLogs ?? []).map((entry) => ({
     ...entry,
     tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
@@ -832,6 +840,7 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
       trafficSourceRows,
       realtimeSummaryRow,
       criticalLogs,
+      analyticsSettings,
     ] = await Promise.all([
       loadHttpAggregationsFromDatabase().catch((error) => {
         console.error("[server-analytics] Failed to load HTTP analytics summary", error);
@@ -875,6 +884,10 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
         }),
       loadLatestCriticalServerLogs({ limit: 25 }).catch((error) => {
         console.error("[server-analytics] Failed to load critical server logs", error);
+        return null;
+      }),
+      loadServerAnalyticsSettings(prisma).catch((error) => {
+        console.error("[server-analytics] Failed to load analytics settings", error);
         return null;
       }),
     ]);
@@ -955,6 +968,10 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
         tags: Array.isArray(entry.tags) ? [...entry.tags] : [],
       }));
     }
+
+    if (analyticsSettings) {
+      settings = analyticsSettings;
+    }
   } else {
     deviceBreakdown = cloneDeviceStats(deviceBreakdown);
     publicPages = clonePageEntries(publicPages);
@@ -981,6 +998,7 @@ export async function collectServerAnalytics(): Promise<ServerAnalytics> {
     generatedAt: new Date().toISOString(),
     isDemoData: !hasDatabaseData,
     ...DEFAULT_ANALYTICS,
+    settings,
     summary,
     requestBreakdown,
     visitorDistribution,


### PR DESCRIPTION
## Summary
- add a persistent `AnalyticsSettings` model plus helpers for loading/saving normalized analytics windows
- surface an owner-only settings form on the server analytics dashboard and wire it to a server action
- teach the aggregation pipeline, realtime service, and docs to respect the stored settings values

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db8c227f4c832d97857fda28e3d8d8