### PR TITLE
Add payout checklist item and clean up profile header

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -6,7 +6,7 @@ import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 import { getUserDisplayName } from "@/lib/names";
 import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 import { prisma } from "@/lib/prisma";
-import { buildProfileChecklist } from "@/lib/profile-completion";
+import { buildProfileChecklist, isPayoutDetailsComplete } from "@/lib/profile-completion";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 import { sortRoles, type Role } from "@/lib/roles";
@@ -205,10 +205,20 @@ export default async function ProfilePage() {
     ? getOnboardingWhatsAppLink(onboardingProfile.show.meta)
     : null;
 
+  const hasPayoutDetails = isPayoutDetailsComplete({
+    method: user.payoutMethod,
+    accountHolder: user.payoutAccountHolder,
+    iban: user.payoutIban,
+    bankName: user.payoutBankName,
+    paypalHandle: user.payoutPaypalHandle,
+    note: user.payoutNote,
+  });
+
   const checklist = buildProfileChecklist({
     hasBasicData,
     hasBirthdate,
     hasDietaryPreference,
+    hasPayoutDetails,
     hasMeasurements,
     photoConsent: { consentGiven: photoConsentSummary.status === "approved" },
     hasWhatsappVisit: whatsappLink ? Boolean(onboardingProfile?.whatsappLinkVisitedAt) : undefined,

--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -60,6 +60,7 @@ import { UserAvatar } from "@/components/user-avatar";
 import { useOnboardingBackgroundData } from "@/components/onboarding/use-onboarding-background-data";
 import {
   buildProfileChecklist,
+  isPayoutDetailsComplete,
   type ProfileChecklistTarget,
   type ProfileCompletionSummary,
 } from "@/lib/profile-completion";
@@ -86,6 +87,7 @@ const CURRENT_YEAR = new Date().getFullYear();
 const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
 const CHECKLIST_TARGETS: ProfileChecklistTarget[] = [
   "stammdaten",
+  "zahlungen",
   "ernaehrung",
   "masse",
   "interessen",
@@ -269,6 +271,7 @@ type ChecklistState = {
   hasBasicData: boolean;
   hasBirthdate: boolean;
   hasDietaryPreference: boolean;
+  hasPayoutDetails?: boolean;
   hasMeasurements?: boolean;
   photoConsentGiven?: boolean;
   hasWhatsappVisit?: boolean;
@@ -515,6 +518,14 @@ function ProfileClientInner({
     hasBasicData: Boolean(initialUser.firstName?.trim() && initialUser.email?.trim()),
     hasBirthdate: Boolean(initialUser.dateOfBirth),
     hasDietaryPreference: Boolean(initialOnboarding?.dietaryPreference?.trim()),
+    hasPayoutDetails: isPayoutDetailsComplete({
+      method: initialUser.payoutMethod,
+      accountHolder: initialUser.payoutAccountHolder,
+      iban: initialUser.payoutIban,
+      bankName: initialUser.payoutBankName,
+      paypalHandle: initialUser.payoutPaypalHandle,
+      note: initialUser.payoutNote,
+    }),
     hasMeasurements: canManageMeasurements ? initialMeasurements.length > 0 : undefined,
     photoConsentGiven: summary.items.find((item) => item.id === "photo-consent")?.complete ?? undefined,
     hasWhatsappVisit: whatsappLink ? Boolean(initialOnboarding?.whatsappLinkVisitedAt) : undefined,
@@ -526,6 +537,7 @@ function ProfileClientInner({
         hasBasicData: state.hasBasicData,
         hasBirthdate: state.hasBirthdate,
         hasDietaryPreference: state.hasDietaryPreference,
+        hasPayoutDetails: state.hasPayoutDetails,
         hasMeasurements: canManageMeasurements ? Boolean(state.hasMeasurements) : undefined,
         photoConsent:
           state.photoConsentGiven === undefined
@@ -605,6 +617,14 @@ function ProfileClientInner({
       updateChecklist({
         hasBasicData: basicsComplete,
         hasBirthdate: Boolean(nextUser.dateOfBirth),
+        hasPayoutDetails: isPayoutDetailsComplete({
+          method: nextUser.payoutMethod,
+          accountHolder: nextUser.payoutAccountHolder,
+          iban: nextUser.payoutIban,
+          bankName: nextUser.payoutBankName,
+          paypalHandle: nextUser.payoutPaypalHandle,
+          note: nextUser.payoutNote,
+        }),
       });
       try {
         await refreshSession?.();
@@ -836,8 +856,6 @@ function ProfileClientInner({
         sortedRoles={sortedRoles}
         summary={summary}
         onboarding={onboarding}
-        createdAtLabel={createdAtLabel}
-        memberSinceLabel={memberSinceLabel}
         percentComplete={percentComplete}
         highlights={highlightTiles}
         activeChecklistTarget={activeChecklistTarget}
@@ -951,8 +969,6 @@ type ProfileOverviewCardProps = {
   sortedRoles: Role[];
   summary: ProfileCompletionSummary;
   onboarding: ProfileClientProps["onboarding"];
-  createdAtLabel: string | null;
-  memberSinceLabel: string | null;
   percentComplete: number;
   highlights: HighlightTileConfig[];
   activeChecklistTarget?: ProfileChecklistTarget;
@@ -965,8 +981,6 @@ function ProfileOverviewCard({
   sortedRoles,
   summary,
   onboarding,
-  createdAtLabel,
-  memberSinceLabel,
   percentComplete,
   highlights,
   activeChecklistTarget,
@@ -1030,12 +1044,6 @@ function ProfileOverviewCard({
                     Keine E-Mail hinterlegt
                   </span>
                 )}
-                {memberSinceLabel || createdAtLabel ? (
-                  <span className="inline-flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-                    <CalendarDays className="h-4 w-4" aria-hidden />
-                    {memberSinceLabel ?? (createdAtLabel ? `Profil seit ${createdAtLabel}` : "")}
-                  </span>
-                ) : null}
               </div>
             </div>
           </div>

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -6,7 +6,7 @@ import { hasRole, requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProductionId } from "@/lib/active-production";
-import { buildProfileChecklist } from "@/lib/profile-completion";
+import { buildProfileChecklist, isPayoutDetailsComplete } from "@/lib/profile-completion";
 
 type MembershipSummary = {
   showId: string;
@@ -149,6 +149,12 @@ export async function GET() {
           lastName: true,
           email: true,
           dateOfBirth: true,
+          payoutMethod: true,
+          payoutAccountHolder: true,
+          payoutIban: true,
+          payoutBankName: true,
+          payoutPaypalHandle: true,
+          payoutNote: true,
         },
       }),
       prisma.productionMembership.findMany({
@@ -199,6 +205,15 @@ export async function GET() {
       .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
       .slice(0, 10);
 
+    const hasPayoutDetails = isPayoutDetailsComplete({
+      method: userRecord?.payoutMethod,
+      accountHolder: userRecord?.payoutAccountHolder,
+      iban: userRecord?.payoutIban,
+      bankName: userRecord?.payoutBankName,
+      paypalHandle: userRecord?.payoutPaypalHandle,
+      note: userRecord?.payoutNote,
+    });
+
     const profileChecklist = buildProfileChecklist({
       hasBasicData: Boolean(
         userRecord?.firstName && userRecord?.lastName && userRecord?.email,
@@ -207,6 +222,7 @@ export async function GET() {
       hasDietaryPreference: Boolean(
         onboardingProfile?.dietaryPreference?.trim(),
       ),
+      hasPayoutDetails,
       hasMeasurements: canManageMeasurements ? measurementCount > 0 : undefined,
       photoConsent: { consentGiven: Boolean(photoConsent?.consentGiven) },
     });

--- a/src/lib/profile-completion.ts
+++ b/src/lib/profile-completion.ts
@@ -1,13 +1,17 @@
+import type { PayoutMethod } from "@prisma/client";
+
 export type ProfileChecklistItemId =
   | "basics"
   | "birthdate"
   | "dietary"
+  | "payout"
   | "measurements"
   | "photo-consent"
   | "whatsapp";
 
 export type ProfileChecklistTarget =
   | "stammdaten"
+  | "zahlungen"
   | "ernaehrung"
   | "masse"
   | "interessen"
@@ -33,6 +37,7 @@ type ChecklistInput = {
   hasBasicData: boolean;
   hasBirthdate: boolean;
   hasDietaryPreference: boolean;
+  hasPayoutDetails?: boolean;
   hasMeasurements?: boolean;
   photoConsent?: { consentGiven: boolean };
   hasWhatsappVisit?: boolean;
@@ -64,6 +69,16 @@ export function buildProfileChecklist(
       targetSection: "ernaehrung",
     },
   ];
+
+  if (input.hasPayoutDetails !== undefined) {
+    items.push({
+      id: "payout",
+      label: "Zahlungsdaten hinterlegt",
+      description: "Stellt reibungslose Erstattungen und Auszahlungen sicher.",
+      complete: Boolean(input.hasPayoutDetails),
+      targetSection: "zahlungen",
+    });
+  }
 
   if (input.hasMeasurements !== undefined) {
     items.push({
@@ -104,4 +119,41 @@ export function buildProfileChecklist(
     total,
     complete: completed === total,
   };
+}
+
+type PayoutDetailsInput = {
+  method: PayoutMethod | null | undefined;
+  accountHolder?: string | null;
+  iban?: string | null;
+  bankName?: string | null;
+  paypalHandle?: string | null;
+  note?: string | null;
+};
+
+function hasFilledValue(value: string | null | undefined) {
+  return Boolean(value?.trim());
+}
+
+export function isPayoutDetailsComplete(input: PayoutDetailsInput): boolean {
+  if (!input.method) {
+    return false;
+  }
+
+  if (input.method === "BANK_TRANSFER") {
+    return (
+      hasFilledValue(input.accountHolder) &&
+      hasFilledValue(input.iban) &&
+      hasFilledValue(input.bankName)
+    );
+  }
+
+  if (input.method === "PAYPAL") {
+    return hasFilledValue(input.paypalHandle);
+  }
+
+  if (input.method === "OTHER") {
+    return hasFilledValue(input.note);
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Summary
- remove the calendar icon and member-since hint from the profile header
- add payout data tracking to the profile checklist and checklist navigation
- ensure payout completion state is surfaced in the dashboard overview API

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dc32322e08832daf69fb312fd3c02c