### PR TITLE
Remove unread notifications card from members dashboard

### DIFF
--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -743,14 +743,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         icon: <Calendar className="h-4 w-4" />,
         tone: "accent",
       },
-      {
-        key: "notifications",
-        label: "Ungelesene Benachrichtigungen",
-        value: numberFormatter.format(stats.unreadNotifications),
-        hint: "Wer zuerst liest, ist informiert",
-        icon: <Bell className="h-4 w-4" />,
-        tone: stats.unreadNotifications > 0 ? "warning" : "neutral",
-      },
     ];
 
     if (finalRehearsalMetric) {
@@ -784,7 +776,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     stats.rehearsalsThisWeek,
     stats.totalMembers,
     stats.totalOnline,
-    stats.unreadNotifications,
   ]);
 
   const profileReminder = useMemo(() => {


### PR DESCRIPTION
## Summary
- remove the "Ungelesene Benachrichtigungen" metric card from the members dashboard metrics list
- update the metrics memo dependencies to reflect the removed card

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ded38b6794832da7bbbca16e818c1e