### PR TITLE
Fix Feedback & Support filters default

### DIFF
--- a/src/components/members/issues/issue-overview.tsx
+++ b/src/components/members/issues/issue-overview.tsx
@@ -93,7 +93,7 @@ function normalizeCounts(counts?: Partial<IssueStatusCounts> | null): IssueStatu
 export function IssueOverview({ initialIssues, initialCounts, breadcrumbs }: IssueOverviewProps) {
   const [issues, setIssues] = useState<IssueSummary[]>(initialIssues);
   const [counts, setCounts] = useState<IssueStatusCounts>(normalizeCounts(initialCounts));
-  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("open");
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>("all");
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilterValue>("all");
   const [searchInput, setSearchInput] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
@@ -159,7 +159,7 @@ export function IssueOverview({ initialIssues, initialCounts, breadcrumbs }: Iss
   };
 
   const handleClearFilters = () => {
-    setStatusFilter("open");
+    setStatusFilter("all");
     setCategoryFilter("all");
     setSearchInput("");
     setSearchTerm("");

--- a/src/types/nodemailer.d.ts
+++ b/src/types/nodemailer.d.ts
@@ -1,0 +1,36 @@
+declare module "nodemailer" {
+  type AddressLike = string | { name?: string | null | undefined; address: string };
+
+  interface Attachment {
+    filename?: string | null | undefined;
+    content?: unknown;
+    path?: string | null | undefined;
+    contentType?: string | null | undefined;
+  }
+
+  export interface SendMailOptions {
+    from?: AddressLike | AddressLike[] | null | undefined;
+    to?: AddressLike | AddressLike[] | null | undefined;
+    cc?: AddressLike | AddressLike[] | null | undefined;
+    bcc?: AddressLike | AddressLike[] | null | undefined;
+    replyTo?: AddressLike | null | undefined;
+    subject?: string | null | undefined;
+    text?: string | null | undefined;
+    html?: string | null | undefined;
+    attachments?: Attachment[] | null | undefined;
+  }
+
+  export interface Transporter<T = unknown> {
+    sendMail(mail: SendMailOptions): Promise<T>;
+    verify(options?: unknown): Promise<void>;
+    close?(): void;
+  }
+
+  export function createTransport(options: unknown): Transporter;
+
+  const nodemailer: {
+    createTransport: typeof createTransport;
+  };
+
+  export default nodemailer;
+}


### PR DESCRIPTION
## Summary
- default the Feedback & Support overview to show all issues so members immediately see every ticket
- reset the status filter to "all" when clearing filters for a consistent UX
- add a lightweight nodemailer declaration file so Next.js type checks pass during builds

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e119055324832d94af64777804a158