### PR TITLE
Remove account summary from user dropdown menu

### DIFF
--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -68,7 +68,6 @@ export function UserNav({ className }: { className?: string }) {
   const { firstName: derivedFirstName } = splitFullName(name);
   const firstNameDisplay =
     session.user.firstName?.trim() ?? derivedFirstName ?? name;
-  const role = session.user.role;
   async function onLogout() {
     try {
       await signOut({ callbackUrl: "/" });
@@ -115,12 +114,6 @@ export function UserNav({ className }: { className?: string }) {
           aria-label="Benutzermenü"
           className="absolute right-0 z-50 mt-2 w-56 rounded-md border border-border/60 bg-card/95 backdrop-blur shadow-md"
         >
-          <div className="px-3 py-2 text-xs text-foreground/70">
-            Angemeldet als
-            <div className="truncate text-foreground">{name}</div>
-            {role && <div className="truncate">Rolle: {role}</div>}
-          </div>
-          <div className="h-px bg-border/60" />
           <div className="py-1">
             <Link
               role="menuitem"


### PR DESCRIPTION
## Summary
- remove the account info header from the user navigation dropdown
- clean up unused role variable in the user nav component

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build > build.log

------
https://chatgpt.com/codex/tasks/task_e_68dfaab09994832dbd581f6f8b1efd26