### PR TITLE
Adjust feedback filter buttons

### DIFF
--- a/src/components/members/issues/issue-overview.tsx
+++ b/src/components/members/issues/issue-overview.tsx
@@ -233,7 +233,7 @@ export function IssueOverview({ initialIssues, initialCounts }: IssueOverviewPro
             ))}
           </div>
 
-          <div className="flex flex-col gap-3 md:flex-row md:items-end">
+          <div className="flex flex-col gap-3 md:flex-row md:items-start">
             <div className="md:w-64">
               <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Kategorie
@@ -265,10 +265,10 @@ export function IssueOverview({ initialIssues, initialCounts }: IssueOverviewPro
                 />
               </div>
               <div className="flex gap-2">
-                <Button type="submit" variant="secondary">
+                <Button type="submit" variant="secondary" size="sm">
                   Anwenden
                 </Button>
-                <Button type="button" variant="ghost" onClick={handleClearFilters}>
+                <Button type="button" variant="ghost" size="sm" onClick={handleClearFilters}>
                   Zurücksetzen
                 </Button>
               </div>


### PR DESCRIPTION
## Summary
- align the "Anwenden" and "Zurücksetzen" filter buttons with the adjacent fields on the feedback overview
- resize the action buttons so they match the status filter pill proportions for consistent typography

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dc307fb484832db07fbff623e2bf3c