### PR TITLE
Fix Prisma migration resilience and auto-recover failed runs

### DIFF
--- a/prisma/migrations/20250926114343_add_limited_blocked_day_kind/migration.sql
+++ b/prisma/migrations/20250926114343_add_limited_blocked_day_kind/migration.sql
@@ -1,2 +1,14 @@
--- AlterEnum
-ALTER TYPE "public"."BlockedDayKind" ADD VALUE IF NOT EXISTS 'LIMITED';
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_enum e
+        JOIN pg_type t ON e.enumtypid = t.oid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = 'public'
+          AND t.typname = 'BlockedDayKind'
+          AND e.enumlabel = 'LIMITED'
+    ) THEN
+        ALTER TYPE "public"."BlockedDayKind" ADD VALUE 'LIMITED';
+    END IF;
+END $$;

--- a/prisma/migrations/20250930120000_file_library/migration.sql
+++ b/prisma/migrations/20250930120000_file_library/migration.sql
@@ -1,9 +1,30 @@
--- CreateEnum
-CREATE TYPE "FileLibraryAccessType" AS ENUM ('VIEW', 'DOWNLOAD', 'UPLOAD');
-CREATE TYPE "FileLibraryAccessTargetType" AS ENUM ('SYSTEM_ROLE', 'APP_ROLE');
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = 'public'
+          AND t.typname = 'FileLibraryAccessType'
+    ) THEN
+        CREATE TYPE "public"."FileLibraryAccessType" AS ENUM ('VIEW', 'DOWNLOAD', 'UPLOAD');
+    END IF;
+END $$;
 
