### PR TITLE
Allow configuring public holiday source for Sperrliste

### DIFF
--- a/prisma/migrations/20250305120000_add_public_holiday_source/migration.sql
+++ b/prisma/migrations/20250305120000_add_public_holiday_source/migration.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "SperrlisteSettings"
+ADD COLUMN "publicHolidaySourceMode" TEXT NOT NULL DEFAULT 'default';
+
+ALTER TABLE "SperrlisteSettings"
+ADD COLUMN "publicHolidaySourceUrl" TEXT;
+
+ALTER TABLE "SperrlisteSettings"
+ADD COLUMN "publicHolidaySourceStatus" TEXT NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE "SperrlisteSettings"
+ADD COLUMN "publicHolidaySourceMessage" TEXT;
+
+ALTER TABLE "SperrlisteSettings"
+ADD COLUMN "publicHolidaySourceCheckedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -671,6 +671,11 @@ model SperrlisteSettings {
   holidaySourceStatus    String   @default("unknown")
   holidaySourceMessage   String?
   holidaySourceCheckedAt DateTime?
+  publicHolidaySourceMode      String   @default("default")
+  publicHolidaySourceUrl       String?
+  publicHolidaySourceStatus    String   @default("unknown")
+  publicHolidaySourceMessage   String?
+  publicHolidaySourceCheckedAt DateTime?
   freezeDays             Int      @default(7)
   preferredWeekdays      Json?
   exceptionWeekdays      Json?

