### PR TITLE
Add icons and badges to navigation entries

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -2,10 +2,15 @@ import Link from "next/link";
 
 import { BuildInfoTimestamp } from "@/components/build-info-timestamp";
 import {
+  type NavigationBadgeVariant,
+  type NavigationItem,
+  type NavigationItemTone,
   ctaNavigation,
   primaryNavigation,
   secondaryNavigation,
 } from "@/config/navigation";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
 type CommitInfo = {
   short: string;
@@ -23,6 +28,61 @@ type SiteFooterProps = {
   isDevBuild: boolean;
   siteTitle: string;
 };
+
+const footerIconToneClasses: Record<NavigationItemTone, string> = {
+  default: "text-muted-foreground",
+  muted: "text-muted-foreground",
+  primary: "text-primary",
+  success: "text-success",
+  info: "text-info",
+  warning: "text-warning",
+  destructive: "text-destructive",
+};
+
+const footerBadgeToneFallback: Partial<
+  Record<NavigationItemTone, NavigationBadgeVariant>
+> = {
+  muted: "muted",
+  primary: "default",
+  success: "success",
+  info: "info",
+  warning: "warning",
+  destructive: "destructive",
+};
+
+function renderFooterNavigationIcon(item: NavigationItem) {
+  const IconComponent = item.icon ?? item.activeIcon;
+  if (!IconComponent) {
+    return null;
+  }
+
+  const tone = item.tone ?? "default";
+  return (
+    <IconComponent
+      aria-hidden
+      className={cn("h-4 w-4 shrink-0", footerIconToneClasses[tone])}
+    />
+  );
+}
+
+function renderFooterNavigationBadge(item: NavigationItem) {
+  if (!item.badge) {
+    return null;
+  }
+
+  const tone = item.tone ?? "default";
+  const variant = item.badge.variant ?? footerBadgeToneFallback[tone] ?? "accent";
+
+  return (
+    <Badge
+      variant={variant}
+      size={item.badge.size ?? "sm"}
+      className="whitespace-nowrap"
+    >
+      {item.badge.label}
+    </Badge>
+  );
+}
 
 export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps) {
   const currentYear = new Date().getFullYear();
@@ -79,8 +139,16 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
               <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
                 {primaryNavigation.map((item) => (
                   <li key={item.href}>
-                    <Link className="transition-colors hover:text-primary" href={item.href}>
-                      {item.label}
+                    <Link
+                      className={cn(
+                        "flex items-center gap-2 transition-colors hover:text-primary",
+                        item.badge ? "flex-wrap" : undefined,
+                      )}
+                      href={item.href}
+                    >
+                      {renderFooterNavigationIcon(item)}
+                      <span>{item.label}</span>
+                      {renderFooterNavigationBadge(item)}
                     </Link>
                   </li>
                 ))}
@@ -94,8 +162,16 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
               <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
                 {secondaryNavigation.map((item) => (
                   <li key={item.href}>
-                    <Link className="transition-colors hover:text-primary" href={item.href}>
-                      {item.label}
+                    <Link
+                      className={cn(
+                        "flex items-center gap-2 transition-colors hover:text-primary",
+                        item.badge ? "flex-wrap" : undefined,
+                      )}
+                      href={item.href}
+                    >
+                      {renderFooterNavigationIcon(item)}
+                      <span>{item.label}</span>
+                      {renderFooterNavigationBadge(item)}
                     </Link>
                   </li>
                 ))}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -15,7 +15,13 @@ import { useSession } from "next-auth/react";
 
 import { NotificationBell } from "@/components/notification-bell";
 import { UserNav } from "@/components/user-nav";
-import { ctaNavigation, primaryNavigation } from "@/config/navigation";
+import {
+  type NavigationBadgeVariant,
+  type NavigationItem,
+  type NavigationItemTone,
+  ctaNavigation,
+  primaryNavigation,
+} from "@/config/navigation";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,6 +29,7 @@ import {
   SheetContent,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
 
 const HEADER_SPACING = {
   gradientHeight: "var(--header-gradient-height)",
@@ -106,6 +113,71 @@ const drawerCtaPaddingStyles = {
 const heroGradientStyles = {
   height: HEADER_SPACING.gradientHeight,
 } satisfies CSSProperties;
+
+const navigationIconToneClasses: Record<NavigationItemTone, string> = {
+  default: "text-foreground/70",
+  muted: "text-muted-foreground",
+  primary: "text-[var(--primary)]",
+  success: "text-success",
+  info: "text-info",
+  warning: "text-warning",
+  destructive: "text-destructive",
+};
+
+const badgeToneFallback: Partial<
+  Record<NavigationItemTone, NavigationBadgeVariant>
+> = {
+  muted: "muted",
+  primary: "default",
+  success: "success",
+  info: "info",
+  warning: "warning",
+  destructive: "destructive",
+};
+
+function getNavigationIcon(
+  item: NavigationItem,
+  { isActive }: { isActive: boolean },
+) {
+  const IconComponent =
+    (isActive ? item.activeIcon ?? item.icon : item.icon) ?? item.activeIcon;
+
+  if (!IconComponent) {
+    return null;
+  }
+
+  const tone = item.tone ?? "default";
+  const toneClass = navigationIconToneClasses[tone];
+
+  return (
+    <IconComponent
+      aria-hidden
+      className={cn(
+        "h-4 w-4 shrink-0 transition-colors duration-300",
+        isActive ? "text-[var(--primary)]" : toneClass,
+      )}
+    />
+  );
+}
+
+function getNavigationBadge(item: NavigationItem) {
+  if (!item.badge) {
+    return null;
+  }
+
+  const tone = item.tone ?? "default";
+  const variant = item.badge.variant ?? badgeToneFallback[tone] ?? "accent";
+
+  return (
+    <Badge
+      variant={variant}
+      size={item.badge.size ?? "sm"}
+      className="whitespace-nowrap"
+    >
+      {item.badge.label}
+    </Badge>
+  );
+}
 
 export function SiteHeader({ siteTitle }: { siteTitle: string }) {
   const headerRef = useRef<HTMLElement | null>(null);
@@ -229,7 +301,11 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
           <div className="hidden items-center gap-[var(--space-md)] md:flex">
             {navigationItems.map((item) => {
               const isActive =
-                pathname === item.href || pathname?.startsWith(`${item.href}/`);
+                pathname === item.href ||
+                Boolean(pathname?.startsWith(`${item.href}/`));
+
+              const iconElement = getNavigationIcon(item, { isActive });
+              const badgeElement = getNavigationBadge(item);
 
               return (
                 <Link
@@ -241,13 +317,16 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
                     "data-[active=true]:font-semibold data-[active=true]:text-[var(--primary)] data-[active=true]:after:scale-x-100",
                     scrolled || !isHomePage
                       ? "text-foreground/90"
-                      : "text-foreground/90 drop-shadow-lg"
+                      : "text-foreground/90 drop-shadow-lg",
+                    iconElement || badgeElement ? "gap-2" : undefined,
                   )}
                   href={item.href}
                   aria-current={isActive ? "page" : undefined}
                   data-active={isActive ? "true" : undefined}
                 >
-                  {item.label}
+                  {iconElement}
+                  <span>{item.label}</span>
+                  {badgeElement}
                 </Link>
               );
             })}
@@ -329,7 +408,11 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
         >
           {navigationItems.map((item) => {
             const isActive =
-              pathname === item.href || pathname?.startsWith(`${item.href}/`);
+              pathname === item.href ||
+              Boolean(pathname?.startsWith(`${item.href}/`));
+
+            const iconElement = getNavigationIcon(item, { isActive });
+            const badgeElement = getNavigationBadge(item);
 
             return (
               <Link
@@ -337,22 +420,32 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
                 onClick={() => setOpen(false)}
                 style={drawerLinkPaddingStyles}
                 className={cn(
-                  "block rounded-lg text-foreground/90 transition-colors duration-200 hover:bg-accent/30 hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                  "flex items-start gap-3 rounded-lg text-foreground/90 transition-colors duration-200 hover:bg-accent/30 hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                   "data-[active=true]:bg-accent/20 data-[active=true]:font-semibold data-[active=true]:text-[var(--primary)] data-[active=true]:ring-1 data-[active=true]:ring-inset data-[active=true]:ring-[var(--primary)]"
                 )}
                 href={item.href}
                 aria-current={isActive ? "page" : undefined}
                 data-active={isActive ? "true" : undefined}
               >
-                <span className="block font-medium">{item.label}</span>
-                {item.description ? (
-                  <span
-                    style={drawerLinkDescriptionStyles}
-                    className="block text-sm text-muted-foreground"
-                  >
-                    {item.description}
+                {iconElement ? (
+                  <span className="mt-0.5 flex h-5 w-5 items-center justify-center">
+                    {iconElement}
                   </span>
                 ) : null}
+                <span className="flex flex-1 flex-col">
+                  <span className="flex items-center gap-2 font-medium">
+                    <span>{item.label}</span>
+                    {badgeElement}
+                  </span>
+                  {item.description ? (
+                    <span
+                      style={drawerLinkDescriptionStyles}
+                      className="mt-1 text-sm text-muted-foreground"
+                    >
+                      {item.description}
+                    </span>
+                  ) : null}
+                </span>
               </Link>
             );
           })}

--- a/src/config/__stories__/navigation.stories.tsx
+++ b/src/config/__stories__/navigation.stories.tsx
@@ -1,0 +1,82 @@
+import type {
+  NavigationBadgeVariant,
+  NavigationItem,
+  NavigationItemTone,
+} from "@/config/navigation";
+import { primaryNavigation, secondaryNavigation } from "@/config/navigation";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+const iconToneClasses: Record<NavigationItemTone, string> = {
+  default: "text-foreground/70",
+  muted: "text-muted-foreground",
+  primary: "text-[var(--primary)]",
+  success: "text-success",
+  info: "text-info",
+  warning: "text-warning",
+  destructive: "text-destructive",
+};
+
+const badgeToneFallback: Partial<
+  Record<NavigationItemTone, NavigationBadgeVariant>
+> = {
+  muted: "muted",
+  primary: "default",
+  success: "success",
+  info: "info",
+  warning: "warning",
+  destructive: "destructive",
+};
+
+function NavigationList({ items }: { items: NavigationItem[] }) {
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => {
+        const IconComponent = item.icon ?? item.activeIcon;
+        const tone = item.tone ?? "default";
+        const badgeVariant = item.badge?.variant ?? badgeToneFallback[tone] ?? "accent";
+
+        return (
+          <li key={item.href} className="flex flex-col gap-1 rounded-lg border border-border/60 bg-card/70 p-4">
+            <div className="flex items-center gap-3">
+              {IconComponent ? (
+                <IconComponent
+                  aria-hidden
+                  className={cn("h-5 w-5", iconToneClasses[tone])}
+                />
+              ) : null}
+              <span className="text-sm font-semibold text-foreground">{item.label}</span>
+              {item.badge ? (
+                <Badge variant={badgeVariant} size={item.badge.size ?? "sm"}>
+                  {item.badge.label}
+                </Badge>
+              ) : null}
+            </div>
+            {item.description ? (
+              <p className="text-sm text-muted-foreground">{item.description}</p>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+const title = "Config/Navigation";
+
+const meta = { title };
+
+export default meta;
+
+export const Overview = () => (
+  <div className="space-y-8 p-6">
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground">Primäre Navigation</h2>
+      <NavigationList items={primaryNavigation} />
+    </section>
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-muted-foreground">Sekundäre Navigation</h2>
+      <NavigationList items={secondaryNavigation} />
+    </section>
+  </div>
+);

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,29 +1,94 @@
+import type { JSX } from "react";
+import type { LucideIcon } from "lucide-react";
+
+export type NavigationItemTone =
+  | "default"
+  | "muted"
+  | "primary"
+  | "success"
+  | "info"
+  | "warning"
+  | "destructive";
+
+export type NavigationBadgeVariant =
+  | "default"
+  | "secondary"
+  | "accent"
+  | "muted"
+  | "success"
+  | "warning"
+  | "info"
+  | "destructive"
+  | "outline"
+  | "ghost";
+
+export type NavigationBadgeSize = "sm" | "md" | "lg";
+
+export type NavigationItemBadge = {
+  label: string;
+  variant?: NavigationBadgeVariant;
+  size?: NavigationBadgeSize;
+};
+
+export type NavigationIconComponent =
+  | LucideIcon
+  | ((props: { className?: string }) => JSX.Element);
+
 export type NavigationItem = {
   label: string;
   href: string;
   description?: string;
+  icon?: NavigationIconComponent;
+  activeIcon?: NavigationIconComponent;
+  tone?: NavigationItemTone;
+  badge?: NavigationItemBadge;
 };
+
+import {
+  BookMarked,
+  Cat,
+  History,
+  LogIn,
+  Mail,
+  ScrollText,
+  Sparkles,
+  Users2,
+} from "lucide-react";
 
 export const primaryNavigation: NavigationItem[] = [
   {
     label: "Über uns",
     href: "/ueber-uns",
     description: "Lerne Ensemble, Geschichte und Werte des Sommertheaters kennen.",
+    icon: Users2,
+    activeIcon: BookMarked,
+    tone: "primary",
   },
   {
     label: "Das Geheimnis",
     href: "/mystery",
     description: "Tauche in die Welt hinter dem mystischen Vorhang ein.",
+    icon: Sparkles,
+    tone: "info",
+    badge: {
+      label: "Neu",
+      variant: "info",
+      size: "sm",
+    },
   },
   {
     label: "Unsere Schulkatze",
     href: "/unsere-schulkatze",
     description: "Lerne Minna kennen – Pausenbegleiterin und Herz unserer Schule.",
+    icon: Cat,
+    tone: "success",
   },
   {
     label: "Chronik",
     href: "/chronik",
     description: "Alle Meilensteine und Produktionen der vergangenen Jahre.",
+    icon: History,
+    tone: "muted",
   },
 ];
 
@@ -31,14 +96,24 @@ export const secondaryNavigation: NavigationItem[] = [
   {
     label: "Login",
     href: "/login",
+    icon: LogIn,
+    tone: "primary",
   },
   {
     label: "Newsletter",
     href: "/onboarding",
+    icon: Mail,
+    badge: {
+      label: "Beliebt",
+      variant: "accent",
+      size: "sm",
+    },
   },
   {
     label: "Impressum",
     href: "/impressum",
+    icon: ScrollText,
+    tone: "muted",
   },
 ];
 


### PR DESCRIPTION
## Summary
- extend the navigation config with tone, badge and icon metadata backed by lucide-react icons
- render the optional icons and badges in the site header and footer with tone-aware styling
- add a navigation story to preview the enriched navigation items for Storybook

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build


------
https://chatgpt.com/codex/tasks/task_e_68de538a669c832db56b115238137de0