### PR TITLE
Align member since row with email styling

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -1113,7 +1113,7 @@ function ProfileOverviewCard({
                   </span>
                 )}
                 {memberSinceLabel || createdAtLabel ? (
-                  <div className="flex flex-col gap-1 text-xs uppercase tracking-wide text-muted-foreground">
+                  <div className="flex items-center gap-2 text-sm font-medium text-foreground">
                     <CalendarDays className="h-4 w-4" aria-hidden />
                     <span>{memberSinceLabel ?? (createdAtLabel ? `Profil seit ${createdAtLabel}` : "")}</span>
                   </div>


### PR DESCRIPTION
## Summary
- align the calendar row in the member profile header so the icon and text sit on one line
- match the member-since text styling with the email link color for consistent emphasis

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68df8cbad680832d9efa1eb0b085e588