### PR TITLE
Highlight logout action in user dropdown

### DIFF
--- a/src/components/user-nav.tsx
+++ b/src/components/user-nav.tsx
@@ -150,7 +150,7 @@ export function UserNav({ className }: { className?: string }) {
             <div className="mx-3 my-1 h-px bg-border/60" />
             <button
               role="menuitem"
-              className="block w-full px-3 py-2 text-left text-sm hover:bg-accent/30 focus:bg-accent/30"
+              className="block w-full px-3 py-2 text-left text-sm text-destructive hover:bg-destructive/10 focus:bg-destructive/15 focus:outline-none"
               onClick={() => {
                 setOpen(false);
                 onLogout();


### PR DESCRIPTION
## Summary
- highlight the logout entry in the user navigation menu with the destructive color scheme so it stands out clearly

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dfae9d9c88832d8967872f4ee1c92f