### PR TITLE
Remove production and activity cards from members dashboard

### DIFF
--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -3,11 +3,7 @@
 import { Fragment, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import {
-  useRealtime,
-  useNotificationRealtime,
-  useRehearsalRealtime,
-} from "@/hooks/useRealtime";
+import { useRealtime, useNotificationRealtime } from "@/hooks/useRealtime";
 import { useOnlineStats } from "@/hooks/useOnlineStats";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -27,7 +23,6 @@ import {
   Calendar,
   Wifi,
   WifiOff,
-  Bell,
   CheckCircle2,
   Sparkles,
   UserRound,
@@ -43,13 +38,6 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-interface RecentActivity {
-  id: string;
-  type: "notification" | "rehearsal" | "attendance";
-  message: string;
-  timestamp: Date;
-}
 
 interface DashboardStats {
   totalOnline: number;
@@ -124,21 +112,6 @@ interface MembersDashboardProps {
   permissions?: readonly string[];
 }
 
-type ActiveProductionOverview = {
-  id: string;
-  title: string | null;
-  year: number;
-};
-
-type ProductionMembershipSummary = {
-  showId: string;
-  title: string | null;
-  year: number;
-  joinedAt: Date | null;
-  leftAt: Date | null;
-  isActive: boolean;
-};
-
 const QUICK_ACTION_LINKS = [
   {
     href: "/mitglieder/profil",
@@ -210,61 +183,12 @@ type OverviewStatsPayload = {
 
 type OverviewResponse = {
   stats?: OverviewStatsPayload;
-  recentActivities?: unknown;
   finalRehearsalWeek?: unknown;
   profileCompletion?: unknown;
-  activeProduction?: unknown;
-  productionMemberships?: unknown;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
-}
-
-function parseRecentActivities(value: unknown): RecentActivity[] {
-  if (!Array.isArray(value)) return [];
-
-  const fallbackTimestamp = () => new Date();
-
-  return value
-    .map((entry) => {
-      if (!isRecord(entry)) return null;
-
-      const rawId = entry.id;
-      const rawType = entry.type;
-      const rawMessage = entry.message;
-      const rawTimestamp = entry.timestamp;
-
-      const timestampCandidate =
-        typeof rawTimestamp === "string" || rawTimestamp instanceof Date
-          ? new Date(rawTimestamp)
-          : fallbackTimestamp();
-      const timestamp = Number.isNaN(timestampCandidate.getTime())
-        ? fallbackTimestamp()
-        : timestampCandidate;
-
-      let id: string;
-      if (typeof rawId === "string" && rawId.trim()) {
-        id = rawId;
-      } else if (typeof rawId === "number" && Number.isFinite(rawId)) {
-        id = String(rawId);
-      } else {
-        id = `activity_${timestamp.getTime()}`;
-      }
-
-      const message = typeof rawMessage === "string" && rawMessage.trim()
-        ? rawMessage
-        : "Aktualisierung";
-
-      const type: RecentActivity["type"] =
-        rawType === "rehearsal" || rawType === "attendance" || rawType === "notification"
-          ? rawType
-          : "notification";
-
-      return { id, type, message, timestamp } satisfies RecentActivity;
-    })
-    .filter((entry): entry is RecentActivity => entry !== null)
-    .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
 }
 
 function parseIsoDate(value: unknown): Date | null {
@@ -327,90 +251,6 @@ function parseProfileCompletion(value: unknown):
   return { complete, completed, total };
 }
 
-function parseActiveProduction(value: unknown): ActiveProductionOverview | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const rawId = value.id;
-  const rawTitle = value.title;
-  const rawYear = value.year;
-
-  if (typeof rawId !== "string" || !rawId) {
-    return null;
-  }
-
-  if (typeof rawYear !== "number" || !Number.isFinite(rawYear)) {
-    return null;
-  }
-
-  const title = typeof rawTitle === "string" && rawTitle.trim() ? rawTitle : null;
-
-  return { id: rawId, title, year: rawYear } satisfies ActiveProductionOverview;
-}
-
-function parseProductionMemberships(value: unknown): ProductionMembershipSummary[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value
-    .map((entry) => {
-      if (!isRecord(entry)) {
-        return null;
-      }
-
-      const rawShowId = entry.showId;
-      const rawTitle = entry.title;
-      const rawYear = entry.year;
-      const rawJoinedAt = entry.joinedAt;
-      const rawLeftAt = entry.leftAt;
-      const rawIsActive = entry.isActive;
-
-      if (typeof rawShowId !== "string" || !rawShowId) {
-        return null;
-      }
-
-      if (typeof rawYear !== "number" || !Number.isFinite(rawYear)) {
-        return null;
-      }
-
-      const title = typeof rawTitle === "string" && rawTitle.trim() ? rawTitle : null;
-      const joinedAt = parseIsoDate(rawJoinedAt);
-      const leftAt = parseIsoDate(rawLeftAt);
-      const isActive = Boolean(rawIsActive);
-
-      return {
-        showId: rawShowId,
-        title,
-        year: rawYear,
-        joinedAt,
-        leftAt,
-        isActive,
-      } satisfies ProductionMembershipSummary;
-    })
-    .filter((entry): entry is ProductionMembershipSummary => entry !== null);
-}
-
-function formatProductionName(entry: { title: string | null; year: number }) {
-  if (entry.title && entry.title.trim()) {
-    return `${entry.title} (${entry.year})`;
-  }
-  return `Produktion ${entry.year}`;
-}
-
-function formatDateLocalized(date: Date | null) {
-  if (!date) {
-    return null;
-  }
-
-  try {
-    return new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" }).format(date);
-  } catch {
-    return null;
-  }
-}
-
 export function MembersDashboard({ permissions: permissionsProp }: MembersDashboardProps = {}) {
   const { data: session } = useSession();
   const { connectionStatus } = useRealtime();
@@ -421,20 +261,12 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
   } = useOnlineStats();
   const contextPermissions = useMembersPermissions();
   const effectivePermissions = permissionsProp ?? contextPermissions;
-  const canAccessProductions =
-    effectivePermissions?.includes("mitglieder.produktionen") ?? false;
 
   const [stats, setStats] = useState<DashboardStats>(INITIAL_STATS);
-  const [recentActivities, setRecentActivities] = useState<RecentActivity[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [finalRehearsalWeek, setFinalRehearsalWeek] = useState<FinalRehearsalWeekInfo | null>(null);
   const [profileCompletion, setProfileCompletion] = useState<
     { complete: boolean; completed: number; total: number } | null
   >(null);
-  const [activeProduction, setActiveProduction] = useState<ActiveProductionOverview | null>(null);
-  const [productionMemberships, setProductionMemberships] = useState<ProductionMembershipSummary[]>([]);
-  const [activeProductionLoaded, setActiveProductionLoaded] = useState(false);
-  const [activeProductionError, setActiveProductionError] = useState(false);
 
   useEffect(() => {
     setStats((prev) => ({ ...prev, totalOnline: liveOnline }));
@@ -444,8 +276,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     let cancelled = false;
 
     async function load() {
-      setIsLoading(true);
-      setActiveProductionError(false);
       try {
         const response = await fetch("/api/dashboard/overview", { cache: "no-store" });
         if (!response.ok) {
@@ -477,19 +307,8 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
 
         setFinalRehearsalWeek(parseFinalRehearsalWeek(payload?.finalRehearsalWeek));
         setProfileCompletion(parseProfileCompletion(payload?.profileCompletion));
-        setActiveProduction(parseActiveProduction(payload?.activeProduction));
-        setProductionMemberships(parseProductionMemberships(payload?.productionMemberships));
-        const activities = parseRecentActivities(payload?.recentActivities);
-
-        setRecentActivities(activities.slice(0, 10));
       } catch (error) {
         console.error("[Dashboard] Error loading overview", error);
-        setActiveProductionError(true);
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-          setActiveProductionLoaded(true);
-        }
       }
     }
 
@@ -499,57 +318,11 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     };
   }, []);
 
-  const addActivity = useCallback((activity: RecentActivity) => {
-    setRecentActivities((prev) => {
-      const filtered = prev.filter((entry) => entry.id !== activity.id);
-      return [activity, ...filtered].slice(0, 10);
-    });
-  }, []);
-
-  useNotificationRealtime((event) => {
-    const activity: RecentActivity = {
-      id: event.notification.id ?? `notification_${Date.now()}`,
-      type: "notification",
-      message: event.notification.title,
-      timestamp: new Date(event.timestamp ?? Date.now()),
-    };
-
-    addActivity(activity);
+  const handleNotificationRealtime = useCallback(() => {
     setStats((prev) => ({ ...prev, unreadNotifications: prev.unreadNotifications + 1 }));
-  });
-
-  useRehearsalRealtime(
-    (event) => {
-      const activity: RecentActivity = {
-        id: `rehearsal_${event.rehearsal.id}_${Date.now()}`,
-        type: "rehearsal",
-        message: `Neue Probe: ${event.rehearsal.title}`,
-        timestamp: new Date(event.timestamp ?? Date.now()),
-      };
-      addActivity(activity);
-    },
-    (event) => {
-      const activity: RecentActivity = {
-        id: `rehearsal_update_${event.rehearsalId}_${Date.now()}`,
-        type: "rehearsal",
-        message: `Probe aktualisiert: ${event.rehearsalId}`,
-        timestamp: new Date(event.timestamp ?? Date.now()),
-      };
-      addActivity(activity);
-    },
-  );
-
-  const getActivityIcon = useCallback((type: RecentActivity["type"]) => {
-    switch (type) {
-      case "attendance":
-        return <CheckCircle2 className="h-4 w-4 text-success" />;
-      case "rehearsal":
-        return <Calendar className="h-4 w-4 text-info" />;
-      case "notification":
-      default:
-        return <Bell className="h-4 w-4 text-accent" />;
-    }
   }, []);
+
+  useNotificationRealtime(handleNotificationRealtime);
 
   const formatTimeAgo = useCallback((date: Date) => {
     const now = new Date();
@@ -561,7 +334,7 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     return `vor ${Math.floor(diffInSeconds / 86400)} Tag(en)`;
   }, []);
 
-  const onlineList = useMemo(() => onlineUsers.slice(0, 6), [onlineUsers]);
+  const onlineList = useMemo(() => onlineUsers.slice(0, 10), [onlineUsers]);
 
   const availableQuickActions = useMemo(() => {
     if (!effectivePermissions.length) {
@@ -619,28 +392,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
       "border-border/60 bg-gradient-to-r from-muted/20 via-background/85 to-background text-muted-foreground",
   };
   const connectionBadgeClass = connectionToneClasses[connectionMeta.state];
-
-  const activeMembership = useMemo(() => {
-    if (!activeProduction) {
-      return null;
-    }
-
-    return (
-      productionMemberships.find((entry) => entry.showId === activeProduction.id) ?? null
-    );
-  }, [activeProduction, productionMemberships]);
-
-  const otherMemberships = useMemo(() => {
-    if (productionMemberships.length === 0) {
-      return [] as ProductionMembershipSummary[];
-    }
-
-    if (!activeProduction) {
-      return productionMemberships;
-    }
-
-    return productionMemberships.filter((entry) => entry.showId !== activeProduction.id);
-  }, [activeProduction, productionMemberships]);
 
   const finalRehearsalMetric = useMemo(() => {
     if (!finalRehearsalWeek) return null;
@@ -825,182 +576,6 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
     );
   }, [profileCompletion]);
 
-  const activeProductionCard = useMemo(() => {
-    if (!activeProductionLoaded) {
-      return (
-        <Card className="rounded-3xl border border-dashed border-border/60 bg-card shadow-sm">
-          <CardContent className="space-y-3 p-6">
-            <div className="h-4 w-32 rounded bg-muted/50" />
-            <div className="h-5 w-48 rounded bg-muted/40" />
-            <div className="h-3 w-full rounded bg-muted/30" />
-          </CardContent>
-        </Card>
-      );
-    }
-
-    if (activeProductionError) {
-      return (
-        <Card className="rounded-3xl border border-destructive/40 bg-destructive/10 text-destructive shadow-sm">
-          <CardContent className="space-y-2 p-6">
-            <p className="text-sm font-semibold">Aktive Produktion konnte nicht geladen werden.</p>
-            <p className="text-xs text-destructive/80">
-              Bitte lade die Seite neu oder versuche es später erneut.
-            </p>
-          </CardContent>
-        </Card>
-      );
-    }
-
-    const membershipSectionTitle = activeProduction ? "Weitere Produktionen" : "Bisherige Produktionen";
-
-    const membershipBadges = otherMemberships.length
-      ? (
-          <div className="space-y-1">
-            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              {membershipSectionTitle}
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {otherMemberships.slice(0, 4).map((membership) => {
-                const label = formatProductionName(membership);
-                const leftLabel = formatDateLocalized(membership.leftAt);
-                const statusText = membership.isActive
-                  ? "aktiv"
-                  : leftLabel
-                    ? `bis ${leftLabel}`
-                    : "archiviert";
-
-                return (
-                  <Badge
-                    key={`membership-${membership.showId}`}
-                    variant="outline"
-                    className={cn(
-                      "border-border/60 bg-card text-foreground",
-                      membership.isActive && "border-primary/40 bg-primary/10 text-primary",
-                    )}
-                  >
-                    <span className="font-medium">{label}</span>
-                    <span className="ml-1 text-[11px] text-muted-foreground">• {statusText}</span>
-                  </Badge>
-                );
-              })}
-            </div>
-            {otherMemberships.length > 4 ? (
-              <p className="text-[11px] text-muted-foreground">
-                + {otherMemberships.length - 4} weitere im Archiv
-              </p>
-            ) : null}
-          </div>
-        )
-      : null;
-
-    const sharedNote = (
-      <p className="text-xs text-muted-foreground">
-        Profilangaben wie Maße, Allergien und Einverständnisse gelten produktonsübergreifend und müssen nicht
-        erneut erfasst werden.
-      </p>
-    );
-
-    if (!activeProduction) {
-      return (
-        <Card className="rounded-3xl border border-dashed border-primary/40 bg-primary/5 shadow-[0_18px_40px_rgba(15,23,42,0.08)]">
-          <CardHeader className="space-y-1">
-            <CardTitle className="text-lg font-semibold text-primary">Keine aktive Produktion ausgewählt</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Wähle eine aktive Produktion, um Rollen, Szenen und Gewerke der aktuellen Saison zu sehen.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <p className="text-sm text-muted-foreground">
-              Sobald du nur einer laufenden Produktion angehörst oder frühere Produktionen ausgelaufen sind, setzen wir
-              deine Mitgliedschaft automatisch auf die aktuelle Produktion.
-            </p>
-            {membershipBadges}
-            {sharedNote}
-            {canAccessProductions ? (
-              <div className="flex flex-wrap gap-2 pt-1">
-                <Button asChild size="sm">
-                  <Link href="/mitglieder/produktionen">Zur Produktionsübersicht</Link>
-                </Button>
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
-      );
-    }
-
-    const productionLabel = formatProductionName(activeProduction);
-    const membership = activeMembership;
-    const joinedLabel = formatDateLocalized(membership?.joinedAt ?? null);
-    const leftLabel = formatDateLocalized(membership?.leftAt ?? null);
-    const statusBadgeLabel = membership?.isActive === false ? "Archiviert" : "Aktiv";
-    const statusBadgeClass =
-      membership?.isActive === false
-        ? "border-border/60 text-muted-foreground"
-        : "border-primary/40 bg-primary/10 text-primary";
-
-    let membershipSubtitle: string | null = null;
-    if (membership?.isActive) {
-      membershipSubtitle = joinedLabel ? `Seit ${joinedLabel} Teil der Produktion.` : "Mitgliedschaft aktiv.";
-    } else if (membership) {
-      membershipSubtitle = joinedLabel && leftLabel
-        ? `Von ${joinedLabel} bis ${leftLabel} aktiv.`
-        : leftLabel
-          ? `Mitgliedschaft beendet am ${leftLabel}.`
-          : "Mitgliedschaft archiviert.";
-    }
-
-    return (
-      <Card className={cn(DASHBOARD_CARD_SURFACE, "relative overflow-hidden")}>
-        <div
-          aria-hidden
-          className="pointer-events-none absolute -right-28 -top-16 h-48 w-48 rounded-full bg-primary/10 opacity-40 blur-3xl dark:bg-primary/20"
-        />
-        <div
-          aria-hidden
-          className="pointer-events-none absolute -left-24 bottom-0 h-44 w-44 rounded-full bg-amber-200/20 opacity-40 blur-3xl dark:bg-amber-500/20"
-        />
-        <CardHeader className="relative z-10 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-1">
-            <CardTitle className="text-lg font-semibold">Aktive Produktion</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Du arbeitest aktuell in {productionLabel}.
-            </p>
-          </div>
-          <Badge variant="outline" className={statusBadgeClass}>
-            {statusBadgeLabel}
-          </Badge>
-        </CardHeader>
-        <CardContent className="relative z-10 space-y-3">
-          <div className="space-y-1">
-            <p className="text-sm font-medium text-foreground">{productionLabel}</p>
-            <p className="text-xs text-muted-foreground">
-              {membershipSubtitle ?? "Mitgliedschaft automatisch verwaltet."}
-            </p>
-          </div>
-          {membershipBadges}
-          {sharedNote}
-          {canAccessProductions ? (
-            <div className="flex flex-wrap gap-2 pt-1">
-              <Button asChild size="sm">
-                <Link href={`/mitglieder/produktionen/${activeProduction.id}`}>Arbeitsbereich öffnen</Link>
-              </Button>
-              <Button asChild size="sm" variant="outline">
-                <Link href="/mitglieder/produktionen">Produktion wechseln</Link>
-              </Button>
-            </div>
-          ) : null}
-        </CardContent>
-      </Card>
-    );
-  }, [
-    activeProduction,
-    activeProductionError,
-    activeProductionLoaded,
-    activeMembership,
-    canAccessProductions,
-    otherMemberships,
-  ]);
-
 
 
   if (!session?.user) {
@@ -1176,87 +751,43 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
           ))}
         </section>
 
-        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-          <div className="space-y-6">
-            {activeProductionCard}
-          </div>
-          <div className="space-y-6 xl:self-start">
-            <Card className={cn("relative overflow-hidden", DASHBOARD_CARD_SURFACE)}>
-              <div
-                aria-hidden
-                className="pointer-events-none absolute -right-24 top-0 h-40 w-40 rounded-full bg-success/15 opacity-40 blur-3xl dark:bg-success/25"
-              />
-              <CardHeader className="relative z-10 space-y-1 pb-4">
-                <CardTitle>Aktive Mitglieder</CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  Wer ist gerade online? Live-Ansicht aktualisiert automatisch.
-                </p>
-              </CardHeader>
-              <CardContent className="relative z-10 flex flex-col gap-4">
-                {onlineList.length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
-                    {onlineLoading ? "Lade Live-Daten …" : "Derzeit ist niemand online."}
-                  </div>
-                ) : (
-                  <ul className="space-y-3">
-                    {onlineList.map((user) => (
-                      <li
-                        key={`${user.id}-${user.joinedAt.getTime()}`}
-                        className="flex items-center justify-between rounded-2xl border border-border/50 bg-gradient-to-r from-muted/20 via-background/90 to-background px-4 py-3"
-                      >
-                        <div className="flex items-center gap-3">
-                          <span className="flex h-2.5 w-2.5 rounded-full bg-success" />
-                          <span className="text-sm font-medium">{user.name}</span>
-                        </div>
-                        <span className="text-xs text-muted-foreground">{formatTimeAgo(user.joinedAt)}</span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </CardContent>
-            </Card>
-
-            <Card className={cn("relative overflow-hidden", DASHBOARD_CARD_SURFACE)}>
-              <div
-                aria-hidden
-                className="pointer-events-none absolute -left-24 top-0 h-40 w-40 rounded-full bg-primary/12 opacity-40 blur-3xl dark:bg-primary/20"
-              />
-              <CardHeader className="relative z-10 space-y-1 pb-4">
-                <CardTitle>Aktivitäten</CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  Neueste Proben, Zusagen und Benachrichtigungen.
-                </p>
-              </CardHeader>
-              <CardContent className="relative z-10 flex flex-col gap-4">
-                {isLoading && recentActivities.length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
-                    Lade Aktivitäten …
-                  </div>
-                ) : recentActivities.length === 0 ? (
-                  <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
-                    Noch keine Aktivitäten erfasst.
-                  </div>
-                ) : (
-                  <ul className="space-y-3">
-                    {recentActivities.map((activity) => (
-                      <li
-                        key={`${activity.id}-${activity.timestamp.getTime()}`}
-                        className="flex items-center gap-3 rounded-2xl border border-border/50 bg-gradient-to-r from-muted/20 via-background/90 to-background px-4 py-3"
-                      >
-                        <div className="flex h-9 w-9 items-center justify-center rounded-xl border border-border/60 bg-muted/40">
-                          {getActivityIcon(activity.type)}
-                        </div>
-                        <div className="flex-1">
-                          <p className="text-sm font-medium">{activity.message}</p>
-                          <p className="text-xs text-muted-foreground">{formatTimeAgo(activity.timestamp)}</p>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </CardContent>
-            </Card>
-          </div>
+        <section>
+          <Card className={cn("relative overflow-hidden", DASHBOARD_CARD_SURFACE)}>
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -right-24 top-0 h-40 w-40 rounded-full bg-success/15 opacity-40 blur-3xl dark:bg-success/25"
+            />
+            <CardHeader className="relative z-10 space-y-1 pb-4">
+              <CardTitle>Aktive Mitglieder</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Wer ist gerade online? Live-Ansicht aktualisiert automatisch.
+              </p>
+            </CardHeader>
+            <CardContent className="relative z-10 flex flex-col gap-4">
+              {onlineList.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-border/60 bg-gradient-to-br from-muted/20 via-background/90 to-background p-4 text-sm text-muted-foreground">
+                  {onlineLoading ? "Lade Live-Daten …" : "Derzeit ist niemand online."}
+                </div>
+              ) : (
+                <ul className="grid gap-3 sm:grid-cols-2">
+                  {onlineList.map((user) => (
+                    <li
+                      key={`${user.id}-${user.joinedAt.getTime()}`}
+                      className="flex items-center justify-between gap-3 rounded-2xl border border-border/50 bg-gradient-to-r from-muted/20 via-background/90 to-background px-4 py-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <span className="flex h-2.5 w-2.5 rounded-full bg-success" />
+                        <span className="text-sm font-medium">{user.name}</span>
+                      </div>
+                      <span className="text-xs text-muted-foreground whitespace-nowrap">
+                        {formatTimeAgo(user.joinedAt)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
         </section>
       </div>
     </Fragment>


### PR DESCRIPTION
## Summary
- simplify the members dashboard data handling by removing the active production and activity state logic
- expand the active members card to span the full width with a two-column layout and show up to ten online entries

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ded7cfd42c832d83bf9824d98f9618