### PR TITLE
feat: add members layout container utility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -156,6 +156,75 @@
     container-name: layout;
   }
 
+  .members-container {
+    width: 100%;
+    margin-inline: auto;
+    --members-max-width: calc(var(--layout-max-width) + 2 * var(--layout-gutter));
+    --members-container-padding-inline: var(--layout-gutter);
+    max-width: var(--members-max-width);
+    padding-inline: var(--members-container-padding-inline);
+  }
+
+  .members-container--width-sm {
+    --members-max-width: 40rem;
+  }
+
+  .members-container--width-md {
+    --members-max-width: 48rem;
+  }
+
+  .members-container--width-lg {
+    --members-max-width: 64rem;
+  }
+
+  .members-container--width-xl {
+    --members-max-width: 80rem;
+  }
+
+  .members-container--width-2xl {
+    --members-max-width: 96rem;
+  }
+
+  .members-container--width-full {
+    --members-max-width: none;
+  }
+
+  .members-container--padding-default {
+    --members-container-padding-inline: var(--layout-gutter);
+  }
+
+  .members-container--padding-compact {
+    --members-container-padding-inline: 0.75rem;
+  }
+
+  .members-container--padding-relaxed {
+    --members-container-padding-inline: 1.5rem;
+  }
+
+  .members-container--padding-none {
+    --members-container-padding-inline: 0;
+  }
+
+  @media (min-width: 640px) {
+    .members-container--padding-compact {
+      --members-container-padding-inline: 1rem;
+    }
+
+    .members-container--padding-relaxed {
+      --members-container-padding-inline: 2rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .members-container--padding-compact {
+      --members-container-padding-inline: 1.5rem;
+    }
+
+    .members-container--padding-relaxed {
+      --members-container-padding-inline: 3rem;
+    }
+  }
+
   .site-main {
     position: relative;
     z-index: 10;

--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -34,28 +34,31 @@ const membersContentSectionVariants = cva("py-6 sm:py-8", {
   },
 });
 
-const membersContentContainerVariants = cva("mx-auto w-full px-4 sm:px-6 lg:px-8", {
-  variants: {
-    width: {
-      sm: "max-w-screen-sm",
-      md: "max-w-screen-md",
-      lg: "max-w-screen-lg",
-      xl: "max-w-screen-xl",
-      "2xl": "max-w-screen-2xl",
-      full: "max-w-none",
+const membersContentContainerVariants = cva(
+  "members-container members-container--padding-default",
+  {
+    variants: {
+      width: {
+        sm: "members-container--width-sm",
+        md: "members-container--width-md",
+        lg: "members-container--width-lg",
+        xl: "members-container--width-xl",
+        "2xl": "members-container--width-2xl",
+        full: "members-container--width-full",
+      },
+      padding: {
+        none: "members-container--padding-none",
+        compact: "members-container--padding-compact",
+        default: "members-container--padding-default",
+        relaxed: "members-container--padding-relaxed",
+      },
     },
-    padding: {
-      none: "px-0",
-      compact: "px-3 sm:px-4 lg:px-6",
-      default: "px-4 sm:px-6 lg:px-8",
-      relaxed: "px-6 sm:px-8 lg:px-12",
+    defaultVariants: {
+      width: "2xl",
+      padding: "default",
     },
   },
-  defaultVariants: {
-    width: "2xl",
-    padding: "default",
-  },
-});
+);
 
 const membersContentStackVariants = cva("space-y-8", {
   variants: {


### PR DESCRIPTION
## Summary
- add a reusable `.members-container` utility with configurable width and padding modifiers
- switch members app shell layout variants to the new utility classes while preserving width options

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68db98b7ab54832d9761f2af94230d89