### PR TITLE
Refine member profile overview layout

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -1066,7 +1066,7 @@ function ProfileOverviewCard({
 
   return (
     <Card className="border border-border/70 bg-gradient-to-br from-background/85 via-background/70 to-background/80 shadow-sm">
-      <CardHeader className="space-y-4">
+      <CardHeader className="space-y-4 pb-2">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-4">
             <UserAvatar
@@ -1113,17 +1113,17 @@ function ProfileOverviewCard({
                   </span>
                 )}
                 {memberSinceLabel || createdAtLabel ? (
-                  <span className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+                  <div className="flex flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
                     <CalendarDays className="h-4 w-4" aria-hidden />
-                    {memberSinceLabel ?? (createdAtLabel ? `Profil seit ${createdAtLabel}` : "")}
-                  </span>
+                    <span>{memberSinceLabel ?? (createdAtLabel ? `Profil seit ${createdAtLabel}` : "")}</span>
+                  </div>
                 ) : null}
               </div>
             </div>
           </div>
         </div>
       </CardHeader>
-      <CardContent className="space-y-4">
+      <CardContent className="space-y-6 pt-2">
         <div className="flex flex-wrap gap-2">
           {sortedRoles.map((role) => (
             <Badge
@@ -1164,23 +1164,23 @@ function ProfileOverviewCard({
           </div>
         ) : null}
         {hasChecklistItems ? (
-          <div className="space-y-1">
-            <span className="text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">Checkliste</span>
-            <ul className="space-y-1">
+          <div className="rounded-xl border border-border/60 bg-background/80 p-4 shadow-inner shadow-primary/5">
+            <div className="text-[0.65rem] font-semibold uppercase tracking-wide text-muted-foreground">Checkliste</div>
+            <ul className="mt-3 space-y-2">
               {summary.items.map((item) => {
                 const target = item.targetSection ?? null;
                 const isActive = target ? activeChecklistTarget === target : false;
                 const isComplete = item.complete;
 
                 const content = (
-                  <div className="flex items-center gap-2">
+                  <div className="flex w-full items-start gap-3">
                     <span
                       className={cn(
-                        "flex h-4 w-4 items-center justify-center rounded border text-[0.65rem]",
+                        "flex h-5 w-5 items-center justify-center rounded-full border text-[0.65rem] transition",
                         isComplete
                           ? "border-success/60 bg-success/10 text-success"
-                          : "border-border/60 bg-background text-muted-foreground/30",
-                        isActive ? "ring-1 ring-primary/40" : "",
+                          : "border-border/60 bg-background text-muted-foreground/40",
+                        isActive ? "ring-2 ring-primary/30" : "",
                       )}
                       aria-hidden
                     >
@@ -1188,7 +1188,7 @@ function ProfileOverviewCard({
                     </span>
                     <span
                       className={cn(
-                        "truncate text-xs",
+                        "flex-1 text-left text-xs leading-snug",
                         isComplete ? "text-muted-foreground/80 line-through" : "text-foreground",
                       )}
                     >
@@ -1204,10 +1204,10 @@ function ProfileOverviewCard({
                         type="button"
                         onClick={() => onChecklistNavigate?.(target)}
                         className={cn(
-                          "flex w-full items-center rounded-md px-2 py-1 text-left transition",
+                          "flex w-full items-center rounded-lg border border-transparent bg-background/40 px-3 py-2 text-left transition",
                           isActive
-                            ? "bg-primary/10 text-foreground ring-1 ring-primary/30"
-                            : "hover:bg-muted/50 text-foreground/90",
+                            ? "border-primary/50 bg-primary/10 text-foreground shadow-sm"
+                            : "hover:border-border/60 hover:bg-muted/40 text-foreground/90",
                           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
                         )}
                       >
@@ -1218,7 +1218,13 @@ function ProfileOverviewCard({
                 }
 
                 return (
-                  <li key={item.id} className="rounded-md px-2 py-1">
+                  <li
+                    key={item.id}
+                    className={cn(
+                      "flex items-center rounded-lg border px-3 py-2",
+                      isComplete ? "border-success/40 bg-success/10" : "border-border/50 bg-muted/30",
+                    )}
+                  >
                     {content}
                   </li>
                 );
@@ -1237,7 +1243,7 @@ function ProfileOverviewCard({
       </CardContent>
       {highlights.length ? (
         <CardContent className="border-t border-border/50 bg-background/60">
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {highlights.map((tile) => (
               <ProfileHighlightTile key={tile.id} {...tile} />
             ))}


### PR DESCRIPTION
## Summary
- Style the profile checklist within its own bordered container and refresh item interactions to match the rest of the design
- Increase spacing between the header content and role badges while stacking the calendar membership hint beneath its icon
- Allow the profile highlight tiles to expand to four columns on large screens

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68deec2a3d98832dacc90829f6bb11f6