### PR TITLE
Adjust mobile quick actions layout in members topbar

### DIFF
--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -266,7 +266,11 @@ function MembersTopbarContent({
     </div>
   ) : null;
 
-  const mobileQuickActions = hasQuickActions ? content.quickActions : null;
+  const mobileQuickActions = hasQuickActions ? (
+    <div className="flex basis-full flex-wrap justify-end gap-2 gap-y-2 sm:basis-auto">
+      {content.quickActions}
+    </div>
+  ) : null;
 
   const homeLink = (
     <Button
@@ -319,7 +323,7 @@ function MembersTopbarContent({
             {homeLink}
           </div>
         ) : (
-          <div className="flex flex-shrink-0 items-center gap-2">
+          <div className="flex flex-1 flex-wrap items-center justify-end gap-2 gap-y-2">
             {mobileQuickActions}
             {homeLink}
           </div>


### PR DESCRIPTION
## Summary
- allow the mobile quick actions wrapper in the members topbar to wrap onto multiple rows
- keep quick actions and the home link right-aligned while ensuring buttons remain visible on narrow screens

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db98b5b6f4832d98f9d5c2d0603c3d