--- a/src/app/(members)/mitglieder/sperrliste/page-client.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page-client.tsx
@@ -17,6 +17,7 @@ interface SperrlistePageClientProps {
   initialSettings: ClientSperrlisteSettings;
   canManageSettings: boolean;
   defaultHolidaySourceUrl: string;
+  defaultPublicHolidaySourceUrl: string;
 }
 
 export function SperrlistePageClient({
@@ -26,10 +27,14 @@ export function SperrlistePageClient({
   initialSettings,
   canManageSettings,
   defaultHolidaySourceUrl,
+  defaultPublicHolidaySourceUrl,
 }: SperrlistePageClientProps) {
   const [settings, setSettings] = useState<ClientSperrlisteSettings>(initialSettings);
   const [holidays, setHolidays] = useState<HolidayRange[]>(initialHolidays);
   const [defaultHolidayUrl, setDefaultHolidayUrl] = useState(defaultHolidaySourceUrl);
+  const [defaultPublicHolidayUrl, setDefaultPublicHolidayUrl] = useState(
+    defaultPublicHolidaySourceUrl,
+  );
 
   return (
     <div className="space-y-6">
@@ -38,6 +43,7 @@ export function SperrlistePageClient({
           <SperrlisteSettingsDialog
             settings={settings}
             defaultHolidaySourceUrl={defaultHolidayUrl}
+            defaultPublicHolidaySourceUrl={defaultPublicHolidayUrl}
             onSettingsChange={(payload) => {
               setSettings(payload.settings);
               if (payload.holidays) {
@@ -45,6 +51,9 @@ export function SperrlistePageClient({
               }
               if (payload.defaults?.holidaySourceUrl) {
                 setDefaultHolidayUrl(payload.defaults.holidaySourceUrl);
+              }
+              if (payload.defaults?.publicHolidaySourceUrl) {
+                setDefaultPublicHolidayUrl(payload.defaults.publicHolidaySourceUrl);
               }
             }}
           />

--- a/src/app/(members)/mitglieder/sperrliste/page.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page.tsx
@@ -7,6 +7,7 @@ import type { BlockedDay as BlockedDayDTO } from "./block-calendar";
 import { getSaxonySchoolHolidayRanges } from "@/lib/holidays";
 import {
   getDefaultHolidaySourceUrl,
+  getDefaultPublicHolidaySourceUrl,
   readSperrlisteSettings,
   resolveSperrlisteSettings,
   toClientSperrlisteSettings,
@@ -68,6 +69,7 @@ export default async function SperrlistePage() {
   const resolvedSettings = resolveSperrlisteSettings(refreshedSettingsRecord);
   const clientSettings = toClientSperrlisteSettings(resolvedSettings);
   const defaultHolidaySourceUrl = getDefaultHolidaySourceUrl();
+  const defaultPublicHolidaySourceUrl = getDefaultPublicHolidaySourceUrl();
 
   const initialBlockedDays: BlockedDayDTO[] = personalBlockedDays.map((entry) => ({
     id: entry.id,
@@ -112,6 +114,7 @@ export default async function SperrlistePage() {
         initialSettings={clientSettings}
         canManageSettings={canManageSettings}
         defaultHolidaySourceUrl={defaultHolidaySourceUrl}
+        defaultPublicHolidaySourceUrl={defaultPublicHolidaySourceUrl}
       />
     </div>
   );

--- a/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
@@ -12,12 +12,14 @@ import type { ClientSperrlisteSettings } from "@/lib/sperrliste-settings";
 interface SperrlisteSettingsDialogProps {
   settings: ClientSperrlisteSettings;
   defaultHolidaySourceUrl: string;
+  defaultPublicHolidaySourceUrl: string;
   onSettingsChange?: (payload: SperrlisteSettingsChangePayload) => void;
 }
 
 export function SperrlisteSettingsDialog({
   settings,
   defaultHolidaySourceUrl,
+  defaultPublicHolidaySourceUrl,
   onSettingsChange,
 }: SperrlisteSettingsDialogProps) {
   const [open, setOpen] = useState(false);
@@ -35,6 +37,7 @@ export function SperrlisteSettingsDialog({
           <SperrlisteSettingsManager
             settings={settings}
             defaultHolidaySourceUrl={defaultHolidaySourceUrl}
+            defaultPublicHolidaySourceUrl={defaultPublicHolidaySourceUrl}
             onSettingsChange={(payload) => {
               onSettingsChange?.(payload);
             }}

--- a/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
@@ -25,12 +25,13 @@ const FREEZE_DAY_PRESETS = [0, 3, 5, 7, 10, 14, 21, 28, 30] as const;
 export type SperrlisteSettingsChangePayload = {
   settings: ClientSperrlisteSettings;
   holidays?: HolidayRange[];
-  defaults?: { holidaySourceUrl: string };
+  defaults?: { holidaySourceUrl: string; publicHolidaySourceUrl: string };
 };
 
 interface SperrlisteSettingsManagerProps {
   settings: ClientSperrlisteSettings;
   defaultHolidaySourceUrl: string;
+  defaultPublicHolidaySourceUrl: string;
   onSettingsChange?: (payload: SperrlisteSettingsChangePayload) => void;
 }
 
@@ -136,42 +137,60 @@ function buildFreezeOptions(current: number | null) {
 export function SperrlisteSettingsManager({
   settings,
   defaultHolidaySourceUrl,
+  defaultPublicHolidaySourceUrl,
   onSettingsChange,
 }: SperrlisteSettingsManagerProps) {
   const contentId = useId();
   const [freezeDaysValue, setFreezeDaysValue] = useState(String(settings.freezeDays));
   const [holidayModeState, setHolidayModeState] = useState<HolidaySourceMode>(settings.holidaySource.mode);
   const [holidayUrlState, setHolidayUrlState] = useState(settings.holidaySource.url ?? "");
+  const [publicHolidayModeState, setPublicHolidayModeState] = useState<HolidaySourceMode>(
+    settings.publicHolidaySource.mode,
+  );
+  const [publicHolidayUrlState, setPublicHolidayUrlState] = useState(
+    settings.publicHolidaySource.url ?? "",
+  );
   const [preferredDays, setPreferredDays] = useState(() => new Set(settings.preferredWeekdays));
   const [exceptionDays, setExceptionDays] = useState(() => new Set(settings.exceptionWeekdays));
   const [status, setStatus] = useState(settings.holidayStatus);
+  const [publicStatus, setPublicStatus] = useState(settings.publicHolidayStatus);
   const [saving, setSaving] = useState(false);
-  const [checking, setChecking] = useState(false);
+  const [checkingSource, setCheckingSource] = useState<"holiday" | "publicHoliday" | null>(null);
   const [error, setError] = useState<ErrorState | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-  const [defaults, setDefaults] = useState({ holidaySourceUrl: defaultHolidaySourceUrl });
+  const [defaults, setDefaults] = useState({
+    holidaySourceUrl: defaultHolidaySourceUrl,
+    publicHolidaySourceUrl: defaultPublicHolidaySourceUrl,
+  });
   const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     setFreezeDaysValue(String(settings.freezeDays));
     setHolidayModeState(settings.holidaySource.mode);
     setHolidayUrlState(settings.holidaySource.url ?? "");
+    setPublicHolidayModeState(settings.publicHolidaySource.mode);
+    setPublicHolidayUrlState(settings.publicHolidaySource.url ?? "");
     setPreferredDays(new Set(settings.preferredWeekdays));
     setExceptionDays(new Set(settings.exceptionWeekdays));
     setStatus(settings.holidayStatus);
+    setPublicStatus(settings.publicHolidayStatus);
   }, [settings]);
 
   useEffect(() => {
-    setDefaults({ holidaySourceUrl: defaultHolidaySourceUrl });
-  }, [defaultHolidaySourceUrl]);
+    setDefaults({
+      holidaySourceUrl: defaultHolidaySourceUrl,
+      publicHolidaySourceUrl: defaultPublicHolidaySourceUrl,
+    });
+  }, [defaultHolidaySourceUrl, defaultPublicHolidaySourceUrl]);
 
   const resetFeedback = () => {
     setError(null);
     setSuccess(null);
   };
 
-  const markStatusPending = () => {
-    setStatus((prev) => {
+  const markStatusPending = (target: "holiday" | "publicHoliday") => {
+    const setter = target === "holiday" ? setStatus : setPublicStatus;
+    setter((prev) => {
       if (prev.status === "unknown" && !prev.checkedAt) {
         return prev;
       }
@@ -189,7 +208,7 @@ export function SperrlisteSettingsManager({
     }
     setHolidayModeState(value);
     resetFeedback();
-    markStatusPending();
+    markStatusPending("holiday");
   };
 
   const handleHolidayUrlInput = (value: string) => {
@@ -198,11 +217,34 @@ export function SperrlisteSettingsManager({
     }
     setHolidayUrlState(value);
     resetFeedback();
-    markStatusPending();
+    markStatusPending("holiday");
+  };
+
+  const handlePublicHolidayModeChange = (value: HolidaySourceMode) => {
+    if (value === publicHolidayModeState) {
+      return;
+    }
+    setPublicHolidayModeState(value);
+    resetFeedback();
+    markStatusPending("publicHoliday");
+  };
+
+  const handlePublicHolidayUrlInput = (value: string) => {
+    if (value === publicHolidayUrlState) {
+      return;
+    }
+    setPublicHolidayUrlState(value);
+    resetFeedback();
+    markStatusPending("publicHoliday");
   };
 
   const holidayMode = holidayModeState;
   const holidayUrl = holidayUrlState;
+  const publicHolidayMode = publicHolidayModeState;
+  const publicHolidayUrl = publicHolidayUrlState;
+  const isCheckingHoliday = checkingSource === "holiday";
+  const isCheckingPublicHoliday = checkingSource === "publicHoliday";
+  const isCheckingAnything = checkingSource !== null;
 
   const preferredList = useMemo(
     () => formatWeekdayList(preferredDays, { fallback: "keine bevorzugten Tage" }),
@@ -220,6 +262,14 @@ export function SperrlisteSettingsManager({
     if (Number.isNaN(parsed.getTime())) return null;
     return CHECKED_AT_FORMATTER.format(parsed);
   }, [status.checkedAt]);
+
+  const publicStatusMeta = useMemo(() => getStatusMeta(publicStatus.status), [publicStatus.status]);
+  const publicFormattedCheckedAt = useMemo(() => {
+    if (!publicStatus.checkedAt) return null;
+    const parsed = new Date(publicStatus.checkedAt);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return CHECKED_AT_FORMATTER.format(parsed);
+  }, [publicStatus.checkedAt]);
 
   const holidayModeSummary = useMemo(() => {
     switch (holidayMode) {
@@ -277,6 +327,64 @@ export function SperrlisteSettingsManager({
     }
   }, [defaults.holidaySourceUrl, holidayMode, holidayUrl]);
 
+  const publicHolidayModeSummary = useMemo(() => {
+    switch (publicHolidayMode) {
+      case "default":
+        return "Standardfeed (Feiertage Sachsen)";
+      case "custom": {
+        const trimmed = publicHolidayUrl.trim();
+        if (!trimmed) return "Eigene URL (noch nicht gesetzt)";
+        try {
+          const parsed = new URL(trimmed);
+          return `Eigene URL (${parsed.hostname})`;
+        } catch {
+          return `Eigene URL (${trimmed})`;
+        }
+      }
+      case "disabled":
+      default:
+        return "Keine Feiertagsquelle";
+    }
+  }, [publicHolidayMode, publicHolidayUrl]);
+
+  const publicHolidaySourceDetails = useMemo(() => {
+    if (publicHolidayMode === "disabled") {
+      return null;
+    }
+
+    const rawUrl =
+      publicHolidayMode === "custom"
+        ? publicHolidayUrl
+        : defaults.publicHolidaySourceUrl ?? "";
+    const trimmed = rawUrl.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      const parsed = new URL(trimmed);
+      const label = `${parsed.hostname}${parsed.pathname}${parsed.search}${parsed.hash}`.replace(/\/$/, "");
+
+      return {
+        href: parsed.toString(),
+        label: label || parsed.hostname,
+      };
+    } catch {
+      if (/^https?:\/\//i.test(trimmed)) {
+        return {
+          href: trimmed,
+          label: trimmed,
+        };
+      }
+
+      return {
+        href: null,
+        label: trimmed,
+      };
+    }
+  }, [defaults.publicHolidaySourceUrl, publicHolidayMode, publicHolidayUrl]);
+
   const freezeDaysNumber = useMemo(() => {
     const parsed = Number.parseInt(freezeDaysValue, 10);
     return Number.isFinite(parsed) ? parsed : null;
@@ -321,6 +429,14 @@ export function SperrlisteSettingsManager({
     if ((trimmedUrl ?? null) !== (initialUrl ?? null)) {
       return true;
     }
+    if (publicHolidayMode !== settings.publicHolidaySource.mode) {
+      return true;
+    }
+    const trimmedPublicUrl = publicHolidayMode === "custom" ? publicHolidayUrl.trim() : null;
+    const initialPublicUrl = settings.publicHolidaySource.url ?? null;
+    if ((trimmedPublicUrl ?? null) !== (initialPublicUrl ?? null)) {
+      return true;
+    }
     return false;
   }, [
     freezeDaysNumber,
@@ -330,9 +446,13 @@ export function SperrlisteSettingsManager({
     initialExceptionWeekdays,
     holidayMode,
     holidayUrl,
+    publicHolidayMode,
+    publicHolidayUrl,
     settings.freezeDays,
     settings.holidaySource.mode,
     settings.holidaySource.url,
+    settings.publicHolidaySource.mode,
+    settings.publicHolidaySource.url,
   ]);
 
   const togglePreferred = (weekday: number) => {
@@ -373,7 +493,7 @@ export function SperrlisteSettingsManager({
     resetFeedback();
   };
 
-  const handleResetToDefault = () => {
+  const handleResetHolidayToDefault = () => {
     const targetUrl = defaults.holidaySourceUrl ?? "";
     const shouldUpdateStatus =
       holidayModeState !== "default" || holidayUrlState.trim() !== targetUrl.trim();
@@ -386,7 +506,26 @@ export function SperrlisteSettingsManager({
     }
 
     if (shouldUpdateStatus) {
-      markStatusPending();
+      markStatusPending("holiday");
+    }
+    resetFeedback();
+  };
+
+  const handleResetPublicToDefault = () => {
+    const targetUrl = defaults.publicHolidaySourceUrl ?? "";
+    const shouldUpdateStatus =
+      publicHolidayModeState !== "default" ||
+      publicHolidayUrlState.trim() !== targetUrl.trim();
+
+    if (publicHolidayModeState !== "default") {
+      setPublicHolidayModeState("default");
+    }
+    if (publicHolidayUrlState !== targetUrl) {
+      setPublicHolidayUrlState(targetUrl);
+    }
+
+    if (shouldUpdateStatus) {
+      markStatusPending("publicHoliday");
     }
     resetFeedback();
   };
@@ -396,47 +535,61 @@ export function SperrlisteSettingsManager({
     setFreezeDaysValue(String(settings.freezeDays));
     setHolidayModeState(settings.holidaySource.mode);
     setHolidayUrlState(settings.holidaySource.url ?? "");
+    setPublicHolidayModeState(settings.publicHolidaySource.mode);
+    setPublicHolidayUrlState(settings.publicHolidaySource.url ?? "");
     setPreferredDays(new Set(settings.preferredWeekdays));
     setExceptionDays(new Set(settings.exceptionWeekdays));
     setStatus(settings.holidayStatus);
+    setPublicStatus(settings.publicHolidayStatus);
   };
 
-  const handleCheckHolidaySource = async () => {
+  const handleCheckSource = async (target: "holiday" | "publicHoliday") => {
     resetFeedback();
 
-    if (holidayMode === "custom" && !holidayUrl.trim()) {
-      setError({ message: "Bitte gib eine gültige URL für die Ferienquelle an." });
+    const mode = target === "holiday" ? holidayMode : publicHolidayMode;
+    const url = target === "holiday" ? holidayUrl : publicHolidayUrl;
+    const label = target === "holiday" ? "Ferienquelle" : "Feiertagsquelle";
+
+    if (mode === "custom" && !url.trim()) {
+      setError({ message: `Bitte gib eine gültige URL für die ${label.toLowerCase()} an.` });
       return;
     }
 
-    setChecking(true);
+    setCheckingSource(target);
     try {
       const response = await fetch("/api/sperrliste/settings/check", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          mode: holidayMode,
-          url: holidayMode === "custom" ? holidayUrl.trim() : null,
+          source: target,
+          mode,
+          url: mode === "custom" ? url.trim() : null,
         }),
       });
 
       const data = (await response.json().catch(() => ({}))) as {
         holidayStatus?: ClientSperrlisteSettings["holidayStatus"];
+        publicHolidayStatus?: ClientSperrlisteSettings["holidayStatus"];
         error?: string;
       };
 
-      if (!response.ok || !data?.holidayStatus) {
-        throw new Error(data?.error || "Ferienquelle konnte nicht geprüft werden.");
+      if (!response.ok) {
+        throw new Error(data?.error || `${label} konnte nicht geprüft werden.`);
       }
 
-      setStatus(data.holidayStatus);
+      if (data.holidayStatus) {
+        setStatus(data.holidayStatus);
+      }
+      if (data.publicHolidayStatus) {
+        setPublicStatus(data.publicHolidayStatus);
+      }
     } catch (err) {
       setError({
-        message: "Ferienquelle konnte nicht geprüft werden.",
+        message: `${label} konnte nicht geprüft werden.`,
         details: err instanceof Error ? err.message : undefined,
       });
     } finally {
-      setChecking(false);
+      setCheckingSource(null);
     }
   };
 
@@ -445,6 +598,7 @@ export function SperrlisteSettingsManager({
     resetFeedback();
 
     const trimmedUrl = holidayMode === "custom" ? holidayUrl.trim() : null;
+    const trimmedPublicUrl = publicHolidayMode === "custom" ? publicHolidayUrl.trim() : null;
     const parsedFreezeDays = Number.parseInt(freezeDaysValue, 10);
 
     if (!Number.isFinite(parsedFreezeDays) || parsedFreezeDays < 0) {
@@ -457,12 +611,19 @@ export function SperrlisteSettingsManager({
       return;
     }
 
+    if (publicHolidayMode === "custom" && !trimmedPublicUrl) {
+      setError({ message: "Bitte gib eine gültige URL für die Feiertagsquelle an." });
+      return;
+    }
+
     const payload = {
       freezeDays: parsedFreezeDays,
       preferredWeekdays: currentPreferredWeekdays,
       exceptionWeekdays: currentExceptionWeekdays,
       holidaySourceMode: holidayMode,
       holidaySourceUrl: trimmedUrl,
+      publicHolidaySourceMode: publicHolidayMode,
+      publicHolidaySourceUrl: trimmedPublicUrl,
     } as const;
 
     setSaving(true);
@@ -476,7 +637,7 @@ export function SperrlisteSettingsManager({
       const data = (await response.json().catch(() => ({}))) as {
         settings?: ClientSperrlisteSettings;
         holidays?: HolidayRange[];
-        defaults?: { holidaySourceUrl: string };
+        defaults?: { holidaySourceUrl: string; publicHolidaySourceUrl: string };
         error?: string;
       };
 
@@ -485,7 +646,12 @@ export function SperrlisteSettingsManager({
       }
 
       setStatus(data.settings.holidayStatus);
-      setDefaults({ holidaySourceUrl: data.defaults?.holidaySourceUrl ?? defaultHolidaySourceUrl });
+      setPublicStatus(data.settings.publicHolidayStatus);
+      setDefaults({
+        holidaySourceUrl: data.defaults?.holidaySourceUrl ?? defaultHolidaySourceUrl,
+        publicHolidaySourceUrl:
+          data.defaults?.publicHolidaySourceUrl ?? defaultPublicHolidaySourceUrl,
+      });
       setSuccess("Sperrlisten-Einstellungen gespeichert.");
 
       onSettingsChange?.({
@@ -557,6 +723,35 @@ export function SperrlisteSettingsManager({
         </div>
         <div className="space-y-2">
           <Text asChild variant="caption" uppercase className="text-muted-foreground">
+            <dt>Feiertagsquelle</dt>
+          </Text>
+          <dd className="space-y-2 leading-5">
+            <div className="flex flex-wrap items-center gap-2">
+              <span>{publicHolidayModeSummary}</span>
+              <Badge variant={STATUS_BADGE_VARIANTS[publicStatusMeta.tone]}>
+                {publicStatusMeta.label}
+              </Badge>
+            </div>
+            {publicHolidaySourceDetails ? (
+              publicHolidaySourceDetails.href ? (
+                <a
+                  href={publicHolidaySourceDetails.href}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="block break-words text-xs text-muted-foreground underline-offset-2 hover:underline sm:text-sm"
+                >
+                  {publicHolidaySourceDetails.label}
+                </a>
+              ) : (
+                <span className="block break-words text-xs text-muted-foreground sm:text-sm">
+                  {publicHolidaySourceDetails.label}
+                </span>
+              )
+            ) : null}
+          </dd>
+        </div>
+        <div className="space-y-2">
+          <Text asChild variant="caption" uppercase className="text-muted-foreground">
             <dt>Sperrfrist</dt>
           </Text>
           <dd className="leading-5">{freezeDaysSummary}</dd>
@@ -599,7 +794,8 @@ export function SperrlisteSettingsManager({
     );
   };
 
-  const StatusIcon = STATUS_ICONS[statusMeta.tone];
+  const HolidayStatusIcon = STATUS_ICONS[statusMeta.tone];
+  const PublicStatusIcon = STATUS_ICONS[publicStatusMeta.tone];
 
   return (
     <Card data-state={expanded ? "expanded" : "collapsed"}>
@@ -611,7 +807,7 @@ export function SperrlisteSettingsManager({
               Sperrlisten-Einstellungen
             </CardTitle>
             <Text variant="small" tone="muted">
-              Verwalte Ferienquelle, Probenplanung und Sperrfrist in einem kompakten Ablauf.
+              Verwalte Ferien- und Feiertagsquellen, Probenplanung und Sperrfrist in einem kompakten Ablauf.
             </Text>
           </div>
           <button
@@ -692,10 +888,10 @@ export function SperrlisteSettingsManager({
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={handleCheckHolidaySource}
-                    disabled={checking || saving}
+                    onClick={() => handleCheckSource("holiday")}
+                    disabled={isCheckingHoliday || saving}
                   >
-                    {checking ? (
+                    {isCheckingHoliday ? (
                       <span className="flex items-center gap-2">
                         <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
                         Quelle prüfen
@@ -707,8 +903,8 @@ export function SperrlisteSettingsManager({
                   <Button
                     type="button"
                     variant="ghost"
-                    onClick={handleResetToDefault}
-                    disabled={checking || saving}
+                    onClick={handleResetHolidayToDefault}
+                    disabled={isCheckingHoliday || saving}
                   >
                     Auf Standard zurücksetzen
                   </Button>
@@ -719,10 +915,10 @@ export function SperrlisteSettingsManager({
                     STATUS_LINE_CLASSES[statusMeta.tone],
                   )}
                 >
-                  <StatusIcon
+                  <HolidayStatusIcon
                     className={cn(
                       "mt-0.5 h-4 w-4 shrink-0",
-                      statusMeta.tone === "unknown" && checking ? "animate-spin" : undefined,
+                      statusMeta.tone === "unknown" && isCheckingHoliday ? "animate-spin" : undefined,
                     )}
                     aria-hidden
                   />
@@ -731,6 +927,98 @@ export function SperrlisteSettingsManager({
                     <p className="text-xs leading-5 opacity-80">
                       {status.message ?? statusMeta.description}
                       {formattedCheckedAt ? ` – geprüft am ${formattedCheckedAt}` : ""}
+                    </p>
+                  </div>
+                </div>
+              </section>
+
+              <section className="space-y-4 rounded-lg border border-border/60 bg-card/40 p-4">
+                <header className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold leading-5">Feiertagsquelle</p>
+                    <p className="text-sm text-muted-foreground">
+                      Steuere, ob gesetzliche Feiertage automatisch eingefärbt werden.
+                    </p>
+                  </div>
+                  <Badge variant={STATUS_BADGE_VARIANTS[publicStatusMeta.tone]}>
+                    {publicStatusMeta.label}
+                  </Badge>
+                </header>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="public-holiday-mode">Quelle</Label>
+                    <Select
+                      value={publicHolidayMode}
+                      onValueChange={(value) => handlePublicHolidayModeChange(value as HolidaySourceMode)}
+                      disabled={saving}
+                    >
+                      <SelectTrigger id="public-holiday-mode">
+                        <SelectValue placeholder="Modus wählen" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="default">Standardfeed (Feiertage Sachsen)</SelectItem>
+                        <SelectItem value="custom">Eigene URL</SelectItem>
+                        <SelectItem value="disabled">Keine Feiertagsquelle</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="public-holiday-url">Eigene URL</Label>
+                    <Input
+                      id="public-holiday-url"
+                      type="url"
+                      value={publicHolidayUrl}
+                      onChange={(event) => handlePublicHolidayUrlInput(event.target.value)}
+                      placeholder={defaults.publicHolidaySourceUrl}
+                      disabled={publicHolidayMode !== "custom" || saving}
+                    />
+                  </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => handleCheckSource("publicHoliday")}
+                    disabled={isCheckingPublicHoliday || saving}
+                  >
+                    {isCheckingPublicHoliday ? (
+                      <span className="flex items-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                        Quelle prüfen
+                      </span>
+                    ) : (
+                      "Quelle prüfen"
+                    )}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={handleResetPublicToDefault}
+                    disabled={isCheckingPublicHoliday || saving}
+                  >
+                    Auf Standard zurücksetzen
+                  </Button>
+                </div>
+                <div
+                  className={cn(
+                    "flex items-start gap-3 rounded-md border px-3 py-2 text-sm",
+                    STATUS_LINE_CLASSES[publicStatusMeta.tone],
+                  )}
+                >
+                  <PublicStatusIcon
+                    className={cn(
+                      "mt-0.5 h-4 w-4 shrink-0",
+                      publicStatusMeta.tone === "unknown" && isCheckingPublicHoliday
+                        ? "animate-spin"
+                        : undefined,
+                    )}
+                    aria-hidden
+                  />
+                  <div className="space-y-1">
+                    <p className="font-medium leading-5">{publicStatusMeta.label}</p>
+                    <p className="text-xs leading-5 opacity-80">
+                      {publicStatus.message ?? publicStatusMeta.description}
+                      {publicFormattedCheckedAt ? ` – geprüft am ${publicFormattedCheckedAt}` : ""}
                     </p>
                   </div>
                 </div>
@@ -844,7 +1132,7 @@ export function SperrlisteSettingsManager({
                   type="button"
                   variant="ghost"
                   onClick={handleDiscardChanges}
-                  disabled={saving || checking}
+                  disabled={saving || isCheckingAnything}
                 >
                   Verwerfen
                 </Button>

--- a/src/app/api/sperrliste/settings/check/__tests__/route.test.ts
+++ b/src/app/api/sperrliste/settings/check/__tests__/route.test.ts
@@ -31,13 +31,24 @@ const {
         url: null,
         effectiveUrl: url,
       },
+      publicHolidaySource: {
+        mode: "default" as const,
+        url: null,
+        effectiveUrl: publicUrl,
+      },
       holidayStatus: {
         status: "unknown" as const,
         message: null,
         checkedAt: null,
       },
+      publicHolidayStatus: {
+        status: "unknown" as const,
+        message: null,
+        checkedAt: null,
+      },
       updatedAt: null,
-      cacheKey: "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics",
+      cacheKey:
+        "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics|default|https://www.feiertage-deutschland.de/kalender-download/ics/feiertage-sachsen.ics",
     },
     defaultHolidayUrl: url,
     defaultPublicHolidayUrl: publicUrl,
@@ -91,12 +102,13 @@ describe("sperrliste settings check route", () => {
     const checkedAt = new Date("2025-01-02T15:30:00Z");
     fetchHolidayRangesForSettingsMock.mockResolvedValue({
       ranges: [],
-      status: { status: "ok", message: "OK", checkedAt },
+      holidayStatus: { status: "ok", message: "OK", checkedAt },
       publicHolidayStatus: { status: "ok", message: "OK", checkedAt },
     });
 
     const response = await POST(
       createRequest({
+        source: "holiday",
         mode: "default",
         url: "",
       }),
@@ -109,12 +121,19 @@ describe("sperrliste settings check route", () => {
         message: "OK",
         checkedAt: checkedAt.toISOString(),
       },
+      publicHolidayStatus: {
+        status: "ok",
+        message: "OK",
+        checkedAt: checkedAt.toISOString(),
+      },
     });
 
     expect(fetchHolidayRangesForSettingsMock).toHaveBeenCalledTimes(1);
     const candidate = fetchHolidayRangesForSettingsMock.mock.calls[0][0];
     expect(candidate.holidaySource.mode).toBe("default");
     expect(candidate.holidaySource.effectiveUrl).toBe(defaultHolidayUrl);
+    expect(candidate.publicHolidaySource.mode).toBe("default");
+    expect(candidate.publicHolidaySource.effectiveUrl).toBe(defaultPublicHolidayUrl);
   });
 
   it("rejects custom URLs outside the allowlist", async () => {
@@ -122,6 +141,7 @@ describe("sperrliste settings check route", () => {
 
     const response = await POST(
       createRequest({
+        source: "holiday",
         mode: "custom",
         url: "https://untrusted.example.com/ferien.ics",
       }),
@@ -129,7 +149,7 @@ describe("sperrliste settings check route", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: "Diese Ferienquelle ist nicht erlaubt.",
+      error: "Diese Quelle ist nicht erlaubt.",
     });
 
     expect(fetchHolidayRangesForSettingsMock).not.toHaveBeenCalled();

--- a/src/app/api/sperrliste/settings/check/route.ts
+++ b/src/app/api/sperrliste/settings/check/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import {
   getDefaultHolidaySourceUrl,
+  getDefaultPublicHolidaySourceUrl,
   readSperrlisteSettings,
   resolveSperrlisteSettings,
   HOLIDAY_SOURCE_MODES,
@@ -14,6 +15,7 @@ import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 
 const checkSchema = z.object({
+  source: z.enum(["holiday", "publicHoliday"]),
   mode: z.enum(HOLIDAY_SOURCE_MODES),
   url: z
     .union([z.string().trim().url().max(500), z.literal(""), z.null()])
@@ -33,27 +35,66 @@ async function ensurePermission() {
   return null;
 }
 
+function resolveCandidateSource(
+  mode: HolidaySourceMode,
+  url: string | null,
+  defaultUrl: string,
+) {
+  return {
+    mode,
+    url,
+    effectiveUrl:
+      mode === "disabled" ? null : mode === "custom" ? url : defaultUrl,
+  } as const;
+}
+
 function buildCandidateSettings(
   base: ResolvedSperrlisteSettings,
+  source: "holiday" | "publicHoliday",
   mode: HolidaySourceMode,
   url: string | null,
 ): ResolvedSperrlisteSettings {
-  const effectiveUrl =
-    mode === "disabled" ? null : mode === "custom" ? url : getDefaultHolidaySourceUrl();
+  const nextHolidaySource =
+    source === "holiday"
+      ? resolveCandidateSource(mode, url, getDefaultHolidaySourceUrl())
+      : base.holidaySource;
+
+  const nextPublicHolidaySource =
+    source === "publicHoliday"
+      ? resolveCandidateSource(mode, url, getDefaultPublicHolidaySourceUrl())
+      : base.publicHolidaySource;
+
+  const nextHolidayStatus =
+    source === "holiday"
+      ? ({
+          status: nextHolidaySource.mode === "disabled" ? "disabled" : "unknown",
+          message: null,
+          checkedAt: null,
+        } as const)
+      : base.holidayStatus;
+
+  const nextPublicStatus =
+    source === "publicHoliday"
+      ? ({
+          status:
+            nextPublicHolidaySource.mode === "disabled" ? "disabled" : "unknown",
+          message: null,
+          checkedAt: null,
+        } as const)
+      : base.publicHolidayStatus;
+
+  const cacheKey = [
+    `${nextHolidaySource.mode}|${nextHolidaySource.effectiveUrl ?? "none"}`,
+    `${nextPublicHolidaySource.mode}|${nextPublicHolidaySource.effectiveUrl ?? "none"}`,
+  ].join("|");
 
   return {
     ...base,
-    holidaySource: {
-      mode,
-      url,
-      effectiveUrl,
-    },
-    holidayStatus: {
-      status: mode === "disabled" ? "disabled" : "unknown",
-      message: null,
-      checkedAt: null,
-    },
-    cacheKey: `${mode}|${effectiveUrl ?? "none"}`,
+    holidaySource: nextHolidaySource,
+    publicHolidaySource: nextPublicHolidaySource,
+    holidayStatus: nextHolidayStatus,
+    publicHolidayStatus: nextPublicStatus,
+    cacheKey,
   };
 }
 
@@ -80,12 +121,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: issue?.message ?? "Ungültige Eingabe." }, { status: 400 });
   }
 
+  const source = parsed.data.source;
   const mode = parsed.data.mode;
   const url = mode === "custom" ? parsed.data.url : null;
 
   if (mode === "custom" && !url) {
     return NextResponse.json(
-      { error: "Bitte gib eine gültige URL für die Ferienquelle an." },
+      { error: "Bitte gib eine gültige URL für die Quelle an." },
       { status: 400 },
     );
   }
@@ -93,7 +135,7 @@ export async function POST(request: NextRequest) {
   if (mode === "custom" && url && !isHolidaySourceUrlAllowed(url)) {
     console.warn("[sperrliste] blocked custom holiday source", { url });
     return NextResponse.json(
-      { error: "Diese Ferienquelle ist nicht erlaubt." },
+      { error: "Diese Quelle ist nicht erlaubt." },
       { status: 400 },
     );
   }
@@ -101,14 +143,19 @@ export async function POST(request: NextRequest) {
   try {
     const record = await readSperrlisteSettings();
     const resolved = resolveSperrlisteSettings(record);
-    const candidate = buildCandidateSettings(resolved, mode, url);
+    const candidate = buildCandidateSettings(resolved, source, mode, url);
     const result = await fetchHolidayRangesForSettings(candidate);
 
     return NextResponse.json({
       holidayStatus: {
-        status: result.status.status,
-        message: result.status.message,
-        checkedAt: result.status.checkedAt?.toISOString() ?? null,
+        status: result.holidayStatus.status,
+        message: result.holidayStatus.message,
+        checkedAt: result.holidayStatus.checkedAt?.toISOString() ?? null,
+      },
+      publicHolidayStatus: {
+        status: result.publicHolidayStatus.status,
+        message: result.publicHolidayStatus.message,
+        checkedAt: result.publicHolidayStatus.checkedAt?.toISOString() ?? null,
       },
     });
   } catch (error) {

--- a/src/app/api/sperrliste/settings/route.ts
+++ b/src/app/api/sperrliste/settings/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 
 import {
-  applyHolidaySourceStatus,
+  applyHolidaySourceStatuses,
   getDefaultHolidaySourceUrl,
+  getDefaultPublicHolidaySourceUrl,
   readSperrlisteSettings,
   resolveSperrlisteSettings,
   saveSperrlisteSettings,
@@ -26,6 +27,15 @@ const updateSchema = z.object({
     .transform((value) => value ?? []),
   holidaySourceMode: z.enum(["default", "custom", "disabled"]),
   holidaySourceUrl: z
+    .union([z.string().trim().url().max(500), z.literal(""), z.null()])
+    .transform((value) => {
+      if (value === null || value === "") {
+        return null;
+      }
+      return value;
+    }),
+  publicHolidaySourceMode: z.enum(["default", "custom", "disabled"]),
+  publicHolidaySourceUrl: z
     .union([z.string().trim().url().max(500), z.literal(""), z.null()])
     .transform((value) => {
       if (value === null || value === "") {
@@ -65,6 +75,7 @@ export async function GET() {
       settings: toClientSperrlisteSettings(resolved),
       defaults: {
         holidaySourceUrl: getDefaultHolidaySourceUrl(),
+        publicHolidaySourceUrl: getDefaultPublicHolidaySourceUrl(),
       },
     });
   } catch (error) {
@@ -104,10 +115,19 @@ export async function PUT(request: NextRequest) {
 
   const mode = parsed.data.holidaySourceMode;
   const url = mode === "custom" ? parsed.data.holidaySourceUrl : null;
+  const publicMode = parsed.data.publicHolidaySourceMode;
+  const publicUrl = publicMode === "custom" ? parsed.data.publicHolidaySourceUrl : null;
 
   if (mode === "custom" && !url) {
     return NextResponse.json(
       { error: "Bitte gib eine gültige URL für die Ferienquelle an." },
+      { status: 400 },
+    );
+  }
+
+  if (publicMode === "custom" && !publicUrl) {
+    return NextResponse.json(
+      { error: "Bitte gib eine gültige URL für die Feiertagsquelle an." },
       { status: 400 },
     );
   }
@@ -118,6 +138,9 @@ export async function PUT(request: NextRequest) {
 
     const modeChanged = resolvedBefore.holidaySource.mode !== mode;
     const urlChanged = (resolvedBefore.holidaySource.url ?? null) !== (url ?? null);
+    const publicModeChanged = resolvedBefore.publicHolidaySource.mode !== publicMode;
+    const publicUrlChanged =
+      (resolvedBefore.publicHolidaySource.url ?? null) !== (publicUrl ?? null);
 
     const savedRecord = await saveSperrlisteSettings(
       {
@@ -126,13 +149,21 @@ export async function PUT(request: NextRequest) {
         exceptionWeekdays,
         holidaySourceMode: mode,
         holidaySourceUrl: url,
+        publicHolidaySourceMode: publicMode,
+        publicHolidaySourceUrl: publicUrl,
       },
-      { resetStatus: modeChanged || urlChanged },
+      {
+        resetHolidayStatus: modeChanged || urlChanged,
+        resetPublicHolidayStatus: publicModeChanged || publicUrlChanged,
+      },
     );
 
     const resolvedAfterSave = resolveSperrlisteSettings(savedRecord);
     const result = await fetchHolidayRangesForSettings(resolvedAfterSave);
-    await applyHolidaySourceStatus(result.status);
+    await applyHolidaySourceStatuses({
+      holiday: result.holidayStatus,
+      publicHoliday: result.publicHolidayStatus,
+    });
 
     const refreshedRecord = await readSperrlisteSettings();
     const resolved = resolveSperrlisteSettings(refreshedRecord);
@@ -142,6 +173,7 @@ export async function PUT(request: NextRequest) {
       holidays: result.ranges,
       defaults: {
         holidaySourceUrl: getDefaultHolidaySourceUrl(),
+        publicHolidaySourceUrl: getDefaultPublicHolidaySourceUrl(),
       },
     });
   } catch (error) {

--- a/src/lib/__tests__/holidays.test.ts
+++ b/src/lib/__tests__/holidays.test.ts
@@ -21,13 +21,24 @@ const { defaultHolidayUrl, defaultPublicHolidayUrl, resolvedSettings } = vi.hois
         url: null,
         effectiveUrl: url,
       },
+      publicHolidaySource: {
+        mode: "default" as const,
+        url: null,
+        effectiveUrl: publicUrl,
+      },
       holidayStatus: {
         status: "unknown" as const,
         message: null,
         checkedAt: null,
       },
+      publicHolidayStatus: {
+        status: "unknown" as const,
+        message: null,
+        checkedAt: null,
+      },
       updatedAt: null,
-      cacheKey: "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics",
+      cacheKey:
+        "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics|default|https://www.feiertage-deutschland.de/kalender-download/ics/feiertage-sachsen.ics",
     },
   } as const;
 });
@@ -40,8 +51,10 @@ vi.mock("@/lib/sperrliste-settings", () => ({
       ...resolvedSettings,
       holidaySource: { ...resolvedSettings.holidaySource },
       holidayStatus: { ...resolvedSettings.holidayStatus },
+      publicHolidaySource: { ...resolvedSettings.publicHolidaySource },
+      publicHolidayStatus: { ...resolvedSettings.publicHolidayStatus },
     })),
-  applyHolidaySourceStatus: vi.fn().mockResolvedValue(undefined),
+  applyHolidaySourceStatuses: vi.fn().mockResolvedValue(undefined),
   getDefaultHolidaySourceUrl: vi.fn(() => defaultHolidayUrl),
   getDefaultPublicHolidaySourceUrl: vi.fn(() => defaultPublicHolidayUrl),
 }));

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -5,7 +5,7 @@ import { addDays, format, isValid, parseISO } from "date-fns";
 import { SAXONY_PUBLIC_HOLIDAYS } from "@/data/saxony-public-holidays";
 import { SAXONY_SCHOOL_HOLIDAYS } from "@/data/saxony-school-holidays";
 import {
-  applyHolidaySourceStatus,
+  applyHolidaySourceStatuses,
   getDefaultHolidaySourceUrl,
   getDefaultPublicHolidaySourceUrl,
   readSperrlisteSettings,
@@ -190,7 +190,7 @@ type HolidayFetchStatus = {
 
 export type HolidayFetchResult = {
   ranges: HolidayRange[];
-  status: HolidayFetchStatus;
+  holidayStatus: HolidayFetchStatus;
   publicHolidayStatus: HolidayFetchStatus;
 };
 
@@ -492,14 +492,14 @@ function sortHolidayRanges(ranges: HolidayRange[]) {
 
 async function fetchSchoolHolidayRangesForSettings(
   settings: ResolvedSperrlisteSettings,
-): Promise<{ ranges: HolidayRange[]; status: HolidayFetchStatus }> {
+): Promise<{ ranges: HolidayRange[]; holidayStatus: HolidayFetchStatus }> {
   const checkedAt = new Date();
 
   if (settings.holidaySource.mode === "disabled") {
     const ranges = filterRelevantRanges(getStaticSchoolHolidayRanges());
     return {
       ranges,
-      status: {
+      holidayStatus: {
         status: "disabled",
         message: "Ferienquelle ist deaktiviert. Es werden nur statische Termine verwendet.",
         checkedAt,
@@ -511,7 +511,7 @@ async function fetchSchoolHolidayRangesForSettings(
     const ranges = filterRelevantRanges(getStaticSchoolHolidayRanges());
     return {
       ranges,
-      status: createStaticFallbackStatus(
+      holidayStatus: createStaticFallbackStatus(
         "Externe Abrufe sind deaktiviert (OUTBOUND_HTTP_DISABLED). Es wird die statische Ferienliste genutzt.",
         checkedAt,
       ),
@@ -531,7 +531,7 @@ async function fetchSchoolHolidayRangesForSettings(
       const filtered = filterRelevantRanges(primaryRanges);
       return {
         ranges: filtered,
-        status: {
+        holidayStatus: {
           status: "ok",
           message: `Ferienquelle ${primaryUrl} lieferte ${formatRangeCount(filtered.length)}.`,
           checkedAt,
@@ -551,7 +551,7 @@ async function fetchSchoolHolidayRangesForSettings(
       const filtered = filterRelevantRanges(fallbackRanges);
       return {
         ranges: filtered,
-        status: {
+        holidayStatus: {
           status: primaryError ? "error" : "ok",
           message: primaryError
             ? `Primärer Feed (${primaryUrl ?? getDefaultHolidaySourceUrl()}) schlug fehl: ${primaryError.message}. Fallback (${FALLBACK_SAXONY_HOLIDAY_FEED}) lieferte ${formatRangeCount(
@@ -571,18 +571,29 @@ async function fetchSchoolHolidayRangesForSettings(
 
   return {
     ranges: staticRanges,
-    status: createStaticFallbackStatus(
+    holidayStatus: createStaticFallbackStatus(
       `${fallbackMessage} Verwendet werden ${formatRangeCount(staticRanges.length)}.`,
       checkedAt,
     ),
   };
 }
 
-async function fetchPublicHolidayRanges(): Promise<{
-  ranges: HolidayRange[];
-  status: HolidayFetchStatus;
-}> {
+async function fetchPublicHolidayRangesForSettings(
+  settings: ResolvedSperrlisteSettings,
+): Promise<{ ranges: HolidayRange[]; status: HolidayFetchStatus }> {
   const checkedAt = new Date();
+
+  if (settings.publicHolidaySource.mode === "disabled") {
+    const ranges = filterRelevantRanges(getStaticPublicHolidayRanges());
+    return {
+      ranges,
+      status: {
+        status: "disabled",
+        message: "Feiertagsquelle ist deaktiviert. Es werden nur statische Termine verwendet.",
+        checkedAt,
+      },
+    };
+  }
 
   if (isOutboundHttpDisabled()) {
     const ranges = filterRelevantRanges(getStaticPublicHolidayRanges());
@@ -595,7 +606,10 @@ async function fetchPublicHolidayRanges(): Promise<{
     };
   }
 
-  const publicUrl = getDefaultPublicHolidaySourceUrl();
+  const publicUrl =
+    settings.publicHolidaySource.mode === "custom"
+      ? settings.publicHolidaySource.url
+      : settings.publicHolidaySource.effectiveUrl ?? getDefaultPublicHolidaySourceUrl();
   let publicError: Error | null = null;
 
   if (publicUrl) {
@@ -614,6 +628,8 @@ async function fetchPublicHolidayRanges(): Promise<{
       publicError = error instanceof Error ? error : new Error("Feiertagsquelle konnte nicht geladen werden.");
       console.error("[holidays] public holiday feed fetch failed", publicError);
     }
+  } else {
+    publicError = new Error("Keine Feiertagsquelle konfiguriert.");
   }
 
   const staticRanges = filterRelevantRanges(getStaticPublicHolidayRanges());
@@ -635,14 +651,14 @@ export async function fetchHolidayRangesForSettings(
 ): Promise<HolidayFetchResult> {
   const [schoolResult, publicResult] = await Promise.all([
     fetchSchoolHolidayRangesForSettings(settings),
-    fetchPublicHolidayRanges(),
+    fetchPublicHolidayRangesForSettings(settings),
   ]);
 
   const combinedRanges = sortHolidayRanges([...schoolResult.ranges, ...publicResult.ranges]);
 
   return {
     ranges: combinedRanges,
-    status: schoolResult.status,
+    holidayStatus: schoolResult.holidayStatus,
     publicHolidayStatus: publicResult.status,
   };
 }
@@ -653,7 +669,10 @@ export const getSaxonySchoolHolidayRanges = unstable_cache(
     const record = await readSperrlisteSettings();
     const resolved = resolveSperrlisteSettings(record);
     const result = await fetchHolidayRangesForSettings(resolved);
-    await applyHolidaySourceStatus(result.status);
+    await applyHolidaySourceStatuses({
+      holiday: result.holidayStatus,
+      publicHoliday: result.publicHolidayStatus,
+    });
     return result.ranges;
   },
   ["saxony-school-holidays"],

--- a/src/lib/sperrliste-settings.ts
+++ b/src/lib/sperrliste-settings.ts
@@ -34,7 +34,17 @@ export type ResolvedSperrlisteSettings = {
     url: string | null;
     effectiveUrl: string | null;
   };
+  publicHolidaySource: {
+    mode: HolidaySourceMode;
+    url: string | null;
+    effectiveUrl: string | null;
+  };
   holidayStatus: {
+    status: HolidaySourceStatus;
+    message: string | null;
+    checkedAt: Date | null;
+  };
+  publicHolidayStatus: {
     status: HolidaySourceStatus;
     message: string | null;
     checkedAt: Date | null;
@@ -54,7 +64,17 @@ export type ClientSperrlisteSettings = {
     url: string | null;
     effectiveUrl: string | null;
   };
+  publicHolidaySource: {
+    mode: HolidaySourceMode;
+    url: string | null;
+    effectiveUrl: string | null;
+  };
   holidayStatus: {
+    status: HolidaySourceStatus;
+    message: string | null;
+    checkedAt: string | null;
+  };
+  publicHolidayStatus: {
     status: HolidaySourceStatus;
     message: string | null;
     checkedAt: string | null;
@@ -69,12 +89,19 @@ export type SperrlisteSettingsInput = {
   exceptionWeekdays: number[];
   holidaySourceMode: HolidaySourceMode;
   holidaySourceUrl: string | null;
+  publicHolidaySourceMode: HolidaySourceMode;
+  publicHolidaySourceUrl: string | null;
 };
 
 export type HolidayStatusUpdate = {
   status: HolidaySourceStatus;
   message: string | null;
   checkedAt: Date;
+};
+
+export type HolidayStatusUpdates = {
+  holiday: HolidayStatusUpdate;
+  publicHoliday: HolidayStatusUpdate;
 };
 
 const DEFAULT_RECORD_ID = "default" as const;
@@ -167,22 +194,46 @@ export function getDefaultPublicHolidaySourceUrl() {
 }
 
 export function resolveSperrlisteSettings(record: SperrlisteSettingsRecord): ResolvedSperrlisteSettings {
-  const mode = resolveMode(record?.holidaySourceMode);
-  const url = normaliseUrl(record?.holidaySourceUrl);
   const freezeDays = clampNumber(record?.freezeDays, 0, 365, DEFAULT_FREEZE_DAYS);
   const preferredWeekdays = sanitiseWeekdayJson(record?.preferredWeekdays ?? null, DEFAULT_PREFERRED_WEEKDAYS);
   const exceptionWeekdays = sanitiseWeekdayJson(record?.exceptionWeekdays ?? null, DEFAULT_EXCEPTION_WEEKDAYS);
-  const effectiveUrl = mode === "disabled" ? null : mode === "custom" ? url : resolveDefaultHolidayUrl();
 
-  const resolvedStatus = mode === "disabled" ? "disabled" : resolveStatus(record?.holidaySourceStatus);
+  const holidaySourceMode = resolveMode(record?.holidaySourceMode);
+  const holidaySourceUrl = normaliseUrl(record?.holidaySourceUrl);
+  const defaultHolidayUrl = resolveDefaultHolidayUrl();
+  const holidayEffectiveUrl =
+    holidaySourceMode === "disabled"
+      ? null
+      : holidaySourceMode === "custom"
+        ? holidaySourceUrl
+        : defaultHolidayUrl;
+
+  const publicHolidaySourceMode = resolveMode(record?.publicHolidaySourceMode);
+  const publicHolidaySourceUrl = normaliseUrl(record?.publicHolidaySourceUrl);
+  const defaultPublicUrl = resolveDefaultPublicHolidayUrl();
+  const publicHolidayEffectiveUrl =
+    publicHolidaySourceMode === "disabled"
+      ? null
+      : publicHolidaySourceMode === "custom"
+        ? publicHolidaySourceUrl
+        : defaultPublicUrl;
 
   const holidayStatus = {
-    status: resolvedStatus,
+    status: holidaySourceMode === "disabled" ? "disabled" : resolveStatus(record?.holidaySourceStatus),
     message: record?.holidaySourceMessage ?? null,
     checkedAt: record?.holidaySourceCheckedAt ?? null,
   } as const;
 
-  const cacheKey = `${mode}|${effectiveUrl ?? "none"}`;
+  const publicHolidayStatus = {
+    status: publicHolidaySourceMode === "disabled" ? "disabled" : resolveStatus(record?.publicHolidaySourceStatus),
+    message: record?.publicHolidaySourceMessage ?? null,
+    checkedAt: record?.publicHolidaySourceCheckedAt ?? null,
+  } as const;
+
+  const cacheKey = [
+    `${holidaySourceMode}|${holidayEffectiveUrl ?? "none"}`,
+    `${publicHolidaySourceMode}|${publicHolidayEffectiveUrl ?? "none"}`,
+  ].join("|");
 
   return {
     id: record?.id ?? DEFAULT_RECORD_ID,
@@ -190,11 +241,17 @@ export function resolveSperrlisteSettings(record: SperrlisteSettingsRecord): Res
     preferredWeekdays,
     exceptionWeekdays,
     holidaySource: {
-      mode,
-      url,
-      effectiveUrl,
+      mode: holidaySourceMode,
+      url: holidaySourceUrl,
+      effectiveUrl: holidayEffectiveUrl,
+    },
+    publicHolidaySource: {
+      mode: publicHolidaySourceMode,
+      url: publicHolidaySourceUrl,
+      effectiveUrl: publicHolidayEffectiveUrl,
     },
     holidayStatus,
+    publicHolidayStatus,
     updatedAt: record?.updatedAt ?? null,
     cacheKey,
   };
@@ -212,11 +269,23 @@ export function toClientSperrlisteSettings(
       url: resolved.holidaySource.url,
       effectiveUrl: resolved.holidaySource.effectiveUrl,
     },
+    publicHolidaySource: {
+      mode: resolved.publicHolidaySource.mode,
+      url: resolved.publicHolidaySource.url,
+      effectiveUrl: resolved.publicHolidaySource.effectiveUrl,
+    },
     holidayStatus: {
       status: resolved.holidayStatus.status,
       message: resolved.holidayStatus.message,
       checkedAt: resolved.holidayStatus.checkedAt
         ? resolved.holidayStatus.checkedAt.toISOString()
+        : null,
+    },
+    publicHolidayStatus: {
+      status: resolved.publicHolidayStatus.status,
+      message: resolved.publicHolidayStatus.message,
+      checkedAt: resolved.publicHolidayStatus.checkedAt
+        ? resolved.publicHolidayStatus.checkedAt.toISOString()
         : null,
     },
     updatedAt: resolved.updatedAt ? resolved.updatedAt.toISOString() : null,
@@ -246,10 +315,11 @@ function toJsonArray(values: number[]) {
 
 export async function saveSperrlisteSettings(
   data: SperrlisteSettingsInput,
-  options: { resetStatus?: boolean } = {},
+  options: { resetHolidayStatus?: boolean; resetPublicHolidayStatus?: boolean } = {},
 ) {
   const id = DEFAULT_RECORD_ID;
-  const resetStatus = Boolean(options.resetStatus);
+  const resetHolidayStatus = Boolean(options.resetHolidayStatus);
+  const resetPublicHolidayStatus = Boolean(options.resetPublicHolidayStatus);
   const preferredWeekdays = toJsonArray(data.preferredWeekdays);
   const exceptionWeekdays = toJsonArray(data.exceptionWeekdays);
 
@@ -257,14 +327,22 @@ export async function saveSperrlisteSettings(
     freezeDays: clampNumber(data.freezeDays, 0, 365, DEFAULT_FREEZE_DAYS),
     holidaySourceMode: data.holidaySourceMode,
     holidaySourceUrl: normaliseUrl(data.holidaySourceUrl),
+    publicHolidaySourceMode: data.publicHolidaySourceMode,
+    publicHolidaySourceUrl: normaliseUrl(data.publicHolidaySourceUrl),
     preferredWeekdays,
     exceptionWeekdays,
   };
 
-  if (resetStatus) {
+  if (resetHolidayStatus) {
     update.holidaySourceStatus = "unknown";
     update.holidaySourceMessage = null;
     update.holidaySourceCheckedAt = null;
+  }
+
+  if (resetPublicHolidayStatus) {
+    update.publicHolidaySourceStatus = "unknown";
+    update.publicHolidaySourceMessage = null;
+    update.publicHolidaySourceCheckedAt = null;
   }
 
   return prisma.sperrlisteSettings.upsert({
@@ -275,29 +353,42 @@ export async function saveSperrlisteSettings(
       freezeDays: clampNumber(data.freezeDays, 0, 365, DEFAULT_FREEZE_DAYS),
       holidaySourceMode: data.holidaySourceMode,
       holidaySourceUrl: normaliseUrl(data.holidaySourceUrl),
+      publicHolidaySourceMode: data.publicHolidaySourceMode,
+      publicHolidaySourceUrl: normaliseUrl(data.publicHolidaySourceUrl),
       preferredWeekdays,
       exceptionWeekdays,
     },
   });
 }
 
-export async function applyHolidaySourceStatus(update: HolidayStatusUpdate) {
+export async function applyHolidaySourceStatuses(updates: HolidayStatusUpdates) {
   const id = DEFAULT_RECORD_ID;
-  const resolvedStatus = update.status === "disabled" ? "disabled" : update.status;
+  const resolvedHolidayStatus =
+    updates.holiday.status === "disabled" ? "disabled" : updates.holiday.status;
+  const resolvedPublicStatus =
+    updates.publicHoliday.status === "disabled" ? "disabled" : updates.publicHoliday.status;
   return prisma.sperrlisteSettings.upsert({
     where: { id },
     update: {
-      holidaySourceStatus: resolvedStatus,
-      holidaySourceMessage: update.message,
-      holidaySourceCheckedAt: update.checkedAt,
+      holidaySourceStatus: resolvedHolidayStatus,
+      holidaySourceMessage: updates.holiday.message,
+      holidaySourceCheckedAt: updates.holiday.checkedAt,
+      publicHolidaySourceStatus: resolvedPublicStatus,
+      publicHolidaySourceMessage: updates.publicHoliday.message,
+      publicHolidaySourceCheckedAt: updates.publicHoliday.checkedAt,
     },
     create: {
       id,
       holidaySourceMode: "default",
       holidaySourceUrl: null,
-      holidaySourceStatus: resolvedStatus,
-      holidaySourceMessage: update.message,
-      holidaySourceCheckedAt: update.checkedAt,
+      holidaySourceStatus: resolvedHolidayStatus,
+      holidaySourceMessage: updates.holiday.message,
+      holidaySourceCheckedAt: updates.holiday.checkedAt,
+      publicHolidaySourceMode: "default",
+      publicHolidaySourceUrl: null,
+      publicHolidaySourceStatus: resolvedPublicStatus,
+      publicHolidaySourceMessage: updates.publicHoliday.message,
+      publicHolidaySourceCheckedAt: updates.publicHoliday.checkedAt,
       freezeDays: DEFAULT_FREEZE_DAYS,
       preferredWeekdays: [...DEFAULT_PREFERRED_WEEKDAYS],
       exceptionWeekdays: [...DEFAULT_EXCEPTION_WEEKDAYS],


### PR DESCRIPTION
## Summary
- extend Sperrliste settings storage and defaults so both school-holiday and public-holiday feeds persist mode, URL, and status metadata
- expose the new fields through the API layer and UI so members can review, edit, and validate each feed separately
- update holiday fetching and tests to respect the dual-feed configuration and persist status results for both sources

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68deeedb7798832db8d1b84537e97aba