### PR TITLE
feat: widen finance members content layout

### DIFF
--- a/src/app/(members)/mitglieder/finanzen/[[...section]]/page.tsx
+++ b/src/app/(members)/mitglieder/finanzen/[[...section]]/page.tsx
@@ -4,6 +4,8 @@ import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProductionId } from "@/lib/active-production";
 import { FinanceOverview } from "@/components/members/finance/finance-overview";
+import { MembersContentLayout } from "@/components/members/members-app-shell";
+import { FINANCE_CONTENT_LAYOUT } from "../content-layout";
 import {
   createEmptyFinanceSummary,
   mapFinanceBudget,
@@ -227,19 +229,22 @@ export default async function FinancePage({ params, searchParams }: PageProps) {
   const activeShow = showOptions.find((show) => show.id === selectedShowId) ?? null;
 
   return (
-    <FinanceOverview
-      initialEntries={entries}
-      initialSummary={summary}
-      initialBudgets={budgetDtos}
-      showOptions={showOptions}
-      memberOptions={memberOptions}
-      canManage={canManage}
-      canApprove={canApprove}
-      canExport={canExport}
-      allowedScopes={allowedScopes}
-      activeSection={activeSection}
-      selectedShowId={selectedShowId}
-      activeShow={activeShow}
-    />
+    <>
+      <MembersContentLayout {...FINANCE_CONTENT_LAYOUT} />
+      <FinanceOverview
+        initialEntries={entries}
+        initialSummary={summary}
+        initialBudgets={budgetDtos}
+        showOptions={showOptions}
+        memberOptions={memberOptions}
+        canManage={canManage}
+        canApprove={canApprove}
+        canExport={canExport}
+        allowedScopes={allowedScopes}
+        activeSection={activeSection}
+        selectedShowId={selectedShowId}
+        activeShow={activeShow}
+      />
+    </>
   );
 }

--- a/src/app/(members)/mitglieder/finanzen/content-layout.ts
+++ b/src/app/(members)/mitglieder/finanzen/content-layout.ts
@@ -1,0 +1,5 @@
+export const FINANCE_CONTENT_LAYOUT = {
+  width: "full" as const,
+  padding: "compact" as const,
+  spacing: "comfortable" as const,
+};

--- a/src/app/(members)/mitglieder/finanzen/layout.tsx
+++ b/src/app/(members)/mitglieder/finanzen/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function FinanceLayout({ children }: { children: ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Summary
- expand the finance overview route with MembersContentLayout so the module uses the full members shell width
- add a shared finance content layout config and lightweight layout wrapper for future sub-routes

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dba618164c832d911f6ea091784dfc