### PR TITLE
Update impersonation redirect to refresh current view

### DIFF
--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/impersonation-button.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/impersonation-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { useMemo, useTransition } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -10,31 +10,46 @@ import { startImpersonationAction } from "./actions";
 type ImpersonationButtonProps = {
   targetUserId: string;
   targetName: string;
-  redirectTo?: string;
+  redirectTo?: string | null;
   disabled?: boolean;
 };
 
 export function ImpersonationButton({
   targetUserId,
   targetName,
-  redirectTo = "/",
+  redirectTo,
   disabled = false,
 }: ImpersonationButtonProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
+
+  const currentLocation = useMemo(() => {
+    const basePath = pathname || "/";
+    const search = searchParams?.toString() ?? "";
+    return search ? `${basePath}?${search}` : basePath;
+  }, [pathname, searchParams]);
+
+  const redirectTarget = useMemo(() => {
+    if (typeof redirectTo === "string" && redirectTo.startsWith("/")) {
+      return redirectTo;
+    }
+    return currentLocation;
+  }, [currentLocation, redirectTo]);
 
   const handleClick = () => {
     startTransition(async () => {
       const result = await startImpersonationAction({
         targetUserId,
-        redirectTo,
+        redirectTo: redirectTarget,
       });
       if (!result.ok) {
         toast.error(result.error ?? "Aktion konnte nicht ausgeführt werden.");
         return;
       }
       toast.success(`Ansicht als ${targetName} aktiviert.`);
-      if (result.redirectTo) {
+      if (result.redirectTo && result.redirectTo !== currentLocation) {
         router.push(result.redirectTo);
       }
       router.refresh();


### PR DESCRIPTION
## Summary
- derive the impersonation redirect target from the current location so the session switch is reflected immediately
- skip redundant navigation and refresh the router after the server action to avoid manual reloads

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ded3ada604832da03012c20cc96e15