### PR TITLE
Remove unread notifications card from members dashboard

### DIFF
--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -743,14 +743,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         icon: <Calendar className="h-4 w-4" />,
         tone: "accent",
       },
-      {
-        key: "notifications",
-        label: "Ungelesene Benachrichtigungen",
-        value: numberFormatter.format(stats.unreadNotifications),
-        hint: "Wer zuerst liest, ist informiert",
-        icon: <Bell className="h-4 w-4" />,
-        tone: stats.unreadNotifications > 0 ? "warning" : "neutral",
-      },
     ];
 
     if (finalRehearsalMetric) {
@@ -784,7 +776,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     stats.rehearsalsThisWeek,
     stats.totalMembers,
     stats.totalOnline,
-    stats.unreadNotifications,
   ]);
 
   const profileReminder = useMemo(() => {


### PR DESCRIPTION
## Summary
- remove the unread notifications metric from the members dashboard overview list
- tidy the metrics memo dependencies after removing the unused value

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dc2700e948832d8f34d9c792c8e9bc