### PR TITLE
Add mobile cards for server analytics tables

### DIFF
--- a/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
+++ b/src/app/(members)/mitglieder/server-analytics/server-analytics-content.tsx
@@ -153,6 +153,194 @@ function MockDataBadge({ label = "Demo" }: { label?: string }) {
   );
 }
 
+function PagePerformanceMobileSection({
+  entries,
+  uniqueVisitorLabel,
+}: {
+  entries: ServerAnalytics["publicPages"];
+  uniqueVisitorLabel: string;
+}) {
+  if (!entries.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 md:hidden">
+      {entries.map((entry) => (
+        <div
+          key={entry.path}
+          className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
+        >
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-foreground">{entry.title}</p>
+            <p className="text-xs text-muted-foreground">{entry.path}</p>
+            <p className="text-xs text-muted-foreground">
+              Scrolltiefe {percentPreciseFormat.format(entry.avgScrollDepth)}
+            </p>
+          </div>
+          <dl className="grid gap-3 text-sm">
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Aufrufe</dt>
+              <dd className="font-semibold text-foreground">{numberFormat.format(entry.views)}</dd>
+              <dd className="text-xs text-muted-foreground">
+                {numberFormat.format(entry.uniqueVisitors)} {uniqueVisitorLabel}
+              </dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">
+                Ø Zeit auf Seite
+              </dt>
+              <dd className="text-foreground">{formatDuration(entry.avgTimeOnPageSeconds)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Performance</dt>
+              <dd className="text-foreground">Ø Ladezeit {formatMs(entry.loadTimeMs)}</dd>
+              <dd className="text-xs text-muted-foreground">LCP {formatMs(entry.lcpMs)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Absprung</dt>
+              <dd className="text-foreground">{percentPreciseFormat.format(entry.bounceRate)}</dd>
+              <dd className="text-xs text-muted-foreground">
+                Exit-Rate {percentPreciseFormat.format(entry.exitRate)}
+              </dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Zielerfüllung</dt>
+              <dd className="font-semibold text-foreground">
+                {percentPreciseFormat.format(entry.goalCompletionRate)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TrafficSourcesMobileSection({
+  sources,
+}: {
+  sources: ServerAnalytics["trafficSources"];
+}) {
+  if (!sources.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 md:hidden">
+      {sources.map((source) => (
+        <div
+          key={source.channel}
+          className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-semibold text-foreground">{source.channel}</p>
+            <span className={cn("text-xs font-medium", changeTextClass(source.changePercent, true))}>
+              {formatChange(source.changePercent)} vs. Vorwoche
+            </span>
+          </div>
+          <dl className="grid gap-3 text-sm">
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Sessions</dt>
+              <dd className="text-foreground">{numberFormat.format(source.sessions)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">
+                Ø Sitzungsdauer
+              </dt>
+              <dd className="text-foreground">{formatDuration(source.avgSessionDurationSeconds)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Konversion</dt>
+              <dd className="font-semibold text-foreground">
+                {percentPreciseFormat.format(source.conversionRate)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DeviceBreakdownMobileSection({
+  devices,
+}: {
+  devices: ServerAnalytics["deviceBreakdown"];
+}) {
+  if (!devices.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 md:hidden">
+      {devices.map((device) => (
+        <div
+          key={device.device}
+          className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
+        >
+          <p className="text-sm font-semibold text-foreground">{device.device}</p>
+          <dl className="grid gap-3 text-sm">
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Sessions</dt>
+              <dd className="text-foreground">{numberFormat.format(device.sessions)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Anteil</dt>
+              <dd className="text-foreground">{percentPreciseFormat.format(device.share)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Ø Ladezeit</dt>
+              <dd className="text-foreground">{formatMs(device.avgPageLoadMs)}</dd>
+            </div>
+          </dl>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SessionInsightsMobileSection({
+  segments,
+}: {
+  segments: ServerAnalytics["sessionInsights"];
+}) {
+  if (!segments.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3 md:hidden">
+      {segments.map((segment) => (
+        <div
+          key={segment.segment}
+          className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
+        >
+          <p className="text-sm font-semibold text-foreground">{segment.segment}</p>
+          <dl className="grid gap-3 text-sm">
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Ø Dauer</dt>
+              <dd className="text-foreground">{formatDuration(segment.avgSessionDurationSeconds)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Seiten / Sitzung</dt>
+              <dd className="text-foreground">{decimalFormat.format(segment.pagesPerSession)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Retention</dt>
+              <dd className="text-foreground">{percentPreciseFormat.format(segment.retentionRate)}</dd>
+            </div>
+            <div className="space-y-1">
+              <dt className="text-xs font-semibold uppercase text-muted-foreground">Anteil</dt>
+              <dd className="text-foreground">{percentPreciseFormat.format(segment.share)}</dd>
+            </div>
+          </dl>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function parseGeneratedAt(value: string | undefined) {
   const parsed = Date.parse(value ?? "");
   if (Number.isFinite(parsed)) {
@@ -892,55 +1080,10 @@ export function ServerAnalyticsContent({
           </p>
         </CardHeader>
         <CardContent>
-          <div className="space-y-3 md:hidden">
-            {displayAnalytics.publicPages.map((entry) => (
-              <div
-                key={entry.path}
-                className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
-              >
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold text-foreground">{entry.title}</p>
-                  <p className="text-xs text-muted-foreground">{entry.path}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Scrolltiefe {percentPreciseFormat.format(entry.avgScrollDepth)}
-                  </p>
-                </div>
-                <dl className="grid gap-3 text-sm">
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Aufrufe</dt>
-                    <dd className="font-semibold text-foreground">{numberFormat.format(entry.views)}</dd>
-                    <dd className="text-xs text-muted-foreground">
-                      {numberFormat.format(entry.uniqueVisitors)} eindeutige Besucher
-                    </dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">
-                      Ø Zeit auf Seite
-                    </dt>
-                    <dd className="text-foreground">{formatDuration(entry.avgTimeOnPageSeconds)}</dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Performance</dt>
-                    <dd className="text-foreground">Ø Ladezeit {formatMs(entry.loadTimeMs)}</dd>
-                    <dd className="text-xs text-muted-foreground">LCP {formatMs(entry.lcpMs)}</dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Absprung</dt>
-                    <dd className="text-foreground">{percentPreciseFormat.format(entry.bounceRate)}</dd>
-                    <dd className="text-xs text-muted-foreground">
-                      Exit-Rate {percentPreciseFormat.format(entry.exitRate)}
-                    </dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Zielerfüllung</dt>
-                    <dd className="font-semibold text-foreground">
-                      {percentPreciseFormat.format(entry.goalCompletionRate)}
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            ))}
-          </div>
+          <PagePerformanceMobileSection
+            entries={displayAnalytics.publicPages}
+            uniqueVisitorLabel="eindeutige Besucher"
+          />
           <div className="hidden overflow-x-auto md:block">
             <table className="min-w-full divide-y divide-border text-sm">
               <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
@@ -999,55 +1142,10 @@ export function ServerAnalyticsContent({
           </p>
         </CardHeader>
         <CardContent>
-          <div className="space-y-3 md:hidden">
-            {displayAnalytics.memberPages.map((entry) => (
-              <div
-                key={entry.path}
-                className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
-              >
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold text-foreground">{entry.title}</p>
-                  <p className="text-xs text-muted-foreground">{entry.path}</p>
-                  <p className="text-xs text-muted-foreground">
-                    Scrolltiefe {percentPreciseFormat.format(entry.avgScrollDepth)}
-                  </p>
-                </div>
-                <dl className="grid gap-3 text-sm">
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Aufrufe</dt>
-                    <dd className="font-semibold text-foreground">{numberFormat.format(entry.views)}</dd>
-                    <dd className="text-xs text-muted-foreground">
-                      {numberFormat.format(entry.uniqueVisitors)} eindeutige Mitglieder
-                    </dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">
-                      Ø Zeit auf Seite
-                    </dt>
-                    <dd className="text-foreground">{formatDuration(entry.avgTimeOnPageSeconds)}</dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Performance</dt>
-                    <dd className="text-foreground">Ø Ladezeit {formatMs(entry.loadTimeMs)}</dd>
-                    <dd className="text-xs text-muted-foreground">LCP {formatMs(entry.lcpMs)}</dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Absprung</dt>
-                    <dd className="text-foreground">{percentPreciseFormat.format(entry.bounceRate)}</dd>
-                    <dd className="text-xs text-muted-foreground">
-                      Exit-Rate {percentPreciseFormat.format(entry.exitRate)}
-                    </dd>
-                  </div>
-                  <div className="space-y-1">
-                    <dt className="text-xs font-semibold uppercase text-muted-foreground">Zielerfüllung</dt>
-                    <dd className="font-semibold text-foreground">
-                      {percentPreciseFormat.format(entry.goalCompletionRate)}
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            ))}
-          </div>
+          <PagePerformanceMobileSection
+            entries={displayAnalytics.memberPages}
+            uniqueVisitorLabel="eindeutige Mitglieder"
+          />
           <div className="hidden overflow-x-auto md:block">
             <table className="min-w-full divide-y divide-border text-sm">
               <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
@@ -1107,41 +1205,7 @@ export function ServerAnalyticsContent({
             </p>
           </CardHeader>
           <CardContent>
-            <div className="space-y-3 md:hidden">
-              {displayAnalytics.trafficSources.map((source) => (
-                <div
-                  key={source.channel}
-                  className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="text-sm font-semibold text-foreground">{source.channel}</p>
-                    <span className={cn("text-xs font-medium", changeTextClass(source.changePercent, true))}>
-                      {formatChange(source.changePercent)} vs. Vorwoche
-                    </span>
-                  </div>
-                  <dl className="grid gap-3 text-sm">
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Sessions</dt>
-                      <dd className="text-foreground">{numberFormat.format(source.sessions)}</dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">
-                        Ø Sitzungsdauer
-                      </dt>
-                      <dd className="text-foreground">
-                        {formatDuration(source.avgSessionDurationSeconds)}
-                      </dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Konversion</dt>
-                      <dd className="font-semibold text-foreground">
-                        {percentPreciseFormat.format(source.conversionRate)}
-                      </dd>
-                    </div>
-                  </dl>
-                </div>
-              ))}
-            </div>
+            <TrafficSourcesMobileSection sources={displayAnalytics.trafficSources} />
             <div className="hidden overflow-x-auto md:block">
               <table className="min-w-full divide-y divide-border text-sm">
                 <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
@@ -1183,30 +1247,7 @@ export function ServerAnalyticsContent({
             </p>
           </CardHeader>
           <CardContent>
-            <div className="space-y-3 md:hidden">
-              {displayAnalytics.deviceBreakdown.map((device) => (
-                <div
-                  key={device.device}
-                  className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
-                >
-                  <p className="text-sm font-semibold text-foreground">{device.device}</p>
-                  <dl className="grid gap-3 text-sm">
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Sessions</dt>
-                      <dd className="text-foreground">{numberFormat.format(device.sessions)}</dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Anteil</dt>
-                      <dd className="text-foreground">{percentPreciseFormat.format(device.share)}</dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Ø Ladezeit</dt>
-                      <dd className="text-foreground">{formatMs(device.avgPageLoadMs)}</dd>
-                    </div>
-                  </dl>
-                </div>
-              ))}
-            </div>
+            <DeviceBreakdownMobileSection devices={displayAnalytics.deviceBreakdown} />
             <div className="hidden overflow-x-auto md:block">
               <table className="min-w-full divide-y divide-border text-sm">
                 <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
@@ -1245,38 +1286,7 @@ export function ServerAnalyticsContent({
             </p>
           </CardHeader>
           <CardContent>
-            <div className="space-y-3 md:hidden">
-              {displayAnalytics.sessionInsights.map((segment) => (
-                <div
-                  key={segment.segment}
-                  className="space-y-3 rounded-md border border-border/60 bg-background/60 p-3"
-                >
-                  <p className="text-sm font-semibold text-foreground">{segment.segment}</p>
-                  <dl className="grid gap-3 text-sm">
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Ø Dauer</dt>
-                      <dd className="text-foreground">
-                        {formatDuration(segment.avgSessionDurationSeconds)}
-                      </dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">
-                        Seiten / Sitzung
-                      </dt>
-                      <dd className="text-foreground">{decimalFormat.format(segment.pagesPerSession)}</dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Retention</dt>
-                      <dd className="text-foreground">{percentPreciseFormat.format(segment.retentionRate)}</dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-xs font-semibold uppercase text-muted-foreground">Anteil</dt>
-                      <dd className="text-foreground">{percentPreciseFormat.format(segment.share)}</dd>
-                    </div>
-                  </dl>
-                </div>
-              ))}
-            </div>
+            <SessionInsightsMobileSection segments={displayAnalytics.sessionInsights} />
             <div className="hidden overflow-x-auto md:block">
               <table className="min-w-full divide-y divide-border text-sm">
                 <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">


### PR DESCRIPTION
## Summary
- extract reusable mobile card sections for page, traffic, device, and session analytics tables
- render the new mobile sections below the existing cards so small viewports show labeled metrics without horizontal scrolling

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dbf56932c0832db0edb5aeea65c3d2