### PR TITLE
Fix layout container sizing to prevent downscaling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -298,7 +298,9 @@
   }
 
   .layout-container {
-    width: min(100%, calc(var(--layout-max-width) + 2 * var(--layout-gutter)));
+    box-sizing: border-box;
+    width: 100%;
+    max-width: calc(var(--layout-max-width) + 2 * var(--layout-gutter));
     margin-inline: auto;
     padding-inline: var(--layout-gutter);
     container-type: inline-size;
@@ -306,6 +308,7 @@
   }
 
   .members-container {
+    box-sizing: border-box;
     width: 100%;
     margin-inline: auto;
     --members-max-width: calc(var(--layout-max-width) + 2 * var(--layout-gutter));


### PR DESCRIPTION
## Summary
- adjust `.layout-container` sizing to use border-box width and explicit max-width
- align `.members-container` sizing with border-box to preserve expected widths at all breakpoints

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dd34b6d5a8832d95562fad98f76d63