### PR TITLE
Add mobile bottom navigation for members shell

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -7,8 +7,17 @@ import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import type { AssignmentFocus } from "@/components/members-nav";
 import { MembersPermissionsProvider } from "@/components/members/permissions-context";
-import { MembersAppShell } from "@/components/members/members-app-shell";
-import { SidebarProvider, SIDEBAR_COOKIE_NAME } from "@/components/ui/sidebar";
+import {
+  MembersAppShell,
+  MEMBERS_BOTTOM_NAV_COOKIE_NAME,
+  type MembersBottomNavTabId,
+} from "@/components/members/members-app-shell";
+import {
+  SidebarProvider,
+  SIDEBAR_DESKTOP_COOKIE_NAME,
+  SIDEBAR_MOBILE_COOKIE_NAME,
+} from "@/components/ui/sidebar";
+import { Badge } from "@/components/ui/badge";
 import { getActiveProduction } from "@/lib/active-production";
 import { prisma } from "@/lib/prisma";
 import { getUserPermissionKeys } from "@/lib/permissions";
@@ -78,9 +87,28 @@ const isDevBuild = process.env.NODE_ENV === "development";
 
 export default async function MembersLayout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies();
-  const sidebarState = cookieStore.get(SIDEBAR_COOKIE_NAME)?.value;
+  const sidebarDesktopCookie =
+    cookieStore.get(SIDEBAR_DESKTOP_COOKIE_NAME)?.value;
+  const sidebarMobileCookie = cookieStore.get(SIDEBAR_MOBILE_COOKIE_NAME)?.value;
   const defaultSidebarOpen =
-    typeof sidebarState === "undefined" ? true : sidebarState === "true";
+    typeof sidebarDesktopCookie === "undefined"
+      ? true
+      : sidebarDesktopCookie === "true";
+  const defaultSidebarMobileOpen =
+    typeof sidebarMobileCookie === "undefined"
+      ? false
+      : sidebarMobileCookie === "true";
+
+  const bottomNavCookie = cookieStore.get(MEMBERS_BOTTOM_NAV_COOKIE_NAME)?.value;
+  const allowedBottomNavTabs: MembersBottomNavTabId[] = [
+    "home",
+    "assignments",
+    "production",
+    "profile",
+  ];
+  const defaultBottomNavTab = allowedBottomNavTabs.find(
+    (tab) => tab === bottomNavCookie,
+  );
 
   const session = await requireAuth();
   const permissions = await getUserPermissionKeys(session.user);
