### PR TITLE
Align profile tab selector with mobile layout on tablets

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -935,7 +935,7 @@ function ProfileClientInner({
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
         <div className="flex flex-col gap-3">
-          <div className="lg:hidden">
+          <div className="xl:hidden">
             <Select value={activeTab} onValueChange={setActiveTab}>
               <SelectTrigger id="profile-tab-select" className="h-11 w-full justify-between rounded-full border-border/70 px-4 text-sm font-semibold">
                 <SelectValue placeholder="Bereich wählen">
@@ -952,17 +952,17 @@ function ProfileClientInner({
             </Select>
           </div>
 
-          <TabsList className="hidden w-full flex-nowrap items-center justify-between gap-1 overflow-x-auto rounded-full border border-border/70 bg-background/70 p-1 text-muted-foreground shadow-inner ring-1 ring-primary/10 backdrop-blur lg:flex">
+          <TabsList className="hidden w-full flex-nowrap items-center justify-between gap-1 overflow-x-auto rounded-full border border-border/70 bg-background/70 p-1 text-muted-foreground shadow-inner ring-1 ring-primary/10 backdrop-blur xl:flex">
             {tabOptions.map((option) => (
               <TabsTrigger
                 key={option.value}
                 value={option.value}
-                className="inline-flex min-w-0 flex-1 basis-0 items-center justify-center whitespace-nowrap px-2.5 py-2 text-[0.65rem] font-semibold uppercase tracking-wide transition text-center leading-tight lg:px-3.5 lg:text-[0.75rem]"
-                >
-                  {option.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
+                className="inline-flex min-w-0 flex-1 basis-0 items-center justify-center whitespace-nowrap px-2.5 py-2 text-[0.65rem] font-semibold uppercase tracking-wide transition text-center leading-tight xl:px-3.5 xl:text-[0.75rem]"
+              >
+                {option.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
         </div>
 
         <TabsContent value="stammdaten" className="space-y-6">


### PR DESCRIPTION
## Summary
- keep the profile tab selector dropdown visible up to xl breakpoints so tablets share the mobile UI
- limit the pill-style tab list to xl+ screens and update responsive spacing classes accordingly

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e1198233d0832d8385aa7d43e8cfb8