### PR TITLE
Adjust profile tab labels for nutrition and preferences

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -901,11 +901,11 @@ function ProfileClientInner({
       const options: Array<{ value: string; label: string }> = [
         { value: "stammdaten", label: "Stammdaten" },
         { value: "zahlungen", label: "Zahlungsdaten" },
-        { value: "ernaehrung", label: "Ernährung & Allergien" },
+        { value: "ernaehrung", label: "Ernährung" },
         { value: "interessen", label: "Interessen" },
         { value: "freigaben", label: "Freigaben" },
         { value: "onboarding", label: "Onboarding" },
-        { value: "rollen", label: "Rollenpräferenzen" },
+        { value: "rollen", label: "Präferenzen" },
       ];
 
       if (canManageMeasurements) {


### PR DESCRIPTION
## Summary
- rename the profile tab option labels to "Ernährung" and "Präferenzen" for clearer wording in the select menu

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dffd3c50d8832d83787bbc55c85267