### PR TITLE
Add onboarding dashboard PDF export

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
+import { toast } from "sonner";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { OnboardingDashboardData, OnboardingSummary } from "@/lib/onboarding/dashboard-schemas";
@@ -45,6 +46,7 @@ export function DashboardClient({
   const [selectedOnboarding, setSelectedOnboarding] = useState(initialData.onboarding.id);
   const [tabValue, setTabValue] = useState<"global" | "allocation" | "history">("global");
   const [isPending, startTransition] = useTransition();
+  const [isExportingPdf, setIsExportingPdf] = useState(false);
 
   useEffect(() => {
     setSelectedOnboarding(initialData.onboarding.id);
@@ -100,6 +102,55 @@ export function DashboardClient({
     });
   };
 
+  const handleExportPdf = useCallback(async () => {
+    if (!selectedOnboarding || isExportingPdf) {
+      return;
+    }
+    setIsExportingPdf(true);
+    try {
+      const response = await fetch(`/dashboard/onboarding/${selectedOnboarding}/statistics`, {
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        throw new Error(`Export failed (${response.status})`);
+      }
+      const blob = await response.blob();
+      const fallbackName = `onboarding-statistik-${selectedOnboarding}.pdf`;
+      const disposition = response.headers.get("Content-Disposition");
+      let filename = fallbackName;
+      if (disposition) {
+        const utfMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+        if (utfMatch?.[1]) {
+          try {
+            filename = decodeURIComponent(utfMatch[1]);
+          } catch {
+            filename = utfMatch[1];
+          }
+        } else {
+          const simpleMatch = disposition.match(/filename="?([^";]+)"?/i);
+          if (simpleMatch?.[1]) {
+            filename = simpleMatch[1];
+          }
+        }
+      }
+
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast.success("Onboarding-Statistik exportiert.");
+    } catch (error) {
+      console.error("Failed to export onboarding statistics", error);
+      toast.error("PDF konnte nicht erstellt werden.");
+    } finally {
+      setIsExportingPdf(false);
+    }
+  }, [isExportingPdf, selectedOnboarding]);
+
   const historyAvailable = (currentData.history?.length ?? 0) > 0;
 
   return (
@@ -114,6 +165,8 @@ export function DashboardClient({
         isRefreshing={isFetching || isPending}
         onSelect={handleSelect}
         onRefresh={() => void refetch()}
+        onExportPdf={handleExportPdf}
+        isExportingPdf={isExportingPdf}
       />
       <Tabs
         value={tabValue}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { Share2 } from "lucide-react";
+import { Download, Loader2, Share2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -32,6 +32,8 @@ type HeaderBarProps = {
   isRefreshing: boolean;
   onSelect: (id: string) => void;
   onRefresh?: () => void;
+  onExportPdf?: () => void;
+  isExportingPdf?: boolean;
 };
 
 export function HeaderBar({
@@ -44,6 +46,8 @@ export function HeaderBar({
   isRefreshing,
   onSelect,
   onRefresh,
+  onExportPdf,
+  isExportingPdf = false,
 }: HeaderBarProps) {
   const [shareState, setShareState] = useState<"idle" | "success" | "error">("idle");
 
@@ -111,6 +115,22 @@ export function HeaderBar({
               ))}
             </SelectContent>
           </Select>
+          {onExportPdf ? (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full sm:w-auto"
+              onClick={onExportPdf}
+              disabled={isExportingPdf}
+            >
+              {isExportingPdf ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4" />
+              )}
+              {isExportingPdf ? "Bereite PDF vor…" : "Statistik exportieren"}
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="secondary"

--- a/src/app/dashboard/onboarding/[onboardingId]/statistics/route.ts
+++ b/src/app/dashboard/onboarding/[onboardingId]/statistics/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+import { buildOnboardingStatisticsPdfData } from "@/lib/onboarding/dashboard-pdf";
+import { loadOnboardingDashboardSnapshot } from "@/lib/onboarding/dashboard-service";
+import { PdfRenderError, PdfTemplateNotFoundError, renderPdfTemplate } from "@/lib/pdf/engine";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ onboardingId: string }> },
+) {
+  const params = await context.params;
+  const onboardingId = params?.onboardingId;
+
+  if (!onboardingId || typeof onboardingId !== "string") {
+    return NextResponse.json({ error: "Missing onboarding id" }, { status: 400 });
+  }
+
+  try {
+    const dashboard = await loadOnboardingDashboardSnapshot(onboardingId);
+    if (!dashboard) {
+      return NextResponse.json({ error: "Onboarding not found" }, { status: 404 });
+    }
+
+    const payload = buildOnboardingStatisticsPdfData(dashboard);
+    const result = await renderPdfTemplate("onboarding-statistics", payload);
+    const body = new Uint8Array(result.buffer);
+
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${result.filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    if (error instanceof PdfTemplateNotFoundError) {
+      return NextResponse.json({ error: "PDF template missing" }, { status: 404 });
+    }
+    if (error instanceof PdfRenderError) {
+      console.error(
+        `[onboarding-statistics-pdf] Rendering failed for ${error.templateId} (${onboardingId})`,
+        error.originalError,
+      );
+    } else {
+      console.error(`[onboarding-statistics-pdf] Unexpected error for ${onboardingId}`, error);
+    }
+    return NextResponse.json({ error: "Statistik konnte nicht erstellt werden" }, { status: 500 });
+  }
+}

--- a/src/lib/onboarding/dashboard-pdf.ts
+++ b/src/lib/onboarding/dashboard-pdf.ts
@@ -1,0 +1,163 @@
+import type { OnboardingDashboardData } from "./dashboard-schemas";
+import type { OnboardingStatisticsPdfData } from "../pdf/templates/onboarding-statistics";
+
+const numberFormatter = new Intl.NumberFormat("de-DE");
+
+function clampPercentage(value: number | null | undefined) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return Number(Math.round(value * 10) / 10);
+}
+
+function normalizeShare(value: number | null | undefined) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  const percentage = value * 100;
+  return clampPercentage(percentage);
+}
+
+function toDisplayNumber(value: number | string) {
+  if (typeof value === "number") {
+    return numberFormatter.format(value);
+  }
+  return value;
+}
+
+function diversityLabel(status: "ok" | "warning" | "critical") {
+  switch (status) {
+    case "ok":
+      return "Stabil";
+    case "warning":
+      return "Beobachten";
+    case "critical":
+      return "Handeln";
+    default:
+      return "Unbekannt";
+  }
+}
+
+export function buildOnboardingStatisticsPdfData(
+  dashboard: OnboardingDashboardData,
+): OnboardingStatisticsPdfData {
+  const participants = dashboard.onboarding.participants;
+  const generatedAt = new Date();
+  const safeParticipants = Number.isFinite(participants) ? participants : 0;
+
+  const actingRoles = dashboard.global.rolesActing
+    .slice()
+    .sort((a, b) => b.participantShare - a.participantShare)
+    .slice(0, 8)
+    .map((role) => {
+      const participantsCount = Math.round((role.participantShare / 100) * safeParticipants);
+      return {
+        label: role.label,
+        participants: participantsCount,
+        participantShare: clampPercentage(role.participantShare),
+        normalizedShare: normalizeShare(role.normalizedShare),
+      };
+    });
+
+  const crewRoles = dashboard.global.rolesCrew
+    .slice()
+    .sort((a, b) => b.participantShare - a.participantShare)
+    .slice(0, 8)
+    .map((role) => {
+      const participantsCount = Math.round((role.participantShare / 100) * safeParticipants);
+      return {
+        label: role.label,
+        participants: participantsCount,
+        participantShare: clampPercentage(role.participantShare),
+        normalizedShare: normalizeShare(role.normalizedShare),
+      };
+    });
+
+  const interests = dashboard.global.interestTopTags.slice(0, 10).map((entry) => ({
+    label: entry.label,
+    count: entry.value,
+    percentage: clampPercentage(entry.percentage ?? null),
+  }));
+
+  const formatDistribution = (entries: typeof dashboard.global.ageGroups) =>
+    entries.map((entry) => ({
+      label: entry.label,
+      count: entry.value,
+      percentage: clampPercentage(entry.percentage ?? null),
+    }));
+
+  const history = (dashboard.history ?? [])
+    .slice()
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .map((entry) => ({
+      label: entry.label,
+      participants: entry.participants,
+      createdAt: entry.createdAt,
+      focusBothShare: entry.focusBothShare ?? null,
+    }));
+
+  return {
+    generatedAt: generatedAt.toISOString(),
+    onboarding: {
+      id: dashboard.onboarding.id,
+      title: dashboard.onboarding.title,
+      statusLabel: dashboard.onboarding.statusLabel,
+      timeSpan: dashboard.onboarding.timeSpan,
+      participants: dashboard.onboarding.participants,
+    },
+    kpis: dashboard.global.kpis.slice(0, 8).map((kpi) => ({
+      label: kpi.label,
+      value: toDisplayNumber(kpi.value),
+      helper: kpi.helper ?? null,
+    })),
+    focusDistribution: formatDistribution(dashboard.global.focusDistribution),
+    genderDistribution: formatDistribution(dashboard.global.genderDistribution),
+    ageGroups: formatDistribution(dashboard.global.ageGroups),
+    interests,
+    roleCoverage: {
+      acting: clampPercentage(dashboard.global.roleCoverage.acting),
+      crew: clampPercentage(dashboard.global.roleCoverage.crew),
+      actingRoles,
+      crewRoles,
+    },
+    process: {
+      steps: dashboard.global.process.steps.map((step) => ({
+        label: step.label,
+        completionRate: clampPercentage(step.completionRate),
+        dropoutRate: clampPercentage(step.dropoutRate),
+      })),
+      documents: {
+        uploaded: dashboard.global.process.documents.uploaded,
+        pending: dashboard.global.process.documents.pending,
+        skipped: dashboard.global.process.documents.skipped,
+      },
+    },
+    diversity: {
+      shannon: Number.isFinite(dashboard.global.diversity.shannon)
+        ? Number(dashboard.global.diversity.shannon)
+        : null,
+      gini: Number.isFinite(dashboard.global.diversity.gini)
+        ? Number(dashboard.global.diversity.gini)
+        : null,
+      normalized: Number.isFinite(dashboard.global.diversity.normalized)
+        ? Number(dashboard.global.diversity.normalized)
+        : null,
+      statusLabel: diversityLabel(dashboard.global.diversity.status),
+      explanation: dashboard.global.diversity.explanation,
+    },
+    history,
+    photoConsentRate: clampPercentage(
+      dashboard.global.photoConsentRate !== null
+        ? dashboard.global.photoConsentRate * 100
+        : null,
+    ),
+  };
+}

--- a/src/lib/pdf/templates/index.ts
+++ b/src/lib/pdf/templates/index.ts
@@ -1,7 +1,8 @@
 import type { PdfTemplate } from "../types";
 import { onboardingInviteTemplate } from "./onboarding-invite";
+import { onboardingStatisticsTemplate } from "./onboarding-statistics";
 
-const templates = [onboardingInviteTemplate] as const;
+const templates = [onboardingInviteTemplate, onboardingStatisticsTemplate] as const;
 
 const templateMap = new Map<string, PdfTemplate<unknown>>();
 for (const template of templates) {

--- a/src/lib/pdf/templates/onboarding-statistics.ts
+++ b/src/lib/pdf/templates/onboarding-statistics.ts
@@ -1,0 +1,364 @@
+import { z } from "zod";
+
+import type { PdfTemplate } from "../types";
+
+function slugify(value: string) {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function ensurePageSpace(doc: PDFKit.PDFDocument, neededHeight: number) {
+  const bottom = doc.page.height - doc.page.margins.bottom;
+  if (doc.y + neededHeight <= bottom) {
+    return;
+  }
+  doc.addPage();
+  doc.x = doc.page.margins.left;
+  doc.y = doc.page.margins.top;
+}
+
+function drawSectionHeading(doc: PDFKit.PDFDocument, title: string) {
+  ensurePageSpace(doc, 32);
+  doc.moveDown(0.6);
+  doc.font("Helvetica-Bold").fontSize(14).fillColor("#111827").text(title);
+  doc.moveDown(0.2);
+  doc.strokeColor("#e5e7eb").lineWidth(1).moveTo(doc.page.margins.left, doc.y).lineTo(doc.page.width - doc.page.margins.right, doc.y).stroke();
+  doc.moveDown(0.4);
+  doc.fillColor("#111827");
+}
+
+function drawKeyValue(doc: PDFKit.PDFDocument, label: string, value: string) {
+  ensurePageSpace(doc, 18);
+  doc.font("Helvetica-Bold").fontSize(11).fillColor("#1f2937").text(label);
+  doc.moveDown(0.1);
+  doc.font("Helvetica").fontSize(11).fillColor("#374151").text(value);
+  doc.moveDown(0.2);
+}
+
+function drawTable(
+  doc: PDFKit.PDFDocument,
+  headers: readonly string[],
+  rows: readonly (readonly string[])[],
+  widths: readonly number[],
+) {
+  if (!rows.length) {
+    return;
+  }
+
+  const availableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+  const startX = doc.page.margins.left;
+
+  const normalizedWidths = widths.map((width) => (width / widths.reduce((sum, value) => sum + value, 0)) * availableWidth);
+
+  const headerHeight = 18;
+  const rowHeight = 16;
+  ensurePageSpace(doc, headerHeight + rowHeight * rows.length + 12);
+
+  doc.font("Helvetica-Bold").fontSize(10).fillColor("#111827");
+  headers.forEach((header, index) => {
+    const offset = normalizedWidths.slice(0, index).reduce((sum, value) => sum + value, 0);
+    const align = index === headers.length - 1 ? "right" : "left";
+    doc.text(header, startX + offset, doc.y, {
+      width: normalizedWidths[index],
+      align,
+      continued: index < headers.length - 1,
+    });
+  });
+  doc.text(" ");
+  doc.moveDown(0.15);
+  doc.font("Helvetica").fontSize(10).fillColor("#374151");
+
+  rows.forEach((row) => {
+    const rowY = doc.y;
+    row.forEach((cell, index) => {
+      const offset = normalizedWidths.slice(0, index).reduce((sum, value) => sum + value, 0);
+      const align = index === row.length - 1 ? "right" : "left";
+      doc.text(cell, startX + offset, rowY, {
+        width: normalizedWidths[index],
+        align,
+        continued: index < row.length - 1,
+      });
+    });
+    doc.text(" ");
+    doc.moveDown(0.05);
+  });
+  doc.moveDown(0.4);
+}
+
+const distributionEntrySchema = z.object({
+  label: z.string(),
+  count: z.number(),
+  percentage: z.number().nullable(),
+});
+
+const roleEntrySchema = z.object({
+  label: z.string(),
+  participants: z.number(),
+  participantShare: z.number().nullable(),
+  normalizedShare: z.number().nullable(),
+});
+
+const historyEntrySchema = z.object({
+  label: z.string(),
+  participants: z.number(),
+  createdAt: z.string(),
+  focusBothShare: z.number().nullable(),
+});
+
+const onboardingStatisticsSchema = z.object({
+  generatedAt: z.string(),
+  onboarding: z.object({
+    id: z.string(),
+    title: z.string(),
+    statusLabel: z.string(),
+    timeSpan: z.string().nullable(),
+    participants: z.number(),
+  }),
+  kpis: z.array(
+    z.object({
+      label: z.string(),
+      value: z.string(),
+      helper: z.string().nullable(),
+    }),
+  ),
+  focusDistribution: z.array(distributionEntrySchema),
+  genderDistribution: z.array(distributionEntrySchema),
+  ageGroups: z.array(distributionEntrySchema),
+  interests: z.array(distributionEntrySchema),
+  roleCoverage: z.object({
+    acting: z.number().nullable(),
+    crew: z.number().nullable(),
+    actingRoles: z.array(roleEntrySchema),
+    crewRoles: z.array(roleEntrySchema),
+  }),
+  process: z.object({
+    steps: z.array(
+      z.object({
+        label: z.string(),
+        completionRate: z.number().nullable(),
+        dropoutRate: z.number().nullable(),
+      }),
+    ),
+    documents: z.object({
+      uploaded: z.number(),
+      pending: z.number(),
+      skipped: z.number(),
+    }),
+  }),
+  diversity: z.object({
+    shannon: z.number().nullable(),
+    gini: z.number().nullable(),
+    normalized: z.number().nullable(),
+    statusLabel: z.string(),
+    explanation: z.string(),
+  }),
+  history: z.array(historyEntrySchema),
+  photoConsentRate: z.number().nullable(),
+});
+
+export type OnboardingStatisticsPdfData = z.infer<typeof onboardingStatisticsSchema>;
+
+const numberFormatter = new Intl.NumberFormat("de-DE");
+const percentFormatter = new Intl.NumberFormat("de-DE", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+const dateFormatter = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+const dateOnlyFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium" });
+
+function formatPercentage(value: number | null) {
+  if (value === null) {
+    return "–";
+  }
+  return `${percentFormatter.format(value)} %`;
+}
+
+function formatNumber(value: number | null) {
+  if (value === null) {
+    return "–";
+  }
+  return numberFormatter.format(value);
+}
+
+export const onboardingStatisticsTemplate: PdfTemplate<OnboardingStatisticsPdfData> = {
+  id: "onboarding-statistics",
+  label: "Onboarding-Dashboard Report",
+  description:
+    "Verdichtet zentrale Kennzahlen des Onboarding-Dashboards auf wenigen Seiten als übersichtliches PDF.",
+  filename: (data) => {
+    const slug = slugify(data.onboarding.title);
+    const datePart = dateOnlyFormatter.format(new Date(data.generatedAt));
+    return slug ? `onboarding-statistik-${slug}.pdf` : `onboarding-statistik-${datePart}.pdf`;
+  },
+  schema: onboardingStatisticsSchema,
+  documentOptions: {
+    size: "A4",
+    margins: { top: 56, left: 56, right: 56, bottom: 64 },
+  },
+  render(doc, data) {
+    const generatedAt = new Date(data.generatedAt);
+    const subtitle = data.onboarding.timeSpan
+      ? `${data.onboarding.timeSpan} · ${data.onboarding.statusLabel}`
+      : data.onboarding.statusLabel;
+
+    doc.info.Title = `Onboarding-Statistik ${data.onboarding.title}`;
+    doc.info.Subject = "Kennzahlen zum Onboarding";
+    doc.info.Author = "Ensemble Portal";
+
+    doc.font("Helvetica-Bold").fontSize(20).fillColor("#0f172a").text("Onboarding-Statistik", {
+      align: "left",
+    });
+    doc.moveDown(0.3);
+    doc.font("Helvetica-Bold").fontSize(16).fillColor("#111827").text(data.onboarding.title);
+    doc.moveDown(0.2);
+    doc.font("Helvetica").fontSize(11).fillColor("#4b5563").text(subtitle);
+    doc.moveDown(0.2);
+    doc.font("Helvetica").fontSize(10).fillColor("#6b7280").text(
+      `Erstellt am ${dateFormatter.format(generatedAt)} · ${formatNumber(data.onboarding.participants)} Teilnehmende`,
+    );
+
+    drawSectionHeading(doc, "Schlüsselindikatoren");
+    data.kpis.forEach((kpi) => {
+      const helperText = kpi.helper ? ` (${kpi.helper})` : "";
+      drawKeyValue(doc, kpi.label, `${kpi.value}${helperText}`);
+    });
+
+    if (data.photoConsentRate !== null) {
+      drawKeyValue(doc, "Fotoeinverständnis", formatPercentage(data.photoConsentRate));
+    }
+
+    drawSectionHeading(doc, "Fokus und Demografie");
+    drawTable(
+      doc,
+      ["Fokus", "Personen", "Anteil"],
+      data.focusDistribution.map((entry) => [
+        entry.label,
+        formatNumber(entry.count),
+        formatPercentage(entry.percentage),
+      ]),
+      [2, 1, 1],
+    );
+
+    drawTable(
+      doc,
+      ["Geschlecht", "Personen", "Anteil"],
+      data.genderDistribution.map((entry) => [
+        entry.label,
+        formatNumber(entry.count),
+        formatPercentage(entry.percentage),
+      ]),
+      [2, 1, 1],
+    );
+
+    drawTable(
+      doc,
+      ["Altersgruppe", "Personen", "Anteil"],
+      data.ageGroups.map((entry) => [
+        entry.label,
+        formatNumber(entry.count),
+        formatPercentage(entry.percentage),
+      ]),
+      [2, 1, 1],
+    );
+
+    if (data.interests.length) {
+      drawSectionHeading(doc, "Top-Interessen");
+      drawTable(
+        doc,
+        ["Tag", "Nennungen", "Anteil"],
+        data.interests.map((entry) => [
+          entry.label,
+          formatNumber(entry.count),
+          formatPercentage(entry.percentage),
+        ]),
+        [2, 1, 1],
+      );
+    }
+
+    drawSectionHeading(doc, "Rollen & Besetzung");
+    drawKeyValue(doc, "Abdeckung Schauspiel", formatPercentage(data.roleCoverage.acting));
+    drawKeyValue(doc, "Abdeckung Crew", formatPercentage(data.roleCoverage.crew));
+
+    if (data.roleCoverage.actingRoles.length) {
+      drawTable(
+        doc,
+        ["Rolle Schauspiel", "Personen", "Teilnahme", "Interesse"],
+        data.roleCoverage.actingRoles.map((entry) => [
+          entry.label,
+          formatNumber(entry.participants),
+          formatPercentage(entry.participantShare),
+          formatPercentage(entry.normalizedShare),
+        ]),
+        [3, 1, 1, 1],
+      );
+    }
+
+    if (data.roleCoverage.crewRoles.length) {
+      drawTable(
+        doc,
+        ["Rolle Crew", "Personen", "Teilnahme", "Interesse"],
+        data.roleCoverage.crewRoles.map((entry) => [
+          entry.label,
+          formatNumber(entry.participants),
+          formatPercentage(entry.participantShare),
+          formatPercentage(entry.normalizedShare),
+        ]),
+        [3, 1, 1, 1],
+      );
+    }
+
+    drawSectionHeading(doc, "Prozessfortschritt");
+    if (data.process.steps.length) {
+      drawTable(
+        doc,
+        ["Schritt", "Abschluss", "Abbruch"],
+        data.process.steps.map((step) => [
+          step.label,
+          formatPercentage(step.completionRate),
+          formatPercentage(step.dropoutRate),
+        ]),
+        [3, 1, 1],
+      );
+    }
+
+    drawKeyValue(
+      doc,
+      "Unterlagen",
+      `${formatNumber(data.process.documents.uploaded)} hochgeladen · ${formatNumber(
+        data.process.documents.pending,
+      )} offen · ${formatNumber(data.process.documents.skipped)} übersprungen`,
+    );
+
+    drawSectionHeading(doc, "Diversität");
+    const diversityLines = [
+      `Shannon: ${data.diversity.shannon !== null ? data.diversity.shannon.toFixed(2) : "–"}`,
+      `Gini: ${data.diversity.gini !== null ? data.diversity.gini.toFixed(2) : "–"}`,
+      `Normalisiert: ${data.diversity.normalized !== null ? data.diversity.normalized.toFixed(2) : "–"}`,
+    ];
+    drawKeyValue(doc, "Status", data.diversity.statusLabel);
+    drawKeyValue(doc, "Kennzahlen", diversityLines.join(" · "));
+    drawKeyValue(doc, "Erläuterung", data.diversity.explanation);
+
+    if (data.history.length) {
+      drawSectionHeading(doc, "Verlauf");
+      drawTable(
+        doc,
+        ["Zeitpunkt", "Teilnehmende", "Fokus: beide"],
+        data.history.map((entry) => [
+          entry.label,
+          formatNumber(entry.participants),
+          formatPercentage(entry.focusBothShare),
+        ]),
+        [2, 1, 1],
+      );
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add a PDF export button to the onboarding dashboard header and wire it up to a client-side download flow
- introduce a PDF template plus data mapper that condenses onboarding statistics into a printable report
- expose a node runtime route that renders the onboarding statistics PDF for the selected onboarding

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dfebb0520c832dbbb7deae1426fc4a