### PR TITLE
Remove unread notifications card from dashboard

### DIFF
--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -743,14 +743,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         icon: <Calendar className="h-4 w-4" />,
         tone: "accent",
       },
-      {
-        key: "notifications",
-        label: "Ungelesene Benachrichtigungen",
-        value: numberFormatter.format(stats.unreadNotifications),
-        hint: "Wer zuerst liest, ist informiert",
-        icon: <Bell className="h-4 w-4" />,
-        tone: stats.unreadNotifications > 0 ? "warning" : "neutral",
-      },
     ];
 
     if (finalRehearsalMetric) {
@@ -784,7 +776,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     stats.rehearsalsThisWeek,
     stats.totalMembers,
     stats.totalOnline,
-    stats.unreadNotifications,
   ]);
 
   const profileReminder = useMemo(() => {


### PR DESCRIPTION
## Summary
- remove the unread notifications metric card from the members dashboard overview
- keep dashboard metrics memoization dependencies in sync after removal

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68decee9a850832da99cc40e6920a5b6