### PR TITLE
Add onboarding ranking overview tab

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/dashboard-client.tsx
@@ -14,6 +14,7 @@ import { AllocationTab } from "./allocation-tab";
 import { GlobalOverviewTab } from "./global-tab";
 import { HeaderBar } from "./header-bar";
 import { HistoryTab } from "./history-tab";
+import { RankingTab } from "./ranking-tab";
 
 function dashboardQueryKey(onboardingId: string) {
   return ["onboarding-dashboard", onboardingId] as const;
@@ -44,7 +45,7 @@ export function DashboardClient({
   const queryClient = useQueryClient();
   const { socket, joinRoom, leaveRoom } = useRealtime();
   const [selectedOnboarding, setSelectedOnboarding] = useState(initialData.onboarding.id);
-  const [tabValue, setTabValue] = useState<"global" | "allocation" | "history">("global");
+  const [tabValue, setTabValue] = useState<"global" | "ranking" | "allocation" | "history">("global");
   const [isPending, startTransition] = useTransition();
   const [isExportingPdf, setIsExportingPdf] = useState(false);
 
@@ -175,6 +176,7 @@ export function DashboardClient({
       >
         <TabsList>
           <TabsTrigger value="global">Global</TabsTrigger>
+          <TabsTrigger value="ranking">Ranking</TabsTrigger>
           <TabsTrigger value="allocation">Zuteilung</TabsTrigger>
           {historyAvailable ? <TabsTrigger value="history">Historie</TabsTrigger> : null}
         </TabsList>
@@ -188,6 +190,17 @@ export function DashboardClient({
               transition={{ duration: 0.3, ease: "easeOut" }}
             >
               <GlobalOverviewTab data={currentData.global} participants={currentData.onboarding.participants} />
+            </motion.div>
+          </TabsContent>
+          <TabsContent key="ranking" value="ranking" className="space-y-6">
+            <motion.div
+              key={`${currentData.onboarding.id}-ranking`}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.3, ease: "easeOut" }}
+            >
+              <RankingTab ranking={currentData.ranking} />
             </motion.div>
           </TabsContent>
           <TabsContent key="allocation" value="allocation" className="space-y-6">

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { OnboardingDashboardData } from "@/lib/onboarding/dashboard-schemas";
+
+const domainLabels: Record<"acting" | "crew", string> = {
+  acting: "Acting & Rollengrößen",
+  crew: "Gewerke & Crew",
+};
+
+const focusLabel: Record<"acting" | "tech" | "both", string> = {
+  acting: "Fokus Acting",
+  tech: "Fokus Technik",
+  both: "Fokus Acting + Crew",
+};
+
+const focusVariant: Record<"acting" | "tech" | "both", "success" | "warning" | "info"> = {
+  acting: "success",
+  tech: "warning",
+  both: "info",
+};
+
+const numberFormatter = new Intl.NumberFormat("de-DE", {
+  maximumFractionDigits: 0,
+});
+
+const percentageFormatter = new Intl.NumberFormat("de-DE", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
+const scoreFormatter = new Intl.NumberFormat("de-DE", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+type RankingTabProps = {
+  ranking: OnboardingDashboardData["ranking"];
+};
+
+type Domain = "acting" | "crew";
+
+function renderPreferenceBadges(
+  preferences: OnboardingDashboardData["ranking"]["roles"][number]["candidates"][number]["otherPreferences"],
+  label: string,
+) {
+  if (preferences.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-1">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {preferences.map((preference) => (
+          <Badge key={`${preference.domain}-${preference.roleId}-${preference.rank}`} variant="ghost" size="sm">
+            #{preference.rank} {preference.label}
+            <span className="ml-1 text-foreground/70">
+              {percentageFormatter.format(preference.normalizedShare * 100)}%
+            </span>
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CandidateCard({
+  candidate,
+}: {
+  candidate: OnboardingDashboardData["ranking"]["roles"][number]["candidates"][number];
+}) {
+  const preferenceGroups = useMemo(() => {
+    const acting = candidate.otherPreferences.filter((item) => item.domain === "acting");
+    const crew = candidate.otherPreferences.filter((item) => item.domain === "crew");
+    return { acting, crew };
+  }, [candidate.otherPreferences]);
+
+  const shareLabel = percentageFormatter.format(candidate.normalizedShare * 100);
+  const confidencePercentage = Math.round(candidate.confidence * 100);
+  const interestPreview = candidate.interests.slice(0, 4);
+  const remainingInterests = candidate.interests.length - interestPreview.length;
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-background/60 p-4 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-3">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 text-xs font-semibold text-muted-foreground">#{candidate.rank}</span>
+          <div>
+            <p className="text-sm font-semibold leading-5 text-foreground">{candidate.name}</p>
+            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+              {candidate.focus ? (
+                <Badge variant={focusVariant[candidate.focus]} size="sm">
+                  {focusLabel[candidate.focus]}
+                </Badge>
+              ) : null}
+              <Badge variant="outline" size="sm">
+                {shareLabel}% Präferenz
+              </Badge>
+              <Badge variant="ghost" size="sm">
+                Score {scoreFormatter.format(candidate.score)}
+              </Badge>
+              <Badge variant="info" size="sm">
+                Sicherheit {numberFormatter.format(confidencePercentage)}%
+              </Badge>
+              {candidate.experienceYears !== null ? (
+                <Badge variant="secondary" size="sm">
+                  {candidate.experienceYears === 0
+                    ? "Neu dabei"
+                    : `${candidate.experienceYears} Jahre Erfahrung`}
+                </Badge>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {candidate.interests.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {interestPreview.map((interest) => (
+            <Badge key={interest} variant="muted" size="sm">
+              #{interest}
+            </Badge>
+          ))}
+          {remainingInterests > 0 ? (
+            <Badge variant="ghost" size="sm">+{remainingInterests}</Badge>
+          ) : null}
+        </div>
+      ) : null}
+
+      {(preferenceGroups.acting.length > 0 || preferenceGroups.crew.length > 0) && (
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          {preferenceGroups.acting.length > 0
+            ? renderPreferenceBadges(preferenceGroups.acting, "Acting")
+            : null}
+          {preferenceGroups.crew.length > 0
+            ? renderPreferenceBadges(preferenceGroups.crew, "Crew")
+            : null}
+        </div>
+      )}
+
+      {candidate.background ? (
+        <p className="mt-4 text-xs text-muted-foreground line-clamp-2">
+          <span className="font-semibold text-foreground/80">Background:</span> {candidate.background}
+        </p>
+      ) : null}
+
+      {candidate.notes ? (
+        <p className="mt-2 whitespace-pre-line text-xs text-muted-foreground line-clamp-3">
+          <span className="font-semibold text-foreground/80">Notiz:</span> {candidate.notes}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function RoleColumn({
+  domain,
+  role,
+}: {
+  domain: Domain;
+  role: OnboardingDashboardData["ranking"]["roles"][number];
+}) {
+  return (
+    <Card className="h-full">
+      <CardHeader className="space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base font-semibold tracking-tight text-foreground">
+            {role.label}
+          </CardTitle>
+          <Badge variant="muted" size="sm">
+            {role.demand} Personen
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Ranking der stärksten Präferenzen für {domain === "acting" ? "Rollengrößen" : "Gewerke"}.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {role.candidates.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Keine Angaben vorhanden.</p>
+        ) : (
+          role.candidates.map((candidate) => (
+            <CandidateCard key={candidate.userId} candidate={candidate} />
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export function RankingTab({ ranking }: RankingTabProps) {
+  const [domain, setDomain] = useState<Domain>("acting");
+
+  const actingRoles = useMemo(
+    () =>
+      ranking.roles
+        .filter((role) => role.domain === "acting")
+        .slice()
+        .sort((a, b) => a.label.localeCompare(b.label, "de-DE")),
+    [ranking.roles],
+  );
+
+  const crewRoles = useMemo(
+    () =>
+      ranking.roles
+        .filter((role) => role.domain === "crew")
+        .slice()
+        .sort((a, b) => a.label.localeCompare(b.label, "de-DE")),
+    [ranking.roles],
+  );
+
+  useEffect(() => {
+    if (domain === "acting" && actingRoles.length === 0 && crewRoles.length > 0) {
+      setDomain("crew");
+    } else if (domain === "crew" && crewRoles.length === 0 && actingRoles.length > 0) {
+      setDomain("acting");
+    }
+  }, [actingRoles.length, crewRoles.length, domain]);
+
+  return (
+    <Tabs value={domain} onValueChange={(value) => setDomain(value as Domain)} className="space-y-6">
+      <TabsList className="w-fit bg-muted/40">
+        <TabsTrigger value="acting">Acting</TabsTrigger>
+        <TabsTrigger value="crew">Crew</TabsTrigger>
+      </TabsList>
+      <TabsContent value="acting" className="mt-0 space-y-4">
+        {actingRoles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Keine Daten für {domainLabels.acting} verfügbar.
+          </p>
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {actingRoles.map((role) => (
+              <RoleColumn key={role.roleId} role={role} domain="acting" />
+            ))}
+          </div>
+        )}
+      </TabsContent>
+      <TabsContent value="crew" className="mt-0 space-y-4">
+        {crewRoles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Keine Daten für {domainLabels.crew} verfügbar.
+          </p>
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {crewRoles.map((role) => (
+              <RoleColumn key={role.roleId} role={role} domain="crew" />
+            ))}
+          </div>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/src/lib/onboarding/dashboard-schemas.ts
+++ b/src/lib/onboarding/dashboard-schemas.ts
@@ -170,6 +170,41 @@ export const optimizerSummarySchema = z.object({
   fairnessBuckets: z.array(optimizerFairnessBucketSchema),
 });
 
+const rankingPreferenceSchema = z.object({
+  roleId: z.string(),
+  label: z.string(),
+  domain: z.enum(["acting", "crew"]),
+  normalizedShare: z.number(),
+  rank: z.number(),
+});
+
+const rankingCandidateSchema = z.object({
+  userId: z.string(),
+  name: z.string(),
+  focus: z.enum(["acting", "tech", "both"]).nullable(),
+  rank: z.number(),
+  normalizedShare: z.number(),
+  score: z.number(),
+  confidence: z.number(),
+  experienceYears: z.number().nullable(),
+  interests: z.array(z.string()).default([]),
+  background: z.string().nullable(),
+  notes: z.string().nullable(),
+  otherPreferences: z.array(rankingPreferenceSchema),
+});
+
+const rankingRoleSchema = z.object({
+  roleId: z.string(),
+  label: z.string(),
+  domain: z.enum(["acting", "crew"]),
+  demand: z.number(),
+  candidates: z.array(rankingCandidateSchema),
+});
+
+export const onboardingRankingSectionSchema = z.object({
+  roles: z.array(rankingRoleSchema),
+});
+
 export const historySnapshotSchema = z.object({
   onboardingId: z.string(),
   label: z.string(),
@@ -221,6 +256,7 @@ export const onboardingDashboardSchema = z.object({
   }),
   global: onboardingGlobalSectionSchema,
   allocation: onboardingAllocationSectionSchema,
+  ranking: onboardingRankingSectionSchema,
   history: z.array(historySnapshotSchema).optional(),
 });
 
@@ -229,3 +265,5 @@ export type OnboardingSummary = z.infer<typeof onboardingSummarySchema>;
 export type AllocationRole = z.infer<typeof allocationRoleSchema>;
 export type AllocationCandidate = z.infer<typeof allocationCandidateSchema>;
 export type AllocationSlot = z.infer<typeof allocationSlotSchema>;
+export type OnboardingRankingRole = z.infer<typeof rankingRoleSchema>;
+export type OnboardingRankingCandidate = z.infer<typeof rankingCandidateSchema>;

--- a/src/lib/onboarding/dashboard-service.ts
+++ b/src/lib/onboarding/dashboard-service.ts
@@ -228,6 +228,56 @@ function normalizeConfidence(score: number, maxScore: number): number {
   return Math.min(1, score / maxScore);
 }
 
+function normalizeOptionalText(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function buildPreferenceSummary(
+  shares: Map<string, number>,
+  domain: "acting" | "crew",
+  options: { exclude?: string; limit?: number } = {},
+) {
+  const ordered = Array.from(shares.entries())
+    .filter(([, value]) => value > 0)
+    .sort((a, b) => b[1] - a[1])
+    .map(([roleId, value], index) => ({
+      roleId,
+      label: getRolePreferenceTitle(roleId),
+      domain,
+      normalizedShare: roundTo(value, 3),
+      rank: index + 1,
+    }));
+  const filtered = options.exclude
+    ? ordered.filter((entry) => entry.roleId !== options.exclude)
+    : ordered;
+  return typeof options.limit === "number" ? filtered.slice(0, options.limit) : filtered;
+}
+
+function evaluateCandidateForRole(
+  candidate: CandidateInput,
+  roleId: string,
+  domain: "acting" | "crew",
+) {
+  const shares = domain === "acting" ? candidate.actingShares : candidate.crewShares;
+  const share = shares.get(roleId) ?? 0;
+  if (share <= 0) {
+    return null;
+  }
+  const focusAlignment =
+    domain === "acting"
+      ? candidate.focus === "acting" || candidate.focus === "both"
+      : candidate.focus === "tech" || candidate.focus === "both";
+  const quality = 1 + (candidate.experienceYears ?? 0) / 10 + (focusAlignment ? 0.2 : 0);
+  const score = share * quality;
+  const confidence = normalizeConfidence(score, 1.2);
+
+  return { share, focusAlignment, quality, score, confidence };
+}
+
 interface CandidateInput {
   userId: string;
   name: string;
@@ -236,6 +286,8 @@ interface CandidateInput {
   experienceYears: number | null;
   actingShares: Map<string, number>;
   crewShares: Map<string, number>;
+  background: string | null;
+  notes: string | null;
 }
 
 export interface DashboardComputationOptions {
@@ -386,6 +438,8 @@ async function computeOnboardingDashboardData(
           },
           gender: true,
           focus: true,
+          background: true,
+          notes: true,
           dietaryPreference: true,
           dietaryPreferenceStrictness: true,
           memberSinceYear: true,
@@ -696,6 +750,8 @@ async function computeOnboardingDashboardData(
       experienceYears,
       actingShares: actingSharesByUser.get(profile.user.id) ?? new Map<string, number>(),
       crewShares: crewSharesByUser.get(profile.user.id) ?? new Map<string, number>(),
+      background: normalizeOptionalText(profile.background),
+      notes: normalizeOptionalText(profile.notes),
     };
   });
 
@@ -705,26 +761,27 @@ async function computeOnboardingDashboardData(
   actingTotals.forEach((value, roleId) => {
     const candidates = candidateInputs
       .map((candidate) => {
-        const share = candidate.actingShares.get(roleId) ?? 0;
-        const focusAlignment = candidate.focus === "acting" || candidate.focus === "both";
-        const quality = 1 + (candidate.experienceYears ?? 0) / 10 + (focusAlignment ? 0.2 : 0);
-        const score = share * quality;
-        return {
+        const metrics = evaluateCandidateForRole(candidate, roleId, "acting");
+        if (!metrics) {
+          return null;
+        }
+        const allocationCandidate: AllocationCandidate = {
           userId: candidate.userId,
           name: candidate.name,
           focus: candidate.focus ?? undefined,
-          normalizedShare: share,
-          qualityFactor: quality,
-          score,
-          confidence: normalizeConfidence(score, 1.2),
-          justification: focusAlignment
+          normalizedShare: metrics.share,
+          qualityFactor: metrics.quality,
+          score: metrics.score,
+          confidence: metrics.confidence,
+          justification: metrics.focusAlignment
             ? "Hohe Acting-Präferenz"
             : "Acting als Zweitfokus",
           interests: candidate.interests,
           experienceYears: candidate.experienceYears ?? undefined,
-        } satisfies AllocationCandidate;
+        };
+        return allocationCandidate;
       })
-      .filter((candidate) => candidate.normalizedShare > 0)
+      .filter((candidate): candidate is AllocationCandidate => candidate !== null)
       .sort((a, b) => b.score - a.score)
       .slice(0, 12);
 
@@ -739,24 +796,25 @@ async function computeOnboardingDashboardData(
   crewTotals.forEach((value, roleId) => {
     const candidates = candidateInputs
       .map((candidate) => {
-        const share = candidate.crewShares.get(roleId) ?? 0;
-        const focusAlignment = candidate.focus === "tech" || candidate.focus === "both";
-        const quality = 1 + (candidate.experienceYears ?? 0) / 10 + (focusAlignment ? 0.2 : 0);
-        const score = share * quality;
-        return {
+        const metrics = evaluateCandidateForRole(candidate, roleId, "crew");
+        if (!metrics) {
+          return null;
+        }
+        const allocationCandidate: AllocationCandidate = {
           userId: candidate.userId,
           name: candidate.name,
           focus: candidate.focus ?? undefined,
-          normalizedShare: share,
-          qualityFactor: quality,
-          score,
-          confidence: normalizeConfidence(score, 1.2),
-          justification: focusAlignment ? "Technik-Fokus" : "Unterstützender Fokus",
+          normalizedShare: metrics.share,
+          qualityFactor: metrics.quality,
+          score: metrics.score,
+          confidence: metrics.confidence,
+          justification: metrics.focusAlignment ? "Technik-Fokus" : "Unterstützender Fokus",
           interests: candidate.interests,
           experienceYears: candidate.experienceYears ?? undefined,
-        } satisfies AllocationCandidate;
+        };
+        return allocationCandidate;
       })
-      .filter((candidate) => candidate.normalizedShare > 0)
+      .filter((candidate): candidate is AllocationCandidate => candidate !== null)
       .sort((a, b) => b.score - a.score)
       .slice(0, 12);
 
@@ -766,6 +824,56 @@ async function computeOnboardingDashboardData(
       domain: "crew",
       demand: value.userCount,
     });
+  });
+
+  const maxRankingEntries = 20;
+  const rankingRoles = Array.from(allRoles.entries()).map(([roleId, meta]) => {
+    const candidates = candidateInputs
+      .map((candidate) => {
+        const metrics = evaluateCandidateForRole(candidate, roleId, meta.domain);
+        if (!metrics) {
+          return null;
+        }
+        const otherPreferences = [
+          ...buildPreferenceSummary(candidate.actingShares, "acting", {
+            exclude: meta.domain === "acting" ? roleId : undefined,
+            limit: 3,
+          }),
+          ...buildPreferenceSummary(candidate.crewShares, "crew", {
+            exclude: meta.domain === "crew" ? roleId : undefined,
+            limit: 3,
+          }),
+        ];
+
+        return {
+          userId: candidate.userId,
+          name: candidate.name,
+          focus: candidate.focus,
+          normalizedShare: roundTo(metrics.share, 3),
+          score: roundTo(metrics.score, 3),
+          confidence: roundTo(metrics.confidence, 3),
+          experienceYears: candidate.experienceYears,
+          interests: candidate.interests.slice(0, 6),
+          background: candidate.background,
+          notes: candidate.notes,
+          otherPreferences,
+        };
+      })
+      .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, maxRankingEntries)
+      .map((candidate, index) => ({
+        ...candidate,
+        rank: index + 1,
+      }));
+
+    return {
+      roleId,
+      label: meta.label,
+      domain: meta.domain,
+      demand: meta.demand,
+      candidates,
+    };
   });
 
   const defaultCapacity = (demand: number): number => {
@@ -1006,6 +1114,9 @@ async function computeOnboardingDashboardData(
       ),
       conflicts: optimization.conflicts,
       optimizer: optimization.summary,
+    },
+    ranking: {
+      roles: rankingRoles,
     },
     history: historySnapshots,
   });


### PR DESCRIPTION
## Summary
- add a dedicated ranking tab to the onboarding dashboard navigation
- extend the onboarding dashboard schema and service to provide per-role ranking data with interests, notes, and alternate preferences
- implement the ranking tab UI with compact candidate cards and domain filters

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e10c26edb0832d98b2d48cf1aad76b