### PR TITLE
Wrap members template stories with SidebarProvider

### DIFF
--- a/src/components/members/templates/__stories__/members-templates.stories.tsx
+++ b/src/components/members/templates/__stories__/members-templates.stories.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/members/templates";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { SidebarProvider } from "@/components/ui/sidebar";
 
 type StoryMeta = {
   title: string;
@@ -36,13 +37,15 @@ export default meta;
 function TemplatePreviewShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen bg-background">
-      <MembersAppShell
-        permissions={[]}
-        assignmentFocus="none"
-        hasDepartmentMemberships={false}
-      >
-        {children}
-      </MembersAppShell>
+      <SidebarProvider defaultOpen defaultOpenMobile={false}>
+        <MembersAppShell
+          permissions={[]}
+          assignmentFocus="none"
+          hasDepartmentMemberships={false}
+        >
+          {children}
+        </MembersAppShell>
+      </SidebarProvider>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap the members template story shell in SidebarProvider so previewed templates receive sidebar context
- keep the story renderers unchanged while providing sensible desktop/mobile defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0cef2718832dbea31511a1f2aaed