### PR TITLE
Fix analytics settings migration trigger dependency

### DIFF
--- a/prisma/migrations/20251220090000_analytics_settings/migration.sql
+++ b/prisma/migrations/20251220090000_analytics_settings/migration.sql
@@ -14,6 +14,15 @@ CREATE TABLE "analytics_settings" (
     CONSTRAINT "analytics_settings_pkey" PRIMARY KEY ("id")
 );
 
+-- CreateFunction
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."updated_at" = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
 -- CreateTrigger
 CREATE TRIGGER "analytics_settings_set_updated_at"
 BEFORE UPDATE ON "analytics_settings"


### PR DESCRIPTION
## Summary
- add a PostgreSQL trigger helper function to the analytics settings migration so the trigger can be created successfully in production

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dbcad1c258832d9c019399a0328ba0