### PR TITLE
Relax payout validation when untouched and fix onboarding crew toggle

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -338,32 +338,42 @@ export async function PUT(request: NextRequest) {
     : existingUser.payoutPaypalHandle;
   const effectivePayoutNote = payoutNoteProvided ? parsedPayoutNote : existingUser.payoutNote;
 
-  if (effectivePayoutMethod === "BANK_TRANSFER") {
-    if (!effectiveAccountHolder) {
-      return NextResponse.json({ error: "Bitte gib den Kontoinhaber an" }, { status: 400 });
-    }
-    if (!effectiveIban || !IBAN_REGEX.test(effectiveIban)) {
-      return NextResponse.json({ error: "Bitte gib eine gültige IBAN an" }, { status: 400 });
-    }
-    if (!effectiveBankName) {
-      return NextResponse.json({ error: "Bitte gib den Namen deiner Bank an" }, { status: 400 });
-    }
-  } else if (effectivePayoutMethod === "PAYPAL") {
-    if (!effectivePaypalHandle) {
-      return NextResponse.json(
-        { error: "Bitte hinterlege deine PayPal-Adresse oder deinen PayPal.me-Link" },
-        { status: 400 },
-      );
-    }
-    if (!PAYPAL_HANDLE_REGEX.test(effectivePaypalHandle)) {
-      return NextResponse.json(
-        { error: "Bitte gib eine gültige PayPal-Adresse oder einen PayPal.me-Link an" },
-        { status: 400 },
-      );
-    }
-  } else if (effectivePayoutMethod === "OTHER") {
-    if (!effectivePayoutNote) {
-      return NextResponse.json({ error: "Bitte beschreibe deine bevorzugte Auszahlung" }, { status: 400 });
+  const payoutDetailsTouched =
+    payoutMethodProvided ||
+    payoutAccountHolderProvided ||
+    payoutIbanProvided ||
+    payoutBankNameProvided ||
+    payoutPaypalHandleProvided ||
+    payoutNoteProvided;
+
+  if (payoutDetailsTouched) {
+    if (effectivePayoutMethod === "BANK_TRANSFER") {
+      if (!effectiveAccountHolder) {
+        return NextResponse.json({ error: "Bitte gib den Kontoinhaber an" }, { status: 400 });
+      }
+      if (!effectiveIban || !IBAN_REGEX.test(effectiveIban)) {
+        return NextResponse.json({ error: "Bitte gib eine gültige IBAN an" }, { status: 400 });
+      }
+      if (!effectiveBankName) {
+        return NextResponse.json({ error: "Bitte gib den Namen deiner Bank an" }, { status: 400 });
+      }
+    } else if (effectivePayoutMethod === "PAYPAL") {
+      if (!effectivePaypalHandle) {
+        return NextResponse.json(
+          { error: "Bitte hinterlege deine PayPal-Adresse oder deinen PayPal.me-Link" },
+          { status: 400 },
+        );
+      }
+      if (!PAYPAL_HANDLE_REGEX.test(effectivePaypalHandle)) {
+        return NextResponse.json(
+          { error: "Bitte gib eine gültige PayPal-Adresse oder einen PayPal.me-Link an" },
+          { status: 400 },
+        );
+      }
+    } else if (effectivePayoutMethod === "OTHER") {
+      if (!effectivePayoutNote) {
+        return NextResponse.json({ error: "Bitte beschreibe deine bevorzugte Auszahlung" }, { status: 400 });
+      }
     }
   }
 

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1503,6 +1503,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                             <p className="text-sm text-muted-foreground">{pref.description}</p>
                           </div>
                           <Button
+                            type="button"
                             size="sm"
                             variant={active ? "default" : "outline"}
                             onClick={() => togglePreference("acting", pref.code)}
@@ -1573,6 +1574,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                           </div>
                           <div className="flex flex-col items-end gap-2">
                             <Button
+                              type="button"
                               size="sm"
                               variant={active ? "default" : "outline"}
                               onClick={() => togglePreference("crew", pref.code)}


### PR DESCRIPTION
## Summary
- only enforce payout account validation when payout fields are included in the update payload so profile basics can be saved without payment data
- mark onboarding role preference toggle buttons as non-submit buttons to allow Gewerke selections

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dfae0eb7a0832d8207d5e5b8f1b05d