### PR TITLE
refactor: modularize members dashboard layout

### DIFF
--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -12,6 +12,7 @@ import { useOnlineStats } from "@/hooks/useOnlineStats";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   MembersContentHeader,
   MembersContentLayout,
@@ -39,7 +40,6 @@ import {
   PiggyBank,
   CalendarRange,
   UtensilsCrossed,
-  ArrowUpRight,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -89,6 +89,26 @@ type MetricItem = {
   hint?: string | null;
   icon: ReactNode;
   tone: MetricTone;
+  progress?: number;
+  cta?: {
+    label: string;
+    href?: string;
+    onClick?: () => void;
+  };
+};
+
+type DashboardTask = {
+  id: string;
+  title: string;
+  description: string;
+  status: "todo" | "done";
+  icon: ReactNode;
+  progress?: number;
+  cta?: {
+    label: string;
+    href?: string;
+    onClick?: () => void;
+  };
 };
 
 const DASHBOARD_CARD_SURFACE =
@@ -118,6 +138,22 @@ const METRIC_ICON_CLASSES: Record<MetricTone, string> = {
   positive: "border-success/45 bg-success/15 text-success",
   warning: "border-warning/45 bg-warning/15 text-warning",
   destructive: "border-destructive/45 bg-destructive/15 text-destructive",
+};
+
+const METRIC_PROGRESS_CLASSES: Record<MetricTone, string> = {
+  neutral: "bg-muted/40",
+  accent: "bg-primary/10",
+  positive: "bg-success/15",
+  warning: "bg-warning/15",
+  destructive: "bg-destructive/15",
+};
+
+const METRIC_PROGRESS_INDICATOR_CLASSES: Record<MetricTone, string> = {
+  neutral: "bg-primary",
+  accent: "bg-primary",
+  positive: "bg-success",
+  warning: "bg-warning",
+  destructive: "bg-destructive",
 };
 
 interface MembersDashboardProps {
@@ -427,6 +463,7 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
   const [stats, setStats] = useState<DashboardStats>(INITIAL_STATS);
   const [recentActivities, setRecentActivities] = useState<RecentActivity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [finalRehearsalWeek, setFinalRehearsalWeek] = useState<FinalRehearsalWeekInfo | null>(null);
   const [profileCompletion, setProfileCompletion] = useState<
     { complete: boolean; completed: number; total: number } | null
@@ -440,20 +477,30 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     setStats((prev) => ({ ...prev, totalOnline: liveOnline }));
   }, [liveOnline]);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function load() {
-      setIsLoading(true);
+  const loadOverview = useCallback(
+    async ({
+      mode = "initial",
+      signal,
+    }: { mode?: "initial" | "refresh"; signal?: AbortSignal } = {}) => {
+      if (signal?.aborted) return;
+      if (mode === "initial") {
+        setIsLoading(true);
+      } else {
+        setIsRefreshing(true);
+      }
       setActiveProductionError(false);
+
       try {
-        const response = await fetch("/api/dashboard/overview", { cache: "no-store" });
+        const response = await fetch("/api/dashboard/overview", {
+          cache: "no-store",
+          signal,
+        });
         if (!response.ok) {
           console.error("[Dashboard] Failed to load overview", response.status);
           return;
         }
         const payload = (await response.json()) as OverviewResponse;
-        if (cancelled) return;
+        if (signal?.aborted) return;
 
         setStats((prev) => {
           const statsPayload = isRecord(payload?.stats) ? payload.stats : {};
@@ -483,21 +530,31 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
 
         setRecentActivities(activities.slice(0, 10));
       } catch (error) {
+        if (signal?.aborted) return;
         console.error("[Dashboard] Error loading overview", error);
         setActiveProductionError(true);
       } finally {
-        if (!cancelled) {
+        if (signal?.aborted) return;
+        if (mode === "initial") {
           setIsLoading(false);
-          setActiveProductionLoaded(true);
+        } else {
+          setIsRefreshing(false);
         }
+        setActiveProductionLoaded(true);
       }
-    }
+    },
+    [],
+  );
 
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  useEffect(() => {
+    const controller = new AbortController();
+    loadOverview({ mode: "initial", signal: controller.signal }).catch((error) => {
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        console.error("[Dashboard] loadOverview failed", error);
+      }
+    });
+    return () => controller.abort();
+  }, [loadOverview]);
 
   const addActivity = useCallback((activity: RecentActivity) => {
     setRecentActivities((prev) => {
@@ -505,6 +562,14 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
       return [activity, ...filtered].slice(0, 10);
     });
   }, []);
+
+  const handleRefresh = useCallback(() => {
+    loadOverview({ mode: "refresh" }).catch((error) => {
+      if (!(error instanceof DOMException && error.name === "AbortError")) {
+        console.error("[Dashboard] refresh failed", error);
+      }
+    });
+  }, [loadOverview]);
 
   useNotificationRealtime((event) => {
     const activity: RecentActivity = {
@@ -718,6 +783,9 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     : `Aktualisiert ${formatTimeAgo(new Date())}`;
 
   const metrics = useMemo(() => {
+    const onlineProgress = stats.totalMembers > 0 ? stats.totalOnline / stats.totalMembers : 0;
+    const quickLinksByHref = new Map(availableQuickActions.map((link) => [link.href, link]));
+
     const items: MetricItem[] = [
       {
         key: "online",
@@ -726,6 +794,15 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         hint: onlineUpdatedHint,
         icon: <Users className="h-4 w-4" />,
         tone: "positive",
+        progress: onlineProgress,
+        cta: {
+          label: connectionStatus === "connected" ? "Live-Status" : "Neu laden",
+          onClick: connectionStatus === "connected" ? undefined : handleRefresh,
+          href:
+            connectionStatus === "connected"
+              ? quickLinksByHref.get("/mitglieder/mitgliederverwaltung")?.href
+              : undefined,
+        },
       },
       {
         key: "members",
@@ -734,6 +811,13 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         hint: "inkl. Ensemble und Technik",
         icon: <Activity className="h-4 w-4" />,
         tone: "neutral",
+        progress: stats.totalMembers > 0 ? 1 : 0,
+        cta: quickLinksByHref.get("/mitglieder/mitgliederverwaltung")
+          ? {
+              label: "Verwalten",
+              href: "/mitglieder/mitgliederverwaltung",
+            }
+          : undefined,
       },
       {
         key: "rehearsals",
@@ -742,6 +826,18 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         hint: "Termine der laufenden Kalenderwoche",
         icon: <Calendar className="h-4 w-4" />,
         tone: "accent",
+        progress: Math.min(stats.rehearsalsThisWeek / 7, 1),
+        cta: quickLinksByHref.get("/mitglieder/meine-proben")
+          ? {
+              label: "Meine Proben",
+              href: "/mitglieder/meine-proben",
+            }
+          : quickLinksByHref.get("/mitglieder/kalender")
+              ? {
+                  label: "Zum Kalender",
+                  href: "/mitglieder/kalender",
+                }
+              : undefined,
       },
     ];
 
@@ -765,12 +861,25 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         hint: finalRehearsalMetric.hint,
         icon: <Sparkles className="h-4 w-4" />,
         tone: rehearsalTone,
+        progress:
+          typeof finalRehearsalMetric.value === "number"
+            ? Math.min(Math.max(1 - Number(finalRehearsalMetric.value) / 14, 0), 1)
+            : undefined,
+        cta: quickLinksByHref.get("/mitglieder/probenplanung")
+          ? {
+              label: "Probenplanung",
+              href: "/mitglieder/probenplanung",
+            }
+          : undefined,
       });
     }
 
     return items;
   }, [
     finalRehearsalMetric,
+    connectionStatus,
+    handleRefresh,
+    availableQuickActions,
     numberFormatter,
     onlineUpdatedHint,
     stats.rehearsalsThisWeek,
@@ -778,230 +887,77 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     stats.totalOnline,
   ]);
 
-  const profileReminder = useMemo(() => {
-    if (!profileCompletion) {
-      return null;
+  const dashboardTasks = useMemo(() => {
+    const items: DashboardTask[] = [];
+
+    if (profileCompletion) {
+      const total = Math.max(profileCompletion.total, 1);
+      const completed = Math.min(profileCompletion.completed, total);
+      const remaining = Math.max(total - completed, 0);
+      items.push({
+        id: "profile",
+        title: profileCompletion.complete ? "Profil gepflegt" : "Profil vervollständigen",
+        description: profileCompletion.complete
+          ? "Alle Pflichtangaben wurden bestätigt."
+          : `Noch ${remaining} von ${total} Angaben offen.`,
+        status: profileCompletion.complete ? "done" : "todo",
+        icon: profileCompletion.complete ? <CheckCircle2 className="h-4 w-4" /> : <CalendarRange className="h-4 w-4" />,
+        progress: completed / total,
+        cta: {
+          label: profileCompletion.complete ? "Profil ansehen" : "Jetzt ergänzen",
+          href: "/mitglieder/profil",
+        },
+      });
     }
 
-    const remaining = Math.max(profileCompletion.total - profileCompletion.completed, 0);
-
-    if (!profileCompletion.complete) {
-      return (
-        <div className="flex flex-col gap-3 rounded-2xl border border-warning/50 bg-gradient-to-br from-warning/20 via-warning/10 to-warning/5 p-4 text-sm text-warning">
-          <div className="flex items-start gap-2">
-            <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-xl border border-warning/50 bg-warning/20">
-              <CalendarRange className="h-4 w-4" />
-            </div>
-            <div className="space-y-1">
-              <p className="font-semibold">Profilangaben unvollständig</p>
-              <p className="text-xs text-warning/90">
-                {`Noch ${remaining} von ${profileCompletion.total} Aufgaben offen.`}
-              </p>
-            </div>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="border-warning/45 bg-gradient-to-r from-warning/20 via-warning/10 to-warning/5 text-warning transition hover:border-warning/60 hover:bg-warning/15"
-            asChild
-          >
-            <Link href="/mitglieder/profil">Profil aktualisieren</Link>
-          </Button>
-        </div>
-      );
+    if (stats.unreadNotifications > 0) {
+      items.push({
+        id: "notifications",
+        title: "Ungelesene Benachrichtigungen",
+        description: `${numberFormatter.format(stats.unreadNotifications)} Nachricht(en) warten auf dich.`,
+        status: "todo",
+        icon: <Bell className="h-4 w-4" />,
+        progress: 0,
+        cta: {
+          label: "Aktualisieren",
+          onClick: handleRefresh,
+        },
+      });
     }
 
-    return (
-      <div className="flex items-start gap-3 rounded-2xl border border-success/50 bg-gradient-to-br from-success/20 via-success/10 to-success/5 p-4 text-sm text-success">
-        <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-xl border border-success/50 bg-success/20">
-          <CheckCircle2 className="h-4 w-4" />
-        </div>
-        <div>
-          <p className="font-semibold">Profil vollständig</p>
-          <p className="text-xs text-success/90">Alle Angaben sind auf dem aktuellen Stand.</p>
-        </div>
-      </div>
-    );
-  }, [profileCompletion]);
-
-  const activeProductionCard = useMemo(() => {
-    if (!activeProductionLoaded) {
-      return (
-        <Card className="rounded-3xl border border-dashed border-border/60 bg-card shadow-sm">
-          <CardContent className="space-y-3 p-6">
-            <div className="h-4 w-32 rounded bg-muted/50" />
-            <div className="h-5 w-48 rounded bg-muted/40" />
-            <div className="h-3 w-full rounded bg-muted/30" />
-          </CardContent>
-        </Card>
-      );
+    if (finalRehearsalMetric) {
+      const isNumeric = typeof finalRehearsalMetric.value === "number";
+      const progress = isNumeric ? Math.min(Math.max(1 - Number(finalRehearsalMetric.value) / 14, 0), 1) : undefined;
+      items.push({
+        id: "final-rehearsal",
+        title: finalRehearsalMetric.label,
+        description: finalRehearsalMetric.hint ?? "Bleib bei Endproben auf dem Laufenden.",
+        status: finalRehearsalMetric.tone === "positive" ? "done" : "todo",
+        icon: <Sparkles className="h-4 w-4" />,
+        progress,
+        cta: quickActions.find((action) => action.href === "/mitglieder/probenplanung")
+          ? {
+              label: "Probenplanung",
+              href: "/mitglieder/probenplanung",
+            }
+          : quickActions.find((action) => action.href === "/mitglieder/meine-proben")
+              ? {
+                  label: "Meine Proben",
+                  href: "/mitglieder/meine-proben",
+                }
+              : undefined,
+      });
     }
 
-    if (activeProductionError) {
-      return (
-        <Card className="rounded-3xl border border-destructive/40 bg-destructive/10 text-destructive shadow-sm">
-          <CardContent className="space-y-2 p-6">
-            <p className="text-sm font-semibold">Aktive Produktion konnte nicht geladen werden.</p>
-            <p className="text-xs text-destructive/80">
-              Bitte lade die Seite neu oder versuche es später erneut.
-            </p>
-          </CardContent>
-        </Card>
-      );
-    }
-
-    const membershipSectionTitle = activeProduction ? "Weitere Produktionen" : "Bisherige Produktionen";
-
-    const membershipBadges = otherMemberships.length
-      ? (
-          <div className="space-y-1">
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {membershipSectionTitle}
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {otherMemberships.slice(0, 4).map((membership) => {
-                const label = formatProductionName(membership);
-                const leftLabel = formatDateLocalized(membership.leftAt);
-                const statusText = membership.isActive
-                  ? "aktiv"
-                  : leftLabel
-                    ? `bis ${leftLabel}`
-                    : "archiviert";
-
-                return (
-                  <Badge
-                    key={`membership-${membership.showId}`}
-                    variant="outline"
-                    className={cn(
-                      "border-border/60 bg-card text-foreground",
-                      membership.isActive && "border-primary/40 bg-primary/10 text-primary",
-                    )}
-                  >
-                    <span className="font-medium">{label}</span>
-                    <span className="ml-1 text-[11px] text-muted-foreground">• {statusText}</span>
-                  </Badge>
-                );
-              })}
-            </div>
-            {otherMemberships.length > 4 ? (
-              <p className="text-[11px] text-muted-foreground">
-                + {otherMemberships.length - 4} weitere im Archiv
-              </p>
-            ) : null}
-          </div>
-        )
-      : null;
-
-    const sharedNote = (
-      <p className="text-xs text-muted-foreground">
-        Profilangaben wie Maße, Allergien und Einverständnisse gelten produktonsübergreifend und müssen nicht
-        erneut erfasst werden.
-      </p>
-    );
-
-    if (!activeProduction) {
-      return (
-        <Card className="rounded-3xl border border-dashed border-primary/40 bg-primary/5 shadow-[0_18px_40px_rgba(15,23,42,0.08)]">
-          <CardHeader className="space-y-1">
-            <CardTitle className="text-lg font-semibold text-primary">Keine aktive Produktion ausgewählt</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Wähle eine aktive Produktion, um Rollen, Szenen und Gewerke der aktuellen Saison zu sehen.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">
-              Sobald du nur einer laufenden Produktion angehörst oder frühere Produktionen ausgelaufen sind, setzen wir
-              deine Mitgliedschaft automatisch auf die aktuelle Produktion.
-            </p>
-            {membershipBadges}
-            {sharedNote}
-            {canAccessProductions ? (
-              <div className="flex flex-wrap gap-2 pt-1">
-                <Button asChild size="sm">
-                  <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
-                </Button>
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
-      );
-    }
-
-    const productionLabel = formatProductionName(activeProduction);
-    const membership = activeMembership;
-    const joinedLabel = formatDateLocalized(membership?.joinedAt ?? null);
-    const leftLabel = formatDateLocalized(membership?.leftAt ?? null);
-    const statusBadgeLabel = membership?.isActive === false ? "Archiviert" : "Aktiv";
-    const statusBadgeClass =
-      membership?.isActive === false
-        ? "border-border/60 text-muted-foreground"
-        : "border-primary/40 bg-primary/10 text-primary";
-
-    let membershipSubtitle: string | null = null;
-    if (membership?.isActive) {
-      membershipSubtitle = joinedLabel ? `Seit ${joinedLabel} Teil der Produktion.` : "Mitgliedschaft aktiv.";
-    } else if (membership) {
-      membershipSubtitle = joinedLabel && leftLabel
-        ? `Von ${joinedLabel} bis ${leftLabel} aktiv.`
-        : leftLabel
-          ? `Mitgliedschaft beendet am ${leftLabel}.`
-          : "Mitgliedschaft archiviert.";
-    }
-
-    return (
-      <Card className={cn(DASHBOARD_CARD_SURFACE, "relative overflow-hidden")}>
-        <div
-          aria-hidden
-          className="pointer-events-none absolute -right-28 -top-16 h-48 w-48 rounded-full bg-primary/10 opacity-40 blur-3xl dark:bg-primary/20"
-        />
-        <div
-          aria-hidden
-          className="pointer-events-none absolute -left-24 bottom-0 h-44 w-44 rounded-full bg-amber-200/20 opacity-40 blur-3xl dark:bg-amber-500/20"
-        />
-        <CardHeader className="relative z-10 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-1">
-            <CardTitle className="text-lg font-semibold">Aktive Produktion</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Du arbeitest aktuell in {productionLabel}.
-            </p>
-          </div>
-          <Badge variant="outline" className={statusBadgeClass}>
-            {statusBadgeLabel}
-          </Badge>
-        </CardHeader>
-        <CardContent className="relative z-10 space-y-3">
-          <div className="space-y-1">
-            <p className="text-sm font-medium text-foreground">{productionLabel}</p>
-            <p className="text-xs text-muted-foreground">
-              {membershipSubtitle ?? "Mitgliedschaft automatisch verwaltet."}
-            </p>
-          </div>
-          {membershipBadges}
-          {sharedNote}
-          {canAccessProductions ? (
-            <div className="flex flex-wrap gap-2 pt-1">
-              <Button asChild size="sm">
-                <Link href={`/mitglieder/produktionen/${activeProduction.id}`}>Arbeitsbereich öffnen</Link>
-              </Button>
-              <Button asChild size="sm" variant="outline">
-                <Link href="/mitglieder/produktionen">Produktion wechseln</Link>
-              </Button>
-            </div>
-          ) : null}
-        </CardContent>
-      </Card>
-    );
+    return items;
   }, [
-    activeProduction,
-    activeProductionError,
-    activeProductionLoaded,
-    activeMembership,
-    canAccessProductions,
-    otherMemberships,
+    finalRehearsalMetric,
+    handleRefresh,
+    numberFormatter,
+    profileCompletion,
+    quickActions,
+    stats.unreadNotifications,
   ]);
-
-
 
   if (!session?.user) {
     return (
@@ -1017,6 +973,9 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     );
   }
 
+  const heroName = session.user.name || session.user.email || "Mitglied";
+  const formattedOnlineCount = numberFormatter.format(stats.totalOnline);
+
   return (
     <Fragment>
       <MembersContentLayout width="2xl" spacing="comfortable" gap="lg" />
@@ -1030,155 +989,76 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
       </MembersTopbar>
 
       <MembersContentHeader>
-        <PageHeader>
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-            <div className="space-y-1.5">
-              <PageHeaderTitle>Mitglieder-Dashboard</PageHeaderTitle>
-              <PageHeaderDescription>
-                Aktuelle Kennzahlen, Aktivitäten und Schnellzugriffe auf einen Blick.
-              </PageHeaderDescription>
+        <div className="hidden lg:block">
+          <PageHeader>
+            <div className="flex items-end justify-between gap-4">
+              <div className="space-y-1.5">
+                <PageHeaderTitle>Mitglieder-Dashboard</PageHeaderTitle>
+                <PageHeaderDescription>
+                  Aktuelle Kennzahlen, Aktivitäten und Schnellzugriffe auf einen Blick.
+                </PageHeaderDescription>
+              </div>
+              <div className="flex items-center gap-3">
+                <PageHeaderStatus state={connectionMeta.state} icon={connectionMeta.icon}>
+                  {connectionMeta.label}
+                </PageHeaderStatus>
+                {profileCompletion?.complete ? (
+                  <Badge variant="outline" className="border-success/40 bg-success/10 text-success">
+                    Profil aktualisiert
+                  </Badge>
+                ) : null}
+              </div>
             </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <PageHeaderStatus state={connectionMeta.state} icon={connectionMeta.icon}>
-                {connectionMeta.label}
-              </PageHeaderStatus>
-              {profileCompletion?.complete ? (
-                <Badge variant="outline" className="border-success/40 bg-success/10 text-success">
-                  Profil aktualisiert
-                </Badge>
-              ) : null}
-            </div>
-          </div>
-        </PageHeader>
+          </PageHeader>
+        </div>
       </MembersContentHeader>
 
       <div className="space-y-10 pb-12">
-        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)]">
-          <Card className={cn(DASHBOARD_CARD_ACCENT, "relative overflow-hidden")}>
-            <div
-              aria-hidden
-              className="pointer-events-none absolute -left-24 -top-24 h-48 w-48 rounded-full bg-primary/20 opacity-60 blur-3xl dark:bg-primary/30"
+        <section className="space-y-6">
+          <div className="-mx-4 flex snap-x snap-mandatory gap-4 overflow-x-auto pb-2 lg:mx-0 lg:grid lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] lg:gap-6 lg:overflow-visible lg:pb-0">
+            <HomeHeroCard
+              className="min-w-[calc(100vw-2.5rem)] snap-start lg:min-w-0"
+              name={heroName}
+              connectionMeta={connectionMeta}
+              connectionBadgeClass={connectionBadgeClass}
+              quickActions={quickActions}
+              onRefresh={handleRefresh}
+              isRefreshing={isRefreshing}
+              isLoading={isLoading}
+              onlineCountLabel={formattedOnlineCount}
+              onlineUpdatedHint={onlineUpdatedHint}
             />
-            <div
-              aria-hidden
-              className="pointer-events-none absolute -right-24 bottom-0 h-44 w-44 rounded-full bg-emerald-300/25 opacity-70 blur-3xl dark:bg-emerald-500/20"
+            <TaskListCard
+              className="min-w-[calc(100vw-2.5rem)] snap-start lg:min-w-0"
+              tasks={dashboardTasks}
+              isLoading={isLoading}
+              isRefreshing={isRefreshing}
+              onRefresh={handleRefresh}
             />
-            <CardContent className="relative z-10 space-y-6 p-6">
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex items-center gap-4">
-                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-primary/40 bg-primary/10 text-primary">
-                    <Sparkles className="h-5 w-5" />
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-sm text-muted-foreground">Willkommen zurück</p>
-                    <h2 className="text-2xl font-semibold tracking-tight">
-                      {session?.user?.name || session?.user?.email || "Mitglied"}
-                    </h2>
-                  </div>
-                </div>
-                {onlineUsers.length ? (
-                  <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-gradient-to-r from-muted/20 via-background/85 to-background px-3 py-1 text-xs text-muted-foreground backdrop-blur">
-                    <Users className="h-3.5 w-3.5" />
-                    <span>{numberFormatter.format(onlineUsers.length)} online</span>
-                  </div>
-                ) : null}
-              </div>
-              <p className="max-w-2xl text-sm text-muted-foreground">
-                Halte Produktionen, Proben und Teamkommunikation im Blick. Nutze die Schnellaktionen für den direkten Einstieg.
-              </p>
-              <div className="flex flex-wrap items-center gap-3">
-                <div
-                  className={cn(
-                    "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium",
-                    connectionBadgeClass,
-                  )}
-                >
-                  {connectionMeta.icon}
-                  <span>{connectionMeta.label}</span>
-                </div>
-              </div>
-              {profileReminder ? <div>{profileReminder}</div> : null}
-            </CardContent>
-          </Card>
-          <Card className={cn(DASHBOARD_CARD_SURFACE, "relative overflow-hidden")}>
-            <div
-              aria-hidden
-              className="pointer-events-none absolute -right-24 top-1/2 h-44 w-44 -translate-y-1/2 rounded-full bg-primary/10 opacity-60 blur-3xl dark:bg-primary/20"
-            />
-            <CardHeader className="relative z-10 space-y-1 p-6 pb-4">
-              <CardTitle className="text-base font-semibold">Schnellaktionen</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Direkt zu den wichtigsten Bereichen springen.
-              </p>
-            </CardHeader>
-            <CardContent className="relative z-10 p-6 pt-0">
-              {quickActions.length ? (
-                <div className="grid gap-2 sm:grid-cols-2">
-                  {quickActions.map((link) => {
-                    const Icon = link.icon;
-                    return (
-                      <Link
-                        key={link.href}
-                        href={link.href}
-                        className="group relative flex items-center justify-between gap-3 overflow-hidden rounded-xl border border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background px-3 py-3 text-sm font-medium transition hover:border-primary/45 hover:bg-primary/5"
-                      >
-                        <span
-                          aria-hidden
-                          className="pointer-events-none absolute -right-12 -top-12 h-24 w-24 rounded-full bg-primary/10 opacity-0 transition duration-300 group-hover:opacity-80"
-                        />
-                        <span className="flex items-center gap-3">
-                          <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-background/80 text-muted-foreground transition group-hover:border-primary/45 group-hover:text-primary">
-                            <Icon className="h-4 w-4" />
-                          </span>
-                          {link.label}
-                        </span>
-                        <ArrowUpRight className="h-4 w-4 text-muted-foreground transition group-hover:text-primary" />
-                      </Link>
-                    );
-                  })}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">Keine Schnellaktionen verfügbar.</p>
-              )}
-            </CardContent>
-          </Card>
+          </div>
         </section>
 
-        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          {metrics.map((metric) => (
-            <Card
-              key={metric.key}
-              className={cn(
-                "rounded-2xl border",
-                METRIC_CARD_CLASSES[metric.tone],
-              )}
-            >
-              <CardHeader className="space-y-4 p-5">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="space-y-1">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/90">
-                      {metric.label}
-                    </p>
-                    <p className="text-2xl font-semibold tracking-tight">{metric.value}</p>
-                  </div>
-                  <div
-                    className={cn(
-                      "flex h-10 w-10 items-center justify-center rounded-xl border text-sm",
-                      METRIC_ICON_CLASSES[metric.tone],
-                    )}
-                  >
-                    {metric.icon}
-                  </div>
-                </div>
-                {metric.hint ? <p className="text-xs text-muted-foreground">{metric.hint}</p> : null}
-              </CardHeader>
-            </Card>
-          ))}
+        <section>
+          <div className="-mx-4 flex snap-x snap-mandatory gap-4 overflow-x-auto pb-2 sm:mx-0 sm:grid sm:grid-cols-2 sm:gap-4 sm:overflow-visible sm:pb-0 xl:grid-cols-4">
+            {metrics.map((metric) => (
+              <MetricCard key={metric.key} metric={metric} />
+            ))}
+          </div>
         </section>
 
-        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <div className="space-y-6">
-            {activeProductionCard}
+            <ProductionSwitcherCard
+              activeProduction={activeProduction}
+              activeMembership={activeMembership}
+              otherMemberships={otherMemberships}
+              canAccessProductions={canAccessProductions}
+              isLoaded={activeProductionLoaded}
+              hasError={activeProductionError}
+              onRetry={handleRefresh}
+              isRefreshing={isRefreshing}
+              connectionMeta={connectionMeta}
+            />
           </div>
           <div className="space-y-6 xl:self-start">
             <Card className={cn("relative overflow-hidden", DASHBOARD_CARD_SURFACE)}>
@@ -1216,49 +1096,635 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
               </CardContent>
             </Card>
 
-            <Card className={cn("relative overflow-hidden", DASHBOARD_CARD_SURFACE)}>
-              <div
-                aria-hidden
-                className="pointer-events-none absolute -left-24 top-0 h-40 w-40 rounded-full bg-primary/12 opacity-40 blur-3xl dark:bg-primary/20"
-              />
-              <CardHeader className="relative z-10 space-y-1 pb-4">
-                <CardTitle>Aktivitäten</CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  Neueste Proben, Zusagen und Benachrichtigungen.
-                </p>
-              </CardHeader>
-              <CardContent className="relative z-10 flex flex-col gap-4">
-                {isLoading && recentActivities.length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
-                    Lade Aktivitäten …
-                  </div>
-                ) : recentActivities.length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
-                    Noch keine Aktivitäten erfasst.
-                  </div>
-                ) : (
-                  <ul className="space-y-3">
-                    {recentActivities.map((activity) => (
-                      <li
-                        key={`${activity.id}-${activity.timestamp.getTime()}`}
-                        className="flex items-center gap-3 rounded-2xl border border-border/50 bg-gradient-to-r from-muted/20 via-background/90 to-background px-4 py-3"
-                      >
-                        <div className="flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-muted/40">
-                          {getActivityIcon(activity.type)}
-                        </div>
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">{activity.message}</p>
-                          <p className="text-xs text-muted-foreground">{formatTimeAgo(activity.timestamp)}</p>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </CardContent>
-            </Card>
+            <TimelineCard
+              activities={recentActivities}
+              isLoading={isLoading && recentActivities.length === 0}
+              isRefreshing={isRefreshing}
+              onRefresh={handleRefresh}
+              connectionMeta={connectionMeta}
+              getIcon={getActivityIcon}
+              formatTimestamp={formatTimeAgo}
+            />
           </div>
         </section>
       </div>
     </Fragment>
+  );
+}
+
+interface MetricCardProps {
+  metric: MetricItem;
+  className?: string;
+}
+
+function MetricCard({ metric, className }: MetricCardProps) {
+  const clampedProgress =
+    typeof metric.progress === "number"
+      ? Math.min(Math.max(metric.progress, 0), 1)
+      : undefined;
+  const progressPercent =
+    typeof clampedProgress === "number"
+      ? Math.round(clampedProgress * 100)
+      : undefined;
+  const cta = metric.cta;
+
+  const actionButton = cta
+    ? cta.href
+      ? (
+          <Button
+            size="xs"
+            variant="primary"
+            className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.6)]"
+            asChild
+          >
+            <Link href={cta.href}>{cta.label}</Link>
+          </Button>
+        )
+      : cta.onClick
+        ? (
+            <Button
+              size="xs"
+              variant="primary"
+              className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.6)]"
+              onClick={cta.onClick}
+            >
+              {cta.label}
+            </Button>
+          )
+        : null
+    : null;
+
+  return (
+    <Card
+      className={cn(
+        "min-w-[calc(100vw-2.5rem)] snap-start rounded-2xl border sm:min-w-0",
+        METRIC_CARD_CLASSES[metric.tone],
+        className,
+      )}
+    >
+      <CardHeader className="space-y-4 p-5 pb-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/90">
+              {metric.label}
+            </p>
+            <p className="text-2xl font-semibold tracking-tight">{metric.value}</p>
+          </div>
+          <div
+            className={cn(
+              "flex h-10 w-10 items-center justify-center rounded-xl border text-sm",
+              METRIC_ICON_CLASSES[metric.tone],
+            )}
+          >
+            {metric.icon}
+          </div>
+        </div>
+        {metric.hint ? <p className="text-xs text-muted-foreground">{metric.hint}</p> : null}
+      </CardHeader>
+      {(typeof clampedProgress === "number" || actionButton) && (
+        <CardContent className="flex flex-col gap-3 p-5 pt-0">
+          {typeof clampedProgress === "number" ? (
+            <div className="space-y-1.5">
+              <div
+                className={cn(
+                  "h-1.5 w-full overflow-hidden rounded-full",
+                  METRIC_PROGRESS_CLASSES[metric.tone],
+                )}
+              >
+                <div
+                  className={cn(
+                    "h-full rounded-full transition-[width]",
+                    METRIC_PROGRESS_INDICATOR_CLASSES[metric.tone],
+                  )}
+                  style={{ width: `${progressPercent}%` }}
+                  aria-hidden
+                />
+              </div>
+              <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+                {progressPercent}% Fortschritt
+              </span>
+            </div>
+          ) : null}
+          {actionButton ? <div className="pt-1">{actionButton}</div> : null}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+interface HomeHeroCardProps {
+  className?: string;
+  name: string;
+  connectionMeta: { state: "online" | "offline" | "warning" | "error"; icon: ReactNode; label: string };
+  connectionBadgeClass: string;
+  quickActions: QuickActionLink[];
+  onRefresh: () => void;
+  isRefreshing: boolean;
+  isLoading: boolean;
+  onlineCountLabel: string;
+  onlineUpdatedHint: string;
+}
+
+function HomeHeroCard({
+  className,
+  name,
+  connectionMeta,
+  connectionBadgeClass,
+  quickActions,
+  onRefresh,
+  isRefreshing,
+  isLoading,
+  onlineCountLabel,
+  onlineUpdatedHint,
+}: HomeHeroCardProps) {
+  const visibleActions = quickActions.slice(0, 4);
+
+  return (
+    <Card className={cn(DASHBOARD_CARD_ACCENT, "relative overflow-hidden", className)}>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-24 -top-24 h-48 w-48 rounded-full bg-primary/20 opacity-60 blur-3xl dark:bg-primary/30"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-24 bottom-0 h-44 w-44 rounded-full bg-emerald-300/25 opacity-70 blur-3xl dark:bg-emerald-500/20"
+      />
+      <CardContent className="relative z-10 flex h-full flex-col gap-6 p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">Willkommen zurück</p>
+            {isLoading ? (
+              <Skeleton className="h-7 w-40" />
+            ) : (
+              <h2 className="text-2xl font-semibold tracking-tight">{name}</h2>
+            )}
+            <p className="text-xs text-muted-foreground/80">{onlineUpdatedHint}</p>
+          </div>
+          <div className="flex flex-col items-end gap-2 text-xs">
+            <div
+              className={cn(
+                "inline-flex items-center gap-2 rounded-full border px-3 py-1 font-medium",
+                connectionBadgeClass,
+              )}
+            >
+              {connectionMeta.icon}
+              <span>{connectionMeta.label}</span>
+            </div>
+            <Button
+              size="xs"
+              variant="secondary"
+              onClick={onRefresh}
+              disabled={isRefreshing}
+              className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.45)]"
+            >
+              {isRefreshing ? "Aktualisiert …" : "Neu laden"}
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+          <Badge variant="outline" className="border-success/40 bg-success/10 text-success">
+            <Users className="mr-1 h-3.5 w-3.5" />
+            {onlineCountLabel} online
+          </Badge>
+          <span className="text-xs text-muted-foreground/80">
+            Tipp: Ziehe nach unten oder tippe auf „Neu laden“ für mobile Aktualisierung.
+          </span>
+        </div>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+              Schnellstart
+            </p>
+            <span className="text-[11px] text-muted-foreground/70">
+              {visibleActions.length ? "Wische für mehr" : "Keine Aktionen verfügbar"}
+            </span>
+          </div>
+          {isLoading ? (
+            <div className="-mx-1 flex snap-x gap-3 overflow-x-auto pb-1">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <Skeleton key={`hero-skeleton-${index}`} className="h-9 w-28 rounded-full" />
+              ))}
+            </div>
+          ) : visibleActions.length ? (
+            <div className="-mx-1 flex snap-x snap-mandatory gap-3 overflow-x-auto pb-1">
+              {visibleActions.map((action) => {
+                const ActionIcon = action.icon;
+                return (
+                  <Link
+                    key={action.href}
+                    href={action.href}
+                    className="snap-start rounded-full border border-border/50 bg-background/90 px-4 py-2 text-xs font-semibold text-foreground shadow-[0_12px_24px_-16px_rgba(15,23,42,0.5)] transition hover:border-primary/60 hover:bg-primary/5"
+                  >
+                    <span className="flex items-center gap-2">
+                      <ActionIcon className="h-4 w-4" />
+                      {action.label}
+                    </span>
+                  </Link>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="rounded-full border border-dashed border-border/60 bg-background/80 px-4 py-2 text-xs text-muted-foreground">
+              Keine Schnellaktionen verfügbar.
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface TaskListCardProps {
+  className?: string;
+  tasks: DashboardTask[];
+  isLoading: boolean;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+}
+
+function TaskListCard({ className, tasks, isLoading, isRefreshing, onRefresh }: TaskListCardProps) {
+  const hasTasks = tasks.length > 0;
+
+  return (
+    <Card className={cn(DASHBOARD_CARD_SURFACE, "relative overflow-hidden", className)}>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-24 top-0 h-44 w-44 rounded-full bg-warning/15 opacity-40 blur-3xl dark:bg-warning/20"
+      />
+      <CardHeader className="relative z-10 flex flex-row items-center justify-between gap-3 p-6 pb-4">
+        <div className="space-y-1">
+          <CardTitle className="text-base font-semibold">Aufgabenliste</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Bleib auf dem Laufenden und erledige offene Schritte.
+          </p>
+        </div>
+        <Button
+          size="xs"
+          variant="secondary"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.45)]"
+        >
+          {isRefreshing ? "Aktualisiert …" : "Neu laden"}
+        </Button>
+      </CardHeader>
+      <CardContent className="relative z-10 flex flex-col gap-4 p-6 pt-0">
+        {isLoading && !hasTasks ? (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <Skeleton key={`task-skeleton-${index}`} className="h-14 w-full rounded-2xl" />
+            ))}
+          </div>
+        ) : null}
+
+        {!isLoading && !hasTasks ? (
+          <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
+            Alles erledigt! Du bist startklar.
+          </div>
+        ) : null}
+
+        {hasTasks ? (
+          <ul className="space-y-3">
+            {tasks.map((task) => {
+              const progress =
+                typeof task.progress === "number"
+                  ? Math.min(Math.max(task.progress, 0), 1)
+                  : undefined;
+              const percentage =
+                typeof progress === "number"
+                  ? Math.round(progress * 100)
+                  : undefined;
+
+              return (
+                <li
+                  key={task.id}
+                  className="flex flex-col gap-3 rounded-2xl border border-border/60 bg-background/80 p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex items-start gap-3">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-muted/40 text-muted-foreground">
+                        {task.icon}
+                      </div>
+                      <div className="space-y-1">
+                        <p className="text-sm font-semibold text-foreground">{task.title}</p>
+                        <p className="text-xs text-muted-foreground">{task.description}</p>
+                      </div>
+                    </div>
+                    {task.status === "done" ? (
+                      <Badge variant="outline" className="border-success/40 bg-success/10 text-success">
+                        Erledigt
+                      </Badge>
+                    ) : null}
+                  </div>
+                  {typeof progress === "number" ? (
+                    <div className="space-y-1.5">
+                      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted/40">
+                        <div
+                          className="h-full rounded-full bg-primary transition-[width]"
+                          style={{ width: `${percentage}%` }}
+                          aria-hidden
+                        />
+                      </div>
+                      <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+                        {percentage}% abgeschlossen
+                      </span>
+                    </div>
+                  ) : null}
+                  {task.cta ? (
+                    <div className="pt-1">
+                      {task.cta.href ? (
+                        <Button
+                          size="xs"
+                          variant="secondary"
+                          className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.45)]"
+                          asChild
+                        >
+                          <Link href={task.cta.href}>{task.cta.label}</Link>
+                        </Button>
+                      ) : task.cta.onClick ? (
+                        <Button
+                          size="xs"
+                          variant="secondary"
+                          className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.45)]"
+                          onClick={task.cta.onClick}
+                        >
+                          {task.cta.label}
+                        </Button>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface TimelineCardProps {
+  activities: RecentActivity[];
+  isLoading: boolean;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+  connectionMeta: { state: "online" | "offline" | "warning" | "error"; icon: ReactNode; label: string };
+  getIcon: (type: RecentActivity["type"]) => ReactNode;
+  formatTimestamp: (date: Date) => string;
+  className?: string;
+}
+
+function TimelineCard({
+  activities,
+  isLoading,
+  isRefreshing,
+  onRefresh,
+  connectionMeta,
+  getIcon,
+  formatTimestamp,
+  className,
+}: TimelineCardProps) {
+  return (
+    <Card className={cn("relative overflow-hidden", DASHBOARD_CARD_SURFACE, className)}>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-24 top-0 h-40 w-40 rounded-full bg-primary/12 opacity-40 blur-3xl dark:bg-primary/20"
+      />
+      <CardHeader className="relative z-10 flex flex-row items-center justify-between gap-3 pb-4">
+        <div className="space-y-1">
+          <CardTitle>Aktivitäten</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Live-Updates aus Proben, Zusagen und Benachrichtigungen.
+          </p>
+        </div>
+        <Button
+          size="xs"
+          variant="secondary"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.45)]"
+        >
+          {isRefreshing ? "Aktualisiert …" : "Neu laden"}
+        </Button>
+      </CardHeader>
+      <CardContent className="relative z-10 flex flex-col gap-4 p-6 pt-0">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground/80">
+          {connectionMeta.icon}
+          <span>{connectionMeta.label}</span>
+        </div>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={`timeline-skeleton-${index}`} className="h-14 w-full rounded-2xl" />
+            ))}
+          </div>
+        ) : activities.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
+            Noch keine Aktivitäten erfasst.
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {activities.map((activity) => (
+              <li
+                key={`${activity.id}-${activity.timestamp.getTime()}`}
+                className="flex items-center gap-3 rounded-2xl border border-border/50 bg-gradient-to-r from-muted/20 via-background/90 to-background px-4 py-3"
+              >
+                <div className="flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-muted/40">
+                  {getIcon(activity.type)}
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">{activity.message}</p>
+                  <p className="text-xs text-muted-foreground">{formatTimestamp(activity.timestamp)}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface ProductionSwitcherCardProps {
+  activeProduction: ActiveProductionOverview | null;
+  activeMembership: ProductionMembershipSummary | null;
+  otherMemberships: ProductionMembershipSummary[];
+  canAccessProductions: boolean;
+  isLoaded: boolean;
+  hasError: boolean;
+  onRetry: () => void;
+  isRefreshing: boolean;
+  connectionMeta: { state: "online" | "offline" | "warning" | "error"; icon: ReactNode; label: string };
+}
+
+function ProductionSwitcherCard({
+  activeProduction,
+  activeMembership,
+  otherMemberships,
+  canAccessProductions,
+  isLoaded,
+  hasError,
+  onRetry,
+  isRefreshing,
+  connectionMeta,
+}: ProductionSwitcherCardProps) {
+  if (!isLoaded) {
+    return (
+      <Card className="rounded-3xl border border-dashed border-border/60 bg-card p-6">
+        <div className="space-y-3">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-64" />
+          <Skeleton className="h-4 w-full" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <Card className="rounded-3xl border border-destructive/40 bg-destructive/10 text-destructive">
+        <CardContent className="space-y-3 p-6">
+          <p className="text-sm font-semibold">Aktive Produktion konnte nicht geladen werden.</p>
+          <p className="text-xs text-destructive/80">
+            Bitte versuche es erneut. Bei anhaltenden Problemen kontaktiere die Produktionsleitung.
+          </p>
+          <Button
+            size="xs"
+            variant="secondary"
+            onClick={onRetry}
+            className="rounded-full shadow-[0_14px_34px_-18px_rgba(127,29,29,0.45)]"
+          >
+            Erneut laden
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const membershipBadges = otherMemberships.slice(0, 4);
+
+  const statusBadgeLabel = activeMembership?.isActive === false ? "Archiviert" : "Aktiv";
+  const statusBadgeClass = activeMembership?.isActive === false
+    ? "border-border/60 text-muted-foreground"
+    : "border-primary/40 bg-primary/10 text-primary";
+
+  const joinedLabel = formatDateLocalized(activeMembership?.joinedAt ?? null);
+  const leftLabel = formatDateLocalized(activeMembership?.leftAt ?? null);
+
+  let membershipSubtitle: string | null = null;
+  if (activeMembership?.isActive) {
+    membershipSubtitle = joinedLabel ? `Seit ${joinedLabel} Teil der Produktion.` : "Mitgliedschaft aktiv.";
+  } else if (activeMembership) {
+    membershipSubtitle = joinedLabel && leftLabel
+      ? `Von ${joinedLabel} bis ${leftLabel} aktiv.`
+      : leftLabel
+        ? `Mitgliedschaft beendet am ${leftLabel}.`
+        : "Mitgliedschaft archiviert.";
+  }
+
+  return (
+    <Card className={cn(DASHBOARD_CARD_SURFACE, "relative overflow-hidden")}>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-28 -top-16 h-48 w-48 rounded-full bg-primary/10 opacity-40 blur-3xl dark:bg-primary/20"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -left-24 bottom-0 h-44 w-44 rounded-full bg-amber-200/20 opacity-40 blur-3xl dark:bg-amber-500/20"
+      />
+      <CardHeader className="relative z-10 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <CardTitle className="text-lg font-semibold">
+            {activeProduction ? "Aktive Produktion" : "Keine aktive Produktion ausgewählt"}
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {activeProduction
+              ? `Du arbeitest aktuell in ${formatProductionName(activeProduction)}.`
+              : "Wähle eine Produktion, um Rollen und Planungen einzusehen."}
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-2">
+          <Badge variant="outline" className={statusBadgeClass}>
+            {statusBadgeLabel}
+          </Badge>
+          <span className="text-[11px] text-muted-foreground/80">
+            {connectionMeta.label}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="relative z-10 space-y-4">
+        {activeProduction ? (
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">{formatProductionName(activeProduction)}</p>
+            <p className="text-xs text-muted-foreground">
+              {membershipSubtitle ?? "Mitgliedschaft wird automatisch verwaltet."}
+            </p>
+          </div>
+        ) : null}
+
+        {membershipBadges.length ? (
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
+              Weitere Produktionen
+            </p>
+            <div className="flex flex-wrap gap-2">
+            {membershipBadges.map((membership) => {
+              const membershipLeftLabel = formatDateLocalized(membership.leftAt);
+              return (
+                <Badge
+                  key={`membership-${membership.showId}`}
+                  variant="outline"
+                  className={cn(
+                    "border-border/60 bg-card text-foreground",
+                    membership.isActive && "border-primary/40 bg-primary/10 text-primary",
+                  )}
+                >
+                  <span className="font-medium">{formatProductionName(membership)}</span>
+                  <span className="ml-1 text-[11px] text-muted-foreground">
+                    {membership.isActive ? "• aktiv" : membershipLeftLabel ? `• bis ${membershipLeftLabel}` : "• archiviert"}
+                  </span>
+                </Badge>
+              );
+            })}
+            </div>
+            {otherMemberships.length > membershipBadges.length ? (
+              <p className="text-[11px] text-muted-foreground">
+                + {otherMemberships.length - membershipBadges.length} weitere im Archiv
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        <p className="text-xs text-muted-foreground">
+          Profilangaben gelten produktonsübergreifend und bleiben für kommende Produktionen gespeichert.
+        </p>
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          {canAccessProductions && activeProduction ? (
+            <Button
+              asChild
+              size="xs"
+              className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.45)]"
+              disabled={isRefreshing}
+            >
+              <Link href={`/mitglieder/produktionen/${activeProduction.id}`}>Arbeitsbereich öffnen</Link>
+            </Button>
+          ) : null}
+          {canAccessProductions ? (
+            <Button
+              asChild
+              size="xs"
+              variant="secondary"
+              className="rounded-full shadow-[0_14px_34px_-18px_rgba(15,23,42,0.45)]"
+              disabled={isRefreshing}
+            >
+              <Link href="/mitglieder/produktionen">
+                {activeProduction ? "Produktion wechseln" : "Produktion auswählen"}
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary
- refactor the members dashboard into modular cards with swipe-friendly mobile layouts and realtime hooks
- enhance KPI widgets with progress, CTA chips, and refreshed task aggregation for profile, notifications, and rehearsals

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dce143d150832d99db20e383ce852e