### PR TITLE
Restrict latest Docker image builds to production updates

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - production
     paths:
       - '.github/workflows/docker-publish.yml'
       - 'Dockerfile.dev'
@@ -56,7 +57,7 @@ jobs:
               GIT_COMMIT_SHA=${{ github.sha }}
             metadata_tags: |
               type=raw,value=prod
-          - branch: main
+          - branch: production
             environment: latest
             dockerfile: Dockerfile.prod
             build_args: |


### PR DESCRIPTION
## Summary
- trigger the docker publish workflow when the production branch updates
- limit the latest-tag matrix entry to run only for the production branch

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dcfce5680c832d933129460928211b