### PR TITLE
Move calendar and Sperrliste navigation entries to Start & Service

### DIFF
--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -377,6 +377,18 @@ export const membersNavigation = [
         icon: DashboardIcon,
       },
       {
+        href: "/mitglieder/kalender",
+        label: "Kalender",
+        permissionKey: "mitglieder.kalender",
+        icon: PersonalCalendarIcon,
+      },
+      {
+        href: "/mitglieder/sperrliste",
+        label: "Sperrliste",
+        permissionKey: "mitglieder.sperrliste",
+        icon: BlacklistIcon,
+      },
+      {
         href: "/mitglieder/profil",
         label: "Profil",
         permissionKey: "mitglieder.profil",
@@ -436,18 +448,6 @@ export const membersNavigation = [
     id: "assignments",
     label: "Proben & Gewerke",
     items: [
-      {
-        href: "/mitglieder/kalender",
-        label: "Kalender",
-        permissionKey: "mitglieder.kalender",
-        icon: PersonalCalendarIcon,
-      },
-      {
-        href: "/mitglieder/sperrliste",
-        label: "Sperrliste",
-        permissionKey: "mitglieder.sperrliste",
-        icon: BlacklistIcon,
-      },
       {
         href: "/mitglieder/meine-proben",
         label: "Meine Proben",


### PR DESCRIPTION
## Summary
- add Kalender and Sperrliste shortcuts to the Start & Service members navigation group
- remove the duplicated links from the Proben & Gewerke section to avoid redundancy

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dee0803038832d9f70dc76d530b0af