### PR TITLE
Adjust dashboard profile reminder styling

### DIFF
--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -534,19 +534,16 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
 
     if (!profileCompletion.complete) {
       return (
-        <div className="flex flex-col gap-4 rounded-2xl border border-warning/60 bg-warning/20 p-4 text-sm text-warning-foreground shadow-[0_18px_48px_rgba(249,115,22,0.25)] backdrop-blur">
-          <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-col items-center gap-3 text-center sm:flex-row">
-              <div className="space-y-1 text-center">
-                <p className="text-base font-semibold">Profilangaben unvollständig</p>
-                <p className="text-xs text-warning/90">Bitte ergänze fehlende Informationen, um dein Profil abzuschließen.</p>
-              </div>
-              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-warning/60 bg-warning/25 text-warning">
+        <div className="flex flex-col gap-4 rounded-2xl border border-warning bg-warning/20 p-4 text-sm text-warning shadow-[0_18px_48px_rgba(249,115,22,0.25)] backdrop-blur">
+          <div className="flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="flex flex-col items-center gap-3 text-center sm:flex-row sm:items-center">
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-warning bg-warning/25 text-warning">
                 <CalendarRange className="h-5 w-5" />
               </div>
+              <p className="text-base font-semibold">Profilangaben unvollständig</p>
             </div>
             {profileCompletion.total ? (
-              <Badge className="inline-flex items-center justify-center gap-1.5 rounded-xl border-warning/70 bg-warning/25 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-warning-foreground shadow-[0_10px_32px_rgba(249,115,22,0.25)] ring-1 ring-inset ring-warning/60 backdrop-blur-sm">
+              <Badge className="inline-flex items-center justify-center gap-1.5 rounded-xl border border-warning bg-warning/25 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-warning shadow-[0_10px_32px_rgba(249,115,22,0.25)] ring-1 ring-inset ring-warning backdrop-blur-sm">
                 {percentLabel}
               </Badge>
             ) : null}
@@ -555,7 +552,7 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
             type="button"
             variant="outline"
             size="sm"
-            className="border-warning/60 bg-warning/25 text-warning shadow-[0_12px_36px_rgba(249,115,22,0.25)] transition hover:border-warning/70 hover:bg-warning/30"
+            className="border-warning bg-warning/25 text-warning shadow-[0_12px_36px_rgba(249,115,22,0.25)] transition hover:border-warning hover:bg-warning/30"
             asChild
           >
             <Link href="/mitglieder/profil">Profil aktualisieren</Link>


### PR DESCRIPTION
## Summary
- remove the additional helper text from the dashboard profile reminder and place the icon before the headline
- switch the profile reminder border, badge, and button styling to the orange color scheme so the completion text stays on-brand

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dffc982244832db0310d64a14df781