### PR TITLE
Reorganize members navigation and add warehouse group

### DIFF
--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -8,11 +8,12 @@ export type MembersNavIcon = ComponentType<MembersNavIconProps>;
 
 export type MembersNavGroupId =
   | "general"
+  | "media"
   | "assignments"
   | "final-week"
   | "production"
-  | "finance"
   | "inventory"
+  | "finance"
   | "admin";
 
 export const MEMBERS_NAV_ASSIGNMENTS_GROUP_ID: MembersNavGroupId = "assignments";
@@ -391,8 +392,8 @@ export const membersNavigation = [
     ],
   },
   {
-    id: "inventory",
-    label: "Dateien & Material",
+    id: "media",
+    label: "Dateien & Medien",
     items: [
       {
         href: "/mitglieder/archiv-und-bilder",
@@ -405,30 +406,6 @@ export const membersNavigation = [
         label: "Dateisystem",
         permissionKey: "mitglieder.dateisystem",
         icon: FileLibraryIcon,
-      },
-      {
-        href: "/mitglieder/scan",
-        label: "Scanner",
-        permissionKey: "mitglieder.scan",
-        icon: ScannerIcon,
-      },
-      {
-        href: "/mitglieder/inventar-aufkleber",
-        label: "Inventaraufkleber",
-        permissionKey: "mitglieder.inventaraufkleber",
-        icon: InventoryStickersIcon,
-      },
-      {
-        href: "/mitglieder/lagerverwaltung/technik",
-        label: "Technik-Lager",
-        permissionKey: "mitglieder.lager.technik",
-        icon: TechInventoryIcon,
-      },
-      {
-        href: "/mitglieder/lagerverwaltung/kostueme",
-        label: "Kostüm-Lager",
-        permissionKey: "mitglieder.lager.kostueme",
-        icon: CostumeInventoryIcon,
       },
     ],
   },
@@ -476,7 +453,7 @@ export const membersNavigation = [
   },
   {
     id: "final-week",
-    label: "Endprobenwoche",
+    label: "Endproben-Woche",
     items: [
       {
         href: "/mitglieder/endproben-woche/dienstplan",
@@ -531,6 +508,36 @@ export const membersNavigation = [
         label: "Szenen & Breakdowns",
         permissionKey: "mitglieder.produktionen",
         icon: ScenesIcon,
+      },
+    ],
+  },
+  {
+    id: "inventory",
+    label: "Lager & Inventar",
+    items: [
+      {
+        href: "/mitglieder/lagerverwaltung/technik",
+        label: "Technik-Lager",
+        permissionKey: "mitglieder.lager.technik",
+        icon: TechInventoryIcon,
+      },
+      {
+        href: "/mitglieder/lagerverwaltung/kostueme",
+        label: "Kostüm-Lager",
+        permissionKey: "mitglieder.lager.kostueme",
+        icon: CostumeInventoryIcon,
+      },
+      {
+        href: "/mitglieder/inventar-aufkleber",
+        label: "Inventaraufkleber",
+        permissionKey: "mitglieder.inventaraufkleber",
+        icon: InventoryStickersIcon,
+      },
+      {
+        href: "/mitglieder/scan",
+        label: "Scanner",
+        permissionKey: "mitglieder.scan",
+        icon: ScannerIcon,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- reorder the members menu to group service, media, rehearsals, productions, inventory, finance and administration more intuitively
- split the old material section into a media group and a dedicated "Lager & Inventar" block that highlights Technik/Kostüm-Lager together with scanner and sticker tools

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dedf9e428c832da73f6098502de11a