### PR TITLE
Adjust profile tab menu layout

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -943,17 +943,17 @@ function ProfileClientInner({
             </Select>
           </div>
 
-          <TabsList className="hidden w-full items-center justify-between gap-1 overflow-x-auto rounded-full border border-border/70 bg-background/70 p-1 text-muted-foreground shadow-inner ring-1 ring-primary/10 backdrop-blur sm:flex">
+          <TabsList className="hidden w-full flex-nowrap items-center justify-between gap-1 overflow-x-auto rounded-full border border-border/70 bg-background/70 p-1 text-muted-foreground shadow-inner ring-1 ring-primary/10 backdrop-blur sm:flex">
             {tabOptions.map((option) => (
               <TabsTrigger
                 key={option.value}
                 value={option.value}
-                className="flex-1 basis-0 whitespace-nowrap px-4 py-2 text-xs font-semibold uppercase tracking-wide transition sm:px-5 sm:text-sm"
-              >
-                {option.label}
-              </TabsTrigger>
-            ))}
-          </TabsList>
+                className="inline-flex flex-1 basis-0 items-center justify-center whitespace-nowrap px-3 py-2 text-[0.7rem] font-semibold uppercase tracking-wide transition text-center leading-tight sm:px-4 sm:text-xs"
+                >
+                  {option.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
         </div>
 
         <TabsContent value="stammdaten" className="space-y-6">


### PR DESCRIPTION
## Summary
- prevent wrapping in the desktop profile tab list and center the labels for better alignment
- tighten the trigger spacing and reduce font size so all sections from Stammdaten to Onboarding fit on one line

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dfad1899b0832db2e3b999f13f6a56