### PR TITLE
Handle measurement notes without validation errors

### DIFF
--- a/src/app/(members)/mitglieder/profil/actions.ts
+++ b/src/app/(members)/mitglieder/profil/actions.ts
@@ -282,9 +282,19 @@ export async function saveMeasurementAction(
   input: SaveMeasurementInput,
 ): Promise<ActionResult<SaveMeasurementResult>> {
   try {
+    const payload: Record<string, unknown> = {
+      type: input.type,
+      value: input.value,
+      unit: input.unit,
+    };
+
+    if (typeof input.note === "string") {
+      payload.note = input.note;
+    }
+
     const response = await authorizedFetch("/api/measurements", {
       method: "POST",
-      body: JSON.stringify(input),
+      body: JSON.stringify(payload),
     });
 
     const data = await response.json().catch(() => null);

--- a/src/app/api/measurements/route.ts
+++ b/src/app/api/measurements/route.ts
@@ -56,7 +56,12 @@ export async function POST(request: NextRequest) {
     if (!userId) {
       return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
     }
-    const payload = await request.json();
+    const rawPayload = await request.json();
+    const payload = {
+      ...rawPayload,
+      note: typeof rawPayload?.note === "string" ? rawPayload.note : undefined,
+    };
+
     const { userId: overrideUserId, ...data } = measurementRequestSchema.parse(payload);
 
     const targetUserId = overrideUserId ?? userId;


### PR DESCRIPTION
## Summary
- avoid posting null notes in the profile measurement save action
- sanitize the measurements API payload so null notes are treated as optional strings before validation

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dfb2bc57a8832d9843f5ff7a1873ed