### PR TITLE
Adjust profile header layout and remove membership tile

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -735,14 +735,6 @@ function ProfileClientInner({
   const highlightTiles = useMemo<HighlightTileConfig[]>(() => {
     const items: HighlightTileConfig[] = [
       {
-        id: "membership",
-        icon: <CalendarDays className="h-5 w-5" aria-hidden />,
-        title: "Mitgliedschaft",
-        description: memberSinceLabel ?? "Trage dein Eintrittsjahr im Onboarding ein.",
-        hint: createdAtLabel ? `Profil erstellt am ${createdAtLabel}.` : null,
-        tone: memberSinceLabel ? "default" : "warning",
-      },
-      {
         id: "onboarding-focus",
         icon: <Sparkles className="h-5 w-5" aria-hidden />,
         title: "Onboarding-Schwerpunkt",
@@ -810,8 +802,6 @@ function ProfileClientInner({
 
     return items;
   }, [
-    createdAtLabel,
-    memberSinceLabel,
     onboardingBackground,
     onboardingFocusLabel,
     onboardingNotes,
@@ -990,23 +980,23 @@ function ProfileOverviewCard({
                   </Badge>
                 ) : null}
               </div>
-              <div className="space-y-2 text-sm text-muted-foreground">
+              <div className="flex flex-col gap-2 text-sm text-muted-foreground">
                 {email ? (
                   <a
                     href={`mailto:${email}`}
-                    className="inline-flex items-center gap-2 font-medium text-foreground transition hover:text-primary"
+                    className="flex items-center gap-2 font-medium text-foreground transition hover:text-primary"
                   >
                     <Mail className="h-4 w-4" aria-hidden />
                     {email}
                   </a>
                 ) : (
-                  <span className="inline-flex items-center gap-2 text-muted-foreground/80">
+                  <span className="flex items-center gap-2 text-muted-foreground/80">
                     <Mail className="h-4 w-4" aria-hidden />
                     Keine E-Mail hinterlegt
                   </span>
                 )}
                 {memberSinceLabel || createdAtLabel ? (
-                  <span className="inline-flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                  <span className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
                     <CalendarDays className="h-4 w-4" aria-hidden />
                     {memberSinceLabel ?? (createdAtLabel ? `Profil seit ${createdAtLabel}` : "")}
                   </span>


### PR DESCRIPTION
## Summary
- move the "Seit" calendar row below the profile email link by stacking the contact info vertically
- remove the redundant membership highlight tile from the profile overview

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dee12956e4832d99b1cf28bec96c71