--- CreateTable
-CREATE TABLE "FileLibraryFolder" (
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_type t
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = 'public'
+          AND t.typname = 'FileLibraryAccessTargetType'
+    ) THEN
+        CREATE TYPE "public"."FileLibraryAccessTargetType" AS ENUM ('SYSTEM_ROLE', 'APP_ROLE');
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "public"."FileLibraryFolder" (
     "id" TEXT NOT NULL,
     "parentId" TEXT,
     "name" TEXT NOT NULL,
@@ -17,7 +38,7 @@ CREATE TABLE "FileLibraryFolder" (
     CONSTRAINT "FileLibraryFolder_pkey" PRIMARY KEY ("id")
 );
 
-CREATE TABLE "FileLibraryItem" (
+CREATE TABLE IF NOT EXISTS "public"."FileLibraryItem" (
     "id" TEXT NOT NULL,
     "folderId" TEXT NOT NULL,
     "fileName" TEXT NOT NULL,
@@ -31,26 +52,95 @@ CREATE TABLE "FileLibraryItem" (
     CONSTRAINT "FileLibraryItem_pkey" PRIMARY KEY ("id")
 );
 
-CREATE TABLE "FileLibraryFolderAccess" (
+CREATE TABLE IF NOT EXISTS "public"."FileLibraryFolderAccess" (
     "id" TEXT NOT NULL,
     "folderId" TEXT NOT NULL,
-    "accessType" "FileLibraryAccessType" NOT NULL,
-    "targetType" "FileLibraryAccessTargetType" NOT NULL,
-    "systemRole" "Role",
+    "accessType" "public"."FileLibraryAccessType" NOT NULL,
+    "targetType" "public"."FileLibraryAccessTargetType" NOT NULL,
+    "systemRole" "public"."Role",
     "appRoleId" TEXT,
     CONSTRAINT "FileLibraryFolderAccess_pkey" PRIMARY KEY ("id")
 );
 
--- Indexes
-CREATE INDEX "FileLibraryFolder_parentId_idx" ON "FileLibraryFolder"("parentId");
-CREATE INDEX "FileLibraryItem_folderId_createdAt_idx" ON "FileLibraryItem"("folderId", "createdAt");
-CREATE INDEX "FileLibraryFolderAccess_folderId_accessType_idx" ON "FileLibraryFolderAccess"("folderId", "accessType");
-CREATE UNIQUE INDEX "FileLibraryFolderAccess_folderId_accessType_systemRole_appRoleId_key" ON "FileLibraryFolderAccess"("folderId", "accessType", "systemRole", "appRoleId");
+CREATE INDEX IF NOT EXISTS "FileLibraryFolder_parentId_idx" ON "public"."FileLibraryFolder"("parentId");
+CREATE INDEX IF NOT EXISTS "FileLibraryItem_folderId_createdAt_idx" ON "public"."FileLibraryItem"("folderId", "createdAt");
+CREATE INDEX IF NOT EXISTS "FileLibraryFolderAccess_folderId_accessType_idx" ON "public"."FileLibraryFolderAccess"("folderId", "accessType");
+CREATE UNIQUE INDEX IF NOT EXISTS "FileLibraryFolderAccess_folderId_accessType_systemRole_appRoleId_key" ON "public"."FileLibraryFolderAccess"("folderId", "accessType", "systemRole", "appRoleId");
 
--- Foreign keys
-ALTER TABLE "FileLibraryFolder" ADD CONSTRAINT "FileLibraryFolder_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-ALTER TABLE "FileLibraryFolder" ADD CONSTRAINT "FileLibraryFolder_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "FileLibraryItem" ADD CONSTRAINT "FileLibraryItem_folderId_fkey" FOREIGN KEY ("folderId") REFERENCES "FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-ALTER TABLE "FileLibraryItem" ADD CONSTRAINT "FileLibraryItem_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-ALTER TABLE "FileLibraryFolderAccess" ADD CONSTRAINT "FileLibraryFolderAccess_folderId_fkey" FOREIGN KEY ("folderId") REFERENCES "FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-ALTER TABLE "FileLibraryFolderAccess" ADD CONSTRAINT "FileLibraryFolderAccess_appRoleId_fkey" FOREIGN KEY ("appRoleId") REFERENCES "AppRole"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FileLibraryFolder_parentId_fkey'
+          AND conrelid = 'public.FileLibraryFolder'::regclass
+    ) THEN
+        ALTER TABLE "public"."FileLibraryFolder"
+            ADD CONSTRAINT "FileLibraryFolder_parentId_fkey"
+            FOREIGN KEY ("parentId") REFERENCES "public"."FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FileLibraryFolder_createdById_fkey'
+          AND conrelid = 'public.FileLibraryFolder'::regclass
+    ) THEN
+        ALTER TABLE "public"."FileLibraryFolder"
+            ADD CONSTRAINT "FileLibraryFolder_createdById_fkey"
+            FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FileLibraryItem_folderId_fkey'
+          AND conrelid = 'public.FileLibraryItem'::regclass
+    ) THEN
+        ALTER TABLE "public"."FileLibraryItem"
+            ADD CONSTRAINT "FileLibraryItem_folderId_fkey"
+            FOREIGN KEY ("folderId") REFERENCES "public"."FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FileLibraryItem_uploadedById_fkey'
+          AND conrelid = 'public.FileLibraryItem'::regclass
+    ) THEN
+        ALTER TABLE "public"."FileLibraryItem"
+            ADD CONSTRAINT "FileLibraryItem_uploadedById_fkey"
+            FOREIGN KEY ("uploadedById") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FileLibraryFolderAccess_folderId_fkey'
+          AND conrelid = 'public.FileLibraryFolderAccess'::regclass
+    ) THEN
+        ALTER TABLE "public"."FileLibraryFolderAccess"
+            ADD CONSTRAINT "FileLibraryFolderAccess_folderId_fkey"
+            FOREIGN KEY ("folderId") REFERENCES "public"."FileLibraryFolder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FileLibraryFolderAccess_appRoleId_fkey'
+          AND conrelid = 'public.FileLibraryFolderAccess'::regclass
+    ) THEN
+        ALTER TABLE "public"."FileLibraryFolderAccess"
+            ADD CONSTRAINT "FileLibraryFolderAccess_appRoleId_fkey"
+            FOREIGN KEY ("appRoleId") REFERENCES "public"."AppRole"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/scripts/run-prisma-migrate.mjs
+++ b/scripts/run-prisma-migrate.mjs
@@ -9,6 +9,98 @@ import { PrismaClient } from "@prisma/client";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const schemaPath = join(__dirname, "..", "prisma", "schema.prisma");
+
+function toUtf8(value) {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (value instanceof Buffer) return value.toString("utf8");
+  return String(value);
+}
+
+function collectErrorOutput(error) {
+  return [error?.stdout, error?.stderr, error?.message].map(toUtf8).filter(Boolean).join("\n");
+}
+
+function includesFailedMigrationHint(error) {
+  if (!error) return false;
+  const output = collectErrorOutput(error);
+  if (!output) return false;
+  return /P3009/.test(output) || /failed migrations?/i.test(output);
+}
+
+function parseFailedMigrations(output) {
+  if (!output) return [];
+  const lines = output.split(/\r?\n/);
+  const result = [];
+  let capture = false;
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    if (!capture && /have failed/i.test(line)) {
+      capture = true;
+      continue;
+    }
+    if (!capture) continue;
+    const match = line.match(/^\s*-\s+(.+?)\s*$/);
+    if (match) {
+      result.push(match[1].trim());
+      continue;
+    }
+    if (line.trim() === "" && result.length > 0) {
+      break;
+    }
+  }
+  return result;
+}
+
+function resolveFailedMigrations(prismaExecutable) {
+  let statusOutput = "";
+  try {
+    statusOutput = execFileSync(
+      prismaExecutable,
+      ["migrate", "status", "--schema", schemaPath],
+      { env: process.env, encoding: "utf8" },
+    );
+  } catch (error) {
+    const combined = collectErrorOutput(error);
+    if (combined) {
+      statusOutput = combined;
+    } else {
+      throw error;
+    }
+  }
+
+  const failedMigrations = parseFailedMigrations(statusOutput);
+  if (failedMigrations.length === 0) {
+    console.warn("[prisma-migrate] prisma migrate status reported no failed migrations to resolve.");
+    return [];
+  }
+
+  const resolved = [];
+  for (const migrationName of failedMigrations) {
+    console.warn(
+      `[prisma-migrate] Detected failed migration \"${migrationName}\". Marking as rolled back before retrying...`,
+    );
+    execFileSync(
+      prismaExecutable,
+      ["migrate", "resolve", "--rolled-back", migrationName, "--schema", schemaPath],
+      {
+        stdio: "inherit",
+        env: process.env,
+      },
+    );
+    resolved.push(migrationName);
+  }
+
+  return resolved;
+}
+
+function runMigrateDeploy(prismaExecutable) {
+  execFileSync(prismaExecutable, ["migrate", "deploy"], {
+    stdio: "inherit",
+    env: process.env,
+  });
+}
 
 function shouldSkip() {
   const flag = process.env.SKIP_PRISMA_MIGRATE;
@@ -102,12 +194,33 @@ async function main() {
 
   try {
     console.log("[prisma-migrate] Ensuring database schema is up to date (prisma migrate deploy)...");
-    execFileSync(prismaExecutable, ["migrate", "deploy"], {
-      stdio: "inherit",
-      env: process.env,
-    });
+    runMigrateDeploy(prismaExecutable);
     console.log("[prisma-migrate] Prisma migrations applied successfully.");
   } catch (error) {
+    if (includesFailedMigrationHint(error)) {
+      console.warn(
+        "[prisma-migrate] Detected failed migrations in the target database. Attempting automatic recovery...",
+      );
+      try {
+        const resolved = resolveFailedMigrations(prismaExecutable);
+        if (resolved.length > 0) {
+          console.log(
+            `[prisma-migrate] Resolved ${resolved.length} failed migration(s). Retrying prisma migrate deploy...`,
+          );
+          runMigrateDeploy(prismaExecutable);
+          console.log("[prisma-migrate] Prisma migrations applied successfully after automatic recovery.");
+          await announceOwnerSetupLink();
+          return;
+        }
+      } catch (innerError) {
+        console.error("[prisma-migrate] Automatic migration recovery failed.");
+        if (innerError instanceof Error && innerError.message) {
+          console.error(innerError.message);
+        }
+        process.exit(typeof innerError?.status === "number" ? innerError.status : 1);
+      }
+    }
+
     console.error("[prisma-migrate] Failed to apply Prisma migrations.");
     if (error instanceof Error && error.message) {
       console.error(error.message);


### PR DESCRIPTION
## Summary
- guard the BlockedDayKind enum migration with an idempotent DO block so repeated deploys succeed
- harden the file library migration by checking for existing types, tables, indexes, and constraints before creating them
- enhance scripts/run-prisma-migrate.mjs to detect failed migrations, mark them rolled back, and retry automatically

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dbc5095e28832d856c288e65605be5