@@ -129,6 +157,15 @@ export default async function MembersLayout({ children }: { children: React.Reac
     ["--members-topbar-offset" as const]: "var(--header-height)",
   } as React.CSSProperties;
 
+  const appBarStatus = activeProduction
+    ? (
+        <Badge variant="outline" className="gap-1 font-medium">
+          <span className="text-muted-foreground">Saison</span>
+          <span className="text-foreground">{activeProduction.year}</span>
+        </Badge>
+      )
+    : null;
+
   return (
     <div className="app-shell bg-background">
       <MysticBackground />
@@ -136,6 +173,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
       <main className="relative z-10 flex min-h-0 flex-col pt-[var(--header-height)]">
         <SidebarProvider
           defaultOpen={defaultSidebarOpen}
+          defaultOpenMobile={defaultSidebarMobileOpen}
           className="flex-1 min-h-0 bg-background"
           style={layoutStyle}
         >
@@ -146,6 +184,8 @@ export default async function MembersLayout({ children }: { children: React.Reac
               assignmentFocus={assignmentFocus}
               hasDepartmentMemberships={hasDepartmentMemberships}
               impersonation={session.impersonation ?? null}
+              defaultBottomNavTab={defaultBottomNavTab}
+              appBarSlots={{ status: appBarStatus }}
               globalFooter={
                 <SiteFooter
                   buildInfo={buildInfo}

--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Menu } from "lucide-react";
 
 import {
   Sidebar,
@@ -19,6 +19,14 @@ import { MembersNav, type AssignmentFocus } from "@/components/members-nav";
 import { cn } from "@/lib/utils";
 import type { ImpersonationDetails } from "@/lib/auth/impersonation";
 import { ImpersonationBanner } from "@/components/members/impersonation-banner/impersonation-banner";
+import {
+  filterMembersNavigationByPermissions,
+  selectMembersNavigation,
+} from "@/lib/members-navigation";
+import {
+  defaultMembersNavIcon,
+  type MembersNavItem,
+} from "@/config/members-navigation";
 
 const membersContentSectionVariants = cva("py-6 sm:py-8", {
   variants: {
@@ -107,6 +115,49 @@ const DEFAULT_CONTENT_LAYOUT: MembersContentLayoutState = {
   gap: "md",
 };
 
+export const MEMBERS_BOTTOM_NAV_COOKIE_NAME = "members_bottom_nav_tab";
+const MEMBERS_BOTTOM_NAV_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+
+export type MembersBottomNavTabId =
+  | "home"
+  | "assignments"
+  | "production"
+  | "profile";
+
+type MembersBottomNavItemId = MembersBottomNavTabId | "menu";
+
+type MembersBottomNavItem = {
+  id: MembersBottomNavItemId;
+  label: string;
+  href?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  ariaLabel?: string;
+  badge?: string;
+};
+
+function convertBadgeToString(
+  badge: MembersNavItem["badge"],
+): string | undefined {
+  if (typeof badge === "string" || typeof badge === "number") {
+    return String(badge);
+  }
+  return undefined;
+}
+
+function createBottomNavItem(
+  id: MembersBottomNavTabId,
+  item: MembersNavItem,
+): MembersBottomNavItem {
+  return {
+    id,
+    label: item.label,
+    href: item.href,
+    icon: item.icon ?? defaultMembersNavIcon,
+    ariaLabel: item.ariaLabel,
+    badge: convertBadgeToString(item.badge),
+  };
+}
+
 function mergeContentLayout(
   base: MembersContentLayoutState,
   patch?: MembersContentLayoutConfig | null,
@@ -184,6 +235,8 @@ interface MembersAppShellProps {
   contentLayout?: MembersContentLayoutConfig;
   globalFooter?: React.ReactNode;
   impersonation?: ImpersonationDetails | null;
+  defaultBottomNavTab?: MembersBottomNavTabId;
+  appBarSlots?: Partial<MembersTopbarSlots>;
 }
 
 interface MembersTopbarSlots {
@@ -199,6 +252,18 @@ const INITIAL_TOPBAR: MembersTopbarSlots = {
   quickActions: null,
   status: null,
 };
+
+function areTopbarSlotsEqual(
+  a: MembersTopbarSlots,
+  b: MembersTopbarSlots,
+) {
+  return (
+    a.breadcrumbs === b.breadcrumbs &&
+    a.title === b.title &&
+    a.quickActions === b.quickActions &&
+    a.status === b.status
+  );
+}
 
 const MEMBERS_TOPBAR_STICKY_STYLE: React.CSSProperties = {
   top: "var(--members-topbar-offset, 0px)",
@@ -230,7 +295,8 @@ function useMembersAppShellContext() {
 
 function SidebarMobileAutoClose() {
   const pathname = usePathname();
-  const { isMobile, setOpenMobile } = useSidebar();
+  const sidebar = useSidebar();
+  const { isMobile, setOpenMobile } = sidebar;
 
   React.useEffect(() => {
     if (!isMobile) {
@@ -243,6 +309,303 @@ function SidebarMobileAutoClose() {
   }, [isMobile, pathname, setOpenMobile]);
 
   return null;
+}
+
+function isPathActive(pathname: string, href: string) {
+  if (pathname === href) return true;
+  if (href === "/mitglieder") return pathname === "/mitglieder";
+  return pathname.startsWith(`${href}/`);
+}
+
+interface MembersBottomNavProps {
+  permissions: readonly string[];
+  assignmentFocus: AssignmentFocus;
+  hasDepartmentMemberships: boolean;
+  activeProduction?: { id: string; title: string | null; year: number };
+  defaultTab?: MembersBottomNavTabId;
+}
+
+function MembersBottomNav({
+  permissions,
+  assignmentFocus,
+  hasDepartmentMemberships,
+  activeProduction,
+  defaultTab,
+}: MembersBottomNavProps) {
+  const pathname = usePathname() ?? "";
+  const sidebar = useSidebar();
+  const { isMobile, setOpenMobile } = sidebar;
+
+  const navigation = React.useMemo(() => {
+    const groups = selectMembersNavigation({
+      hasDepartmentMemberships,
+      activeProduction: activeProduction ?? null,
+    });
+    return filterMembersNavigationByPermissions(groups, permissions);
+  }, [
+    permissions,
+    hasDepartmentMemberships,
+    activeProduction,
+  ]);
+
+  const { groups: navGroups, flat } = navigation;
+
+  const itemsByHref = React.useMemo(() => {
+    const map = new Map<string, MembersNavItem>();
+    for (const item of flat) {
+      map.set(item.href, item);
+    }
+    return map;
+  }, [flat]);
+
+  const findFirstAvailable = React.useCallback(
+    (candidates: readonly (string | null | undefined)[]) => {
+      for (const candidate of candidates) {
+        if (!candidate) continue;
+        const item = itemsByHref.get(candidate);
+        if (item) {
+          return item;
+        }
+      }
+      return null;
+    },
+    [itemsByHref],
+  );
+
+  const generalGroup = React.useMemo(
+    () => navGroups.find((group) => group.id === "general") ?? null,
+    [navGroups],
+  );
+
+  const assignmentsCandidates = React.useMemo(() => {
+    const order: string[] = [];
+    const push = (href: string) => {
+      if (!order.includes(href)) {
+        order.push(href);
+      }
+    };
+
+    if (assignmentFocus === "departments") {
+      push("/mitglieder/meine-gewerke");
+      push("/mitglieder/meine-proben");
+    } else if (assignmentFocus === "rehearsals") {
+      push("/mitglieder/meine-proben");
+      push("/mitglieder/kalender");
+    } else if (assignmentFocus === "both") {
+      push("/mitglieder/kalender");
+      push("/mitglieder/meine-proben");
+      push("/mitglieder/meine-gewerke");
+    } else {
+      push("/mitglieder/kalender");
+      push("/mitglieder/meine-proben");
+      push("/mitglieder/meine-gewerke");
+    }
+
+    push("/mitglieder/probenplanung");
+    push("/mitglieder/koerpermasse");
+
+    return order;
+  }, [assignmentFocus]);
+
+  const homeNavItem = React.useMemo(() => {
+    return (
+      findFirstAvailable(["/mitglieder"]) ??
+      (generalGroup?.items.find((item) => itemsByHref.has(item.href)) ?? null)
+    );
+  }, [findFirstAvailable, generalGroup, itemsByHref]);
+
+  const assignmentsNavItem = React.useMemo(() => {
+    const item = findFirstAvailable(assignmentsCandidates);
+    if (item) return item;
+    const assignmentsGroup =
+      navGroups.find((group) => group.id === "assignments") ?? null;
+    return (
+      assignmentsGroup?.items.find((groupItem) =>
+        itemsByHref.has(groupItem.href),
+      ) ?? null
+    );
+  }, [assignmentsCandidates, findFirstAvailable, navGroups, itemsByHref]);
+
+  const productionNavItem = React.useMemo(() => {
+    const dynamicHref = activeProduction
+      ? `/mitglieder/produktionen/${activeProduction.id}`
+      : null;
+    const item = findFirstAvailable([
+      dynamicHref,
+      "/mitglieder/produktionen",
+      "/mitglieder/produktionen/gewerke",
+    ]);
+    if (item) return item;
+    const productionGroup =
+      navGroups.find((group) => group.id === "production") ?? null;
+    return (
+      productionGroup?.items.find((groupItem) =>
+        itemsByHref.has(groupItem.href),
+      ) ?? null
+    );
+  }, [findFirstAvailable, activeProduction, navGroups, itemsByHref]);
+
+  const profileNavItem = React.useMemo(() => {
+    const item = findFirstAvailable(["/mitglieder/profil"]);
+    if (item) return item;
+    const fallback = generalGroup?.items.find(
+      (groupItem) =>
+        groupItem.href !== homeNavItem?.href && itemsByHref.has(groupItem.href),
+    );
+    return fallback ?? null;
+  }, [findFirstAvailable, generalGroup, homeNavItem, itemsByHref]);
+
+  const sections = React.useMemo(() => {
+    const list: MembersBottomNavItem[] = [];
+    const usedHrefs = new Set<string>();
+
+    if (homeNavItem) {
+      list.push(createBottomNavItem("home", homeNavItem));
+      usedHrefs.add(homeNavItem.href);
+    }
+
+    if (assignmentsNavItem && !usedHrefs.has(assignmentsNavItem.href)) {
+      list.push(createBottomNavItem("assignments", assignmentsNavItem));
+      usedHrefs.add(assignmentsNavItem.href);
+    }
+
+    if (productionNavItem && !usedHrefs.has(productionNavItem.href)) {
+      list.push(createBottomNavItem("production", productionNavItem));
+      usedHrefs.add(productionNavItem.href);
+    }
+
+    if (profileNavItem && !usedHrefs.has(profileNavItem.href)) {
+      list.push(createBottomNavItem("profile", profileNavItem));
+      usedHrefs.add(profileNavItem.href);
+    }
+
+    return list;
+  }, [homeNavItem, assignmentsNavItem, productionNavItem, profileNavItem]);
+
+  const sectionsWithMenu = React.useMemo(() => {
+    if (sections.length === 0) {
+      return sections;
+    }
+
+    const menuItem: MembersBottomNavItem = {
+      id: "menu",
+      label: "Menü",
+      icon: Menu,
+      ariaLabel: "Navigation öffnen",
+    };
+
+    return [...sections, menuItem];
+  }, [sections]);
+
+  const initialActiveSection = React.useMemo<MembersBottomNavItemId>(() => {
+    const matched = sections.find((section) => {
+      const href = section.href;
+      if (typeof href !== "string") {
+        return false;
+      }
+      return isPathActive(pathname, href);
+    });
+    if (matched) {
+      return matched.id;
+    }
+
+    if (defaultTab) {
+      const defaultSection = sections.find(
+        (section) => section.id === defaultTab && section.href,
+      );
+      if (defaultSection) {
+        return defaultSection.id;
+      }
+    }
+
+    const firstNavigable = sections.find((section) => Boolean(section.href));
+    return firstNavigable ? firstNavigable.id : "menu";
+  }, [sections, pathname, defaultTab]);
+
+  const [activeSection, setActiveSection] = React.useState<MembersBottomNavItemId>(
+    initialActiveSection,
+  );
+
+  React.useEffect(() => {
+    setActiveSection(initialActiveSection);
+  }, [initialActiveSection]);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    if (
+      !sections.some((section) =>
+        section.id === activeSection ? Boolean(section.href) : false,
+      )
+    ) {
+      return;
+    }
+
+    document.cookie = `${MEMBERS_BOTTOM_NAV_COOKIE_NAME}=${activeSection}; path=/; max-age=${MEMBERS_BOTTOM_NAV_COOKIE_MAX_AGE}`;
+  }, [activeSection, sections]);
+
+  if (!isMobile || sectionsWithMenu.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 lg:hidden">
+      <div className="pointer-events-auto border-t border-border/60 bg-background/90 shadow-lg shadow-black/5 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+        <nav className="mx-auto flex max-w-lg items-stretch gap-1 px-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-2">
+          {sectionsWithMenu.map((section) => {
+            const Icon = section.icon;
+            const isActive = activeSection === section.id && section.id !== "menu";
+
+            if (!section.href) {
+              return (
+                <button
+                  key={section.id}
+                  type="button"
+                  onClick={() => setOpenMobile(true)}
+                  className={cn(
+                    "flex flex-1 flex-col items-center justify-center gap-1 rounded-full px-2 py-2 text-xs font-medium text-muted-foreground transition-colors",
+                    "hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  )}
+                  aria-label={section.ariaLabel ?? section.label}
+                  aria-haspopup="dialog"
+                  aria-expanded={sidebar.openMobile}
+                >
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                  <span className="text-[11px] leading-4">{section.label}</span>
+                </button>
+              );
+            }
+
+            return (
+              <Link
+                key={section.id}
+                href={section.href}
+                className={cn(
+                  "relative flex flex-1 flex-col items-center justify-center gap-1 rounded-full px-2 py-2 text-xs font-medium transition-colors",
+                  "text-muted-foreground hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isActive && "bg-primary/10 text-primary",
+                )}
+                data-active={isActive}
+                aria-label={section.ariaLabel ?? section.label}
+                aria-current={isActive ? "page" : undefined}
+                onClick={() => setActiveSection(section.id)}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                <span className="text-[11px] leading-4">{section.label}</span>
+                {section.badge ? (
+                  <span className="absolute right-2 top-1 rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-none text-primary-foreground">
+                    {section.badge}
+                  </span>
+                ) : null}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
 }
 
 function MembersTopbarContent({
@@ -355,9 +718,27 @@ export function MembersAppShell({
   contentLayout,
   globalFooter,
   impersonation,
+  defaultBottomNavTab,
+  appBarSlots,
 }: MembersAppShellProps) {
-  const [topbarContent, setTopbarContentState] =
-    React.useState<MembersTopbarSlots>(INITIAL_TOPBAR);
+  const initialTopbar = React.useMemo<MembersTopbarSlots>(
+    () => ({ ...INITIAL_TOPBAR, ...appBarSlots }),
+    [appBarSlots],
+  );
+  const initialTopbarRef = React.useRef(initialTopbar);
+
+  const [topbarContent, setTopbarContentState] = React.useState<MembersTopbarSlots>(
+    initialTopbar,
+  );
+
+  React.useEffect(() => {
+    const previousInitial = initialTopbarRef.current;
+    initialTopbarRef.current = initialTopbar;
+
+    setTopbarContentState((current) =>
+      areTopbarSlotsEqual(current, previousInitial) ? initialTopbar : current,
+    );
+  }, [initialTopbar]);
   const [contentHeader, setContentHeaderState] =
     React.useState<React.ReactNode>(null);
   const [contentFooter, setContentFooterState] =
@@ -407,7 +788,7 @@ export function MembersAppShell({
   );
 
   const setTopbarContent = React.useCallback((value: MembersTopbarSlots | null) => {
-    setTopbarContentState(value ?? INITIAL_TOPBAR);
+    setTopbarContentState(value ?? initialTopbarRef.current);
   }, []);
 
   const setContentHeader = React.useCallback((value: React.ReactNode | null) => {
@@ -445,7 +826,7 @@ export function MembersAppShell({
           assignmentFocus={assignmentFocus}
           hasDepartmentMemberships={hasDepartmentMemberships}
         />
-        <SidebarRail />
+        <SidebarRail className="hidden lg:flex" />
       </Sidebar>
       <MembersAppShellContext.Provider value={contextValue}>
         <SidebarInset id="main" className="min-h-svh">
@@ -458,7 +839,7 @@ export function MembersAppShell({
               <ImpersonationBanner details={impersonation} />
             </div>
           ) : null}
-          <main className="flex-1 pb-12">
+          <main className="flex-1 pb-24 lg:pb-12">
             {contentHeader ? (
               <header className="border-b border-border/60 bg-background/60">
                 <div
@@ -488,7 +869,16 @@ export function MembersAppShell({
               </footer>
             ) : null}
           </main>
-          {globalFooter}
+          <MembersBottomNav
+            permissions={permissions}
+            assignmentFocus={assignmentFocus}
+            hasDepartmentMemberships={hasDepartmentMemberships}
+            activeProduction={activeProduction}
+            defaultTab={defaultBottomNavTab}
+          />
+          {globalFooter ? (
+            <div className="pb-24 lg:pb-0">{globalFooter}</div>
+          ) : null}
         </SidebarInset>
       </MembersAppShellContext.Provider>
     </>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -25,7 +25,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-export const SIDEBAR_COOKIE_NAME = "sidebar_state";
+export const SIDEBAR_DESKTOP_COOKIE_NAME = "sidebar_desktop_state";
+export const SIDEBAR_MOBILE_COOKIE_NAME = "sidebar_mobile_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH_MIN_REM = 14;
 const SIDEBAR_WIDTH_MAX_REM = 20;
@@ -44,6 +45,7 @@ type SidebarContextProps = {
   openMobile: boolean;
   setOpenMobile: (open: boolean) => void;
   isMobile: boolean;
+  isDesktop: boolean;
   toggleSidebar: () => void;
 };
 
@@ -76,6 +78,9 @@ const SidebarProvider = React.forwardRef<
     defaultOpen?: boolean;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
+    defaultOpenMobile?: boolean;
+    openMobile?: boolean;
+    onOpenMobileChange?: (open: boolean) => void;
   }
 >(
   (
@@ -83,6 +88,9 @@ const SidebarProvider = React.forwardRef<
       defaultOpen = true,
       open: openProp,
       onOpenChange: setOpenProp,
+      defaultOpenMobile = false,
+      openMobile: openMobileProp,
+      onOpenMobileChange: setOpenMobileProp,
       className,
       style,
       children,
@@ -91,7 +99,9 @@ const SidebarProvider = React.forwardRef<
     ref,
   ) => {
     const isMobile = useMediaQuery(SIDEBAR_MOBILE_BREAKPOINT);
-    const [openMobile, setOpenMobile] = React.useState(false);
+    const [openMobileState, _setOpenMobileState] = React.useState(
+      defaultOpenMobile,
+    );
 
     const [_open, _setOpen] = React.useState(defaultOpen);
     const open = openProp ?? _open;
@@ -105,10 +115,29 @@ const SidebarProvider = React.forwardRef<
         }
 
         if (typeof document !== "undefined") {
-          document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+          document.cookie = `${SIDEBAR_DESKTOP_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
         }
       },
       [setOpenProp, open],
+    );
+
+    const openMobile = openMobileProp ?? openMobileState;
+
+    const setOpenMobile = React.useCallback(
+      (value: boolean | ((value: boolean) => boolean)) => {
+        const nextValue =
+          typeof value === "function" ? value(openMobile) : value;
+        if (setOpenMobileProp) {
+          setOpenMobileProp(nextValue);
+        } else {
+          _setOpenMobileState(nextValue);
+        }
+
+        if (typeof document !== "undefined") {
+          document.cookie = `${SIDEBAR_MOBILE_COOKIE_NAME}=${nextValue}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+        }
+      },
+      [setOpenMobileProp, openMobile],
     );
 
     const toggleSidebar = React.useCallback(() => {
@@ -137,6 +166,7 @@ const SidebarProvider = React.forwardRef<
       return () => window.removeEventListener("keydown", handleKeyDown);
     }, [toggleSidebar]);
 
+    const isDesktop = !isMobile;
     const state = open ? "expanded" : "collapsed";
 
     const contextValue = React.useMemo<SidebarContextProps>(
@@ -145,11 +175,21 @@ const SidebarProvider = React.forwardRef<
         open,
         setOpen,
         isMobile,
+        isDesktop,
         openMobile,
         setOpenMobile,
         toggleSidebar,
       }),
-      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+      [
+        state,
+        open,
+        setOpen,
+        isMobile,
+        isDesktop,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+      ],
     );
 
     return (


### PR DESCRIPTION
## Summary
- add a mobile MembersBottomNav to the members app shell and expose its cookie configuration
- update the sidebar provider to manage separate desktop/mobile open states with distinct cookies
- wire the members layout to provide app bar slots and default bottom nav tab from cookies

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dc9d5f9238832da93cb4d540ea9231