### PR TITLE
Complete onboarding role preference management

### DIFF
--- a/src/app/(members)/mitglieder/profil/__stories__/onboarding-section.stories.tsx
+++ b/src/app/(members)/mitglieder/profil/__stories__/onboarding-section.stories.tsx
@@ -3,6 +3,11 @@ import { OnboardingSection } from "../profile-client";
 
 const title = "Members/Profile/OnboardingSection";
 
+const defaultPreferences: OnboardingSectionProps["rolePreferences"] = [
+  { code: "acting_lead", domain: "acting", weight: 80 },
+  { code: "crew_stage", domain: "crew", weight: 60 },
+];
+
 const createOnboarding = (
   overrides: Partial<NonNullable<OnboardingSectionProps["onboarding"]>> = {},
 ): NonNullable<OnboardingSectionProps["onboarding"]> => ({
@@ -15,6 +20,7 @@ const createOnboarding = (
   dietaryPreferenceStrictness: "Flexibel",
   whatsappLinkVisitedAt: null,
   updatedAt: new Date().toISOString(),
+  preferences: defaultPreferences,
   show: { title: "Sommerproduktion", year: 2025 },
   ...overrides,
 });
@@ -22,6 +28,8 @@ const createOnboarding = (
 const baseProps: OnboardingSectionProps = {
   onboarding: createOnboarding(),
   onOnboardingChange: () => undefined,
+  rolePreferences: defaultPreferences,
+  onRolePreferencesChange: () => undefined,
   whatsappLink: "https://example.com/whatsapp",
   whatsappVisitedAt: null,
   onWhatsAppVisit: async () => ({ visitedAt: new Date().toISOString(), alreadyVisited: false }),

--- a/src/app/(members)/mitglieder/profil/__tests__/onboarding-section.test.tsx
+++ b/src/app/(members)/mitglieder/profil/__tests__/onboarding-section.test.tsx
@@ -29,6 +29,8 @@ function createProps(overrides: Partial<OnboardingSectionProps> = {}): Onboardin
   return {
     onboarding: null,
     onOnboardingChange: vi.fn(),
+    rolePreferences: [],
+    onRolePreferencesChange: vi.fn(),
     whatsappLink: "https://example.com",
     whatsappVisitedAt: null,
     onWhatsAppVisit: defaultOnWhatsAppVisit,

--- a/src/app/(members)/mitglieder/profil/actions.ts
+++ b/src/app/(members)/mitglieder/profil/actions.ts
@@ -357,6 +357,16 @@ export type SaveOnboardingResult = {
   };
 };
 
+export type SaveRolePreferencesInput = {
+  code: string;
+  domain: "acting" | "crew";
+  weight: number;
+};
+
+export type SaveRolePreferencesResult = {
+  preferences: SaveRolePreferencesInput[];
+};
+
 export async function saveOnboardingAction(
   input: SaveOnboardingInput,
 ): Promise<ActionResult<SaveOnboardingResult>> {
@@ -398,5 +408,71 @@ export async function saveOnboardingAction(
   } catch (error) {
     console.error("[profile][onboarding]", error);
     return { ok: false, error: "Netzwerkfehler: Onboarding-Angaben konnten nicht gespeichert werden." };
+  }
+}
+
+export async function saveRolePreferencesAction(
+  preferences: SaveRolePreferencesInput[],
+): Promise<ActionResult<SaveRolePreferencesResult>> {
+  try {
+    const payload = {
+      preferences: preferences.map((pref) => ({
+        code: pref.code,
+        domain: pref.domain,
+        weight: pref.weight,
+      })),
+    };
+
+    const response = await authorizedFetch("/api/profile/onboarding/preferences", {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json().catch(() => null);
+    if (!response.ok) {
+      const error = typeof data?.error === "string" ? data.error : "Präferenzen konnten nicht gespeichert werden.";
+      return { ok: false, error };
+    }
+
+    const rawPreferences = Array.isArray(data?.preferences) ? (data.preferences as unknown[]) : [];
+    const normalized = rawPreferences
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return null;
+        }
+
+        const candidate = entry as {
+          code?: unknown;
+          domain?: unknown;
+          weight?: unknown;
+        };
+
+        const code = typeof candidate.code === "string" ? candidate.code.trim() : "";
+        if (!code) {
+          return null;
+        }
+
+        const domain = candidate.domain;
+        if (domain !== "acting" && domain !== "crew") {
+          return null;
+        }
+
+        const numericWeight =
+          typeof candidate.weight === "number" && Number.isFinite(candidate.weight) ? candidate.weight : 0;
+
+        const normalizedEntry: SaveRolePreferencesInput = {
+          code,
+          domain,
+          weight: numericWeight,
+        };
+
+        return normalizedEntry;
+      })
+      .filter((entry): entry is SaveRolePreferencesInput => Boolean(entry));
+
+    return { ok: true, data: { preferences: normalized } };
+  } catch (error) {
+    console.error("[profile][onboarding.preferences]", error);
+    return { ok: false, error: "Netzwerkfehler: Präferenzen konnten nicht gespeichert werden." };
   }
 }

--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -48,6 +48,7 @@ export default async function ProfilePage() {
       avatarImageUpdatedAt: true,
       role: true,
       roles: { select: { role: true } },
+      rolePreferences: { select: { code: true, domain: true, weight: true } },
       appRoles: {
         select: {
           role: { select: { id: true, name: true, systemRole: true, isSystem: true } },
@@ -144,6 +145,12 @@ export default async function ProfilePage() {
     ...user.roles.map((entry) => entry.role as Role),
   ]);
 
+  const preferenceSummaries = user.rolePreferences.map((preference) => ({
+    code: preference.code,
+    domain: preference.domain,
+    weight: preference.weight,
+  }));
+
   const customRoles = user.appRoles
     .map((entry) => entry.role)
     .filter((role): role is { id: string; name: string; systemRole: Role | null; isSystem: boolean } => Boolean(role))
@@ -225,6 +232,7 @@ export default async function ProfilePage() {
         dietaryPreferenceStrictness: onboardingProfile.dietaryPreferenceStrictness ?? null,
         whatsappLinkVisitedAt: onboardingProfile.whatsappLinkVisitedAt?.toISOString() ?? null,
         updatedAt: onboardingProfile.updatedAt?.toISOString() ?? null,
+        preferences: preferenceSummaries,
         show: onboardingProfile.show
           ? {
               title: onboardingProfile.show.title ?? null,
@@ -260,6 +268,7 @@ export default async function ProfilePage() {
           payoutNote: user.payoutNote ?? null,
         }}
         onboarding={onboarding}
+        rolePreferences={preferenceSummaries}
         interests={interestNames}
         allergies={allergies}
         measurements={measurementSummaries}

--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -31,6 +31,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
 import { PhotoConsentCard } from "@/components/members/photo-consent-card";
 import { MeasurementForm } from "@/components/forms/measurement-form";
 import type { MeasurementFormData } from "@/data/measurements";
@@ -59,6 +60,15 @@ import { ALLERGY_LEVEL_STYLES } from "@/data/allergy-styles";
 import { UserAvatar } from "@/components/user-avatar";
 import { useOnboardingBackgroundData } from "@/components/onboarding/use-onboarding-background-data";
 import {
+  getRolePreferenceDescription,
+  getRolePreferenceTitle,
+  listRolePreferenceDefinitions,
+} from "@/lib/onboarding/role-preferences";
+import {
+  getRolePreferenceWeightLabel,
+  normalizeRolePreferenceWeight,
+} from "@/lib/onboarding/role-preference-utils";
+import {
   buildProfileChecklist,
   type ProfileChecklistTarget,
   type ProfileCompletionSummary,
@@ -74,9 +84,11 @@ import {
   saveInterestsAction,
   saveMeasurementAction,
   saveOnboardingAction,
+  saveRolePreferencesAction,
   updateProfileBasicsAction,
   upsertAllergyAction,
   type UpdateProfileBasicsResult,
+  type SaveRolePreferencesInput,
 } from "./actions";
 import { ProfileCompletionProvider, useProfileCompletion } from "./profile-completion-context";
 
@@ -100,6 +112,90 @@ const ONBOARDING_FOCUS_LABELS: Record<OnboardingFocus, string> = {
 };
 
 const PROFILE_ONBOARDING_BACKGROUND_SUGGESTIONS = ["Schule", "Ausbildung", "Beruf"] as const;
+
+const ROLE_PREFERENCE_DEFINITIONS = {
+  acting: listRolePreferenceDefinitions("acting"),
+  crew: listRolePreferenceDefinitions("crew"),
+} as const;
+
+const DEFAULT_ROLE_PREFERENCE_WEIGHT = 60;
+
+type RolePreferenceFormEntry = {
+  code: string;
+  title: string;
+  description: string | null;
+  domain: "acting" | "crew";
+  weight: number;
+  enabled: boolean;
+  isCustom: boolean;
+};
+
+type RolePreferenceFormState = {
+  acting: RolePreferenceFormEntry[];
+  crew: RolePreferenceFormEntry[];
+};
+
+function buildPreferenceFormState(
+  preferences: ProfileClientProps["rolePreferences"],
+): RolePreferenceFormState {
+  const remaining = new Map(preferences.map((pref) => [pref.code, pref]));
+
+  const acting: RolePreferenceFormEntry[] = ROLE_PREFERENCE_DEFINITIONS.acting.map((definition) => {
+    const existing = remaining.get(definition.code);
+    if (existing) {
+      remaining.delete(definition.code);
+    }
+    const weight = existing ? normalizeRolePreferenceWeight(existing.weight) : DEFAULT_ROLE_PREFERENCE_WEIGHT;
+    return {
+      code: definition.code,
+      title: definition.title,
+      description: definition.description,
+      domain: "acting" as const,
+      weight,
+      enabled: existing ? existing.weight > 0 : false,
+      isCustom: false,
+    } satisfies RolePreferenceFormEntry;
+  });
+
+  const crew: RolePreferenceFormEntry[] = ROLE_PREFERENCE_DEFINITIONS.crew.map((definition) => {
+    const existing = remaining.get(definition.code);
+    if (existing) {
+      remaining.delete(definition.code);
+    }
+    const weight = existing ? normalizeRolePreferenceWeight(existing.weight) : DEFAULT_ROLE_PREFERENCE_WEIGHT;
+    return {
+      code: definition.code,
+      title: definition.title,
+      description: definition.description,
+      domain: "crew" as const,
+      weight,
+      enabled: existing ? existing.weight > 0 : false,
+      isCustom: false,
+    } satisfies RolePreferenceFormEntry;
+  });
+
+  for (const pref of remaining.values()) {
+    const domain = pref.domain === "acting" ? "acting" : "crew";
+    const title = getRolePreferenceTitle(pref.code);
+    const description = getRolePreferenceDescription(pref.code);
+    const entry: RolePreferenceFormEntry = {
+      code: pref.code,
+      title,
+      description,
+      domain,
+      weight: normalizeRolePreferenceWeight(pref.weight),
+      enabled: pref.weight > 0,
+      isCustom: true,
+    };
+    if (domain === "acting") {
+      acting.push(entry);
+    } else {
+      crew.push(entry);
+    }
+  }
+
+  return { acting, crew };
+}
 
 const PAYOUT_METHOD_OPTIONS: Array<{ value: PayoutMethod; label: string }> = [
   { value: "BANK_TRANSFER", label: "Banküberweisung" },
@@ -139,6 +235,11 @@ type ProfileClientProps = {
     payoutPaypalHandle: string | null;
     payoutNote: string | null;
   };
+  rolePreferences: Array<{
+    code: string;
+    domain: "acting" | "crew";
+    weight: number;
+  }>;
   onboarding: {
     focus: string;
     background: string | null;
@@ -149,6 +250,11 @@ type ProfileClientProps = {
     dietaryPreferenceStrictness: string | null;
     whatsappLinkVisitedAt: string | null;
     updatedAt: string | null;
+    preferences: Array<{
+      code: string;
+      domain: "acting" | "crew";
+      weight: number;
+    }>;
     show: { title: string | null; year: number } | null;
   } | null;
   interests: string[];
@@ -447,6 +553,7 @@ function formatDate(value: string | null | undefined) {
 
 export function ProfileClient({
   user,
+  rolePreferences,
   onboarding,
   interests,
   allergies,
@@ -459,6 +566,7 @@ export function ProfileClient({
     <ProfileCompletionProvider initialSummary={checklist}>
       <ProfileClientInner
         initialUser={user}
+        initialRolePreferences={rolePreferences}
         initialOnboarding={onboarding}
         initialInterests={interests}
         initialAllergies={allergies}
@@ -472,6 +580,7 @@ export function ProfileClient({
 
 type ProfileClientInnerProps = {
   initialUser: ProfileUser;
+  initialRolePreferences: ProfileClientProps["rolePreferences"];
   initialOnboarding: ProfileClientProps["onboarding"];
   initialInterests: string[];
   initialAllergies: ProfileClientProps["allergies"];
@@ -482,6 +591,7 @@ type ProfileClientInnerProps = {
 
 function ProfileClientInner({
   initialUser,
+  initialRolePreferences,
   initialOnboarding,
   initialInterests,
   initialAllergies,
@@ -494,6 +604,9 @@ function ProfileClientInner({
 
   const [user, setUser] = useState<ProfileUser>(initialUser);
   const [onboarding, setOnboarding] = useState<ProfileClientProps["onboarding"]>(initialOnboarding);
+  const [rolePreferences, setRolePreferences] = useState<ProfileClientProps["rolePreferences"]>(
+    initialRolePreferences,
+  );
   const [interests, setInterests] = useState<string[]>(initialInterests);
   const [allergies, setAllergies] = useState<Allergy[]>(initialAllergies);
   const [measurements, setMeasurements] = useState<Measurement[]>(() =>
@@ -629,6 +742,7 @@ function ProfileClientInner({
             dietaryPreferenceStrictness: preference.strictnessLabel,
             whatsappLinkVisitedAt: null,
             updatedAt: null,
+            preferences: [],
             show: null,
           } satisfies OnboardingProfile;
         }
@@ -706,6 +820,7 @@ function ProfileClientInner({
             dietaryPreferenceStrictness: null,
             whatsappLinkVisitedAt: visitedAt,
             updatedAt: null,
+            preferences: [],
             show: null,
           } satisfies OnboardingProfile;
         }
@@ -909,6 +1024,8 @@ function ProfileClientInner({
           <OnboardingSection
             onboarding={onboarding}
             onOnboardingChange={setOnboarding}
+            rolePreferences={rolePreferences}
+            onRolePreferencesChange={setRolePreferences}
             whatsappLink={whatsappLink}
             whatsappVisitedAt={whatsappVisitedAt}
             onWhatsAppVisit={handleWhatsAppVisit}
@@ -1474,6 +1591,7 @@ function BasicsSection({ user, onUserUpdated }: BasicsSectionProps) {
             </Button>
           </div>
         </form>
+
       </CardContent>
     </Card>
   );
@@ -1704,6 +1822,7 @@ function PaymentSection({ user, onUserUpdated }: PaymentSectionProps) {
             </Button>
           </div>
         </form>
+
       </CardContent>
     </Card>
   );
@@ -2400,6 +2519,8 @@ function InterestsSection({ interests, onInterestsChange }: InterestsSectionProp
 export type OnboardingSectionProps = {
   onboarding: ProfileClientProps["onboarding"];
   onOnboardingChange: (next: ProfileClientProps["onboarding"]) => void;
+  rolePreferences: ProfileClientProps["rolePreferences"];
+  onRolePreferencesChange: (next: ProfileClientProps["rolePreferences"]) => void;
   whatsappLink: string | null;
   whatsappVisitedAt: string | null;
   onWhatsAppVisit?: () => Promise<{ visitedAt: string | null; alreadyVisited: boolean }>;
@@ -2409,6 +2530,8 @@ export type OnboardingSectionProps = {
 export function OnboardingSection({
   onboarding,
   onOnboardingChange,
+  rolePreferences,
+  onRolePreferencesChange,
   whatsappLink,
   whatsappVisitedAt,
   onWhatsAppVisit,
@@ -2425,6 +2548,10 @@ export function OnboardingSection({
   const [formState, setFormState] = useState<OnboardingFormState>(initialForm);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const initialPreferences = useMemo(() => buildPreferenceFormState(rolePreferences), [rolePreferences]);
+  const [preferenceForm, setPreferenceForm] = useState<RolePreferenceFormState>(initialPreferences);
+  const [preferenceError, setPreferenceError] = useState<string | null>(null);
+  const [preferenceSubmitting, setPreferenceSubmitting] = useState(false);
   const { backgroundSuggestions, classSuggestions, activeTag, requiresClass } =
     useOnboardingBackgroundData(formState.background, {
       initialSuggestions: PROFILE_ONBOARDING_BACKGROUND_SUGGESTIONS,
@@ -2435,6 +2562,51 @@ export function OnboardingSection({
   useEffect(() => {
     setFormState(initialForm);
   }, [initialForm]);
+
+  useEffect(() => {
+    setPreferenceForm(initialPreferences);
+  }, [initialPreferences]);
+
+  const includesActing = formState.focus === "acting" || formState.focus === "both";
+  const includesCrew = formState.focus === "tech" || formState.focus === "both";
+
+  const toggleRolePreference = useCallback((domain: "acting" | "crew", code: string) => {
+    setPreferenceForm((prev) => {
+      const entries = domain === "acting" ? prev.acting : prev.crew;
+      const nextEntries = entries.map((entry) => {
+        if (entry.code !== code) {
+          return entry;
+        }
+        const nextEnabled = !entry.enabled;
+        const nextWeight = nextEnabled
+          ? entry.weight > 0
+            ? entry.weight
+            : DEFAULT_ROLE_PREFERENCE_WEIGHT
+          : entry.weight;
+        return {
+          ...entry,
+          enabled: nextEnabled,
+          weight: normalizeRolePreferenceWeight(nextWeight),
+        } satisfies RolePreferenceFormEntry;
+      });
+      return domain === "acting"
+        ? { ...prev, acting: nextEntries }
+        : { ...prev, crew: nextEntries };
+    });
+  }, []);
+
+  const changePreferenceWeight = useCallback((domain: "acting" | "crew", code: string, weight: number) => {
+    const normalized = normalizeRolePreferenceWeight(weight);
+    setPreferenceForm((prev) => {
+      const entries = domain === "acting" ? prev.acting : prev.crew;
+      const nextEntries = entries.map((entry) =>
+        entry.code === code ? { ...entry, weight: normalized } : entry,
+      );
+      return domain === "acting"
+        ? { ...prev, acting: nextEntries }
+        : { ...prev, crew: nextEntries };
+    });
+  }, []);
 
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -2478,6 +2650,7 @@ export function OnboardingSection({
         dietaryPreference: onboarding?.dietaryPreference ?? null,
         dietaryPreferenceStrictness: onboarding?.dietaryPreferenceStrictness ?? null,
         whatsappLinkVisitedAt: onboarding?.whatsappLinkVisitedAt ?? null,
+        preferences: onboarding?.preferences ?? rolePreferences,
         show: onboarding?.show ?? null,
       };
       onOnboardingChange(next);
@@ -2493,6 +2666,53 @@ export function OnboardingSection({
       setSubmitting(false);
     }
   };
+
+  const handlePreferenceSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPreferenceError(null);
+    if (preferenceSubmitting) {
+      return;
+    }
+
+    const payload: SaveRolePreferencesInput[] = [
+      ...preferenceForm.acting
+        .filter((pref) => pref.enabled && pref.weight > 0)
+        .map((pref) => ({ code: pref.code, domain: "acting" as const, weight: pref.weight })),
+      ...preferenceForm.crew
+        .filter((pref) => pref.enabled && pref.weight > 0)
+        .map((pref) => ({ code: pref.code, domain: "crew" as const, weight: pref.weight })),
+    ];
+
+    if (!payload.length) {
+      setPreferenceError("Bitte wähle mindestens eine Präferenz aus.");
+      return;
+    }
+
+    setPreferenceSubmitting(true);
+    try {
+      const result = await saveRolePreferencesAction(payload);
+      if (!result.ok) {
+        setPreferenceError(result.error);
+        toast.error(result.error);
+        return;
+      }
+
+      const saved = result.data.preferences;
+      onRolePreferencesChange(saved);
+      if (onboarding) {
+        onOnboardingChange({ ...onboarding, preferences: saved });
+      }
+      setPreferenceForm(buildPreferenceFormState(saved));
+      toast.success("Präferenzen gespeichert");
+    } finally {
+      setPreferenceSubmitting(false);
+    }
+  };
+
+  const actingPreferences = preferenceForm.acting;
+  const crewPreferences = preferenceForm.crew;
+  const actingDisabled = !includesActing;
+  const crewDisabled = !includesCrew;
 
   const handleWhatsAppClick = async () => {
     if (!whatsappLink) {
@@ -2727,6 +2947,172 @@ export function OnboardingSection({
                 </>
               ) : (
                 "Onboarding speichern"
+              )}
+            </Button>
+          </div>
+        </form>
+
+        <Separator />
+
+        <form className="space-y-6" onSubmit={handlePreferenceSubmit}>
+          <div className="space-y-1">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Rollenpräferenzen</h3>
+            <p className="text-xs text-muted-foreground">
+              Markiere, in welchen Bereichen du aktiv sein möchtest und wie intensiv du dich einbringen willst.
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold">Schauspiel</h4>
+                {!includesActing ? (
+                  <span className="text-xs text-muted-foreground">
+                    Fokus auf Schauspiel aktivieren, um diese Auswahl zu bearbeiten.
+                  </span>
+                ) : null}
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                {actingPreferences.map((pref) => {
+                  const weightLabel = getRolePreferenceWeightLabel(pref.weight);
+                  return (
+                    <div
+                      key={pref.code}
+                      className={cn(
+                        "flex flex-col gap-3 rounded-lg border p-4 transition",
+                        pref.enabled ? "border-primary bg-primary/5" : "border-border bg-background",
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <h5 className="text-sm font-medium">{pref.title}</h5>
+                            {pref.isCustom ? (
+                              <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
+                                Individuell
+                              </Badge>
+                            ) : null}
+                          </div>
+                          {pref.description ? (
+                            <p className="text-xs text-muted-foreground">{pref.description}</p>
+                          ) : null}
+                        </div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={pref.enabled ? "default" : "outline"}
+                          onClick={() => toggleRolePreference("acting", pref.code)}
+                          disabled={actingDisabled}
+                        >
+                          {pref.enabled ? "Ausgewählt" : "Wählen"}
+                        </Button>
+                      </div>
+                      {pref.enabled ? (
+                        <div className="space-y-2">
+                          <input
+                            type="range"
+                            min={10}
+                            max={100}
+                            step={10}
+                            value={pref.weight}
+                            onChange={(event) =>
+                              changePreferenceWeight("acting", pref.code, event.currentTarget.valueAsNumber)
+                            }
+                            className="w-full accent-primary"
+                          />
+                          <div className="flex justify-between text-xs text-muted-foreground">
+                            <span>Intensität</span>
+                            <span>{weightLabel}</span>
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h4 className="text-sm font-semibold">Gewerke</h4>
+                {!includesCrew ? (
+                  <span className="text-xs text-muted-foreground">
+                    Fokus auf Gewerke aktivieren, um diese Auswahl zu bearbeiten.
+                  </span>
+                ) : null}
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                {crewPreferences.map((pref) => {
+                  const weightLabel = getRolePreferenceWeightLabel(pref.weight);
+                  return (
+                    <div
+                      key={pref.code}
+                      className={cn(
+                        "flex flex-col gap-3 rounded-lg border p-4 transition",
+                        pref.enabled ? "border-primary/70 bg-primary/5" : "border-border bg-background",
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-2">
+                            <h5 className="text-sm font-medium">{pref.title}</h5>
+                            {pref.isCustom ? (
+                              <Badge variant="outline" className="border-primary/40 bg-primary/10 text-primary">
+                                Individuell
+                              </Badge>
+                            ) : null}
+                          </div>
+                          {pref.description ? (
+                            <p className="text-xs text-muted-foreground">{pref.description}</p>
+                          ) : null}
+                        </div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={pref.enabled ? "default" : "outline"}
+                          onClick={() => toggleRolePreference("crew", pref.code)}
+                          disabled={crewDisabled}
+                        >
+                          {pref.enabled ? "Ausgewählt" : "Wählen"}
+                        </Button>
+                      </div>
+                      {pref.enabled ? (
+                        <div className="space-y-2">
+                          <input
+                            type="range"
+                            min={10}
+                            max={100}
+                            step={10}
+                            value={pref.weight}
+                            onChange={(event) =>
+                              changePreferenceWeight("crew", pref.code, event.currentTarget.valueAsNumber)
+                            }
+                            className="w-full accent-primary"
+                          />
+                          <div className="flex justify-between text-xs text-muted-foreground">
+                            <span>Intensität</span>
+                            <span>{weightLabel}</span>
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          </div>
+
+          {preferenceError ? <p className="text-sm text-destructive">{preferenceError}</p> : null}
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={preferenceSubmitting}>
+              {preferenceSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                  Speichern…
+                </>
+              ) : (
+                "Präferenzen speichern"
               )}
             </Button>
           </div>

--- a/src/app/api/profile/onboarding/preferences/route.ts
+++ b/src/app/api/profile/onboarding/preferences/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import {
+  getRolePreferenceDefinition,
+  isCustomRolePreference,
+} from "@/lib/onboarding/role-preferences";
+import { broadcastOnboardingDashboardForUser } from "@/lib/onboarding/dashboard-events";
+
+const preferenceSchema = z.object({
+  code: z
+    .string()
+    .min(1)
+    .max(120)
+    .transform((value) => value.trim()),
+  domain: z.enum(["acting", "crew"]),
+  weight: z.number().int().min(0).max(100),
+});
+
+const payloadSchema = z.object({
+  preferences: z.array(preferenceSchema).max(32),
+});
+
+export async function PUT(request: NextRequest) {
+  const session = await requireAuth();
+  const userId = session.user?.id;
+
+  if (!userId) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+
+  const json = await request.json().catch(() => null);
+  if (!json || typeof json !== "object") {
+    return NextResponse.json({ error: "Ungültige Eingabe" }, { status: 400 });
+  }
+
+  const parseResult = payloadSchema.safeParse(json);
+  if (!parseResult.success) {
+    const message = parseResult.error.issues[0]?.message ?? "Ungültige Eingabe";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const seenCodes = new Set<string>();
+  const sanitized: Array<{ code: string; domain: "acting" | "crew"; weight: number }> = [];
+
+  for (const entry of parseResult.data.preferences) {
+    const code = entry.code;
+    if (!code) {
+      continue;
+    }
+    if (seenCodes.has(code)) {
+      continue;
+    }
+    seenCodes.add(code);
+
+    const definition = getRolePreferenceDefinition(code);
+    if (definition) {
+      if (definition.domain !== entry.domain) {
+        return NextResponse.json({ error: "Unzulässige Kombination aus Rolle und Bereich." }, { status: 400 });
+      }
+    } else if (!isCustomRolePreference(code)) {
+      return NextResponse.json({ error: "Unbekannte Präferenz." }, { status: 400 });
+    }
+
+    const normalizedWeight = Math.max(0, Math.min(100, entry.weight));
+    if (normalizedWeight <= 0) {
+      continue;
+    }
+
+    sanitized.push({ code, domain: entry.domain, weight: normalizedWeight });
+  }
+
+  try {
+    const updated = await prisma.$transaction(async (tx) => {
+      const existing = await tx.memberRolePreference.findMany({
+        where: { userId },
+        select: { id: true, code: true, domain: true, weight: true },
+      });
+
+      const existingByCode = new Map(existing.map((pref) => [pref.code, pref]));
+      const targetCodes = new Set(sanitized.map((pref) => pref.code));
+
+      const removeIds = existing
+        .filter((pref) => !targetCodes.has(pref.code))
+        .map((pref) => pref.id);
+
+      if (removeIds.length) {
+        await tx.memberRolePreference.deleteMany({ where: { id: { in: removeIds } } });
+      }
+
+      for (const pref of sanitized) {
+        const current = existingByCode.get(pref.code);
+        if (!current) {
+          await tx.memberRolePreference.create({
+            data: {
+              userId,
+              code: pref.code,
+              domain: pref.domain,
+              weight: pref.weight,
+            },
+          });
+          continue;
+        }
+
+        if (current.domain !== pref.domain || current.weight !== pref.weight) {
+          await tx.memberRolePreference.update({
+            where: { id: current.id },
+            data: {
+              domain: pref.domain,
+              weight: pref.weight,
+            },
+          });
+        }
+      }
+
+      return tx.memberRolePreference.findMany({
+        where: { userId },
+        select: { code: true, domain: true, weight: true },
+        orderBy: [{ domain: "asc" }, { code: "asc" }],
+      });
+    });
+
+    try {
+      await broadcastOnboardingDashboardForUser(userId);
+    } catch (error) {
+      console.error("[profile.onboarding.preferences] realtime update failed", error);
+    }
+
+    return NextResponse.json({
+      preferences: updated.map((pref) => ({
+        code: pref.code,
+        domain: pref.domain,
+        weight: pref.weight,
+      })),
+    });
+  } catch (error) {
+    console.error("[profile.onboarding.preferences]", error);
+    return NextResponse.json(
+      { error: "Onboarding-Präferenzen konnten nicht gespeichert werden." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -24,6 +24,11 @@ import {
 import { cn } from "@/lib/utils";
 import { listRolePreferenceDefinitions } from "@/lib/onboarding/role-preferences";
 import {
+  createCustomRolePreferenceCode,
+  getRolePreferenceWeightLabel,
+  normalizeRolePreferenceWeight,
+} from "@/lib/onboarding/role-preference-utils";
+import {
   DIETARY_STYLE_OPTIONS,
   DIETARY_STRICTNESS_OPTIONS,
   DEFAULT_STRICTNESS_FOR_NONE,
@@ -61,14 +66,6 @@ const CURRENT_YEAR = new Date().getFullYear();
 const BASE_BACKGROUND_SUGGESTIONS = ["Schule", "Berufsschule", "Universität", "Ausbildung", "Beruf"] as const;
 
 const allergyLevelStyles = ALLERGY_LEVEL_STYLES;
-
-const weightLabels: { threshold: number; label: string }[] = [
-  { threshold: 0, label: "Nur mal reinschauen" },
-  { threshold: 25, label: "Locker interessiert" },
-  { threshold: 50, label: "Motiviert" },
-  { threshold: 75, label: "Sehr engagiert" },
-  { threshold: 90, label: "Herzensprojekt" },
-];
 
 const focusLabels: Record<"acting" | "tech" | "both", string> = {
   acting: "Schauspiel",
@@ -282,13 +279,6 @@ function createDietaryId() {
     return crypto.randomUUID();
   }
   return Math.random().toString(36).slice(2, 10);
-}
-
-function createPreferenceCode() {
-  if (typeof crypto !== "undefined" && crypto.randomUUID) {
-    return `custom-${crypto.randomUUID()}`;
-  }
-  return `custom-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 function formatProductionLabel(production: InviteMeta["production"]) {
@@ -545,7 +535,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
     if (!Number.isFinite(weight)) {
       return;
     }
-    const normalizedWeight = Math.min(100, Math.max(0, Math.round(weight)));
+    const normalizedWeight = normalizeRolePreferenceWeight(weight);
     setForm((prev) => {
       const key = domain === "acting" ? "actingPreferences" : "crewPreferences";
       const updated = prev[key].map((pref) =>
@@ -578,7 +568,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
         crewPreferences: [
           ...prev.crewPreferences,
           {
-            code: createPreferenceCode(),
+            code: createCustomRolePreferenceCode(),
             title,
             description: description || "Individuelle Aufgabe im Team",
             weight: 60,
@@ -602,10 +592,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
   }, []);
 
   const preferenceSummary = useMemo(() => {
-    const buildLabel = (entry: PreferenceEntry) => {
-      const match = [...weightLabels].reverse().find((label) => entry.weight >= label.threshold);
-      return match?.label ?? "Interesse";
-    };
+    const buildLabel = (entry: PreferenceEntry) => getRolePreferenceWeightLabel(entry.weight);
     const mapEntry = (entry: PreferenceEntry, domain: "acting" | "crew"): PreferenceSummaryEntry => ({
       code: entry.code,
       title: entry.title,
@@ -1501,7 +1488,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                 <div className="grid gap-4 md:grid-cols-2">
                   {form.actingPreferences.map((pref) => {
                     const active = pref.enabled;
-                    const weightLabel = [...weightLabels].reverse().find((label) => pref.weight >= label.threshold)?.label ?? "";
+                    const weightLabel = getRolePreferenceWeightLabel(pref.weight);
                     return (
                       <div
                         key={pref.code}
@@ -1561,7 +1548,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                 <div className="grid gap-4 md:grid-cols-2">
                   {form.crewPreferences.map((pref) => {
                     const active = pref.enabled;
-                    const weightLabel = [...weightLabels].reverse().find((label) => pref.weight >= label.threshold)?.label ?? "";
+                    const weightLabel = getRolePreferenceWeightLabel(pref.weight);
                     return (
                       <div
                         key={pref.code}

--- a/src/lib/onboarding/role-preference-utils.ts
+++ b/src/lib/onboarding/role-preference-utils.ts
@@ -1,0 +1,35 @@
+export const ROLE_PREFERENCE_WEIGHT_LABELS: ReadonlyArray<{
+  threshold: number;
+  label: string;
+}> = [
+  { threshold: 0, label: "Nur mal reinschauen" },
+  { threshold: 25, label: "Locker interessiert" },
+  { threshold: 50, label: "Motiviert" },
+  { threshold: 75, label: "Sehr engagiert" },
+  { threshold: 90, label: "Herzensprojekt" },
+];
+
+export function getRolePreferenceWeightLabel(weight: number): string {
+  const normalized = normalizeRolePreferenceWeight(weight);
+  const match = [...ROLE_PREFERENCE_WEIGHT_LABELS]
+    .reverse()
+    .find((entry) => normalized >= entry.threshold);
+  return match?.label ?? "Interesse";
+}
+
+export function normalizeRolePreferenceWeight(weight: number): number {
+  if (!Number.isFinite(weight)) {
+    return 0;
+  }
+  const rounded = Math.round(weight);
+  if (rounded < 0) return 0;
+  if (rounded > 100) return 100;
+  return rounded;
+}
+
+export function createCustomRolePreferenceCode(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `custom-${crypto.randomUUID()}`;
+  }
+  return `custom-${Math.random().toString(36).slice(2, 10)}`;
+}


### PR DESCRIPTION
## Summary
- add shared helpers and API route for onboarding role preferences
- integrate role preference editing throughout the onboarding wizard and member profile
- update related stories, tests, and server actions to persist and surface preference weights

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dedc640f2c832db4a034c40fb3b0b3