### PR TITLE
Add payment checklist item and hide completed profile tasks

### DIFF
--- a/src/app/(members)/mitglieder/profil/page.tsx
+++ b/src/app/(members)/mitglieder/profil/page.tsx
@@ -6,7 +6,7 @@ import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
 import { getUserDisplayName } from "@/lib/names";
 import { getOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
 import { prisma } from "@/lib/prisma";
-import { buildProfileChecklist } from "@/lib/profile-completion";
+import { buildProfileChecklist, isPaymentDetailsComplete } from "@/lib/profile-completion";
 import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 import { sortRoles, type Role } from "@/lib/roles";
@@ -206,6 +206,14 @@ export default async function ProfilePage() {
   const hasBasicData = Boolean(user.firstName?.trim() && user.email?.trim());
   const hasBirthdate = Boolean(user.dateOfBirth);
   const hasDietaryPreference = Boolean(user.onboardingProfile?.dietaryPreference?.trim());
+  const hasPaymentDetails = isPaymentDetailsComplete({
+    payoutMethod: user.payoutMethod,
+    payoutAccountHolder: user.payoutAccountHolder,
+    payoutIban: user.payoutIban,
+    payoutBankName: user.payoutBankName,
+    payoutPaypalHandle: user.payoutPaypalHandle,
+    payoutNote: user.payoutNote,
+  });
 
   const onboardingProfile = user.onboardingProfile;
   const whatsappLink = onboardingProfile?.show
@@ -215,6 +223,7 @@ export default async function ProfilePage() {
   const checklist = buildProfileChecklist({
     hasBasicData,
     hasBirthdate,
+    hasPaymentDetails,
     hasDietaryPreference,
     hasMeasurements,
     photoConsent: { consentGiven: photoConsentSummary.status === "approved" },

--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/lib/onboarding/role-preference-utils";
 import {
   buildProfileChecklist,
+  isPaymentDetailsComplete,
   type ProfileChecklistTarget,
   type ProfileCompletionSummary,
 } from "@/lib/profile-completion";
@@ -96,6 +97,7 @@ const CURRENT_YEAR = new Date().getFullYear();
 const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
 const CHECKLIST_TARGETS: ProfileChecklistTarget[] = [
   "stammdaten",
+  "zahlungen",
   "ernaehrung",
   "masse",
   "interessen",
@@ -280,6 +282,17 @@ type Measurement = Omit<ProfileClientProps["measurements"][number], "type" | "un
 };
 type OnboardingProfile = NonNullable<ProfileClientProps["onboarding"]>;
 
+function isProfilePaymentComplete(user: ProfileUser): boolean {
+  return isPaymentDetailsComplete({
+    payoutMethod: user.payoutMethod,
+    payoutAccountHolder: user.payoutAccountHolder,
+    payoutIban: user.payoutIban,
+    payoutBankName: user.payoutBankName,
+    payoutPaypalHandle: user.payoutPaypalHandle,
+    payoutNote: user.payoutNote,
+  });
+}
+
 function mapUpdatedUserFromPayload(
   previous: ProfileUser,
   payload: UpdateProfileBasicsResult["user"],
@@ -366,6 +379,7 @@ type OnboardingFormState = {
 type ChecklistState = {
   hasBasicData: boolean;
   hasBirthdate: boolean;
+  hasPaymentDetails: boolean;
   hasDietaryPreference: boolean;
   hasMeasurements?: boolean;
   photoConsentGiven?: boolean;
@@ -619,6 +633,7 @@ function ProfileClientInner({
   const [, setChecklistState] = useState<ChecklistState>(() => ({
     hasBasicData: Boolean(initialUser.firstName?.trim() && initialUser.email?.trim()),
     hasBirthdate: Boolean(initialUser.dateOfBirth),
+    hasPaymentDetails: isProfilePaymentComplete(initialUser),
     hasDietaryPreference: Boolean(initialOnboarding?.dietaryPreference?.trim()),
     hasMeasurements: canManageMeasurements ? initialMeasurements.length > 0 : undefined,
     photoConsentGiven: summary.items.find((item) => item.id === "photo-consent")?.complete ?? undefined,
@@ -630,6 +645,7 @@ function ProfileClientInner({
       buildProfileChecklist({
         hasBasicData: state.hasBasicData,
         hasBirthdate: state.hasBirthdate,
+        hasPaymentDetails: state.hasPaymentDetails,
         hasDietaryPreference: state.hasDietaryPreference,
         hasMeasurements: canManageMeasurements ? Boolean(state.hasMeasurements) : undefined,
         photoConsent:
@@ -702,6 +718,7 @@ function ProfileClientInner({
       updateChecklist({
         hasBasicData: basicsComplete,
         hasBirthdate: Boolean(nextUser.dateOfBirth),
+        hasPaymentDetails: isProfilePaymentComplete(nextUser),
       });
       try {
         await refreshSession?.();
@@ -998,13 +1015,10 @@ function ProfileOverviewCard({
 }: ProfileOverviewCardProps) {
   const email = user.email?.trim() ?? "";
   const show = onboarding?.show ?? null;
-  const checklistBadgeLabel = summary.total
-    ? summary.complete
-      ? "Profil vollständig"
-      : `${percentComplete}% vollständig`
-    : null;
+  const checklistBadgeLabel = summary.complete ? "Profil vollständig" : null;
   const checklistCountLabel = summary.total ? `${summary.completed}/${summary.total}` : null;
-  const hasChecklistItems = summary.items.length > 0;
+  const pendingChecklistItems = summary.items.filter((item) => !item.complete);
+  const hasChecklistItems = pendingChecklistItems.length > 0;
   const hasHighlights = highlights.length > 0;
 
   return (
@@ -1117,7 +1131,7 @@ function ProfileOverviewCard({
               <div className="rounded-xl border border-border/60 bg-background/80 p-4 shadow-inner shadow-primary/5">
                 <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Checkliste</div>
                 <ul className="mt-3 space-y-2">
-                  {summary.items.map((item) => {
+                  {pendingChecklistItems.map((item) => {
                     const target = item.targetSection ?? null;
                     const isActive = target ? activeChecklistTarget === target : false;
                     const isComplete = item.complete;

--- a/src/app/api/dashboard/overview/route.ts
+++ b/src/app/api/dashboard/overview/route.ts
@@ -6,7 +6,7 @@ import { hasRole, requireAuth } from "@/lib/rbac";
 import { prisma } from "@/lib/prisma";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProductionId } from "@/lib/active-production";
-import { buildProfileChecklist } from "@/lib/profile-completion";
+import { buildProfileChecklist, isPaymentDetailsComplete } from "@/lib/profile-completion";
 
 type MembershipSummary = {
   showId: string;
@@ -149,6 +149,12 @@ export async function GET() {
           lastName: true,
           email: true,
           dateOfBirth: true,
+          payoutMethod: true,
+          payoutAccountHolder: true,
+          payoutIban: true,
+          payoutBankName: true,
+          payoutPaypalHandle: true,
+          payoutNote: true,
         },
       }),
       prisma.productionMembership.findMany({
@@ -199,11 +205,21 @@ export async function GET() {
       .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
       .slice(0, 10);
 
+    const hasPaymentDetails = isPaymentDetailsComplete({
+      payoutMethod: userRecord?.payoutMethod,
+      payoutAccountHolder: userRecord?.payoutAccountHolder,
+      payoutIban: userRecord?.payoutIban,
+      payoutBankName: userRecord?.payoutBankName,
+      payoutPaypalHandle: userRecord?.payoutPaypalHandle,
+      payoutNote: userRecord?.payoutNote,
+    });
+
     const profileChecklist = buildProfileChecklist({
       hasBasicData: Boolean(
         userRecord?.firstName && userRecord?.lastName && userRecord?.email,
       ),
       hasBirthdate: Boolean(userRecord?.dateOfBirth),
+      hasPaymentDetails,
       hasDietaryPreference: Boolean(
         onboardingProfile?.dietaryPreference?.trim(),
       ),

--- a/src/lib/profile-completion.ts
+++ b/src/lib/profile-completion.ts
@@ -1,6 +1,7 @@
 export type ProfileChecklistItemId =
   | "basics"
   | "birthdate"
+  | "payments"
   | "dietary"
   | "measurements"
   | "photo-consent"
@@ -8,6 +9,7 @@ export type ProfileChecklistItemId =
 
 export type ProfileChecklistTarget =
   | "stammdaten"
+  | "zahlungen"
   | "ernaehrung"
   | "masse"
   | "interessen"
@@ -32,11 +34,46 @@ export type ProfileCompletionSummary = {
 type ChecklistInput = {
   hasBasicData: boolean;
   hasBirthdate: boolean;
+  hasPaymentDetails?: boolean;
   hasDietaryPreference: boolean;
   hasMeasurements?: boolean;
   photoConsent?: { consentGiven: boolean };
   hasWhatsappVisit?: boolean;
 };
+
+export type PaymentDetailsInput = {
+  payoutMethod?: string | null;
+  payoutAccountHolder?: string | null;
+  payoutIban?: string | null;
+  payoutBankName?: string | null;
+  payoutPaypalHandle?: string | null;
+  payoutNote?: string | null;
+};
+
+export function isPaymentDetailsComplete(details: PaymentDetailsInput): boolean {
+  const method = details.payoutMethod?.trim();
+  if (!method) {
+    return false;
+  }
+
+  switch (method) {
+    case "BANK_TRANSFER": {
+      return Boolean(
+        details.payoutAccountHolder?.trim() &&
+          details.payoutIban?.trim() &&
+          details.payoutBankName?.trim(),
+      );
+    }
+    case "PAYPAL": {
+      return Boolean(details.payoutPaypalHandle?.trim());
+    }
+    case "OTHER": {
+      return Boolean(details.payoutNote?.trim());
+    }
+    default:
+      return false;
+  }
+}
 
 export function buildProfileChecklist(
   input: ChecklistInput,
@@ -55,6 +92,13 @@ export function buildProfileChecklist(
       description: "Hilft bei der Verwaltung notwendiger Einverständnisse.",
       complete: input.hasBirthdate,
       targetSection: "stammdaten",
+    },
+    {
+      id: "payments",
+      label: "Zahlungsdaten hinterlegt",
+      description: "Stelle sicher, dass wir Auszahlungen veranlassen können.",
+      complete: Boolean(input.hasPaymentDetails),
+      targetSection: "zahlungen",
     },
     {
       id: "dietary",


### PR DESCRIPTION
## Summary
- add a reusable helper to evaluate payment details and include them in the profile checklist
- feed payment completion data into the profile page, dashboard API, and client state
- hide completed checklist entries on the profile overview and only show the completion badge when fully done

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68df95b28d58832db61ee17853ab14d8