### PR TITLE
Refactor members navigation structure and add command palette

### DIFF
--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/typography";
+import type { MembersNavGroup, MembersNavItem } from "@/config/members-navigation";
 import {
   MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
   defaultMembersNavIcon,
@@ -34,7 +35,8 @@ import {
   type AssignmentFocus,
 } from "@/lib/members-navigation";
 import { cn } from "@/lib/utils";
-import { ChevronsUpDown } from "lucide-react";
+import { ChevronsUpDown, Search } from "lucide-react";
+import { DropdownMenu } from "@/components/ui/dropdown-menu";
 
 export type { AssignmentFocus } from "@/lib/members-navigation";
 
@@ -224,16 +226,402 @@ function MembersNavProductionSwitcher({
   );
 }
 
+function MembersNavigationGroups({
+  groups,
+  pathname,
+  isCollapsed,
+  onNavigate,
+}: {
+  groups: readonly MembersNavGroup[];
+  pathname: string;
+  isCollapsed: boolean;
+  onNavigate?: () => void;
+}) {
+  return groups.map((group) => (
+    <SidebarGroup key={group.id}>
+      <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {group.items.map((item) => {
+            const active = isActive(pathname, item.href);
+            const Icon = item.icon ?? defaultMembersNavIcon;
+            const badgeContent = item.badge;
+            const hasBadgeValue =
+              badgeContent !== undefined &&
+              badgeContent !== null &&
+              badgeContent !== false;
+            const showBadge = !isCollapsed && hasBadgeValue;
+            const isPrimitiveBadge =
+              typeof badgeContent === "string" ||
+              typeof badgeContent === "number";
+            const reserveBadgeSpace = showBadge && isPrimitiveBadge;
+
+            return (
+              <SidebarMenuItem key={item.href}>
+                <SidebarMenuButton
+                  asChild
+                  isActive={active}
+                  tooltip={item.label}
+                  className={cn(
+                    "gap-[var(--space-2xs)]",
+                    isCollapsed && "justify-center",
+                  )}
+                >
+                  <Link
+                    href={item.href}
+                    aria-label={item.ariaLabel ?? item.label}
+                    aria-current={active ? "page" : undefined}
+                    onClick={onNavigate}
+                  >
+                    <Icon
+                      className={cn(
+                        "h-4 w-4 shrink-0 transition-opacity",
+                        active ? "opacity-100" : "opacity-70",
+                        !isCollapsed && "mt-0.5",
+                      )}
+                    />
+                    {!isCollapsed ? (
+                      <div
+                        className={cn(
+                          "flex min-w-0 flex-1 flex-col",
+                          reserveBadgeSpace && "pr-8",
+                        )}
+                      >
+                        <span className="break-words text-sidebar-foreground leading-5">
+                          {item.label}
+                        </span>
+                      </div>
+                    ) : null}
+                    {showBadge ? (
+                      isPrimitiveBadge ? (
+                        <SidebarMenuBadge className="border border-sidebar-border/60 bg-sidebar/50 text-eyebrow text-sidebar-foreground/70">
+                          {badgeContent}
+                        </SidebarMenuBadge>
+                      ) : (
+                        <span className="ml-auto flex shrink-0 items-center">{badgeContent}</span>
+                      )
+                    ) : null}
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            );
+          })}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  ));
+}
+
+function MembersPrimaryRailItem({
+  tab,
+  pathname,
+  onNavigate,
+}: {
+  tab: MembersNavGroup;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const router = useRouter();
+  const [primaryItem, ...overflowItems] = tab.items;
+  if (!primaryItem) {
+    return null;
+  }
+
+  const Icon = primaryItem.icon ?? defaultMembersNavIcon;
+  const tabIsActive = tab.items.some((item) => isActive(pathname, item.href));
+
+  return (
+    <SidebarMenuItem>
+      <div className="flex w-full items-center justify-center gap-1">
+        <SidebarMenuButton
+          asChild
+          isActive={tabIsActive}
+          tooltip={tab.label}
+          className="h-9 w-9 justify-center"
+        >
+          <Link
+            href={primaryItem.href}
+            aria-label={primaryItem.ariaLabel ?? tab.label}
+            aria-current={tabIsActive ? "page" : undefined}
+            onClick={onNavigate}
+          >
+            <Icon
+              className={cn(
+                "h-4 w-4",
+                tabIsActive ? "opacity-100" : "opacity-70",
+              )}
+            />
+          </Link>
+        </SidebarMenuButton>
+        {overflowItems.length > 0 ? (
+          <DropdownMenu
+            className="shrink-0"
+            align="left"
+            items={overflowItems.map((item) => {
+              const ItemIcon = item.icon ?? defaultMembersNavIcon;
+              return {
+                label: item.label,
+                icon: <ItemIcon className="h-4 w-4" aria-hidden="true" />,
+                onClick: () => {
+                  router.push(item.href);
+                  onNavigate?.();
+                },
+              };
+            })}
+          />
+        ) : null}
+      </div>
+    </SidebarMenuItem>
+  );
+}
+
+function MembersPrimaryTabs({
+  tabs,
+  pathname,
+  isCollapsed,
+  isMobile,
+  onNavigate,
+}: {
+  tabs: readonly MembersNavGroup[];
+  pathname: string;
+  isCollapsed: boolean;
+  isMobile: boolean;
+  onNavigate?: () => void;
+}) {
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  const showRail = isCollapsed && !isMobile;
+
+  if (showRail) {
+    return (
+      <nav aria-label="Primäre Bereiche" className="mt-[var(--space-sm)]">
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu className="flex flex-col gap-[var(--space-3xs)]">
+              {tabs.map((tab) => (
+                <MembersPrimaryRailItem
+                  key={tab.id}
+                  tab={tab}
+                  pathname={pathname}
+                  onNavigate={onNavigate}
+                />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </nav>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-[var(--space-sm)]">
+      <MembersNavigationGroups
+        groups={tabs}
+        pathname={pathname}
+        isCollapsed={isCollapsed}
+        onNavigate={onNavigate}
+      />
+    </div>
+  );
+}
+
+function MembersSecondaryDrawer({
+  groups,
+  pathname,
+  isCollapsed,
+  onNavigate,
+}: {
+  groups: readonly MembersNavGroup[];
+  pathname: string;
+  isCollapsed: boolean;
+  onNavigate?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (groups.length === 0) {
+    return null;
+  }
+
+  if (isCollapsed) {
+    return (
+      <div className="mt-[var(--space-sm)]">
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          className="w-full rounded-md border border-sidebar-border/60 bg-sidebar/60 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-sidebar-foreground/70 transition hover:bg-sidebar/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-expanded={open}
+        >
+          Weitere Bereiche
+        </button>
+        {open ? (
+          <div className="mt-[var(--space-xs)] space-y-[var(--space-sm)] rounded-lg border border-sidebar-border/60 bg-sidebar/80 p-[var(--space-sm)] shadow-lg">
+            <MembersNavigationGroups
+              groups={groups}
+              pathname={pathname}
+              isCollapsed={false}
+              onNavigate={() => {
+                setOpen(false);
+                onNavigate?.();
+              }}
+            />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-[var(--space-sm)] flex flex-col gap-[var(--space-sm)]">
+      <MembersNavigationGroups
+        groups={groups}
+        pathname={pathname}
+        isCollapsed={isCollapsed}
+        onNavigate={onNavigate}
+      />
+    </div>
+  );
+}
+
+function MembersContextActions({
+  quickActions,
+  pathname,
+  isCollapsed,
+  onNavigate,
+  onOpenCommandPalette,
+  showCommandAction = true,
+}: {
+  quickActions: readonly MembersNavItem[];
+  pathname: string;
+  isCollapsed: boolean;
+  onNavigate?: () => void;
+  onOpenCommandPalette?: () => void;
+  showCommandAction?: boolean;
+}) {
+  const hasQuickActions = quickActions.length > 0;
+  const showSearchAction = Boolean(onOpenCommandPalette) && showCommandAction;
+
+  if (!hasQuickActions && !showSearchAction) {
+    return null;
+  }
+
+  if (isCollapsed) {
+    return (
+      <SidebarGroup>
+        <SidebarGroupContent>
+          <SidebarMenu className="flex flex-col gap-[var(--space-3xs)]">
+            {quickActions.map((action) => {
+              const Icon = action.icon ?? defaultMembersNavIcon;
+              const active = isActive(pathname, action.href);
+              return (
+                <SidebarMenuItem key={action.href}>
+                  <SidebarMenuButton
+                    asChild
+                    tooltip={action.label}
+                    isActive={active}
+                    className="h-9 w-9 justify-center"
+                  >
+                    <Link
+                      href={action.href}
+                      aria-label={action.ariaLabel ?? action.label}
+                      aria-current={active ? "page" : undefined}
+                      onClick={onNavigate}
+                    >
+                      <Icon
+                        className={cn(
+                          "h-4 w-4",
+                          active ? "opacity-100" : "opacity-70",
+                        )}
+                      />
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              );
+            })}
+            {showSearchAction ? (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  onClick={() => {
+                    onOpenCommandPalette?.();
+                    onNavigate?.();
+                  }}
+                  tooltip="Navigation durchsuchen"
+                  className="h-9 w-9 justify-center"
+                >
+                  <Search className="h-4 w-4" aria-hidden="true" />
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ) : null}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    );
+  }
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Schnellzugriffe</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {quickActions.map((action) => {
+            const Icon = action.icon ?? defaultMembersNavIcon;
+            const active = isActive(pathname, action.href);
+            return (
+              <SidebarMenuItem key={action.href}>
+                <SidebarMenuButton
+                  asChild
+                  isActive={active}
+                  className="gap-[var(--space-2xs)]"
+                >
+                  <Link
+                    href={action.href}
+                    aria-label={action.ariaLabel ?? action.label}
+                    aria-current={active ? "page" : undefined}
+                    onClick={onNavigate}
+                  >
+                    <Icon className="h-4 w-4" aria-hidden="true" />
+                    <span className="truncate text-sm leading-5">{action.label}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            );
+          })}
+          {showSearchAction ? (
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                type="button"
+                onClick={() => {
+                  onOpenCommandPalette?.();
+                  onNavigate?.();
+                }}
+                className="gap-[var(--space-2xs)]"
+              >
+                <Search className="h-4 w-4" aria-hidden="true" />
+                <span className="truncate text-sm leading-5">
+                  Navigation durchsuchen
+                </span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ) : null}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
 export function MembersNav({
   permissions,
   activeProduction,
   assignmentFocus = "none",
   hasDepartmentMemberships = false,
+  onOpenCommandPalette,
 }: {
   permissions?: readonly string[];
   activeProduction?: ActiveProductionNavInfo;
   assignmentFocus?: AssignmentFocus;
   hasDepartmentMemberships?: boolean;
+  onOpenCommandPalette?: () => void;
 }) {
   const pathname = usePathname() ?? "";
   const router = useRouter();
@@ -241,7 +629,7 @@ export function MembersNav({
   const normalizedQuery = query.trim().toLowerCase();
   const isFiltering = normalizedQuery.length > 0;
   const searchInputId = useId();
-  const { state, isMobile } = useSidebar();
+  const { state, isMobile, setOpenMobile } = useSidebar();
   const isCollapsed = !isMobile && state === "collapsed";
 
   const assignmentLabel = useMemo(
@@ -249,49 +637,71 @@ export function MembersNav({
     [assignmentFocus, permissions],
   );
 
-  const baseGroups = useMemo(
+  const baseSelection = useMemo(
     () =>
       selectMembersNavigation({
-        groups: membersNavigation,
+        structure: membersNavigation,
         hasDepartmentMemberships,
         activeProduction: activeProduction ?? null,
       }),
     [activeProduction, hasDepartmentMemberships],
   );
 
-  const labelledGroups = useMemo(
-    () =>
-      baseGroups.map((group) =>
-        group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID
-          ? { ...group, label: assignmentLabel }
-          : group,
-      ),
-    [assignmentLabel, baseGroups],
+  const labelledSelection = useMemo(() => {
+    const updateGroupLabel = (group: MembersNavGroup) =>
+      group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID
+        ? { ...group, label: assignmentLabel }
+        : group;
+
+    return {
+      primaryTabs: baseSelection.primaryTabs.map(updateGroupLabel),
+      secondaryMenu: baseSelection.secondaryMenu.map(updateGroupLabel),
+      quickActions: baseSelection.quickActions.map((item) => ({ ...item })),
+    };
+  }, [assignmentLabel, baseSelection]);
+
+  const permittedSelection = useMemo(
+    () => filterMembersNavigationByPermissions(labelledSelection, permissions),
+    [labelledSelection, permissions],
   );
 
-  const { groups: permittedGroups, flat: permittedFlat } = useMemo(
-    () => filterMembersNavigationByPermissions(labelledGroups, permissions),
-    [labelledGroups, permissions],
-  );
-
-  const { groups, flat } = useMemo(() => {
+  const filteredSelection = useMemo(() => {
     if (!isFiltering) {
-      return { groups: permittedGroups, flat: permittedFlat };
+      return permittedSelection;
     }
 
-    return filterMembersNavigationByQuery(permittedGroups, normalizedQuery);
-  }, [permittedFlat, permittedGroups, isFiltering, normalizedQuery]);
+    return filterMembersNavigationByQuery(permittedSelection, normalizedQuery);
+  }, [permittedSelection, isFiltering, normalizedQuery]);
 
   const emptyStateMessage = isFiltering
     ? "Keine Bereiche gefunden. Passe die Suche an."
     : "Keine Bereiche verfügbar.";
-  const firstMatch = flat[0];
+
+  const firstMatch = useMemo(() => {
+    const flatItems = filteredSelection.flat;
+    if (flatItems.length > 0) {
+      return flatItems[0];
+    }
+    const quick = filteredSelection.quickActions;
+    return quick.length > 0 ? quick[0] : null;
+  }, [filteredSelection]);
 
   const activeProductionTitle = activeProduction
     ? activeProduction.title && activeProduction.title.trim()
       ? activeProduction.title
       : `Produktion ${activeProduction.year}`
     : null;
+
+  const handleNavigate = useCallback(() => {
+    if (isMobile) {
+      setOpenMobile(false);
+    }
+  }, [isMobile, setOpenMobile]);
+
+  const combinedGroups = useMemo(
+    () => [...filteredSelection.primaryTabs, ...filteredSelection.secondaryMenu],
+    [filteredSelection.primaryTabs, filteredSelection.secondaryMenu],
+  );
 
   return (
     <>
@@ -318,6 +728,7 @@ export function MembersNav({
                   event.preventDefault();
                   if (firstMatch.href && firstMatch.href !== pathname) {
                     router.push(firstMatch.href);
+                    handleNavigate();
                   }
                 }
               }}
@@ -341,85 +752,47 @@ export function MembersNav({
           currentPath={pathname}
         />
 
-        {groups.length === 0 ? (
+        <MembersContextActions
+          quickActions={filteredSelection.quickActions}
+          pathname={pathname}
+          isCollapsed={isCollapsed}
+          onNavigate={handleNavigate}
+          onOpenCommandPalette={onOpenCommandPalette}
+          showCommandAction={!isFiltering}
+        />
+
+        {combinedGroups.length === 0 ? (
           <div className="mx-[var(--space-xs)] rounded-lg border border-dashed border-sidebar-border/60 bg-sidebar/40 p-[var(--space-xs)] text-sidebar-foreground/70">
             <Text variant="small" className="text-sidebar-foreground/70">
               {emptyStateMessage}
             </Text>
           </div>
+        ) : isFiltering ? (
+          <MembersNavigationGroups
+            groups={combinedGroups}
+            pathname={pathname}
+            isCollapsed={isCollapsed}
+            onNavigate={() => {
+              handleNavigate();
+              setQuery("");
+            }}
+          />
         ) : (
-          groups.map((group) => (
-            <SidebarGroup key={group.id}>
-              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {group.items.map((item) => {
-                    const active = isActive(pathname, item.href);
-                    const Icon = item.icon ?? defaultMembersNavIcon;
-                    const badgeContent = item.badge;
-                    const hasBadgeValue =
-                      badgeContent !== undefined &&
-                      badgeContent !== null &&
-                      badgeContent !== false;
-                    const showBadge = !isCollapsed && hasBadgeValue;
-                    const isPrimitiveBadge =
-                      typeof badgeContent === "string" ||
-                      typeof badgeContent === "number";
-                    const reserveBadgeSpace = showBadge && isPrimitiveBadge;
-
-                    return (
-                      <SidebarMenuItem key={item.href}>
-                        <SidebarMenuButton
-                          asChild
-                          isActive={active}
-                          tooltip={item.label}
-                          className={cn(
-                            "gap-[var(--space-2xs)]",
-                            isCollapsed && "justify-center",
-                          )}
-                        >
-                          <Link
-                            href={item.href}
-                            aria-label={item.ariaLabel ?? item.label}
-                            aria-current={active ? "page" : undefined}
-                          >
-                            <Icon
-                              className={cn(
-                                "h-4 w-4 shrink-0 transition-opacity",
-                                active ? "opacity-100" : "opacity-70",
-                                !isCollapsed && "mt-0.5",
-                              )}
-                            />
-                            {!isCollapsed ? (
-                              <div
-                                className={cn(
-                                  "flex min-w-0 flex-1 flex-col",
-                                  reserveBadgeSpace && "pr-8",
-                                )}
-                              >
-                                <span className="break-words text-sidebar-foreground leading-5">
-                                  {item.label}
-                                </span>
-                              </div>
-                            ) : null}
-                            {showBadge ? (
-                              isPrimitiveBadge ? (
-                                <SidebarMenuBadge className="border border-sidebar-border/60 bg-sidebar/50 text-eyebrow text-sidebar-foreground/70">
-                                  {badgeContent}
-                                </SidebarMenuBadge>
-                              ) : (
-                                <span className="ml-auto flex shrink-0 items-center">{badgeContent}</span>
-                              )
-                            ) : null}
-                          </Link>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          ))
+          <>
+            <MembersPrimaryTabs
+              tabs={filteredSelection.primaryTabs}
+              pathname={pathname}
+              isCollapsed={isCollapsed}
+              isMobile={isMobile}
+              onNavigate={handleNavigate}
+            />
+            <MembersSecondaryDrawer
+              groups={filteredSelection.secondaryMenu}
+              pathname={pathname}
+              isCollapsed={isCollapsed}
+              onNavigate={handleNavigate}
+            />
+          </>
         )}
       </SidebarContent>
     </>

--- a/src/components/members/members-app-shell.tsx
+++ b/src/components/members/members-app-shell.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { cva, type VariantProps } from "class-variance-authority";
 import { ArrowLeft } from "lucide-react";
 
@@ -23,6 +23,25 @@ import {
   MembersBottomNav,
   type MembersBottomNavTabId,
 } from "@/components/members/members-bottom-nav";
+import {
+  selectMembersNavigation,
+  filterMembersNavigationByPermissions,
+  filterMembersNavigationByQuery,
+  collectMembersNavigationItems,
+} from "@/lib/members-navigation";
+import {
+  defaultMembersNavIcon,
+  membersNavigation,
+  type MembersNavItem,
+} from "@/config/members-navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 
 export { MEMBERS_BOTTOM_NAV_COOKIE_NAME } from "@/components/members/members-bottom-nav";
 export type { MembersBottomNavTabId } from "@/components/members/members-bottom-nav";
@@ -253,7 +272,7 @@ function useMembersAppShellContext() {
 }
 
 function SidebarMobileAutoClose() {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
   const sidebar = useSidebar();
   const { isMobile, setOpenMobile } = sidebar;
 
@@ -384,7 +403,66 @@ export function MembersAppShell({
   appBarSlots,
   layoutVariant = "default",
 }: MembersAppShellProps) {
+  const router = useRouter();
+  const pathname = usePathname() ?? "";
   const isBottomNavLayout = layoutVariant === "bottom-nav";
+  const [commandPaletteOpen, setCommandPaletteOpen] = React.useState(false);
+  const [commandQuery, setCommandQuery] = React.useState("");
+  const normalizedCommandQuery = commandQuery.trim().toLowerCase();
+  const commandSelection = React.useMemo(
+    () =>
+      selectMembersNavigation({
+        structure: membersNavigation,
+        hasDepartmentMemberships,
+        activeProduction: activeProduction ?? null,
+      }),
+    [hasDepartmentMemberships, activeProduction],
+  );
+  const permittedCommandSelection = React.useMemo(
+    () => filterMembersNavigationByPermissions(commandSelection, permissions),
+    [commandSelection, permissions],
+  );
+  const searchCommandSelection = React.useMemo(
+    () =>
+      normalizedCommandQuery
+        ? filterMembersNavigationByQuery(
+            permittedCommandSelection,
+            normalizedCommandQuery,
+          )
+        : permittedCommandSelection,
+    [permittedCommandSelection, normalizedCommandQuery],
+  );
+  const commandItems = React.useMemo(() => {
+    const unique = new Map<string, MembersNavItem>();
+    for (const item of collectMembersNavigationItems(searchCommandSelection)) {
+      if (!unique.has(item.href)) {
+        unique.set(item.href, item);
+      }
+    }
+    return Array.from(unique.values());
+  }, [searchCommandSelection]);
+
+  const handleCommandSelect = React.useCallback(
+    (href: string) => {
+      setCommandPaletteOpen(false);
+      setCommandQuery("");
+      router.push(href);
+    },
+    [router],
+  );
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setCommandPaletteOpen(true);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   const initialTopbar = React.useMemo<MembersTopbarSlots>(
     () => ({ ...INITIAL_TOPBAR, ...appBarSlots }),
     [appBarSlots],
@@ -489,6 +567,7 @@ export function MembersAppShell({
           activeProduction={activeProduction}
           assignmentFocus={assignmentFocus}
           hasDepartmentMemberships={hasDepartmentMemberships}
+          onOpenCommandPalette={() => setCommandPaletteOpen(true)}
         />
         <SidebarRail className={cn(isBottomNavLayout && "hidden lg:flex")} />
       </Sidebar>
@@ -554,7 +633,121 @@ export function MembersAppShell({
           ) : null}
         </SidebarInset>
       </MembersAppShellContext.Provider>
+      <MembersCommandPalette
+        open={commandPaletteOpen}
+        onOpenChange={setCommandPaletteOpen}
+        query={commandQuery}
+        onQueryChange={setCommandQuery}
+        results={commandItems}
+        onSelect={handleCommandSelect}
+        activePath={pathname}
+      />
     </>
+  );
+}
+
+function getCommandBadgeText(value: MembersNavItem["badge"]) {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  return null;
+}
+
+interface MembersCommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  query: string;
+  onQueryChange: (value: string) => void;
+  results: MembersNavItem[];
+  onSelect: (href: string) => void;
+  activePath: string;
+}
+
+function MembersCommandPalette({
+  open,
+  onOpenChange,
+  query,
+  onQueryChange,
+  results,
+  onSelect,
+  activePath,
+}: MembersCommandPaletteProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        onOpenChange(next);
+        if (!next) {
+          onQueryChange("");
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Navigation durchsuchen</DialogTitle>
+          <DialogDescription>
+            Schnellzugriff auf Mitgliederbereiche und Werkzeuge.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-4 space-y-4">
+          <Input
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Bereiche oder Aktionen suchen…"
+            autoFocus
+          />
+          <div className="max-h-80 overflow-y-auto rounded-md border border-border/60 bg-background/80">
+            {results.length > 0 ? (
+              <ul className="divide-y divide-border/60">
+                {results.map((item) => {
+                  const Icon = item.icon ?? defaultMembersNavIcon;
+                  const badgeText = getCommandBadgeText(item.badge);
+                  const isActive =
+                    activePath === item.href ||
+                    activePath.startsWith(`${item.href}/`);
+
+                  return (
+                    <li key={`${item.href}-${item.label}`}>
+                      <button
+                        type="button"
+                        className={cn(
+                          "flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          isActive
+                            ? "bg-muted text-foreground"
+                            : "hover:bg-muted/70",
+                        )}
+                        onClick={() => onSelect(item.href)}
+                      >
+                        <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                        <span className="flex-1 truncate">{item.label}</span>
+                        {badgeText ? (
+                          <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                            {badgeText}
+                          </span>
+                        ) : null}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <div className="px-4 py-6 text-sm text-muted-foreground">
+                Keine Treffer gefunden. Passe deine Suche an.
+              </div>
+            )}
+          </div>
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Shortcut: <kbd className="rounded border border-border px-1 py-0.5">⌘</kbd>
+            <kbd className="rounded border border-border px-1 py-0.5">K</kbd> oder
+            <span className="ml-1 inline-flex items-center gap-1">
+              <kbd className="rounded border border-border px-1 py-0.5">Ctrl</kbd>
+              <kbd className="rounded border border-border px-1 py-0.5">K</kbd>
+            </span>
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/members/members-bottom-nav.tsx
+++ b/src/components/members/members-bottom-nav.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/members-navigation";
 import {
   defaultMembersNavIcon,
+  membersNavigation,
   type MembersNavItem,
 } from "@/config/members-navigation";
 import { useSidebar } from "@/components/ui/sidebar";
@@ -76,11 +77,12 @@ function useMembersNavigationSections({
   activeProduction?: { id: string; title: string | null; year: number };
 }) {
   return React.useMemo(() => {
-    const groups = selectMembersNavigation({
+    const selection = selectMembersNavigation({
+      structure: membersNavigation,
       hasDepartmentMemberships,
       activeProduction: activeProduction ?? null,
     });
-    return filterMembersNavigationByPermissions(groups, permissions);
+    return filterMembersNavigationByPermissions(selection, permissions);
   }, [permissions, hasDepartmentMemberships, activeProduction]);
 }
 
@@ -109,7 +111,11 @@ export function MembersBottomNav({
     activeProduction,
   });
 
-  const { groups: navGroups, flat } = navigation;
+  const { flat } = navigation;
+  const navGroups = React.useMemo(
+    () => [...navigation.primaryTabs, ...navigation.secondaryMenu],
+    [navigation.primaryTabs, navigation.secondaryMenu],
+  );
 
   const itemsByHref = React.useMemo(() => {
     const map = new Map<string, MembersNavItem>();

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -33,6 +33,12 @@ export interface MembersNavGroup {
   items: readonly MembersNavItem[];
 }
 
+export interface MembersNavigationStructure {
+  primaryTabs: readonly MembersNavGroup[];
+  secondaryMenu: readonly MembersNavGroup[];
+  quickActions: readonly MembersNavItem[];
+}
+
 function createMembersNavIcon(children: ReactNode): MembersNavIcon {
   const Icon: MembersNavIcon = ({ className }) => (
     <svg
@@ -365,247 +371,292 @@ export const membersAssignmentsTodoItem: MembersNavItem = {
   icon: DepartmentTodosIcon,
 };
 
-export const membersNavigation = [
+const generalNavigationGroup: MembersNavGroup = {
+  id: "general",
+  label: "Allgemein",
+  items: [
+    {
+      href: "/mitglieder",
+      label: "Dashboard",
+      permissionKey: "mitglieder.dashboard",
+      icon: DashboardIcon,
+    },
+    {
+      href: "/mitglieder/profil",
+      label: "Profil",
+      permissionKey: "mitglieder.profil",
+      icon: ProfileIcon,
+    },
+    {
+      href: "/mitglieder/archiv-und-bilder",
+      label: "Archiv und Bilder",
+      permissionKey: "mitglieder.galerie",
+      icon: ArchiveIcon,
+    },
+    {
+      href: "/mitglieder/dateisystem",
+      label: "Dateisystem",
+      permissionKey: "mitglieder.dateisystem",
+      icon: FileLibraryIcon,
+    },
+    {
+      href: "/mitglieder/sperrliste",
+      label: "Sperrliste",
+      permissionKey: "mitglieder.sperrliste",
+      icon: BlacklistIcon,
+    },
+    {
+      href: "/mitglieder/scan",
+      label: "Scanner",
+      permissionKey: "mitglieder.scan",
+      icon: ScannerIcon,
+    },
+    {
+      href: "/mitglieder/inventar-aufkleber",
+      label: "Inventaraufkleber",
+      permissionKey: "mitglieder.inventaraufkleber",
+      icon: InventoryStickersIcon,
+    },
+    {
+      href: "/mitglieder/issues",
+      label: "Feedback & Support",
+      permissionKey: "mitglieder.issues",
+      icon: IssuesIcon,
+    },
+  ],
+};
+
+const assignmentsNavigationGroup: MembersNavGroup = {
+  id: "assignments",
+  label: "Proben & Gewerke",
+  items: [
+    {
+      href: "/mitglieder/kalender",
+      label: "Kalender",
+      permissionKey: "mitglieder.kalender",
+      icon: PersonalCalendarIcon,
+    },
+    {
+      href: "/mitglieder/meine-proben",
+      label: "Meine Proben",
+      permissionKey: "mitglieder.meine-proben",
+      icon: RehearsalsIcon,
+    },
+    {
+      href: "/mitglieder/meine-gewerke",
+      label: "Meine Gewerke",
+      permissionKey: "mitglieder.meine-gewerke",
+      icon: DepartmentsIcon,
+    },
+    {
+      href: "/mitglieder/koerpermasse",
+      label: "Körpermaße",
+      permissionKey: "mitglieder.koerpermasse",
+      icon: BodyMeasurementsIcon,
+    },
+    {
+      href: "/mitglieder/probenplanung",
+      label: "Probenplanung",
+      permissionKey: "mitglieder.probenplanung",
+      icon: RehearsalPlanningIcon,
+    },
+  ],
+};
+
+const finalWeekNavigationGroup: MembersNavGroup = {
+  id: "final-week",
+  label: "Endproben Woche",
+  items: [
+    {
+      href: "/mitglieder/endproben-woche/dienstplan",
+      label: "Dienstplan",
+      permissionKey: "mitglieder.endprobenwoche",
+      icon: DutyRosterIcon,
+    },
+    {
+      href: "/mitglieder/endproben-woche/essenplanung",
+      label: "Essensplanung",
+      permissionKey: "mitglieder.essenplanung",
+      icon: CateringIcon,
+    },
+    {
+      href: "/mitglieder/endproben-woche/menueplan",
+      label: "Menüplan",
+      permissionKey: "mitglieder.essenplanung",
+      icon: MealPlanIcon,
+    },
+    {
+      href: "/mitglieder/endproben-woche/einkaufsliste",
+      label: "Einkaufsliste",
+      permissionKey: "mitglieder.essenplanung",
+      icon: ShoppingListIcon,
+    },
+  ],
+};
+
+const inventoryNavigationGroup: MembersNavGroup = {
+  id: "inventory",
+  label: "Lagerverwaltung",
+  items: [
+    {
+      href: "/mitglieder/lagerverwaltung/technik",
+      label: "Technik-Lager",
+      permissionKey: "mitglieder.lager.technik",
+      icon: TechInventoryIcon,
+    },
+    {
+      href: "/mitglieder/lagerverwaltung/kostueme",
+      label: "Kostüm-Lager",
+      permissionKey: "mitglieder.lager.kostueme",
+      icon: CostumeInventoryIcon,
+    },
+  ],
+};
+
+const productionNavigationGroup: MembersNavGroup = {
+  id: "production",
+  label: "Produktion",
+  items: [
+    {
+      href: "/mitglieder/produktionen",
+      label: "Übersicht",
+      permissionKey: "mitglieder.produktionen",
+      icon: ProductionIcon,
+    },
+    {
+      href: "/mitglieder/produktionen/gewerke",
+      label: "Gewerke & Teams",
+      permissionKey: "mitglieder.produktionen",
+      icon: DepartmentsOverviewIcon,
+    },
+    {
+      href: "/mitglieder/produktionen/besetzung",
+      label: "Rollen & Besetzung",
+      permissionKey: "mitglieder.produktionen",
+      icon: CastIcon,
+    },
+    {
+      href: "/mitglieder/produktionen/szenen",
+      label: "Szenen & Breakdowns",
+      permissionKey: "mitglieder.produktionen",
+      icon: ScenesIcon,
+    },
+  ],
+};
+
+const financeNavigationGroup: MembersNavGroup = {
+  id: "finance",
+  label: "Finanzen",
+  items: [
+    {
+      href: "/mitglieder/finanzen",
+      label: "Finanz-Dashboard",
+      permissionKey: "mitglieder.finanzen",
+      icon: FinanceDashboardIcon,
+    },
+    {
+      href: "/mitglieder/finanzen/buchungen",
+      label: "Buchungen",
+      permissionKey: "mitglieder.finanzen",
+      icon: FinanceBookingsIcon,
+    },
+    {
+      href: "/mitglieder/finanzen/budgets",
+      label: "Budgets",
+      permissionKey: "mitglieder.finanzen",
+      icon: FinanceBudgetsIcon,
+    },
+    {
+      href: "/mitglieder/finanzen/export",
+      label: "Exporte",
+      permissionKey: "mitglieder.finanzen.export",
+      icon: FinanceExportIcon,
+    },
+  ],
+};
+
+const adminNavigationGroup: MembersNavGroup = {
+  id: "admin",
+  label: "Verwaltung",
+  items: [
+    {
+      href: "/mitglieder/mitgliederverwaltung",
+      label: "Mitgliederverwaltung",
+      permissionKey: "mitglieder.rollenverwaltung",
+      icon: MembersAdminIcon,
+    },
+    {
+      href: "/mitglieder/server-analytics",
+      label: "Server-Statistiken",
+      permissionKey: "mitglieder.server.analytics",
+      icon: ServerAnalyticsIcon,
+    },
+    {
+      href: "/mitglieder/onboarding",
+      label: "Onboarding-Statistiken",
+      permissionKey: "mitglieder.onboarding.analytics",
+      icon: DashboardIcon,
+    },
+    {
+      href: "/mitglieder/rechte",
+      label: "Rechteverwaltung",
+      permissionKey: "mitglieder.rechte",
+      icon: PermissionsIcon,
+    },
+    {
+      href: "/mitglieder/fotoerlaubnisse",
+      label: "Fotoerlaubnisse",
+      permissionKey: "mitglieder.fotoerlaubnisse",
+      icon: PhotoConsentIcon,
+    },
+    {
+      href: "/mitglieder/website",
+      label: "Website & Theme",
+      permissionKey: "mitglieder.website.settings",
+      icon: WebsiteIcon,
+    },
+  ],
+};
+
+export const membersPrimaryTabs = [
+  generalNavigationGroup,
+  assignmentsNavigationGroup,
+  productionNavigationGroup,
+  financeNavigationGroup,
+  adminNavigationGroup,
+] as const;
+
+export const membersSecondaryMenu = [
+  inventoryNavigationGroup,
+  finalWeekNavigationGroup,
+] as const;
+
+export const membersQuickActions = [
+  membersAssignmentsTodoItem,
   {
-    id: "general",
-    label: "Allgemein",
-    items: [
-      {
-        href: "/mitglieder",
-        label: "Dashboard",
-        permissionKey: "mitglieder.dashboard",
-        icon: DashboardIcon,
-      },
-      {
-        href: "/mitglieder/profil",
-        label: "Profil",
-        permissionKey: "mitglieder.profil",
-        icon: ProfileIcon,
-      },
-      {
-        href: "/mitglieder/archiv-und-bilder",
-        label: "Archiv und Bilder",
-        permissionKey: "mitglieder.galerie",
-        icon: ArchiveIcon,
-      },
-      {
-        href: "/mitglieder/dateisystem",
-        label: "Dateisystem",
-        permissionKey: "mitglieder.dateisystem",
-        icon: FileLibraryIcon,
-      },
-      {
-        href: "/mitglieder/sperrliste",
-        label: "Sperrliste",
-        permissionKey: "mitglieder.sperrliste",
-        icon: BlacklistIcon,
-      },
-      {
-        href: "/mitglieder/scan",
-        label: "Scanner",
-        permissionKey: "mitglieder.scan",
-        icon: ScannerIcon,
-      },
-      {
-        href: "/mitglieder/inventar-aufkleber",
-        label: "Inventaraufkleber",
-        permissionKey: "mitglieder.inventaraufkleber",
-        icon: InventoryStickersIcon,
-      },
-      {
-        href: "/mitglieder/issues",
-        label: "Feedback & Support",
-        permissionKey: "mitglieder.issues",
-        icon: IssuesIcon,
-      },
-    ],
+    href: "/mitglieder/scan",
+    label: "Scanner öffnen",
+    permissionKey: "mitglieder.scan",
+    icon: ScannerIcon,
   },
   {
-    id: "inventory",
-    label: "Lagerverwaltung",
-    items: [
-      {
-        href: "/mitglieder/lagerverwaltung/technik",
-        label: "Technik-Lager",
-        permissionKey: "mitglieder.lager.technik",
-        icon: TechInventoryIcon,
-      },
-      {
-        href: "/mitglieder/lagerverwaltung/kostueme",
-        label: "Kostüm-Lager",
-        permissionKey: "mitglieder.lager.kostueme",
-        icon: CostumeInventoryIcon,
-      },
-    ],
+    href: "/mitglieder/inventar-aufkleber",
+    label: "Inventaraufkleber",
+    permissionKey: "mitglieder.inventaraufkleber",
+    icon: InventoryStickersIcon,
   },
   {
-    id: "assignments",
-    label: "Proben & Gewerke",
-    items: [
-      {
-        href: "/mitglieder/kalender",
-        label: "Kalender",
-        permissionKey: "mitglieder.kalender",
-        icon: PersonalCalendarIcon,
-      },
-      {
-        href: "/mitglieder/meine-proben",
-        label: "Meine Proben",
-        permissionKey: "mitglieder.meine-proben",
-        icon: RehearsalsIcon,
-      },
-      {
-        href: "/mitglieder/meine-gewerke",
-        label: "Meine Gewerke",
-        permissionKey: "mitglieder.meine-gewerke",
-        icon: DepartmentsIcon,
-      },
-      {
-        href: "/mitglieder/koerpermasse",
-        label: "Körpermaße",
-        permissionKey: "mitglieder.koerpermasse",
-        icon: BodyMeasurementsIcon,
-      },
-      {
-        href: "/mitglieder/probenplanung",
-        label: "Probenplanung",
-        permissionKey: "mitglieder.probenplanung",
-        icon: RehearsalPlanningIcon,
-      },
-    ],
+    href: "/mitglieder/issues",
+    label: "Feedback & Support",
+    permissionKey: "mitglieder.issues",
+    icon: IssuesIcon,
   },
-  {
-    id: "final-week",
-    label: "Endproben Woche",
-    items: [
-      {
-        href: "/mitglieder/endproben-woche/dienstplan",
-        label: "Dienstplan",
-        permissionKey: "mitglieder.endprobenwoche",
-        icon: DutyRosterIcon,
-      },
-      {
-        href: "/mitglieder/endproben-woche/essenplanung",
-        label: "Essensplanung",
-        permissionKey: "mitglieder.essenplanung",
-        icon: CateringIcon,
-      },
-      {
-        href: "/mitglieder/endproben-woche/menueplan",
-        label: "Menüplan",
-        permissionKey: "mitglieder.essenplanung",
-        icon: MealPlanIcon,
-      },
-      {
-        href: "/mitglieder/endproben-woche/einkaufsliste",
-        label: "Einkaufsliste",
-        permissionKey: "mitglieder.essenplanung",
-        icon: ShoppingListIcon,
-      },
-    ],
-  },
-  {
-    id: "production",
-    label: "Produktion",
-    items: [
-      {
-        href: "/mitglieder/produktionen",
-        label: "Übersicht",
-        permissionKey: "mitglieder.produktionen",
-        icon: ProductionIcon,
-      },
-      {
-        href: "/mitglieder/produktionen/gewerke",
-        label: "Gewerke & Teams",
-        permissionKey: "mitglieder.produktionen",
-        icon: DepartmentsOverviewIcon,
-      },
-      {
-        href: "/mitglieder/produktionen/besetzung",
-        label: "Rollen & Besetzung",
-        permissionKey: "mitglieder.produktionen",
-        icon: CastIcon,
-      },
-      {
-        href: "/mitglieder/produktionen/szenen",
-        label: "Szenen & Breakdowns",
-        permissionKey: "mitglieder.produktionen",
-        icon: ScenesIcon,
-      },
-    ],
-  },
-  {
-    id: "finance",
-    label: "Finanzen",
-    items: [
-      {
-        href: "/mitglieder/finanzen",
-        label: "Finanz-Dashboard",
-        permissionKey: "mitglieder.finanzen",
-        icon: FinanceDashboardIcon,
-      },
-      {
-        href: "/mitglieder/finanzen/buchungen",
-        label: "Buchungen",
-        permissionKey: "mitglieder.finanzen",
-        icon: FinanceBookingsIcon,
-      },
-      {
-        href: "/mitglieder/finanzen/budgets",
-        label: "Budgets",
-        permissionKey: "mitglieder.finanzen",
-        icon: FinanceBudgetsIcon,
-      },
-      {
-        href: "/mitglieder/finanzen/export",
-        label: "Exporte",
-        permissionKey: "mitglieder.finanzen.export",
-        icon: FinanceExportIcon,
-      },
-    ],
-  },
-  {
-    id: "admin",
-    label: "Verwaltung",
-    items: [
-      {
-        href: "/mitglieder/mitgliederverwaltung",
-        label: "Mitgliederverwaltung",
-        permissionKey: "mitglieder.rollenverwaltung",
-        icon: MembersAdminIcon,
-      },
-      {
-        href: "/mitglieder/server-analytics",
-        label: "Server-Statistiken",
-        permissionKey: "mitglieder.server.analytics",
-        icon: ServerAnalyticsIcon,
-      },
-      {
-        href: "/mitglieder/onboarding",
-        label: "Onboarding-Statistiken",
-        permissionKey: "mitglieder.onboarding.analytics",
-        icon: DashboardIcon,
-      },
-      {
-        href: "/mitglieder/rechte",
-        label: "Rechteverwaltung",
-        permissionKey: "mitglieder.rechte",
-        icon: PermissionsIcon,
-      },
-      {
-        href: "/mitglieder/fotoerlaubnisse",
-        label: "Fotoerlaubnisse",
-        permissionKey: "mitglieder.fotoerlaubnisse",
-        icon: PhotoConsentIcon,
-      },
-      {
-        href: "/mitglieder/website",
-        label: "Website & Theme",
-        permissionKey: "mitglieder.website.settings",
-        icon: WebsiteIcon,
-      },
-    ],
-  },
-] satisfies readonly MembersNavGroup[];
+] as const;
+
+export const membersNavigation: MembersNavigationStructure = {
+  primaryTabs: membersPrimaryTabs,
+  secondaryMenu: membersSecondaryMenu,
+  quickActions: membersQuickActions,
+};
 
 export const defaultMembersNavIcon = DefaultIcon;

--- a/src/lib/__tests__/members-navigation.test.ts
+++ b/src/lib/__tests__/members-navigation.test.ts
@@ -30,10 +30,18 @@ const BASE_PERMISSIONS = [
   "mitglieder.produktionen",
 ];
 
+function collectGroups(
+  selection: ReturnType<typeof selectMembersNavigation>,
+) {
+  return [...selection.primaryTabs, ...selection.secondaryMenu];
+}
+
 describe("selectMembersNavigation", () => {
   it("injects department todo item when memberships are present", () => {
-    const groups = selectMembersNavigation({ hasDepartmentMemberships: true });
-    const assignments = groups.find((group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID);
+    const selection = selectMembersNavigation({ hasDepartmentMemberships: true });
+    const assignments = collectGroups(selection).find(
+      (group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
+    );
 
     expect(assignments).toBeDefined();
     const todoIndex = assignments!.items.findIndex(
@@ -48,8 +56,10 @@ describe("selectMembersNavigation", () => {
   });
 
   it("omits the department todo item without memberships", () => {
-    const groups = selectMembersNavigation({ hasDepartmentMemberships: false });
-    const assignments = groups.find((group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID);
+    const selection = selectMembersNavigation({ hasDepartmentMemberships: false });
+    const assignments = collectGroups(selection).find(
+      (group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
+    );
 
     expect(assignments).toBeDefined();
     const todoIndex = assignments!.items.findIndex(
@@ -66,8 +76,10 @@ describe("selectMembersNavigation", () => {
       year: 2025,
     };
 
-    const groups = selectMembersNavigation({ activeProduction });
-    const production = groups.find((group) => group.id === MEMBERS_NAV_PRODUCTION_GROUP_ID);
+    const selection = selectMembersNavigation({ activeProduction });
+    const production = collectGroups(selection).find(
+      (group) => group.id === MEMBERS_NAV_PRODUCTION_GROUP_ID,
+    );
 
     expect(production).toBeDefined();
     const item = production!.items.find(
@@ -82,17 +94,20 @@ describe("selectMembersNavigation", () => {
 
 describe("filterMembersNavigationByPermissions", () => {
   it("hides finance navigation for members without finance permissions", () => {
-    const groups = selectMembersNavigation();
-    const { groups: filtered } = filterMembersNavigationByPermissions(groups, BASE_PERMISSIONS);
+    const selection = selectMembersNavigation();
+    const filtered = filterMembersNavigationByPermissions(selection, BASE_PERMISSIONS);
+    const groups = collectGroups(filtered);
 
-    expect(filtered.some((group) => group.id === "finance")).toBe(false);
+    expect(groups.some((group) => group.id === "finance")).toBe(false);
   });
 
   it("keeps only department related assignments for department-focused members", () => {
-    const groups = selectMembersNavigation({ hasDepartmentMemberships: true });
+    const selection = selectMembersNavigation({ hasDepartmentMemberships: true });
     const permissions = ["mitglieder.meine-gewerke"] as const;
-    const { groups: filtered } = filterMembersNavigationByPermissions(groups, permissions);
-    const assignments = filtered.find((group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID);
+    const filtered = filterMembersNavigationByPermissions(selection, permissions);
+    const assignments = collectGroups(filtered).find(
+      (group) => group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
+    );
 
     expect(assignments).toBeDefined();
     const hrefs = assignments!.items.map((item) => item.href);

--- a/src/lib/members-navigation.ts
+++ b/src/lib/members-navigation.ts
@@ -1,4 +1,8 @@
-import type { MembersNavGroup, MembersNavItem } from "@/config/members-navigation";
+import type {
+  MembersNavGroup,
+  MembersNavItem,
+  MembersNavigationStructure,
+} from "@/config/members-navigation";
 import {
   MEMBERS_NAV_ASSIGNMENTS_GROUP_ID,
   MEMBERS_NAV_PRODUCTION_GROUP_ID,
@@ -15,18 +19,36 @@ export interface ActiveProductionNavInfo {
   year: number;
 }
 
+export interface MembersNavigationSelection {
+  primaryTabs: MembersNavGroup[];
+  secondaryMenu: MembersNavGroup[];
+  quickActions: MembersNavItem[];
+}
+
 export interface MembersNavigationSelectorOptions {
-  groups?: readonly MembersNavGroup[];
+  structure?: MembersNavigationStructure;
   hasDepartmentMemberships?: boolean;
   activeProduction?: ActiveProductionNavInfo | null;
 }
 
-export interface MembersNavigationFilterResult {
-  groups: MembersNavGroup[];
+export interface MembersNavigationFilterResult
+  extends MembersNavigationSelection {
   flat: MembersNavItem[];
 }
 
 function cloneGroupItems(items: readonly MembersNavItem[]) {
+  return items.map((item) => ({ ...item }));
+}
+
+function cloneGroup(group: MembersNavGroup): MembersNavGroup {
+  return { ...group, items: cloneGroupItems(group.items) };
+}
+
+function cloneGroups(groups: readonly MembersNavGroup[]) {
+  return groups.map((group) => cloneGroup(group));
+}
+
+function cloneItems(items: readonly MembersNavItem[]) {
   return items.map((item) => ({ ...item }));
 }
 
@@ -57,11 +79,11 @@ function removeTodoItem(items: MembersNavItem[]) {
 }
 
 export function selectMembersNavigation({
-  groups = membersNavigation,
+  structure = membersNavigation,
   hasDepartmentMemberships = false,
   activeProduction = null,
-}: MembersNavigationSelectorOptions = {}): MembersNavGroup[] {
-  return groups.map((group) => {
+}: MembersNavigationSelectorOptions = {}): MembersNavigationSelection {
+  const applyGroupTransforms = (group: MembersNavGroup): MembersNavGroup => {
     if (group.id === MEMBERS_NAV_ASSIGNMENTS_GROUP_ID) {
       const items = cloneGroupItems(group.items);
       if (hasDepartmentMemberships) {
@@ -106,8 +128,27 @@ export function selectMembersNavigation({
       return { ...group, items };
     }
 
-    return { ...group, items: cloneGroupItems(group.items) };
-  });
+    return cloneGroup(group);
+  };
+
+  const primaryTabs = structure.primaryTabs.map(applyGroupTransforms);
+  const secondaryMenu = structure.secondaryMenu.map(applyGroupTransforms);
+
+  let quickActions = cloneItems(structure.quickActions);
+  if (!hasDepartmentMemberships) {
+    quickActions = quickActions.filter(
+      (item) => item.href !== membersAssignmentsTodoItem.href,
+    );
+  } else {
+    const todoIncluded = quickActions.some(
+      (item) => item.href === membersAssignmentsTodoItem.href,
+    );
+    if (!todoIncluded) {
+      quickActions.unshift({ ...membersAssignmentsTodoItem });
+    }
+  }
+
+  return { primaryTabs, secondaryMenu, quickActions };
 }
 
 export function resolveAssignmentsGroupLabel(
@@ -130,47 +171,90 @@ export function resolveAssignmentsGroupLabel(
   return "Proben";
 }
 
-export function filterMembersNavigationByPermissions(
+function filterGroupByPermissions(
+  group: MembersNavGroup,
+  permissionSet: Set<string> | null,
+): MembersNavGroup {
+  const items = group.items.filter((item) => {
+    if (!item.permissionKey || !permissionSet) return true;
+    return permissionSet.has(item.permissionKey);
+  });
+  return { ...group, items };
+}
+
+function filterQuickActionsByPermissions(
+  actions: readonly MembersNavItem[],
+  permissionSet: Set<string> | null,
+): MembersNavItem[] {
+  return actions
+    .filter((item) => {
+      if (!item.permissionKey || !permissionSet) return true;
+      return permissionSet.has(item.permissionKey);
+    })
+    .map((item) => ({ ...item }));
+}
+
+function filterNavigationGroups(
   groups: readonly MembersNavGroup[],
+  permissionSet: Set<string> | null,
+): MembersNavGroup[] {
+  return groups
+    .map((group) => filterGroupByPermissions(group, permissionSet))
+    .filter((group) => group.items.length > 0);
+}
+
+export function filterMembersNavigationByPermissions(
+  selection: MembersNavigationSelection,
   permissions: readonly string[] | undefined,
 ): MembersNavigationFilterResult {
   const permissionSet = permissions ? new Set(permissions) : null;
 
-  const filteredGroups = groups
-    .map((group) => {
-      const items = group.items.filter((item) => {
-        if (!item.permissionKey || !permissionSet) return true;
-        return permissionSet.has(item.permissionKey);
-      });
-      return { ...group, items };
-    })
-    .filter((group) => group.items.length > 0);
+  const primaryTabs = filterNavigationGroups(selection.primaryTabs, permissionSet);
+  const secondaryMenu = filterNavigationGroups(selection.secondaryMenu, permissionSet);
+  const quickActions = filterQuickActionsByPermissions(
+    selection.quickActions,
+    permissionSet,
+  );
 
-  const flat = filteredGroups.flatMap((group) => group.items);
-  return { groups: filteredGroups, flat };
+  const flat = [...primaryTabs, ...secondaryMenu].flatMap((group) => group.items);
+  return { primaryTabs, secondaryMenu, quickActions, flat };
 }
 
 export function filterMembersNavigationByQuery(
-  groups: readonly MembersNavGroup[],
+  selection: MembersNavigationSelection,
   normalizedQuery: string,
 ): MembersNavigationFilterResult {
   if (!normalizedQuery) {
-    const clonedGroups = groups.map((group) => ({ ...group, items: cloneGroupItems(group.items) }));
-    const flat = clonedGroups.flatMap((group) => group.items);
-    return { groups: clonedGroups, flat };
+    const primaryTabs = cloneGroups(selection.primaryTabs);
+    const secondaryMenu = cloneGroups(selection.secondaryMenu);
+    const quickActions = cloneItems(selection.quickActions);
+    const flat = [...primaryTabs, ...secondaryMenu].flatMap((group) => group.items);
+    return { primaryTabs, secondaryMenu, quickActions, flat };
   }
 
-  const filteredGroups = groups
+  const includesQuery = (item: MembersNavItem) =>
+    item.label.toLowerCase().includes(normalizedQuery);
+
+  const primaryTabs = selection.primaryTabs
     .map((group) => {
-      const items = group.items.filter((item) =>
-        item.label.toLowerCase().includes(normalizedQuery),
-      );
+      const items = group.items.filter(includesQuery);
       return { ...group, items };
     })
     .filter((group) => group.items.length > 0);
 
-  const flat = filteredGroups.flatMap((group) => group.items);
-  return { groups: filteredGroups, flat };
+  const secondaryMenu = selection.secondaryMenu
+    .map((group) => {
+      const items = group.items.filter(includesQuery);
+      return { ...group, items };
+    })
+    .filter((group) => group.items.length > 0);
+
+  const quickActions = selection.quickActions
+    .filter(includesQuery)
+    .map((item) => ({ ...item }));
+
+  const flat = [...primaryTabs, ...secondaryMenu].flatMap((group) => group.items);
+  return { primaryTabs, secondaryMenu, quickActions, flat };
 }
 
 export interface MembersNavigationItemMatch {
@@ -180,9 +264,10 @@ export interface MembersNavigationItemMatch {
 
 export function findMembersNavigationItem(
   href: string,
-  options: { groups?: readonly MembersNavGroup[] } = {},
+  options: { structure?: MembersNavigationStructure } = {},
 ): MembersNavigationItemMatch | null {
-  const groupsToSearch = options.groups ?? membersNavigation;
+  const structure = options.structure ?? membersNavigation;
+  const groupsToSearch = [...structure.primaryTabs, ...structure.secondaryMenu];
 
   for (const group of groupsToSearch) {
     const item = group.items.find((candidate) => candidate.href === href);
@@ -192,4 +277,14 @@ export function findMembersNavigationItem(
   }
 
   return null;
+}
+
+export function collectMembersNavigationItems(
+  selection: MembersNavigationSelection | MembersNavigationFilterResult,
+): MembersNavItem[] {
+  return [
+    ...selection.primaryTabs.flatMap((group) => group.items.map((item) => ({ ...item }))),
+    ...selection.secondaryMenu.flatMap((group) => group.items.map((item) => ({ ...item }))),
+    ...selection.quickActions.map((item) => ({ ...item })),
+  ];
 }


### PR DESCRIPTION
## Summary
- restructure the members navigation config into primary tabs, secondary menu, and quick actions with curated shortcuts
- refactor navigation helpers and the mobile bottom nav to consume the new structure while preserving permission/query logic
- overhaul the members navigation UI with dedicated primary/secondary/quick action components and add a command palette dialog in the app shell
- update the members navigation unit tests to reflect the new model

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dcda66c11c832da2572d641394a567