### PR TITLE
Add dedicated calendar permission

### DIFF
--- a/src/app/(members)/mitglieder/kalender/page.tsx
+++ b/src/app/(members)/mitglieder/kalender/page.tsx
@@ -42,7 +42,7 @@ export const dynamic = "force-dynamic";
 
 export default async function MitgliederKalenderPage() {
   const session = await requireAuth();
-  const allowed = await hasPermission(session.user, "mitglieder.meine-proben");
+  const allowed = await hasPermission(session.user, "mitglieder.kalender");
   if (!allowed) {
     return (
       <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">

--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -150,7 +150,7 @@ const QUICK_ACTION_LINKS = [
     href: "/mitglieder/kalender",
     label: "Kalender",
     icon: CalendarRange,
-    permissionKey: "mitglieder.meine-proben",
+    permissionKey: "mitglieder.kalender",
   },
   {
     href: "/mitglieder/meine-proben",

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -445,7 +445,7 @@ export const membersNavigation = [
       {
         href: "/mitglieder/kalender",
         label: "Kalender",
-        permissionKey: "mitglieder.meine-proben",
+        permissionKey: "mitglieder.kalender",
         icon: PersonalCalendarIcon,
       },
       {

--- a/src/lib/__tests__/members-navigation.test.ts
+++ b/src/lib/__tests__/members-navigation.test.ts
@@ -20,6 +20,7 @@ const BASE_PERMISSIONS = [
   "mitglieder.galerie",
   "mitglieder.sperrliste",
   "mitglieder.issues",
+  "mitglieder.kalender",
   "mitglieder.meine-proben",
   "mitglieder.meine-gewerke",
   "mitglieder.koerpermasse",
@@ -109,9 +110,10 @@ describe("resolveAssignmentsGroupLabel", () => {
 
   it("infers label from permissions when focus is none", () => {
     expect(
-      resolveAssignmentsGroupLabel("none", ["mitglieder.meine-gewerke", "mitglieder.meine-proben"]),
+      resolveAssignmentsGroupLabel("none", ["mitglieder.meine-gewerke", "mitglieder.kalender"]),
     ).toBe("Proben & Gewerke");
     expect(resolveAssignmentsGroupLabel("none", ["mitglieder.meine-gewerke"])).toBe("Gewerke");
+    expect(resolveAssignmentsGroupLabel("none", ["mitglieder.kalender"])).toBe("Proben");
     expect(resolveAssignmentsGroupLabel("none", [])).toBe("Proben");
   });
 });

--- a/src/lib/members-navigation.ts
+++ b/src/lib/members-navigation.ts
@@ -120,7 +120,9 @@ export function resolveAssignmentsGroupLabel(
 
   const permissionSet =
     permissions instanceof Set ? permissions : new Set(permissions ?? []);
-  const canSeeRehearsals = permissionSet.has("mitglieder.meine-proben");
+  const canSeeRehearsals =
+    permissionSet.has("mitglieder.meine-proben") ||
+    permissionSet.has("mitglieder.kalender");
   const canSeeDepartments = permissionSet.has("mitglieder.meine-gewerke");
 
   if (canSeeRehearsals && canSeeDepartments) return "Proben & Gewerke";

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -55,6 +55,13 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { key: "mitglieder.profil", label: "Profilbereich aufrufen", category: "base" },
   { key: "mitglieder.scan", label: "Scanner & Check-in nutzen", category: "base" },
   {
+    key: "mitglieder.kalender",
+    label: "Kalender öffnen",
+    description:
+      "Persönliche Proben, Gewerke-Termine und Blocker im Mitgliederkalender betrachten.",
+    category: "self",
+  },
+  {
     key: "mitglieder.inventaraufkleber",
     label: "Inventaraufkleber erstellen",
     description: "Druckfertige Inventaraufkleber mit QR-Codes erstellen und exportieren.",


### PR DESCRIPTION
## Summary
- add a dedicated `mitglieder.kalender` permission to the registry and gate the calendar route against it
- update dashboard quick actions, navigation, and tests to recognise the new calendar permission

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ded3873624832d9c8ce21b5967c850