### PR TITLE
Use external public holiday feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,9 @@ SYNC_BATCH_LIMIT=50
 
 # Optional: ICS feed for sächsische Schulferien. Wird genutzt, um die Sperrliste zu annotieren.
 #SAXONY_HOLIDAYS_ICS_URL=https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics
-#SAXONY_PUBLIC_HOLIDAYS_ICS_URL=https://example.com/feiertage-sachsen.ics # Optional eigene Quelle statt der internen Standardliste
+# Optional: Eigene Quelle für gesetzliche Feiertage in Sachsen statt des Standardfeeds
+# (https://www.officeholidays.com/ics/germany/saxony).
+#SAXONY_PUBLIC_HOLIDAYS_ICS_URL=https://example.com/feiertage-sachsen.ics
 # Optional: Deaktiviert ausgehende HTTP-Abfragen und aktiviert den statischen Ferien-Datensatz.
 #OUTBOUND_HTTP_DISABLED=0
 

--- a/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-manager.tsx
@@ -12,7 +12,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Text } from "@/components/ui/typography";
 import { cn } from "@/lib/utils";
 import {
-  DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED,
   type ClientSperrlisteSettings,
   type HolidaySourceStatus,
   type HolidaySourceMode,
@@ -229,9 +228,6 @@ export function SperrlisteSettingsManager({
     if (value === publicHolidayModeState) {
       return;
     }
-    if (value === "custom" && publicHolidayUrlState === DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED) {
-      setPublicHolidayUrlState("");
-    }
     setPublicHolidayModeState(value);
     resetFeedback();
     markStatusPending("publicHoliday");
@@ -337,8 +333,19 @@ export function SperrlisteSettingsManager({
 
   const publicHolidayModeSummary = useMemo(() => {
     switch (publicHolidayMode) {
-      case "default":
-        return "Standardfeed (Interne Feiertage Sachsen)";
+      case "default": {
+        const trimmed = defaults.publicHolidaySourceUrl?.trim();
+        if (!trimmed) {
+          return "Standardfeed (nicht konfiguriert)";
+        }
+        try {
+          const parsed = new URL(trimmed);
+          const label = `${parsed.hostname}${parsed.pathname}${parsed.search}${parsed.hash}`.replace(/\/$/, "");
+          return `Standardfeed (${label || parsed.hostname})`;
+        } catch {
+          return `Standardfeed (${trimmed})`;
+        }
+      }
       case "custom": {
         const trimmed = publicHolidayUrl.trim();
         if (!trimmed) return "Eigene URL (noch nicht gesetzt)";
@@ -353,21 +360,11 @@ export function SperrlisteSettingsManager({
       default:
         return "Keine Feiertagsquelle";
     }
-  }, [publicHolidayMode, publicHolidayUrl]);
+  }, [defaults.publicHolidaySourceUrl, publicHolidayMode, publicHolidayUrl]);
 
   const publicHolidaySourceDetails = useMemo(() => {
     if (publicHolidayMode === "disabled") {
       return null;
-    }
-
-    if (
-      publicHolidayMode !== "custom" &&
-      defaults.publicHolidaySourceUrl === DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED
-    ) {
-      return {
-        href: null,
-        label: "Interne Standardliste",
-      } as const;
     }
 
     const rawUrl =
@@ -974,7 +971,7 @@ export function SperrlisteSettingsManager({
                         <SelectValue placeholder="Modus wählen" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="default">Standardfeed (Interne Feiertage Sachsen)</SelectItem>
+                        <SelectItem value="default">Standardfeed (Sachsen, OfficeHolidays)</SelectItem>
                         <SelectItem value="custom">Eigene URL</SelectItem>
                         <SelectItem value="disabled">Keine Feiertagsquelle</SelectItem>
                       </SelectContent>
@@ -987,11 +984,7 @@ export function SperrlisteSettingsManager({
                       type="url"
                       value={publicHolidayUrl}
                       onChange={(event) => handlePublicHolidayUrlInput(event.target.value)}
-                      placeholder={
-                        defaults.publicHolidaySourceUrl === DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED
-                          ? ""
-                          : defaults.publicHolidaySourceUrl
-                      }
+                      placeholder={defaults.publicHolidaySourceUrl ?? ""}
                       disabled={publicHolidayMode !== "custom" || saving}
                     />
                   </div>

--- a/src/app/api/sperrliste/settings/check/__tests__/route.test.ts
+++ b/src/app/api/sperrliste/settings/check/__tests__/route.test.ts
@@ -14,7 +14,7 @@ const {
   defaultPublicHolidayUrl,
 } = vi.hoisted(() => {
   const url = "https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics";
-  const publicUrl = "static:saxony-public-holidays";
+  const publicUrl = "https://www.officeholidays.com/ics/germany/saxony";
   return {
     requireAuthMock: vi.fn(),
     hasPermissionMock: vi.fn(),
@@ -48,7 +48,7 @@ const {
       },
       updatedAt: null,
       cacheKey:
-        "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics|default|static:saxony-public-holidays",
+        "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics|default|https://www.officeholidays.com/ics/germany/saxony",
     },
     defaultHolidayUrl: url,
     defaultPublicHolidayUrl: publicUrl,
@@ -59,7 +59,7 @@ vi.mock("@/lib/rbac", () => ({ requireAuth: requireAuthMock }));
 vi.mock("@/lib/permissions", () => ({ hasPermission: hasPermissionMock }));
 vi.mock("@/lib/sperrliste-settings", () => ({
   HOLIDAY_SOURCE_MODES: ["default", "custom", "disabled"] as const,
-  DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED: "static:saxony-public-holidays",
+  DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED: "https://www.officeholidays.com/ics/germany/saxony",
   getDefaultHolidaySourceUrl: vi.fn(() => defaultHolidayUrl),
   getDefaultPublicHolidaySourceUrl: vi.fn(() => defaultPublicHolidayUrl),
   readSperrlisteSettings: readSperrlisteSettingsMock,

--- a/src/lib/__tests__/holidays.test.ts
+++ b/src/lib/__tests__/holidays.test.ts
@@ -7,7 +7,7 @@ vi.mock("next/cache", () => ({
 
 const { defaultHolidayUrl, defaultPublicHolidayUrl, resolvedSettings } = vi.hoisted(() => {
   const url = "https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics";
-  const publicUrl = "static:saxony-public-holidays";
+  const publicUrl = "https://www.officeholidays.com/ics/germany/saxony";
   return {
     defaultHolidayUrl: url,
     defaultPublicHolidayUrl: publicUrl,
@@ -38,13 +38,13 @@ const { defaultHolidayUrl, defaultPublicHolidayUrl, resolvedSettings } = vi.hois
       },
       updatedAt: null,
       cacheKey:
-        "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics|default|static:saxony-public-holidays",
+        "default|https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics|default|https://www.officeholidays.com/ics/germany/saxony",
     },
   } as const;
 });
 
 vi.mock("@/lib/sperrliste-settings", () => ({
-  DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED: "static:saxony-public-holidays",
+  DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED: "https://www.officeholidays.com/ics/germany/saxony",
   readSperrlisteSettings: vi.fn().mockResolvedValue(null),
   resolveSperrlisteSettings: vi
     .fn()
@@ -114,7 +114,7 @@ describe("getSaxonySchoolHolidayRanges", () => {
         return a.id.localeCompare(b.id);
       });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
     expect(ranges).toEqual(expected);
   });
 });

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -5,7 +5,6 @@ import { addDays, format, isValid, parseISO } from "date-fns";
 import { SAXONY_PUBLIC_HOLIDAYS } from "@/data/saxony-public-holidays";
 import { SAXONY_SCHOOL_HOLIDAYS } from "@/data/saxony-school-holidays";
 import {
-  DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED,
   applyHolidaySourceStatuses,
   getDefaultHolidaySourceUrl,
   getDefaultPublicHolidaySourceUrl,
@@ -601,18 +600,6 @@ async function fetchPublicHolidayRangesForSettings(
     settings.publicHolidaySource.mode === "custom"
       ? settings.publicHolidaySource.url
       : settings.publicHolidaySource.effectiveUrl ?? getDefaultPublicHolidaySourceUrl();
-
-  if (publicUrl === DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED) {
-    const ranges = filterRelevantRanges(getStaticPublicHolidayRanges());
-    return {
-      ranges,
-      status: {
-        status: "ok",
-        message: "Feiertagsquelle nutzt die interne Standardliste.",
-        checkedAt,
-      },
-    };
-  }
 
   if (isOutboundHttpDisabled()) {
     const ranges = filterRelevantRanges(getStaticPublicHolidayRanges());

--- a/src/lib/sperrliste-settings.ts
+++ b/src/lib/sperrliste-settings.ts
@@ -4,7 +4,8 @@ import type { Prisma, SperrlisteSettings } from "@prisma/client";
 export const DEFAULT_SAXONY_HOLIDAY_FEED =
   "https://www.feiertage-deutschland.de/kalender-download/ics/schulferien-sachsen.ics";
 
-export const DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED = "static:saxony-public-holidays";
+export const DEFAULT_SAXONY_PUBLIC_HOLIDAY_FEED =
+  "https://www.officeholidays.com/ics/germany/saxony";
 
 export const DEFAULT_FREEZE_DAYS = 7;
 export const DEFAULT_PREFERRED_WEEKDAYS = [6, 0] as const;


### PR DESCRIPTION
## Summary
- switch the Saxony public holiday default to the OfficeHolidays ICS feed and document the override option
- align the Sperrliste settings UI with the remote feed by updating labels, placeholders, and summaries
- refresh holiday-related tests to use the new feed URL and expect the additional network request

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68df94c9c5f8832da4f22c01f20d15f2