### PR TITLE
Add configurable mail server settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/dexie": "^1.3.35",
     "@types/node": "^24",
+    "@types/nodemailer": "^7.0.2",
     "@types/pdfkit": "^0.17.3",
     "@types/qrcode": "^1.5.5",
     "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.5.2
+      '@types/nodemailer':
+        specifier: ^7.0.2
+        version: 7.0.2
       '@types/pdfkit':
         specifier: ^0.17.3
         version: 0.17.3
@@ -270,6 +273,131 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-sesv2@3.901.0':
+    resolution: {integrity: sha512-xCS2qZlvgbXKZbJW8XgU8OEAL7BJyVqJ5yODOQxa1TJFZ/+wEhik9XZtULjNnQqa29sJDpPltuSDG1aDG2OUxQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-sso@3.901.0':
+    resolution: {integrity: sha512-sGyDjjkJ7ppaE+bAKL/Q5IvVCxtoyBIzN+7+hWTS/mUxWJ9EOq9238IqmVIIK6sYNIzEf9yhobfMARasPYVTNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/core@3.901.0':
+    resolution: {integrity: sha512-brKAc3y64tdhyuEf+OPIUln86bRTqkLgb9xkd6kUdIeA5+qmp/N6amItQz+RN4k4O3kqkCPYnAd3LonTKluobw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.901.0':
+    resolution: {integrity: sha512-5hAdVl3tBuARh3zX5MLJ1P/d+Kr5kXtDU3xm1pxUEF4xt2XkEEpwiX5fbkNkz2rbh3BCt2gOHsAbh6b3M7n+DA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.901.0':
+    resolution: {integrity: sha512-Ggr7+0M6QZEsrqRkK7iyJLf4LkIAacAxHz9c4dm9hnDdU7vqrlJm6g73IxMJXWN1bIV7IxfpzB11DsRrB/oNjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.901.0':
+    resolution: {integrity: sha512-zxadcDS0hNJgv8n4hFYJNOXyfjaNE1vvqIiF/JzZSQpSSYXzCd+WxXef5bQh+W3giDtRUmkvP5JLbamEFjZKyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.901.0':
+    resolution: {integrity: sha512-dPuFzMF7L1s/lQyT3wDxqLe82PyTH+5o1jdfseTEln64LJMl0ZMWaKX/C1UFNDxaTd35Cgt1bDbjjAWHMiKSFQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.901.0':
+    resolution: {integrity: sha512-/IWgmgM3Cl1wTdJA5HqKMAojxLkYchh5kDuphApxKhupLu6Pu0JBOHU8A5GGeFvOycyaVwosod6zDduINZxe+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.901.0':
+    resolution: {integrity: sha512-SjmqZQHmqFSET7+6xcZgtH7yEyh5q53LN87GqwYlJZ6KJ5oNw11acUNEhUOL1xTSJEvaWqwTIkS2zqrzLcM9bw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.901.0':
+    resolution: {integrity: sha512-NYjy/6NLxH9m01+pfpB4ql8QgAorJcu8tw69kzHwUd/ql6wUDTbC7HcXqtKlIwWjzjgj2BKL7j6SyFapgCuafA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.901.0':
+    resolution: {integrity: sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-logger@3.901.0':
+    resolution: {integrity: sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.901.0':
+    resolution: {integrity: sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.901.0':
+    resolution: {integrity: sha512-prgjVC3fDT2VIlmQPiw/cLee8r4frTam9GILRUVQyDdNtshNwV3MiaSCLzzQJjKJlLgnBLNUHJCSmvUVtg+3iA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.901.0':
+    resolution: {integrity: sha512-Zby4F03fvD9xAgXGPywyk4bC1jCbnyubMEYChLYohD+x20ULQCf+AimF/Btn7YL+hBpzh1+RmqmvZcx+RgwgNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/nested-clients@3.901.0':
+    resolution: {integrity: sha512-feAAAMsVwctk2Tms40ONybvpfJPLCmSdI+G+OTrNpizkGLNl6ik2Ng2RzxY6UqOfN8abqKP/DOUj1qYDRDG8ag==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.901.0':
+    resolution: {integrity: sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.901.0':
+    resolution: {integrity: sha512-2IWxbll/pRucp1WQkHi2W5E2SVPGBvk4Is923H7gpNksbVFws18ItjMM8ZpGm44cJEoy1zR5gjhLFklatpuoOw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/token-providers@3.901.0':
+    resolution: {integrity: sha512-pJEr1Ggbc/uVTDqp9IbNu9hdr0eQf3yZix3s4Nnyvmg4xmJSGAlbPC9LrNr5u3CDZoc8Z9CuLrvbP4MwYquNpQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/types@3.901.0':
+    resolution: {integrity: sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.893.0':
+    resolution: {integrity: sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-endpoints@3.901.0':
+    resolution: {integrity: sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-locate-window@3.893.0':
+    resolution: {integrity: sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.901.0':
+    resolution: {integrity: sha512-Ntb6V/WFI21Ed4PDgL/8NSfoZQQf9xzrwNgiwvnxgAl/KvAvRBgQtqj5gHsDX8Nj2YmJuVoHfH9BGjL9VQ4WNg==}
+
+  '@aws-sdk/util-user-agent-node@3.901.0':
+    resolution: {integrity: sha512-l59KQP5TY7vPVUfEURc7P5BJKuNg1RSsAKBQW7LHLECXjLqDUbo2SMLrexLBEoArSt6E8QOrIN0C8z/0Xk0jYw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.901.0':
+    resolution: {integrity: sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.0.1':
+    resolution: {integrity: sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1389,6 +1517,178 @@ packages:
     resolution: {integrity: sha512-/ZqxUvKeEztU9drOoPC/8opEPOk+jLlB2q4+xpx6HVLq6aFu3pMpalkTpAQz8XfRfpLp8O25bh6pGPcHDCYpqg==}
     engines: {node: '>=12.*'}
 
+  '@smithy/abort-controller@4.2.0':
+    resolution: {integrity: sha512-PLUYa+SUKOEZtXFURBu/CNxlsxfaFGxSBPcStL13KpVeVWIfdezWyDqkz7iDLmwnxojXD0s5KzuB5HGHvt4Aeg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.3.0':
+    resolution: {integrity: sha512-9oH+n8AVNiLPK/iK/agOsoWfrKZ3FGP3502tkksd6SRsKMYiu7AFX0YXo6YBADdsAj7C+G/aLKdsafIJHxuCkQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.14.0':
+    resolution: {integrity: sha512-XJ4z5FxvY/t0Dibms/+gLJrI5niRoY0BCmE02fwmPcRYFPI4KI876xaE79YGWIKnEslMbuQPsIEsoU/DXa0DoA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.0':
+    resolution: {integrity: sha512-SOhFVvFH4D5HJZytb0bLKxCrSnwcqPiNlrw+S4ZXjMnsC+o9JcUQzbZOEQcA8yv9wJFNhfsUiIUKiEnYL68Big==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.0':
+    resolution: {integrity: sha512-BG3KSmsx9A//KyIfw+sqNmWFr1YBUr+TwpxFT7yPqAk0yyDh7oSNgzfNH7pS6OC099EGx2ltOULvumCFe8bcgw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.0':
+    resolution: {integrity: sha512-ugv93gOhZGysTctZh9qdgng8B+xO0cj+zN0qAZ+Sgh7qTQGPOJbMdIuyP89KNfUyfAqFSNh5tMvC+h2uCpmTtA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.0':
+    resolution: {integrity: sha512-ZmK5X5fUPAbtvRcUPtk28aqIClVhbfcmfoS4M7UQBTnDdrNxhsrxYVv0ZEl5NaPSyExsPWqL4GsPlRvtlwg+2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.0':
+    resolution: {integrity: sha512-6ZAnwrXFecrA4kIDOcz6aLBhU5ih2is2NdcZtobBDSdSHtE9a+MThB5uqyK4XXesdOCvOcbCm2IGB95birTSOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.3.0':
+    resolution: {integrity: sha512-jFVjuQeV8TkxaRlcCNg0GFVgg98tscsmIrIwRFeC74TIUyLE3jmY9xgc1WXrPQYRjQNK3aRoaIk6fhFRGOIoGw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.0':
+    resolution: {integrity: sha512-yaVBR0vQnOnzex45zZ8ZrPzUnX73eUC8kVFaAAbn04+6V7lPtxn56vZEBBAhgS/eqD6Zm86o6sJs6FuQVoX5qg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.0':
+    resolution: {integrity: sha512-rpTQ7D65/EAbC6VydXlxjvbifTf4IH+sADKg6JmAvhkflJO2NvDeyU9qsWUNBelJiQFcXKejUHWRSdmpJmEmiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.0':
+    resolution: {integrity: sha512-G5CJ//eqRd9OARrQu9MK1H8fNm2sMtqFh6j8/rPozhEL+Dokpvi1Og+aCixTuwDAGZUkJPk6hJT5jchbk/WCyg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.0':
+    resolution: {integrity: sha512-5QgHNuWdT9j9GwMPPJCKxy2KDxZ3E5l4M3/5TatSZrqYVoEiqQrDfAq8I6KWZw7RZOHtVtCzEPdYz7rHZixwcA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.3.0':
+    resolution: {integrity: sha512-RHZ/uWCmSNZ8cneoWEVsVwMZBKy/8123hEpm57vgGXA3Irf/Ja4v9TVshHK2ML5/IqzAZn0WhINHOP9xl+Qy6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.0':
+    resolution: {integrity: sha512-rV6wFre0BU6n/tx2Ztn5LdvEdNZ2FasQbPQmDOPfV9QQyDmsCkOAB0osQjotRCQg+nSKFmINhyda0D3AnjSBJw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.0':
+    resolution: {integrity: sha512-6POSYlmDnsLKb7r1D3SVm7RaYW6H1vcNcTWGWrF7s9+2noNYvUsm7E4tz5ZQ9HXPmKn6Hb67pBDRIjrT4w/d7Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.0':
+    resolution: {integrity: sha512-Q4oFD0ZmI8yJkiPPeGUITZj++4HHYCW3pYBYfIobUCkYpI6mbkzmG1MAQQ3lJYYWj3iNqfzOenUZu+jqdPQ16A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.0':
+    resolution: {integrity: sha512-BjATSNNyvVbQxOOlKse0b0pSezTWGMvA87SvoFoFlkRsKXVsN3bEtjCxvsNXJXfnAzlWFPaT9DmhWy1vn0sNEA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.0':
+    resolution: {integrity: sha512-Ylv1ttUeKatpR0wEOMnHf1hXMktPUMObDClSWl2TpCVT4DwtJhCeighLzSLbgH3jr5pBNM0LDXT5yYxUvZ9WpA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.3.0':
+    resolution: {integrity: sha512-VCUPPtNs+rKWlqqntX0CbVvWyjhmX30JCtzO+s5dlzzxrvSfRh5SY0yxnkirvc1c80vdKQttahL71a9EsdolSQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.0':
+    resolution: {integrity: sha512-MKNyhXEs99xAZaFhm88h+3/V+tCRDQ+PrDzRqL0xdDpq4gjxcMmf5rBA3YXgqZqMZ/XwemZEurCBQMfxZOWq/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.7.0':
+    resolution: {integrity: sha512-3BDx/aCCPf+kkinYf5QQhdQ9UAGihgOVqI3QO5xQfSaIWvUE4KYLtiGRWsNe1SR7ijXC0QEPqofVp5Sb0zC8xQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.6.0':
+    resolution: {integrity: sha512-4lI9C8NzRPOv66FaY1LL1O/0v0aLVrq/mXP/keUa9mJOApEeae43LsLd2kZRUJw91gxOQfLIrV3OvqPgWz1YsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.0':
+    resolution: {integrity: sha512-AlBmD6Idav2ugmoAL6UtR6ItS7jU5h5RNqLMZC7QrLCoITA9NzIN3nx9GWi8g4z1pfWh2r9r96SX/jHiNwPJ9A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.2.0':
+    resolution: {integrity: sha512-+erInz8WDv5KPe7xCsJCp+1WCjSbah9gWcmUXc9NqmhyPx59tf7jqFz+za1tRG1Y5KM1Cy1rWCcGypylFp4mvA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.0':
+    resolution: {integrity: sha512-U8q1WsSZFjXijlD7a4wsDQOvOwV+72iHSfq1q7VD+V75xP/pdtm0WIGuaFJ3gcADDOKj2MIBn4+zisi140HEnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.2.0':
+    resolution: {integrity: sha512-qzHp7ZDk1Ba4LDwQVCNp90xPGqSu7kmL7y5toBpccuhi3AH7dcVBIT/pUxYcInK4jOy6FikrcTGq5wxcka8UaQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.0':
+    resolution: {integrity: sha512-FxUHS3WXgx3bTWR6yQHNHHkQHZm/XKIi/CchTnKvBulN6obWpcbzJ6lDToXn+Wp0QlVKd7uYAz2/CTw1j7m+Kg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.0':
+    resolution: {integrity: sha512-TXeCn22D56vvWr/5xPqALc9oO+LN+QpFjrSM7peG/ckqEPoI3zaKZFp+bFwfmiHhn5MGWPaLCqDOJPPIixk9Wg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.0':
+    resolution: {integrity: sha512-u9OOfDa43MjagtJZ8AapJcmimP+K2Z7szXn8xbty4aza+7P1wjFmy2ewjSbhEiYQoW1unTlOAIV165weYAaowA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.0':
+    resolution: {integrity: sha512-BWSiuGbwRnEE2SFfaAZEX0TqaxtvtSYPM/J73PFVm+A29Fg1HTPiYFb8TmX1DXp4hgcdyJcNQmprfd5foeORsg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.4.0':
+    resolution: {integrity: sha512-vtO7ktbixEcrVzMRmpQDnw/Ehr9UWjBvSJ9fyAbadKkC4w5Cm/4lMO8cHz8Ysb8uflvQUNRcuux/oNHKPXkffg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
@@ -1576,6 +1876,9 @@ packages:
 
   '@types/node@24.5.2':
     resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
+
+  '@types/nodemailer@7.0.2':
+    resolution: {integrity: sha512-Zo6uOA9157WRgBk/ZhMpTQ/iCWLMk7OIs/Q9jvHarMvrzUUP/MDdPHL2U1zpf57HrrWGv4nYQn5uIxna0xY3xw==}
 
   '@types/pdfkit@0.17.3':
     resolution: {integrity: sha512-E4tp2qFaghqfS4K5TR4Gn1uTIkg0UAkhUgvVIszr5cS6ZmbioPWEkvhNDy3GtR9qdKC8DLQAnaaMlTcf346VsA==}
@@ -1923,6 +2226,9 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bowser@2.12.1:
+    resolution: {integrity: sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -2554,6 +2860,10 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-xml-parser@5.2.5:
+    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
+    hasBin: true
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3950,6 +4260,9 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
+  strnum@2.1.1:
+    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4384,6 +4697,391 @@ snapshots:
       lru-cache: 11.2.2
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-locate-window': 3.893.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.901.0
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sesv2@3.901.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/credential-provider-node': 3.901.0
+      '@aws-sdk/middleware-host-header': 3.901.0
+      '@aws-sdk/middleware-logger': 3.901.0
+      '@aws-sdk/middleware-recursion-detection': 3.901.0
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/region-config-resolver': 3.901.0
+      '@aws-sdk/signature-v4-multi-region': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@aws-sdk/util-user-agent-browser': 3.901.0
+      '@aws-sdk/util-user-agent-node': 3.901.0
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/core': 3.14.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/hash-node': 4.2.0
+      '@smithy/invalid-dependency': 4.2.0
+      '@smithy/middleware-content-length': 4.2.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-retry': 4.4.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.0
+      '@smithy/util-defaults-mode-browser': 4.2.0
+      '@smithy/util-defaults-mode-node': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.901.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/middleware-host-header': 3.901.0
+      '@aws-sdk/middleware-logger': 3.901.0
+      '@aws-sdk/middleware-recursion-detection': 3.901.0
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/region-config-resolver': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@aws-sdk/util-user-agent-browser': 3.901.0
+      '@aws-sdk/util-user-agent-node': 3.901.0
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/core': 3.14.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/hash-node': 4.2.0
+      '@smithy/invalid-dependency': 4.2.0
+      '@smithy/middleware-content-length': 4.2.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-retry': 4.4.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.0
+      '@smithy/util-defaults-mode-browser': 4.2.0
+      '@smithy/util-defaults-mode-node': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/xml-builder': 3.901.0
+      '@smithy/core': 3.14.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/signature-v4': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-stream': 4.4.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/credential-provider-env': 3.901.0
+      '@aws-sdk/credential-provider-http': 3.901.0
+      '@aws-sdk/credential-provider-process': 3.901.0
+      '@aws-sdk/credential-provider-sso': 3.901.0
+      '@aws-sdk/credential-provider-web-identity': 3.901.0
+      '@aws-sdk/nested-clients': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/credential-provider-imds': 4.2.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.901.0':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.901.0
+      '@aws-sdk/credential-provider-http': 3.901.0
+      '@aws-sdk/credential-provider-ini': 3.901.0
+      '@aws-sdk/credential-provider-process': 3.901.0
+      '@aws-sdk/credential-provider-sso': 3.901.0
+      '@aws-sdk/credential-provider-web-identity': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/credential-provider-imds': 4.2.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.901.0':
+    dependencies:
+      '@aws-sdk/client-sso': 3.901.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/token-providers': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/nested-clients': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@aws/lambda-invoke-store': 0.0.1
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-arn-parser': 3.893.0
+      '@smithy/core': 3.14.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/signature-v4': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-stream': 4.4.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@smithy/core': 3.14.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.901.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/middleware-host-header': 3.901.0
+      '@aws-sdk/middleware-logger': 3.901.0
+      '@aws-sdk/middleware-recursion-detection': 3.901.0
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/region-config-resolver': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@aws-sdk/util-user-agent-browser': 3.901.0
+      '@aws-sdk/util-user-agent-node': 3.901.0
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/core': 3.14.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/hash-node': 4.2.0
+      '@smithy/invalid-dependency': 4.2.0
+      '@smithy/middleware-content-length': 4.2.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-retry': 4.4.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.0
+      '@smithy/util-defaults-mode-browser': 4.2.0
+      '@smithy/util-defaults-mode-node': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.901.0':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/signature-v4': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/nested-clients': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.901.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.893.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.893.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/types': 4.6.0
+      bowser: 2.12.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.901.0':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.901.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      fast-xml-parser: 5.2.5
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.0.1': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5299,6 +5997,280 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@smithy/abort-controller@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.3.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/core@3.14.0':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-stream': 4.4.0
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/querystring-builder': 4.2.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.3.0':
+    dependencies:
+      '@smithy/core': 3.14.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/service-error-classification': 4.2.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.0':
+    dependencies:
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.3.0':
+    dependencies:
+      '@smithy/abort-controller': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/querystring-builder': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+
+  '@smithy/shared-ini-file-loader@4.3.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.7.0':
+    dependencies:
+      '@smithy/core': 3.14.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-stream': 4.4.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.6.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.0':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.2.0':
+    dependencies:
+      '@smithy/property-provider': 4.2.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      bowser: 2.12.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.0':
+    dependencies:
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/credential-provider-imds': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.0':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.4.0':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.0.0': {}
@@ -5468,6 +6440,13 @@ snapshots:
   '@types/node@24.5.2':
     dependencies:
       undici-types: 7.12.0
+
+  '@types/nodemailer@7.0.2':
+    dependencies:
+      '@aws-sdk/client-sesv2': 3.901.0
+      '@types/node': 24.5.2
+    transitivePeerDependencies:
+      - aws-crt
 
   '@types/pdfkit@0.17.3':
     dependencies:
@@ -5846,6 +6825,8 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bowser@2.12.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -6656,6 +7637,10 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-xml-parser@5.2.5:
+    dependencies:
+      strnum: 2.1.1
 
   fastq@1.19.1:
     dependencies:
@@ -8148,6 +9133,8 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  strnum@2.1.1: {}
 
   styled-jsx@5.1.6(react@19.1.1):
     dependencies:

--- a/prisma/migrations/20260120120000_server_settings/migration.sql
+++ b/prisma/migrations/20260120120000_server_settings/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "public"."ServerSettings" (
+    "id" TEXT NOT NULL DEFAULT 'default',
+    "mailHost" TEXT,
+    "mailPort" INTEGER NOT NULL DEFAULT 587,
+    "mailSecure" BOOLEAN NOT NULL DEFAULT false,
+    "mailUsername" TEXT,
+    "mailPassword" TEXT,
+    "mailFromAddress" TEXT,
+    "mailFromName" TEXT,
+    "mailReplyTo" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ServerSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateFunction
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW."updatedAt" = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- CreateTrigger
+CREATE TRIGGER "ServerSettings_set_updated_at"
+BEFORE UPDATE ON "public"."ServerSettings"
+FOR EACH ROW
+EXECUTE FUNCTION "public"."set_current_timestamp_updated_at"();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -683,6 +683,20 @@ model SperrlisteSettings {
   updatedAt              DateTime @updatedAt
 }
 
+model ServerSettings {
+  id              String   @id @default("default")
+  mailHost        String?
+  mailPort        Int      @default(587)
+  mailSecure      Boolean  @default(false)
+  mailUsername    String?
+  mailPassword    String?
+  mailFromAddress String?
+  mailFromName    String?
+  mailReplyTo     String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}
+
 model MysteryTip {
   id             String   @id @default(cuid())
   text           String

--- a/prisma/seed.mjs
+++ b/prisma/seed.mjs
@@ -80,6 +80,12 @@ async function main() {
     },
   });
 
+  await prisma.serverSettings.upsert({
+    where: { id: "default" },
+    update: {},
+    create: { id: "default" },
+  });
+
   await prisma.homepageCountdown.upsert({
     where: { id: "public" },
     update: {

--- a/src/app/(members)/mitglieder/server-einstellungen/actions.ts
+++ b/src/app/(members)/mitglieder/server-einstellungen/actions.ts
@@ -1,0 +1,280 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { verifyMailTransport } from "@/lib/email/transporter";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import {
+  MAX_MAIL_PORT,
+  MIN_MAIL_PORT,
+  applyServerSettingsPatch,
+  loadResolvedServerSettings,
+  saveServerSettings,
+  toClientServerSettings,
+  type ClientServerSettings,
+  type ServerSettingsInput,
+} from "@/lib/server-settings";
+
+const EMAIL_SCHEMA = z.string().email();
+
+const MAX_TEXT_LENGTH = 255;
+const MAX_NAME_LENGTH = 120;
+const MAX_PASSWORD_LENGTH = 512;
+
+type FieldErrors = Record<string, string[]>;
+
+function appendFieldError(errors: FieldErrors, field: string, message: string) {
+  if (!errors[field]) {
+    errors[field] = [];
+  }
+  errors[field]!.push(message);
+}
+
+function validateServerSettingsPayload(
+  raw: Partial<Record<keyof ServerSettingsInput, unknown>>,
+): { success: true; data: ServerSettingsInput } | { success: false; fieldErrors: FieldErrors } {
+  const errors: FieldErrors = {};
+  const data: ServerSettingsInput = {};
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailHost")) {
+    const value = raw.mailHost;
+    if (value === null) {
+      data.mailHost = null;
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        data.mailHost = null;
+      } else if (trimmed.length > MAX_TEXT_LENGTH) {
+        appendFieldError(errors, "mailHost", `Maximal ${MAX_TEXT_LENGTH} Zeichen erlaubt.`);
+      } else {
+        data.mailHost = trimmed;
+      }
+    } else if (value === undefined) {
+      // ignore
+    } else {
+      appendFieldError(errors, "mailHost", "Ungültiger Servername.");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailPort")) {
+    const value = raw.mailPort;
+    if (value === null || value === undefined || value === "") {
+      // ignore empty values
+    } else {
+      const numeric = typeof value === "number" ? value : Number(String(value));
+      if (!Number.isFinite(numeric) || !Number.isInteger(numeric)) {
+        appendFieldError(errors, "mailPort", "Der Port muss eine ganze Zahl sein.");
+      } else if (numeric < MIN_MAIL_PORT || numeric > MAX_MAIL_PORT) {
+        appendFieldError(
+          errors,
+          "mailPort",
+          `Der Port muss zwischen ${MIN_MAIL_PORT} und ${MAX_MAIL_PORT} liegen.`,
+        );
+      } else {
+        data.mailPort = numeric;
+      }
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailSecure")) {
+    const value = raw.mailSecure;
+    if (typeof value === "boolean") {
+      data.mailSecure = value;
+    } else if (typeof value === "string") {
+      if (value === "true") {
+        data.mailSecure = true;
+      } else if (value === "false") {
+        data.mailSecure = false;
+      } else {
+        appendFieldError(errors, "mailSecure", "Ungültiger Wert für TLS/SSL.");
+      }
+    } else if (value !== undefined && value !== null) {
+      appendFieldError(errors, "mailSecure", "Ungültiger Wert für TLS/SSL.");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailUsername")) {
+    const value = raw.mailUsername;
+    if (value === null) {
+      data.mailUsername = null;
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        data.mailUsername = null;
+      } else if (trimmed.length > MAX_TEXT_LENGTH) {
+        appendFieldError(errors, "mailUsername", `Maximal ${MAX_TEXT_LENGTH} Zeichen erlaubt.`);
+      } else {
+        data.mailUsername = trimmed;
+      }
+    } else if (value !== undefined) {
+      appendFieldError(errors, "mailUsername", "Ungültiger Benutzername.");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailPassword")) {
+    const value = raw.mailPassword;
+    if (value === null) {
+      data.mailPassword = null;
+    } else if (typeof value === "string") {
+      if (value.length === 0) {
+        data.mailPassword = null;
+      } else if (value.length > MAX_PASSWORD_LENGTH) {
+        appendFieldError(errors, "mailPassword", `Maximal ${MAX_PASSWORD_LENGTH} Zeichen erlaubt.`);
+      } else {
+        data.mailPassword = value;
+      }
+    } else if (value !== undefined) {
+      appendFieldError(errors, "mailPassword", "Ungültiges Passwort.");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailFromAddress")) {
+    const value = raw.mailFromAddress;
+    if (value === null) {
+      data.mailFromAddress = null;
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        data.mailFromAddress = null;
+      } else if (!EMAIL_SCHEMA.safeParse(trimmed).success) {
+        appendFieldError(errors, "mailFromAddress", "Ungültige E-Mail-Adresse.");
+      } else {
+        data.mailFromAddress = trimmed;
+      }
+    } else if (value !== undefined) {
+      appendFieldError(errors, "mailFromAddress", "Ungültige E-Mail-Adresse.");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailFromName")) {
+    const value = raw.mailFromName;
+    if (value === null) {
+      data.mailFromName = null;
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        data.mailFromName = null;
+      } else if (trimmed.length > MAX_NAME_LENGTH) {
+        appendFieldError(errors, "mailFromName", `Maximal ${MAX_NAME_LENGTH} Zeichen erlaubt.`);
+      } else {
+        data.mailFromName = trimmed;
+      }
+    } else if (value !== undefined) {
+      appendFieldError(errors, "mailFromName", "Ungültiger Anzeigename.");
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(raw, "mailReplyTo")) {
+    const value = raw.mailReplyTo;
+    if (value === null) {
+      data.mailReplyTo = null;
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        data.mailReplyTo = null;
+      } else if (!EMAIL_SCHEMA.safeParse(trimmed).success) {
+        appendFieldError(errors, "mailReplyTo", "Ungültige E-Mail-Adresse.");
+      } else {
+        data.mailReplyTo = trimmed;
+      }
+    } else if (value !== undefined) {
+      appendFieldError(errors, "mailReplyTo", "Ungültige E-Mail-Adresse.");
+    }
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { success: false, fieldErrors: errors };
+  }
+
+  return { success: true, data };
+}
+
+export type SaveServerSettingsResult =
+  | { success: true; settings: ClientServerSettings }
+  | {
+      success: false;
+      error: "not_authorized" | "no_database" | "validation_failed" | "update_failed";
+      fieldErrors?: FieldErrors;
+    };
+
+export async function saveServerSettingsAction(
+  input: Partial<Record<keyof ServerSettingsInput, unknown>>,
+): Promise<SaveServerSettingsResult> {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.settings");
+  if (!allowed) {
+    return { success: false, error: "not_authorized" };
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return { success: false, error: "no_database" };
+  }
+
+  const parsed = validateServerSettingsPayload(input);
+  if (!parsed.success) {
+    return { success: false, error: "validation_failed", fieldErrors: parsed.fieldErrors };
+  }
+
+  try {
+    const saved = await saveServerSettings(parsed.data);
+    revalidatePath("/mitglieder/server-einstellungen");
+    return { success: true, settings: toClientServerSettings(saved) };
+  } catch (error) {
+    console.error("[server-settings] Speichern fehlgeschlagen", error);
+    return { success: false, error: "update_failed" };
+  }
+}
+
+export type TestMailServerResult =
+  | { success: true; message: string }
+  | {
+      success: false;
+      error: "not_authorized" | "no_database" | "validation_failed" | "test_failed";
+      fieldErrors?: FieldErrors;
+      message?: string;
+    };
+
+export async function testMailServerConnectionAction(
+  input: Partial<Record<keyof ServerSettingsInput, unknown>>,
+): Promise<TestMailServerResult> {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.settings");
+  if (!allowed) {
+    return { success: false, error: "not_authorized" };
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return { success: false, error: "no_database" };
+  }
+
+  const parsed = validateServerSettingsPayload(input);
+  if (!parsed.success) {
+    return { success: false, error: "validation_failed", fieldErrors: parsed.fieldErrors };
+  }
+
+  try {
+    const current = await loadResolvedServerSettings();
+    const merged = applyServerSettingsPatch(current, parsed.data);
+
+    if (!merged.mailHost) {
+      return {
+        success: false,
+        error: "validation_failed",
+        fieldErrors: { mailHost: ["Bitte gib einen SMTP-Server an."] },
+      };
+    }
+
+    await verifyMailTransport(merged);
+    return { success: true, message: "Verbindung erfolgreich getestet." };
+  } catch (error) {
+    console.error("[server-settings] SMTP-Test fehlgeschlagen", error);
+    const message = error instanceof Error ? error.message : undefined;
+    return {
+      success: false,
+      error: "test_failed",
+      message: message ?? "Verbindung zum SMTP-Server konnte nicht aufgebaut werden.",
+    };
+  }
+}

--- a/src/app/(members)/mitglieder/server-einstellungen/page.tsx
+++ b/src/app/(members)/mitglieder/server-einstellungen/page.tsx
@@ -1,0 +1,50 @@
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import {
+  loadResolvedServerSettings,
+  toClientServerSettings,
+  type ClientServerSettings,
+} from "@/lib/server-settings";
+
+import { ServerSettingsContent } from "./server-settings-content";
+
+export default async function ServerSettingsPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.settings");
+
+  if (!allowed) {
+    return <div className="text-sm text-muted-foreground">Kein Zugriff auf die Servereinstellungen.</div>;
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        Die Datenbank ist nicht konfiguriert. Servereinstellungen können nicht geladen werden.
+      </div>
+    );
+  }
+
+  try {
+    const resolved = await loadResolvedServerSettings();
+    const clientSettings: ClientServerSettings = toClientServerSettings(resolved);
+
+    return (
+      <div className="space-y-8">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold tracking-tight">Servereinstellungen</h1>
+          <p className="text-sm text-muted-foreground">
+            Hinterlege den SMTP-Server für Systemnachrichten und teste die Verbindung direkt aus dem Backend.
+          </p>
+        </div>
+        <ServerSettingsContent initialSettings={clientSettings} />
+      </div>
+    );
+  } catch (error) {
+    console.error("[server-settings] Laden fehlgeschlagen", error);
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive">
+        Servereinstellungen konnten nicht geladen werden.
+      </div>
+    );
+  }
+}

--- a/src/app/(members)/mitglieder/server-einstellungen/server-settings-content.tsx
+++ b/src/app/(members)/mitglieder/server-einstellungen/server-settings-content.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { useId, useMemo, useState, useTransition, type ChangeEvent, type FormEvent } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import type { ClientServerSettings } from "@/lib/server-settings";
+
+import {
+  saveServerSettingsAction,
+  testMailServerConnectionAction,
+  type SaveServerSettingsResult,
+  type TestMailServerResult,
+} from "./actions";
+
+type ServerSettingsFormValues = {
+  mailHost: string;
+  mailPort: string;
+  mailSecure: boolean;
+  mailUsername: string;
+  mailFromAddress: string;
+  mailFromName: string;
+  mailReplyTo: string;
+};
+
+type PasswordState = {
+  mode: "preserve" | "update" | "clear";
+  value: string;
+};
+
+type FieldErrors = Record<string, string[]>;
+
+type TestFeedback = {
+  variant: "success" | "error";
+  message: string;
+} | null;
+
+const dateFormatter = new Intl.DateTimeFormat("de-DE", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+function isValidationError<Result extends { success: boolean; error?: unknown; fieldErrors?: FieldErrors }>(
+  result: Result,
+): result is Result & { success: false; fieldErrors: FieldErrors } {
+  return result.success === false && Boolean(result.fieldErrors);
+}
+
+type ServerSettingsContentProps = {
+  initialSettings: ClientServerSettings;
+};
+
+export function ServerSettingsContent({ initialSettings }: ServerSettingsContentProps) {
+  const [formState, setFormState] = useState<ServerSettingsFormValues>({
+    mailHost: initialSettings.mailHost,
+    mailPort: String(initialSettings.mailPort ?? ""),
+    mailSecure: initialSettings.mailSecure,
+    mailUsername: initialSettings.mailUsername,
+    mailFromAddress: initialSettings.mailFromAddress,
+    mailFromName: initialSettings.mailFromName,
+    mailReplyTo: initialSettings.mailReplyTo,
+  });
+  const [passwordState, setPasswordState] = useState<PasswordState>({ mode: "preserve", value: "" });
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [testFeedback, setTestFeedback] = useState<TestFeedback>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(initialSettings.updatedAt);
+  const [passwordPersisted, setPasswordPersisted] = useState<boolean>(initialSettings.mailPasswordSet);
+  const passwordHintId = useId();
+
+  const [isSaving, startSaving] = useTransition();
+  const [isTesting, startTesting] = useTransition();
+
+  const lastUpdatedLabel = useMemo(() => {
+    if (!lastUpdated) {
+      return "Noch nie gespeichert";
+    }
+    const parsed = new Date(lastUpdated);
+    if (Number.isNaN(parsed.valueOf())) {
+      return "Unbekannt";
+    }
+    return dateFormatter.format(parsed);
+  }, [lastUpdated]);
+
+  const clearFieldError = (field: keyof FieldErrors) => {
+    if (fieldErrors[field]?.length) {
+      setFieldErrors((previous) => {
+        const next = { ...previous };
+        delete next[field];
+        return next;
+      });
+    }
+  };
+
+  const handleTextChange = (field: keyof ServerSettingsFormValues) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setFormState((previous) => ({ ...previous, [field]: value }));
+      clearFieldError(field);
+    };
+
+  const handleSecureChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const checked = event.target.checked;
+    setFormState((previous) => ({ ...previous, mailSecure: checked }));
+    clearFieldError("mailSecure");
+  };
+
+  const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setPasswordState({ mode: "update", value });
+    clearFieldError("mailPassword");
+  };
+
+  const resetPasswordState = () => {
+    setPasswordState({ mode: "preserve", value: "" });
+    clearFieldError("mailPassword");
+  };
+
+  const handleClearPassword = () => {
+    setPasswordState({ mode: "clear", value: "" });
+    clearFieldError("mailPassword");
+  };
+
+  const buildPayload = (): Record<string, unknown> => {
+    const payload: Record<string, unknown> = {
+      mailHost: formState.mailHost,
+      mailSecure: formState.mailSecure,
+      mailUsername: formState.mailUsername,
+      mailFromAddress: formState.mailFromAddress,
+      mailFromName: formState.mailFromName,
+      mailReplyTo: formState.mailReplyTo,
+    };
+
+    const trimmedPort = formState.mailPort.trim();
+    payload.mailPort = trimmedPort === "" ? "" : trimmedPort;
+
+    if (passwordState.mode === "update") {
+      payload.mailPassword = passwordState.value;
+    } else if (passwordState.mode === "clear") {
+      payload.mailPassword = "";
+    }
+
+    return payload;
+  };
+
+  const applySaveResult = (result: SaveServerSettingsResult) => {
+    if (result.success) {
+      setFormState({
+        mailHost: result.settings.mailHost,
+        mailPort: String(result.settings.mailPort ?? ""),
+        mailSecure: result.settings.mailSecure,
+        mailUsername: result.settings.mailUsername,
+        mailFromAddress: result.settings.mailFromAddress,
+        mailFromName: result.settings.mailFromName,
+        mailReplyTo: result.settings.mailReplyTo,
+      });
+      setPasswordState({ mode: "preserve", value: "" });
+      setFieldErrors({});
+      setTestFeedback(null);
+      setLastUpdated(result.settings.updatedAt);
+      setPasswordPersisted(result.settings.mailPasswordSet);
+      toast.success("Servereinstellungen gespeichert.");
+      return;
+    }
+
+    if (result.error === "not_authorized") {
+      toast.error("Du darfst diese Einstellungen nicht ändern.");
+      return;
+    }
+
+    if (result.error === "no_database") {
+      toast.error("Ohne Datenbank können die Einstellungen nicht gespeichert werden.");
+      return;
+    }
+
+    if (isValidationError(result)) {
+      setFieldErrors(result.fieldErrors);
+      toast.error("Bitte prüfe die markierten Felder.");
+      return;
+    }
+
+    toast.error("Die Einstellungen konnten nicht gespeichert werden.");
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setTestFeedback(null);
+    startSaving(async () => {
+      const payload = buildPayload();
+      const result = await saveServerSettingsAction(payload);
+      applySaveResult(result);
+    });
+  };
+
+  const applyTestResult = (result: TestMailServerResult) => {
+    if (result.success) {
+      const feedback: TestFeedback = { variant: "success", message: result.message };
+      setTestFeedback(feedback);
+      toast.success(result.message);
+      return;
+    }
+
+    if (result.error === "not_authorized") {
+      const message = "Du darfst die Verbindung nicht testen.";
+      setTestFeedback({ variant: "error", message });
+      toast.error(message);
+      return;
+    }
+
+    if (result.error === "no_database") {
+      const message = "Ohne Datenbankverbindung kann keine Prüfung erfolgen.";
+      setTestFeedback({ variant: "error", message });
+      toast.error(message);
+      return;
+    }
+
+    if (isValidationError(result)) {
+      setFieldErrors(result.fieldErrors);
+      const message = "Bitte prüfe die markierten Felder.";
+      setTestFeedback({ variant: "error", message });
+      toast.error(message);
+      return;
+    }
+
+    const message = result.message ?? "Verbindungstest fehlgeschlagen.";
+    setTestFeedback({ variant: "error", message });
+    toast.error(message);
+  };
+
+  const handleTest = () => {
+    setTestFeedback(null);
+    startTesting(async () => {
+      const payload = buildPayload();
+      const result = await testMailServerConnectionAction(payload);
+      applyTestResult(result);
+    });
+  };
+
+  const renderFieldErrors = (field: keyof FieldErrors) => {
+    const messages = fieldErrors[field];
+    if (!messages?.length) {
+      return null;
+    }
+    return (
+      <ul className="space-y-1 pt-1 text-xs text-destructive">
+        {messages.map((message, index) => (
+          <li key={`${field}-${index}`}>{message}</li>
+        ))}
+      </ul>
+    );
+  };
+
+  const passwordHint = (() => {
+    if (passwordState.mode === "update") {
+      return "Neues Passwort wird beim Speichern übernommen.";
+    }
+    if (passwordState.mode === "clear") {
+      return "Das gespeicherte Passwort wird entfernt.";
+    }
+    if (passwordPersisted) {
+      return "Aktuell ist ein Passwort hinterlegt.";
+    }
+    return "Es ist kein Passwort hinterlegt.";
+  })();
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-col gap-2">
+        <CardTitle>SMTP-Server</CardTitle>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <span>Zuletzt aktualisiert: {lastUpdatedLabel}</span>
+          {passwordPersisted ? <Badge variant="muted">Passwort gespeichert</Badge> : null}
+        </div>
+      </CardHeader>
+      <CardContent>
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="mailHost">SMTP-Server</Label>
+              <Input
+                id="mailHost"
+                autoComplete="off"
+                value={formState.mailHost}
+                onChange={handleTextChange("mailHost")}
+                placeholder="smtp.example.org"
+              />
+              {renderFieldErrors("mailHost")}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="mailPort">Port</Label>
+              <Input
+                id="mailPort"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={formState.mailPort}
+                onChange={handleTextChange("mailPort")}
+                placeholder="587"
+              />
+              {renderFieldErrors("mailPort")}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="flex items-center gap-3 text-sm font-medium text-foreground" htmlFor="mailSecure">
+              <input
+                id="mailSecure"
+                type="checkbox"
+                checked={formState.mailSecure}
+                onChange={handleSecureChange}
+                className="h-4 w-4 rounded border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              />
+              <span>TLS/SSL für den Versand verwenden</span>
+            </label>
+            <p className="text-xs text-muted-foreground">
+              Aktiviere diese Option für sichere Verbindungen (z.&nbsp;B. Port 465 oder STARTTLS).
+            </p>
+            {renderFieldErrors("mailSecure")}
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="mailUsername">Benutzername</Label>
+              <Input
+                id="mailUsername"
+                autoComplete="off"
+                value={formState.mailUsername}
+                onChange={handleTextChange("mailUsername")}
+                placeholder="smtp-user"
+              />
+              {renderFieldErrors("mailUsername")}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="mailPassword">Passwort</Label>
+              <Input
+                id="mailPassword"
+                type="password"
+                autoComplete="new-password"
+                value={passwordState.mode === "update" ? passwordState.value : ""}
+                placeholder={passwordPersisted ? "Passwort unverändert" : "Passwort eingeben"}
+                onChange={handlePasswordChange}
+                aria-describedby={passwordHintId}
+              />
+              <div
+                id={passwordHintId}
+                className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground"
+              >
+                <span>{passwordHint}</span>
+                {passwordState.mode !== "preserve" ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    onClick={resetPasswordState}
+                    disabled={isSaving || isTesting}
+                  >
+                    Änderung verwerfen
+                  </Button>
+                ) : null}
+                {passwordState.mode !== "clear" && passwordPersisted ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    onClick={handleClearPassword}
+                    disabled={isSaving || isTesting}
+                  >
+                    Passwort löschen
+                  </Button>
+                ) : null}
+              </div>
+              {renderFieldErrors("mailPassword")}
+            </div>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="mailFromName">Absendername</Label>
+              <Input
+                id="mailFromName"
+                value={formState.mailFromName}
+                onChange={handleTextChange("mailFromName")}
+                placeholder="Sommertheater"
+              />
+              {renderFieldErrors("mailFromName")}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="mailFromAddress">Absenderadresse</Label>
+              <Input
+                id="mailFromAddress"
+                type="email"
+                autoComplete="off"
+                value={formState.mailFromAddress}
+                onChange={handleTextChange("mailFromAddress")}
+                placeholder="post@example.org"
+              />
+              {renderFieldErrors("mailFromAddress")}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="mailReplyTo">Antwortadresse (optional)</Label>
+            <Input
+              id="mailReplyTo"
+              type="email"
+              autoComplete="off"
+              value={formState.mailReplyTo}
+              onChange={handleTextChange("mailReplyTo")}
+              placeholder="support@example.org"
+            />
+            {renderFieldErrors("mailReplyTo")}
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="submit" disabled={isSaving} data-state={isSaving ? "loading" : undefined}>
+              Einstellungen speichern
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleTest}
+              disabled={isTesting || isSaving}
+              data-state={isTesting ? "loading" : undefined}
+            >
+              Verbindung testen
+            </Button>
+            {testFeedback ? (
+              <span
+                className={
+                  testFeedback.variant === "success"
+                    ? "text-xs font-medium text-success"
+                    : "text-xs font-medium text-destructive"
+                }
+              >
+                {testFeedback.message}
+              </span>
+            ) : null}
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -320,6 +320,21 @@ const ServerAnalyticsIcon = createMembersNavIcon(
   </>,
 );
 
+const ServerSettingsIcon = createMembersNavIcon(
+  <>
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <path d="M7 9h10" />
+    <path d="M12 5v4" />
+    <circle cx="12" cy="16" r="2" />
+    <path d="M12 12v1" />
+    <path d="M12 19v1" />
+    <path d="M15.3 14.7l.7.7" />
+    <path d="M8 20l.7-.7" />
+    <path d="M8.7 14.7l-.7.7" />
+    <path d="M16 20l-.7-.7" />
+  </>,
+);
+
 const FinanceDashboardIcon = createMembersNavIcon(
   <>
     <rect x="3" y="6" width="18" height="12" rx="2" />
@@ -598,6 +613,12 @@ export const membersNavigation = [
         label: "Website & Theme",
         permissionKey: "mitglieder.website.settings",
         icon: WebsiteIcon,
+      },
+      {
+        href: "/mitglieder/server-einstellungen",
+        label: "Servereinstellungen",
+        permissionKey: "mitglieder.server.settings",
+        icon: ServerSettingsIcon,
       },
       {
         href: "/mitglieder/server-analytics",

--- a/src/lib/__tests__/server-settings.test.ts
+++ b/src/lib/__tests__/server-settings.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MAIL_PORT,
+  applyServerSettingsPatch,
+  formatSenderAddress,
+  resolveServerSettings,
+  toClientServerSettings,
+  type ResolvedServerSettings,
+} from "@/lib/server-settings";
+
+function createResolved(overrides: Partial<ResolvedServerSettings> = {}): ResolvedServerSettings {
+  return {
+    id: "default",
+    mailHost: "smtp.example.org",
+    mailPort: DEFAULT_MAIL_PORT,
+    mailSecure: false,
+    mailUsername: "user",
+    mailPassword: "secret",
+    mailFromAddress: "mailer@example.org",
+    mailFromName: "Mailer",
+    mailReplyTo: null,
+    updatedAt: new Date("2025-01-01T12:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("resolveServerSettings", () => {
+  it("returns defaults for null record", () => {
+    const resolved = resolveServerSettings(null);
+    expect(resolved.id).toBe("default");
+    expect(resolved.mailHost).toBeNull();
+    expect(resolved.mailPort).toBe(DEFAULT_MAIL_PORT);
+    expect(resolved.mailSecure).toBe(false);
+    expect(resolved.mailUsername).toBeNull();
+    expect(resolved.mailPassword).toBeNull();
+  });
+
+  it("sanitises invalid email fields", () => {
+    const resolved = resolveServerSettings({
+      id: "default",
+      mailHost: "smtp.local",
+      mailPort: 25,
+      mailSecure: true,
+      mailUsername: "mailer",
+      mailPassword: "pw",
+      mailFromAddress: "invalid",
+      mailFromName: "  Sender  ",
+      mailReplyTo: "",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    expect(resolved.mailFromAddress).toBeNull();
+    expect(resolved.mailFromName).toBe("Sender");
+    expect(resolved.mailReplyTo).toBeNull();
+  });
+});
+
+describe("toClientServerSettings", () => {
+  it("converts resolved settings for the client", () => {
+    const resolved = createResolved({ updatedAt: new Date("2025-05-05T10:00:00Z") });
+    const client = toClientServerSettings(resolved);
+
+    expect(client.mailHost).toBe("smtp.example.org");
+    expect(client.mailPasswordSet).toBe(true);
+    expect(client.updatedAt).toBe("2025-05-05T10:00:00.000Z");
+  });
+
+  it("marks missing password correctly", () => {
+    const resolved = createResolved({ mailPassword: null });
+    const client = toClientServerSettings(resolved);
+    expect(client.mailPasswordSet).toBe(false);
+  });
+});
+
+describe("applyServerSettingsPatch", () => {
+  it("merges overrides with base settings", () => {
+    const base = createResolved();
+    const patched = applyServerSettingsPatch(base, {
+      mailHost: "smtp.other.org",
+      mailPort: 465,
+      mailSecure: true,
+      mailPassword: null,
+      mailReplyTo: "reply@example.org",
+    });
+
+    expect(patched.mailHost).toBe("smtp.other.org");
+    expect(patched.mailPort).toBe(465);
+    expect(patched.mailSecure).toBe(true);
+    expect(patched.mailPassword).toBeNull();
+    expect(patched.mailReplyTo).toBe("reply@example.org");
+  });
+
+  it("keeps base values when patch is undefined", () => {
+    const base = createResolved();
+    const patched = applyServerSettingsPatch(base, {});
+    expect(patched.mailHost).toBe(base.mailHost);
+    expect(patched.mailPort).toBe(base.mailPort);
+  });
+});
+
+describe("formatSenderAddress", () => {
+  it("combines name and address when both are present", () => {
+    const resolved = createResolved();
+    expect(formatSenderAddress(resolved)).toBe("Mailer <mailer@example.org>");
+  });
+
+  it("falls back to username when address is missing", () => {
+    const resolved = createResolved({ mailFromAddress: null });
+    expect(formatSenderAddress(resolved)).toBe("user");
+  });
+
+  it("returns null when no sender information is available", () => {
+    const resolved = createResolved({ mailUsername: null, mailFromAddress: null });
+    expect(formatSenderAddress(resolved)).toBeNull();
+  });
+});

--- a/src/lib/email/email-service.ts
+++ b/src/lib/email/email-service.ts
@@ -1,47 +1,73 @@
+import type { SendMailOptions } from "nodemailer";
+
+import { createTransporterFromSettings } from "@/lib/email/transporter";
+import {
+  formatSenderAddress,
+  loadResolvedServerSettings,
+  type ResolvedServerSettings,
+} from "@/lib/server-settings";
+
 export type EmailService = {
   to: string;
   subject: string;
   html: string;
 };
 
-type SendGridModule = {
-  setApiKey(apiKey: string | undefined): void;
-  send(data: { to: string; from?: string; subject: string; html: string }): Promise<unknown>;
+type CachedMailer = {
+  signature: string;
+  transporter: ReturnType<typeof createTransporterFromSettings>;
 };
 
-function isSendGridModule(value: unknown): value is SendGridModule {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { setApiKey?: unknown }).setApiKey === 'function' &&
-    typeof (value as { send?: unknown }).send === 'function'
-  );
+let cachedMailer: CachedMailer | null = null;
+
+function createSettingsSignature(settings: ResolvedServerSettings): string {
+  const host = settings.mailHost ?? "";
+  const port = settings.mailPort;
+  const secure = settings.mailSecure ? "1" : "0";
+  const username = settings.mailUsername ?? "";
+  const password = settings.mailPassword ?? "";
+  return [host, port, secure, username, password].join("|");
 }
 
-// Diese Funktion muss je nach gewähltem E-Mail-Service implementiert werden
-// (z.B. SendGrid, Amazon SES, etc.)
+async function resolveMailer() {
+  const settings = await loadResolvedServerSettings();
+  const signature = createSettingsSignature(settings);
+
+  if (!cachedMailer || cachedMailer.signature !== signature) {
+    cachedMailer = {
+      signature,
+      transporter: createTransporterFromSettings(settings),
+    };
+  }
+
+  return { settings, transporter: cachedMailer.transporter };
+}
+
 export async function sendEmail({ to, subject, html }: EmailService): Promise<void> {
-  if (process.env.EMAIL_SERVICE === 'sendgrid') {
-    const importedModule = (await import('@sendgrid/mail')) as unknown;
-    const candidate =
-      typeof importedModule === 'object' && importedModule !== null && 'default' in importedModule
-        ? (importedModule as { default: unknown }).default
-        : importedModule;
+  const { settings, transporter } = await resolveMailer();
 
-    if (!isSendGridModule(candidate)) {
-      throw new Error('SendGrid Modul konnte nicht geladen werden');
-    }
+  const from = formatSenderAddress(settings) ?? process.env.EMAIL_FROM ?? null;
+  if (!from) {
+    throw new Error("Es ist keine Absenderadresse für E-Mails konfiguriert.");
+  }
 
-    candidate.setApiKey(process.env.SENDGRID_API_KEY);
+  const replyTo = settings.mailReplyTo ?? process.env.EMAIL_REPLY_TO ?? null;
 
-    await candidate.send({
-      to,
-      from: process.env.EMAIL_FROM,
-      subject,
-      html,
-    });
-  } else {
-    // Andere E-Mail-Service-Implementierungen hier...
-    throw new Error('Kein E-Mail-Service konfiguriert');
+  const mailOptions: SendMailOptions = {
+    to,
+    from,
+    subject,
+    html,
+  };
+
+  if (replyTo) {
+    mailOptions.replyTo = replyTo;
+  }
+
+  try {
+    await transporter.sendMail(mailOptions);
+  } catch (error) {
+    console.error("[mail] Versand fehlgeschlagen", error);
+    throw new Error("E-Mail konnte nicht versendet werden.");
   }
 }

--- a/src/lib/email/transporter.ts
+++ b/src/lib/email/transporter.ts
@@ -1,0 +1,28 @@
+import nodemailer, { type Transporter } from "nodemailer";
+
+import type { ResolvedServerSettings } from "@/lib/server-settings";
+
+export type MailTransporter = Transporter;
+
+export function createTransporterFromSettings(settings: ResolvedServerSettings): Transporter {
+  if (!settings.mailHost) {
+    throw new Error("Es ist kein SMTP-Server konfiguriert.");
+  }
+
+  const auth =
+    settings.mailUsername && settings.mailPassword
+      ? { user: settings.mailUsername, pass: settings.mailPassword }
+      : undefined;
+
+  return nodemailer.createTransport({
+    host: settings.mailHost,
+    port: settings.mailPort,
+    secure: settings.mailSecure,
+    auth,
+  });
+}
+
+export async function verifyMailTransport(settings: ResolvedServerSettings): Promise<void> {
+  const transporter = createTransporterFromSettings(settings);
+  await transporter.verify();
+}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -284,6 +284,12 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     category: "analytics",
   },
   {
+    key: "mitglieder.server.settings",
+    label: "Servereinstellungen verwalten",
+    description: "SMTP-Server und technische Basisdienste konfigurieren.",
+    category: "membership",
+  },
+  {
     key: "mitglieder.server.analytics",
     label: "Server-Statistiken einsehen",
     description: "Auslastung, Antwortzeiten und Nutzungsverhalten in der Server-Statistik abrufen.",

--- a/src/lib/server-settings.ts
+++ b/src/lib/server-settings.ts
@@ -1,0 +1,229 @@
+import { prisma } from "@/lib/prisma";
+import type { Prisma, ServerSettings } from "@prisma/client";
+import { z } from "zod";
+
+export const DEFAULT_SERVER_SETTINGS_ID = "default";
+export const DEFAULT_MAIL_PORT = 587;
+export const MIN_MAIL_PORT = 1;
+export const MAX_MAIL_PORT = 65535;
+
+const EMAIL_SCHEMA = z.string().email();
+
+function trimToNull(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalisePort(value: number | null | undefined): number {
+  if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
+    return DEFAULT_MAIL_PORT;
+  }
+  const intPort = Math.trunc(value);
+  if (!Number.isInteger(intPort)) {
+    return DEFAULT_MAIL_PORT;
+  }
+  return Math.min(Math.max(intPort, MIN_MAIL_PORT), MAX_MAIL_PORT);
+}
+
+function normaliseBoolean(value: boolean | null | undefined, fallback = false): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return fallback;
+}
+
+function normaliseEmail(value: string | null | undefined): string | null {
+  const trimmed = trimToNull(value);
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = EMAIL_SCHEMA.safeParse(trimmed);
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data;
+}
+
+export type ServerSettingsRecord = ServerSettings | null;
+
+export type ResolvedServerSettings = {
+  id: string;
+  mailHost: string | null;
+  mailPort: number;
+  mailSecure: boolean;
+  mailUsername: string | null;
+  mailPassword: string | null;
+  mailFromAddress: string | null;
+  mailFromName: string | null;
+  mailReplyTo: string | null;
+  updatedAt: Date | null;
+};
+
+export function resolveServerSettings(record: ServerSettingsRecord): ResolvedServerSettings {
+  return {
+    id: record?.id ?? DEFAULT_SERVER_SETTINGS_ID,
+    mailHost: trimToNull(record?.mailHost ?? null),
+    mailPort: normalisePort(record?.mailPort ?? DEFAULT_MAIL_PORT),
+    mailSecure: normaliseBoolean(record?.mailSecure, false),
+    mailUsername: trimToNull(record?.mailUsername ?? null),
+    mailPassword: record?.mailPassword ?? null,
+    mailFromAddress: normaliseEmail(record?.mailFromAddress ?? null),
+    mailFromName: trimToNull(record?.mailFromName ?? null),
+    mailReplyTo: normaliseEmail(record?.mailReplyTo ?? null),
+    updatedAt: record?.updatedAt ?? null,
+  };
+}
+
+export type ClientServerSettings = {
+  id: string;
+  mailHost: string;
+  mailPort: number;
+  mailSecure: boolean;
+  mailUsername: string;
+  mailFromAddress: string;
+  mailFromName: string;
+  mailReplyTo: string;
+  mailPasswordSet: boolean;
+  updatedAt: string | null;
+};
+
+export function toClientServerSettings(resolved: ResolvedServerSettings): ClientServerSettings {
+  return {
+    id: resolved.id,
+    mailHost: resolved.mailHost ?? "",
+    mailPort: resolved.mailPort,
+    mailSecure: resolved.mailSecure,
+    mailUsername: resolved.mailUsername ?? "",
+    mailFromAddress: resolved.mailFromAddress ?? "",
+    mailFromName: resolved.mailFromName ?? "",
+    mailReplyTo: resolved.mailReplyTo ?? "",
+    mailPasswordSet: Boolean(resolved.mailPassword && resolved.mailPassword.length > 0),
+    updatedAt: resolved.updatedAt ? resolved.updatedAt.toISOString() : null,
+  };
+}
+
+export type ServerSettingsInput = {
+  mailHost?: string | null;
+  mailPort?: number | null;
+  mailSecure?: boolean | null;
+  mailUsername?: string | null;
+  mailPassword?: string | null;
+  mailFromAddress?: string | null;
+  mailFromName?: string | null;
+  mailReplyTo?: string | null;
+};
+
+export async function readServerSettings() {
+  return prisma.serverSettings.findUnique({ where: { id: DEFAULT_SERVER_SETTINGS_ID } });
+}
+
+export async function ensureServerSettingsRecord() {
+  const existing = await prisma.serverSettings.findUnique({ where: { id: DEFAULT_SERVER_SETTINGS_ID } });
+  if (existing) {
+    return existing;
+  }
+  return prisma.serverSettings.create({ data: { id: DEFAULT_SERVER_SETTINGS_ID } });
+}
+
+export async function loadResolvedServerSettings(): Promise<ResolvedServerSettings> {
+  const record = await ensureServerSettingsRecord();
+  return resolveServerSettings(record);
+}
+
+export async function saveServerSettings(input: ServerSettingsInput) {
+  const update: Prisma.ServerSettingsUpdateInput = {};
+  const create: Prisma.ServerSettingsCreateInput = {
+    id: DEFAULT_SERVER_SETTINGS_ID,
+  };
+
+  if (input.mailHost !== undefined) {
+    update.mailHost = input.mailHost;
+    create.mailHost = input.mailHost;
+  }
+
+  if (input.mailPort !== undefined && input.mailPort !== null) {
+    update.mailPort = input.mailPort;
+    create.mailPort = input.mailPort;
+  }
+
+  if (input.mailSecure !== undefined && input.mailSecure !== null) {
+    update.mailSecure = input.mailSecure;
+    create.mailSecure = input.mailSecure;
+  }
+
+  if (input.mailUsername !== undefined) {
+    update.mailUsername = input.mailUsername;
+    create.mailUsername = input.mailUsername;
+  }
+
+  if (input.mailPassword !== undefined) {
+    update.mailPassword = input.mailPassword;
+    create.mailPassword = input.mailPassword;
+  }
+
+  if (input.mailFromAddress !== undefined) {
+    update.mailFromAddress = input.mailFromAddress;
+    create.mailFromAddress = input.mailFromAddress;
+  }
+
+  if (input.mailFromName !== undefined) {
+    update.mailFromName = input.mailFromName;
+    create.mailFromName = input.mailFromName;
+  }
+
+  if (input.mailReplyTo !== undefined) {
+    update.mailReplyTo = input.mailReplyTo;
+    create.mailReplyTo = input.mailReplyTo;
+  }
+
+  const record = await prisma.serverSettings.upsert({
+    where: { id: DEFAULT_SERVER_SETTINGS_ID },
+    update,
+    create,
+  });
+
+  return resolveServerSettings(record);
+}
+
+export function applyServerSettingsPatch(
+  base: ResolvedServerSettings,
+  patch: ServerSettingsInput,
+): ResolvedServerSettings {
+  return {
+    ...base,
+    mailHost: patch.mailHost !== undefined ? trimToNull(patch.mailHost) : base.mailHost,
+    mailPort:
+      patch.mailPort !== undefined && patch.mailPort !== null
+        ? normalisePort(patch.mailPort)
+        : base.mailPort,
+    mailSecure:
+      patch.mailSecure !== undefined && patch.mailSecure !== null
+        ? normaliseBoolean(patch.mailSecure, base.mailSecure)
+        : base.mailSecure,
+    mailUsername: patch.mailUsername !== undefined ? trimToNull(patch.mailUsername) : base.mailUsername,
+    mailPassword: patch.mailPassword !== undefined ? patch.mailPassword : base.mailPassword,
+    mailFromAddress:
+      patch.mailFromAddress !== undefined ? normaliseEmail(patch.mailFromAddress) : base.mailFromAddress,
+    mailFromName: patch.mailFromName !== undefined ? trimToNull(patch.mailFromName) : base.mailFromName,
+    mailReplyTo:
+      patch.mailReplyTo !== undefined ? normaliseEmail(patch.mailReplyTo) : base.mailReplyTo,
+  };
+}
+
+export function formatSenderAddress(settings: ResolvedServerSettings): string | null {
+  const fromAddress = settings.mailFromAddress ?? settings.mailUsername ?? null;
+  if (!fromAddress) {
+    return null;
+  }
+  const displayName = settings.mailFromName ? settings.mailFromName.trim() : "";
+  if (!displayName || !settings.mailFromAddress) {
+    return fromAddress;
+  }
+  return `${displayName} <${fromAddress}>`;
+}


### PR DESCRIPTION
## Summary
- add a members area page for managing SMTP settings, including test and save flows with permission gating
- persist mail server configuration in Prisma, seed a default record, and hook the mailer up to the stored values
- cover the server settings helper logic with unit tests

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e1094f5c94832d9576e3afa0cb4a81