### PR TITLE
Add bottom nav layout variant for members area

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -14,8 +14,8 @@ import {
 } from "@/components/members/members-app-shell";
 import {
   SidebarProvider,
-  SIDEBAR_DESKTOP_COOKIE_NAME,
-  SIDEBAR_MOBILE_COOKIE_NAME,
+  SIDEBAR_BOTTOM_NAV_COOKIE_NAME,
+  SIDEBAR_RAIL_COOKIE_NAME,
 } from "@/components/ui/sidebar";
 import { Badge } from "@/components/ui/badge";
 import { getActiveProduction } from "@/lib/active-production";
@@ -88,8 +88,9 @@ const isDevBuild = process.env.NODE_ENV === "development";
 export default async function MembersLayout({ children }: { children: React.ReactNode }) {
   const cookieStore = await cookies();
   const sidebarDesktopCookie =
-    cookieStore.get(SIDEBAR_DESKTOP_COOKIE_NAME)?.value;
-  const sidebarMobileCookie = cookieStore.get(SIDEBAR_MOBILE_COOKIE_NAME)?.value;
+    cookieStore.get(SIDEBAR_RAIL_COOKIE_NAME)?.value;
+  const sidebarMobileCookie =
+    cookieStore.get(SIDEBAR_BOTTOM_NAV_COOKIE_NAME)?.value;
   const defaultSidebarOpen =
     typeof sidebarDesktopCookie === "undefined"
       ? true
@@ -186,6 +187,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
               impersonation={session.impersonation ?? null}
               defaultBottomNavTab={defaultBottomNavTab}
               appBarSlots={{ status: appBarStatus }}
+              layoutVariant="bottom-nav"
               globalFooter={
                 <SiteFooter
                   buildInfo={buildInfo}

--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ArrowLeft, Menu } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 
 import {
   Sidebar,
@@ -20,13 +20,12 @@ import { cn } from "@/lib/utils";
 import type { ImpersonationDetails } from "@/lib/auth/impersonation";
 import { ImpersonationBanner } from "@/components/members/impersonation-banner/impersonation-banner";
 import {
-  filterMembersNavigationByPermissions,
-  selectMembersNavigation,
-} from "@/lib/members-navigation";
-import {
-  defaultMembersNavIcon,
-  type MembersNavItem,
-} from "@/config/members-navigation";
+  MembersBottomNav,
+  type MembersBottomNavTabId,
+} from "@/components/members/members-bottom-nav";
+
+export { MEMBERS_BOTTOM_NAV_COOKIE_NAME } from "@/components/members/members-bottom-nav";
+export type { MembersBottomNavTabId } from "@/components/members/members-bottom-nav";
 
 const membersContentSectionVariants = cva("py-6 sm:py-8", {
   variants: {
@@ -115,49 +114,6 @@ const DEFAULT_CONTENT_LAYOUT: MembersContentLayoutState = {
   gap: "md",
 };
 
-export const MEMBERS_BOTTOM_NAV_COOKIE_NAME = "members_bottom_nav_tab";
-const MEMBERS_BOTTOM_NAV_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-
-export type MembersBottomNavTabId =
-  | "home"
-  | "assignments"
-  | "production"
-  | "profile";
-
-type MembersBottomNavItemId = MembersBottomNavTabId | "menu";
-
-type MembersBottomNavItem = {
-  id: MembersBottomNavItemId;
-  label: string;
-  href?: string;
-  icon: React.ComponentType<{ className?: string }>;
-  ariaLabel?: string;
-  badge?: string;
-};
-
-function convertBadgeToString(
-  badge: MembersNavItem["badge"],
-): string | undefined {
-  if (typeof badge === "string" || typeof badge === "number") {
-    return String(badge);
-  }
-  return undefined;
-}
-
-function createBottomNavItem(
-  id: MembersBottomNavTabId,
-  item: MembersNavItem,
-): MembersBottomNavItem {
-  return {
-    id,
-    label: item.label,
-    href: item.href,
-    icon: item.icon ?? defaultMembersNavIcon,
-    ariaLabel: item.ariaLabel,
-    badge: convertBadgeToString(item.badge),
-  };
-}
-
 function mergeContentLayout(
   base: MembersContentLayoutState,
   patch?: MembersContentLayoutConfig | null,
@@ -226,6 +182,8 @@ function getContentClasses(layout: MembersContentLayoutState) {
   };
 }
 
+type MembersAppShellLayoutVariant = "default" | "bottom-nav";
+
 interface MembersAppShellProps {
   children: React.ReactNode;
   permissions: readonly string[];
@@ -237,6 +195,7 @@ interface MembersAppShellProps {
   impersonation?: ImpersonationDetails | null;
   defaultBottomNavTab?: MembersBottomNavTabId;
   appBarSlots?: Partial<MembersTopbarSlots>;
+  layoutVariant?: MembersAppShellLayoutVariant;
 }
 
 interface MembersTopbarSlots {
@@ -309,303 +268,6 @@ function SidebarMobileAutoClose() {
   }, [isMobile, pathname, setOpenMobile]);
 
   return null;
-}
-
-function isPathActive(pathname: string, href: string) {
-  if (pathname === href) return true;
-  if (href === "/mitglieder") return pathname === "/mitglieder";
-  return pathname.startsWith(`${href}/`);
-}
-
-interface MembersBottomNavProps {
-  permissions: readonly string[];
-  assignmentFocus: AssignmentFocus;
-  hasDepartmentMemberships: boolean;
-  activeProduction?: { id: string; title: string | null; year: number };
-  defaultTab?: MembersBottomNavTabId;
-}
-
-function MembersBottomNav({
-  permissions,
-  assignmentFocus,
-  hasDepartmentMemberships,
-  activeProduction,
-  defaultTab,
-}: MembersBottomNavProps) {
-  const pathname = usePathname() ?? "";
-  const sidebar = useSidebar();
-  const { isMobile, setOpenMobile } = sidebar;
-
-  const navigation = React.useMemo(() => {
-    const groups = selectMembersNavigation({
-      hasDepartmentMemberships,
-      activeProduction: activeProduction ?? null,
-    });
-    return filterMembersNavigationByPermissions(groups, permissions);
-  }, [
-    permissions,
-    hasDepartmentMemberships,
-    activeProduction,
-  ]);
-
-  const { groups: navGroups, flat } = navigation;
-
-  const itemsByHref = React.useMemo(() => {
-    const map = new Map<string, MembersNavItem>();
-    for (const item of flat) {
-      map.set(item.href, item);
-    }
-    return map;
-  }, [flat]);
-
-  const findFirstAvailable = React.useCallback(
-    (candidates: readonly (string | null | undefined)[]) => {
-      for (const candidate of candidates) {
-        if (!candidate) continue;
-        const item = itemsByHref.get(candidate);
-        if (item) {
-          return item;
-        }
-      }
-      return null;
-    },
-    [itemsByHref],
-  );
-
-  const generalGroup = React.useMemo(
-    () => navGroups.find((group) => group.id === "general") ?? null,
-    [navGroups],
-  );
-
-  const assignmentsCandidates = React.useMemo(() => {
-    const order: string[] = [];
-    const push = (href: string) => {
-      if (!order.includes(href)) {
-        order.push(href);
-      }
-    };
-
-    if (assignmentFocus === "departments") {
-      push("/mitglieder/meine-gewerke");
-      push("/mitglieder/meine-proben");
-    } else if (assignmentFocus === "rehearsals") {
-      push("/mitglieder/meine-proben");
-      push("/mitglieder/kalender");
-    } else if (assignmentFocus === "both") {
-      push("/mitglieder/kalender");
-      push("/mitglieder/meine-proben");
-      push("/mitglieder/meine-gewerke");
-    } else {
-      push("/mitglieder/kalender");
-      push("/mitglieder/meine-proben");
-      push("/mitglieder/meine-gewerke");
-    }
-
-    push("/mitglieder/probenplanung");
-    push("/mitglieder/koerpermasse");
-
-    return order;
-  }, [assignmentFocus]);
-
-  const homeNavItem = React.useMemo(() => {
-    return (
-      findFirstAvailable(["/mitglieder"]) ??
-      (generalGroup?.items.find((item) => itemsByHref.has(item.href)) ?? null)
-    );
-  }, [findFirstAvailable, generalGroup, itemsByHref]);
-
-  const assignmentsNavItem = React.useMemo(() => {
-    const item = findFirstAvailable(assignmentsCandidates);
-    if (item) return item;
-    const assignmentsGroup =
-      navGroups.find((group) => group.id === "assignments") ?? null;
-    return (
-      assignmentsGroup?.items.find((groupItem) =>
-        itemsByHref.has(groupItem.href),
-      ) ?? null
-    );
-  }, [assignmentsCandidates, findFirstAvailable, navGroups, itemsByHref]);
-
-  const productionNavItem = React.useMemo(() => {
-    const dynamicHref = activeProduction
-      ? `/mitglieder/produktionen/${activeProduction.id}`
-      : null;
-    const item = findFirstAvailable([
-      dynamicHref,
-      "/mitglieder/produktionen",
-      "/mitglieder/produktionen/gewerke",
-    ]);
-    if (item) return item;
-    const productionGroup =
-      navGroups.find((group) => group.id === "production") ?? null;
-    return (
-      productionGroup?.items.find((groupItem) =>
-        itemsByHref.has(groupItem.href),
-      ) ?? null
-    );
-  }, [findFirstAvailable, activeProduction, navGroups, itemsByHref]);
-
-  const profileNavItem = React.useMemo(() => {
-    const item = findFirstAvailable(["/mitglieder/profil"]);
-    if (item) return item;
-    const fallback = generalGroup?.items.find(
-      (groupItem) =>
-        groupItem.href !== homeNavItem?.href && itemsByHref.has(groupItem.href),
-    );
-    return fallback ?? null;
-  }, [findFirstAvailable, generalGroup, homeNavItem, itemsByHref]);
-
-  const sections = React.useMemo(() => {
-    const list: MembersBottomNavItem[] = [];
-    const usedHrefs = new Set<string>();
-
-    if (homeNavItem) {
-      list.push(createBottomNavItem("home", homeNavItem));
-      usedHrefs.add(homeNavItem.href);
-    }
-
-    if (assignmentsNavItem && !usedHrefs.has(assignmentsNavItem.href)) {
-      list.push(createBottomNavItem("assignments", assignmentsNavItem));
-      usedHrefs.add(assignmentsNavItem.href);
-    }
-
-    if (productionNavItem && !usedHrefs.has(productionNavItem.href)) {
-      list.push(createBottomNavItem("production", productionNavItem));
-      usedHrefs.add(productionNavItem.href);
-    }
-
-    if (profileNavItem && !usedHrefs.has(profileNavItem.href)) {
-      list.push(createBottomNavItem("profile", profileNavItem));
-      usedHrefs.add(profileNavItem.href);
-    }
-
-    return list;
-  }, [homeNavItem, assignmentsNavItem, productionNavItem, profileNavItem]);
-
-  const sectionsWithMenu = React.useMemo(() => {
-    if (sections.length === 0) {
-      return sections;
-    }
-
-    const menuItem: MembersBottomNavItem = {
-      id: "menu",
-      label: "Menü",
-      icon: Menu,
-      ariaLabel: "Navigation öffnen",
-    };
-
-    return [...sections, menuItem];
-  }, [sections]);
-
-  const initialActiveSection = React.useMemo<MembersBottomNavItemId>(() => {
-    const matched = sections.find((section) => {
-      const href = section.href;
-      if (typeof href !== "string") {
-        return false;
-      }
-      return isPathActive(pathname, href);
-    });
-    if (matched) {
-      return matched.id;
-    }
-
-    if (defaultTab) {
-      const defaultSection = sections.find(
-        (section) => section.id === defaultTab && section.href,
-      );
-      if (defaultSection) {
-        return defaultSection.id;
-      }
-    }
-
-    const firstNavigable = sections.find((section) => Boolean(section.href));
-    return firstNavigable ? firstNavigable.id : "menu";
-  }, [sections, pathname, defaultTab]);
-
-  const [activeSection, setActiveSection] = React.useState<MembersBottomNavItemId>(
-    initialActiveSection,
-  );
-
-  React.useEffect(() => {
-    setActiveSection(initialActiveSection);
-  }, [initialActiveSection]);
-
-  React.useEffect(() => {
-    if (typeof document === "undefined") {
-      return;
-    }
-
-    if (
-      !sections.some((section) =>
-        section.id === activeSection ? Boolean(section.href) : false,
-      )
-    ) {
-      return;
-    }
-
-    document.cookie = `${MEMBERS_BOTTOM_NAV_COOKIE_NAME}=${activeSection}; path=/; max-age=${MEMBERS_BOTTOM_NAV_COOKIE_MAX_AGE}`;
-  }, [activeSection, sections]);
-
-  if (!isMobile || sectionsWithMenu.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 lg:hidden">
-      <div className="pointer-events-auto border-t border-border/60 bg-background/90 shadow-lg shadow-black/5 backdrop-blur supports-[backdrop-filter]:bg-background/70">
-        <nav className="mx-auto flex max-w-lg items-stretch gap-1 px-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-2">
-          {sectionsWithMenu.map((section) => {
-            const Icon = section.icon;
-            const isActive = activeSection === section.id && section.id !== "menu";
-
-            if (!section.href) {
-              return (
-                <button
-                  key={section.id}
-                  type="button"
-                  onClick={() => setOpenMobile(true)}
-                  className={cn(
-                    "flex flex-1 flex-col items-center justify-center gap-1 rounded-full px-2 py-2 text-xs font-medium text-muted-foreground transition-colors",
-                    "hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  )}
-                  aria-label={section.ariaLabel ?? section.label}
-                  aria-haspopup="dialog"
-                  aria-expanded={sidebar.openMobile}
-                >
-                  <Icon className="h-5 w-5" aria-hidden="true" />
-                  <span className="text-[11px] leading-4">{section.label}</span>
-                </button>
-              );
-            }
-
-            return (
-              <Link
-                key={section.id}
-                href={section.href}
-                className={cn(
-                  "relative flex flex-1 flex-col items-center justify-center gap-1 rounded-full px-2 py-2 text-xs font-medium transition-colors",
-                  "text-muted-foreground hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  isActive && "bg-primary/10 text-primary",
-                )}
-                data-active={isActive}
-                aria-label={section.ariaLabel ?? section.label}
-                aria-current={isActive ? "page" : undefined}
-                onClick={() => setActiveSection(section.id)}
-              >
-                <Icon className="h-5 w-5" aria-hidden="true" />
-                <span className="text-[11px] leading-4">{section.label}</span>
-                {section.badge ? (
-                  <span className="absolute right-2 top-1 rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-none text-primary-foreground">
-                    {section.badge}
-                  </span>
-                ) : null}
-              </Link>
-            );
-          })}
-        </nav>
-      </div>
-    </div>
-  );
 }
 
 function MembersTopbarContent({
@@ -720,7 +382,9 @@ export function MembersAppShell({
   impersonation,
   defaultBottomNavTab,
   appBarSlots,
+  layoutVariant = "default",
 }: MembersAppShellProps) {
+  const isBottomNavLayout = layoutVariant === "bottom-nav";
   const initialTopbar = React.useMemo<MembersTopbarSlots>(
     () => ({ ...INITIAL_TOPBAR, ...appBarSlots }),
     [appBarSlots],
@@ -826,7 +490,7 @@ export function MembersAppShell({
           assignmentFocus={assignmentFocus}
           hasDepartmentMemberships={hasDepartmentMemberships}
         />
-        <SidebarRail className="hidden lg:flex" />
+        <SidebarRail className={cn(isBottomNavLayout && "hidden lg:flex")} />
       </Sidebar>
       <MembersAppShellContext.Provider value={contextValue}>
         <SidebarInset id="main" className="min-h-svh">
@@ -839,7 +503,12 @@ export function MembersAppShell({
               <ImpersonationBanner details={impersonation} />
             </div>
           ) : null}
-          <main className="flex-1 pb-24 lg:pb-12">
+          <main
+            className={cn(
+              "flex-1",
+              isBottomNavLayout ? "pb-24 lg:pb-12" : "pb-12",
+            )}
+          >
             {contentHeader ? (
               <header className="border-b border-border/60 bg-background/60">
                 <div
@@ -869,15 +538,19 @@ export function MembersAppShell({
               </footer>
             ) : null}
           </main>
-          <MembersBottomNav
-            permissions={permissions}
-            assignmentFocus={assignmentFocus}
-            hasDepartmentMemberships={hasDepartmentMemberships}
-            activeProduction={activeProduction}
-            defaultTab={defaultBottomNavTab}
-          />
+          {isBottomNavLayout ? (
+            <MembersBottomNav
+              permissions={permissions}
+              assignmentFocus={assignmentFocus}
+              hasDepartmentMemberships={hasDepartmentMemberships}
+              activeProduction={activeProduction}
+              defaultTab={defaultBottomNavTab}
+            />
+          ) : null}
           {globalFooter ? (
-            <div className="pb-24 lg:pb-0">{globalFooter}</div>
+            <div className={cn(isBottomNavLayout && "pb-24 lg:pb-0")}>
+              {globalFooter}
+            </div>
           ) : null}
         </SidebarInset>
       </MembersAppShellContext.Provider>

--- a/src/components/members/members-bottom-nav.tsx
+++ b/src/components/members/members-bottom-nav.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Menu } from "lucide-react";
+
+import {
+  filterMembersNavigationByPermissions,
+  selectMembersNavigation,
+} from "@/lib/members-navigation";
+import {
+  defaultMembersNavIcon,
+  type MembersNavItem,
+} from "@/config/members-navigation";
+import { useSidebar } from "@/components/ui/sidebar";
+import type { AssignmentFocus } from "@/components/members-nav";
+import { cn } from "@/lib/utils";
+
+export const MEMBERS_BOTTOM_NAV_COOKIE_NAME = "members_bottom_nav_tab";
+const MEMBERS_BOTTOM_NAV_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+
+export type MembersBottomNavTabId =
+  | "home"
+  | "assignments"
+  | "production"
+  | "profile";
+
+type MembersBottomNavItemId = MembersBottomNavTabId | "menu";
+
+type MembersBottomNavItem = {
+  id: MembersBottomNavItemId;
+  label: string;
+  href?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  ariaLabel?: string;
+  badge?: string;
+};
+
+function convertBadgeToString(
+  badge: MembersNavItem["badge"],
+): string | undefined {
+  if (typeof badge === "string" || typeof badge === "number") {
+    return String(badge);
+  }
+  return undefined;
+}
+
+function createBottomNavItem(
+  id: MembersBottomNavTabId,
+  item: MembersNavItem,
+): MembersBottomNavItem {
+  return {
+    id,
+    label: item.label,
+    href: item.href,
+    icon: item.icon ?? defaultMembersNavIcon,
+    ariaLabel: item.ariaLabel,
+    badge: convertBadgeToString(item.badge),
+  };
+}
+
+function isPathActive(pathname: string, href: string) {
+  if (pathname === href) return true;
+  if (href === "/mitglieder") return pathname === "/mitglieder";
+  return pathname.startsWith(`${href}/`);
+}
+
+function useMembersNavigationSections({
+  permissions,
+  hasDepartmentMemberships,
+  activeProduction,
+}: {
+  permissions: readonly string[];
+  hasDepartmentMemberships: boolean;
+  activeProduction?: { id: string; title: string | null; year: number };
+}) {
+  return React.useMemo(() => {
+    const groups = selectMembersNavigation({
+      hasDepartmentMemberships,
+      activeProduction: activeProduction ?? null,
+    });
+    return filterMembersNavigationByPermissions(groups, permissions);
+  }, [permissions, hasDepartmentMemberships, activeProduction]);
+}
+
+interface MembersBottomNavProps {
+  permissions: readonly string[];
+  assignmentFocus: AssignmentFocus;
+  hasDepartmentMemberships: boolean;
+  activeProduction?: { id: string; title: string | null; year: number };
+  defaultTab?: MembersBottomNavTabId;
+}
+
+export function MembersBottomNav({
+  permissions,
+  assignmentFocus,
+  hasDepartmentMemberships,
+  activeProduction,
+  defaultTab,
+}: MembersBottomNavProps) {
+  const pathname = usePathname() ?? "";
+  const sidebar = useSidebar();
+  const { isMobile, openMobile, setOpenMobile } = sidebar;
+
+  const navigation = useMembersNavigationSections({
+    permissions,
+    hasDepartmentMemberships,
+    activeProduction,
+  });
+
+  const { groups: navGroups, flat } = navigation;
+
+  const itemsByHref = React.useMemo(() => {
+    const map = new Map<string, MembersNavItem>();
+    for (const item of flat) {
+      map.set(item.href, item);
+    }
+    return map;
+  }, [flat]);
+
+  const findFirstAvailable = React.useCallback(
+    (candidates: readonly (string | null | undefined)[]) => {
+      for (const candidate of candidates) {
+        if (!candidate) continue;
+        const item = itemsByHref.get(candidate);
+        if (item) {
+          return item;
+        }
+      }
+      return null;
+    },
+    [itemsByHref],
+  );
+
+  const generalGroup = React.useMemo(
+    () => navGroups.find((group) => group.id === "general") ?? null,
+    [navGroups],
+  );
+
+  const assignmentsCandidates = React.useMemo(() => {
+    const order: string[] = [];
+    const push = (href: string) => {
+      if (!order.includes(href)) {
+        order.push(href);
+      }
+    };
+
+    if (assignmentFocus === "departments") {
+      push("/mitglieder/meine-gewerke");
+      push("/mitglieder/meine-proben");
+    } else if (assignmentFocus === "rehearsals") {
+      push("/mitglieder/meine-proben");
+      push("/mitglieder/kalender");
+    } else if (assignmentFocus === "both") {
+      push("/mitglieder/kalender");
+      push("/mitglieder/meine-proben");
+      push("/mitglieder/meine-gewerke");
+    } else {
+      push("/mitglieder/kalender");
+      push("/mitglieder/meine-proben");
+      push("/mitglieder/meine-gewerke");
+    }
+
+    push("/mitglieder/probenplanung");
+    push("/mitglieder/koerpermasse");
+
+    return order;
+  }, [assignmentFocus]);
+
+  const homeNavItem = React.useMemo(() => {
+    return (
+      findFirstAvailable(["/mitglieder"]) ??
+      (generalGroup?.items.find((item) => itemsByHref.has(item.href)) ?? null)
+    );
+  }, [findFirstAvailable, generalGroup, itemsByHref]);
+
+  const assignmentsNavItem = React.useMemo(() => {
+    const item = findFirstAvailable(assignmentsCandidates);
+    if (item) return item;
+    const assignmentsGroup =
+      navGroups.find((group) => group.id === "assignments") ?? null;
+    return (
+      assignmentsGroup?.items.find((groupItem) =>
+        itemsByHref.has(groupItem.href),
+      ) ?? null
+    );
+  }, [assignmentsCandidates, findFirstAvailable, navGroups, itemsByHref]);
+
+  const productionNavItem = React.useMemo(() => {
+    const dynamicHref = activeProduction
+      ? `/mitglieder/produktionen/${activeProduction.id}`
+      : null;
+    const item = findFirstAvailable([
+      dynamicHref,
+      "/mitglieder/produktionen",
+      "/mitglieder/produktionen/gewerke",
+    ]);
+    if (item) return item;
+    const productionGroup =
+      navGroups.find((group) => group.id === "production") ?? null;
+    return (
+      productionGroup?.items.find((groupItem) =>
+        itemsByHref.has(groupItem.href),
+      ) ?? null
+    );
+  }, [findFirstAvailable, activeProduction, navGroups, itemsByHref]);
+
+  const profileNavItem = React.useMemo(() => {
+    const item = findFirstAvailable(["/mitglieder/profil"]);
+    if (item) return item;
+    const fallback = generalGroup?.items.find(
+      (groupItem) =>
+        groupItem.href !== homeNavItem?.href && itemsByHref.has(groupItem.href),
+    );
+    return fallback ?? null;
+  }, [findFirstAvailable, generalGroup, homeNavItem, itemsByHref]);
+
+  const sections = React.useMemo(() => {
+    const list: MembersBottomNavItem[] = [];
+    const usedHrefs = new Set<string>();
+
+    if (homeNavItem) {
+      list.push(createBottomNavItem("home", homeNavItem));
+      usedHrefs.add(homeNavItem.href);
+    }
+
+    if (assignmentsNavItem && !usedHrefs.has(assignmentsNavItem.href)) {
+      list.push(createBottomNavItem("assignments", assignmentsNavItem));
+      usedHrefs.add(assignmentsNavItem.href);
+    }
+
+    if (productionNavItem && !usedHrefs.has(productionNavItem.href)) {
+      list.push(createBottomNavItem("production", productionNavItem));
+      usedHrefs.add(productionNavItem.href);
+    }
+
+    if (profileNavItem && !usedHrefs.has(profileNavItem.href)) {
+      list.push(createBottomNavItem("profile", profileNavItem));
+      usedHrefs.add(profileNavItem.href);
+    }
+
+    return list;
+  }, [homeNavItem, assignmentsNavItem, productionNavItem, profileNavItem]);
+
+  const sectionsWithMenu = React.useMemo(() => {
+    if (sections.length === 0) {
+      return sections;
+    }
+
+    const menuItem: MembersBottomNavItem = {
+      id: "menu",
+      label: "Menü",
+      icon: Menu,
+      ariaLabel: "Navigation öffnen",
+    };
+
+    return [...sections, menuItem];
+  }, [sections]);
+
+  const initialActiveSection = React.useMemo<MembersBottomNavItemId>(() => {
+    const matched = sections.find((section) => {
+      const href = section.href;
+      if (typeof href !== "string") {
+        return false;
+      }
+      return isPathActive(pathname, href);
+    });
+    if (matched) {
+      return matched.id;
+    }
+
+    if (defaultTab) {
+      const defaultSection = sections.find(
+        (section) => section.id === defaultTab && section.href,
+      );
+      if (defaultSection) {
+        return defaultSection.id;
+      }
+    }
+
+    const firstNavigable = sections.find((section) => Boolean(section.href));
+    return firstNavigable ? firstNavigable.id : "menu";
+  }, [sections, pathname, defaultTab]);
+
+  const [activeSection, setActiveSection] = React.useState<MembersBottomNavItemId>(
+    initialActiveSection,
+  );
+
+  React.useEffect(() => {
+    setActiveSection(initialActiveSection);
+  }, [initialActiveSection]);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    if (
+      !sections.some((section) =>
+        section.id === activeSection ? Boolean(section.href) : false,
+      )
+    ) {
+      return;
+    }
+
+    document.cookie = `${MEMBERS_BOTTOM_NAV_COOKIE_NAME}=${activeSection}; path=/; max-age=${MEMBERS_BOTTOM_NAV_COOKIE_MAX_AGE}`;
+  }, [activeSection, sections]);
+
+  if (!isMobile || sectionsWithMenu.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 lg:hidden">
+      <div className="pointer-events-auto border-t border-border/60 bg-background/90 shadow-lg shadow-black/5 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+        <nav className="mx-auto flex max-w-lg items-stretch gap-1 px-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] pt-2">
+          {sectionsWithMenu.map((section) => {
+            const Icon = section.icon;
+            const isActive = activeSection === section.id && section.id !== "menu";
+
+            if (!section.href) {
+              return (
+                <button
+                  key={section.id}
+                  type="button"
+                  onClick={() => setOpenMobile(true)}
+                  className={cn(
+                    "flex flex-1 flex-col items-center justify-center gap-1 rounded-full px-2 py-2 text-xs font-medium text-muted-foreground transition-colors",
+                    "hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  )}
+                  aria-label={section.ariaLabel ?? section.label}
+                  aria-haspopup="dialog"
+                  aria-expanded={openMobile}
+                >
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                  <span className="text-[11px] leading-4">{section.label}</span>
+                </button>
+              );
+            }
+
+            return (
+              <Link
+                key={section.id}
+                href={section.href}
+                className={cn(
+                  "relative flex flex-1 flex-col items-center justify-center gap-1 rounded-full px-2 py-2 text-xs font-medium transition-colors",
+                  "text-muted-foreground hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isActive && "bg-primary/10 text-primary",
+                )}
+                data-active={isActive}
+                aria-label={section.ariaLabel ?? section.label}
+                aria-current={isActive ? "page" : undefined}
+                onClick={() => setActiveSection(section.id)}
+              >
+                <Icon className="h-5 w-5" aria-hidden="true" />
+                <span className="text-[11px] leading-4">{section.label}</span>
+                {section.badge ? (
+                  <span className="absolute right-2 top-1 rounded-full bg-primary px-1.5 text-[10px] font-semibold leading-none text-primary-foreground">
+                    {section.badge}
+                  </span>
+                ) : null}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -25,8 +25,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
-export const SIDEBAR_DESKTOP_COOKIE_NAME = "sidebar_desktop_state";
-export const SIDEBAR_MOBILE_COOKIE_NAME = "sidebar_mobile_state";
+export const SIDEBAR_RAIL_COOKIE_NAME = "sidebar_rail_state";
+export const SIDEBAR_BOTTOM_NAV_COOKIE_NAME = "sidebar_bottom_nav_state";
+export const SIDEBAR_DESKTOP_COOKIE_NAME = SIDEBAR_RAIL_COOKIE_NAME;
+export const SIDEBAR_MOBILE_COOKIE_NAME = SIDEBAR_BOTTOM_NAV_COOKIE_NAME;
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH_MIN_REM = 14;
 const SIDEBAR_WIDTH_MAX_REM = 20;
@@ -38,12 +40,20 @@ const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_MOBILE_BREAKPOINT = "(max-width: 1023px)";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
+type SidebarStateUpdater = (
+  open: boolean | ((open: boolean) => boolean),
+) => void;
+
 type SidebarContextProps = {
   state: "expanded" | "collapsed";
   open: boolean;
-  setOpen: (open: boolean) => void;
+  setOpen: SidebarStateUpdater;
+  openRail: boolean;
+  setOpenRail: SidebarStateUpdater;
   openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
+  setOpenMobile: SidebarStateUpdater;
+  openBottomNav: boolean;
+  setOpenBottomNav: SidebarStateUpdater;
   isMobile: boolean;
   isDesktop: boolean;
   toggleSidebar: () => void;
@@ -115,7 +125,7 @@ const SidebarProvider = React.forwardRef<
         }
 
         if (typeof document !== "undefined") {
-          document.cookie = `${SIDEBAR_DESKTOP_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+          document.cookie = `${SIDEBAR_RAIL_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
         }
       },
       [setOpenProp, open],
@@ -134,7 +144,7 @@ const SidebarProvider = React.forwardRef<
         }
 
         if (typeof document !== "undefined") {
-          document.cookie = `${SIDEBAR_MOBILE_COOKIE_NAME}=${nextValue}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+          document.cookie = `${SIDEBAR_BOTTOM_NAV_COOKIE_NAME}=${nextValue}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
         }
       },
       [setOpenMobileProp, openMobile],
@@ -174,10 +184,14 @@ const SidebarProvider = React.forwardRef<
         state,
         open,
         setOpen,
+        openRail: open,
+        setOpenRail: setOpen,
         isMobile,
         isDesktop,
         openMobile,
         setOpenMobile,
+        openBottomNav: openMobile,
+        setOpenBottomNav: setOpenMobile,
         toggleSidebar,
       }),
       [


### PR DESCRIPTION
## Summary
- extract a dedicated `MembersBottomNav` component to build mobile navigation tabs and persist the active tab
- add a `layoutVariant` to `MembersAppShell` so the members area can render a bottom navigation on mobile while keeping the rail on large screens
- update the shared sidebar provider and members layout to use new rail/bottom nav cookie keys and wiring for the new variant

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dcd3d349a4832d9c118a99c946a848