### PR TITLE
Align sperrliste settings action with tab header

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/page-client.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page-client.tsx
@@ -38,28 +38,6 @@ export function SperrlistePageClient({
 
   return (
     <div className="space-y-6">
-      {canManageSettings ? (
-        <div className="flex justify-end">
-          <SperrlisteSettingsDialog
-            settings={settings}
-            defaultHolidaySourceUrl={defaultHolidayUrl}
-            defaultPublicHolidaySourceUrl={defaultPublicHolidayUrl}
-            onSettingsChange={(payload) => {
-              setSettings(payload.settings);
-              if (payload.holidays) {
-                setHolidays(payload.holidays);
-              }
-              if (payload.defaults?.holidaySourceUrl) {
-                setDefaultHolidayUrl(payload.defaults.holidaySourceUrl);
-              }
-              if (payload.defaults?.publicHolidaySourceUrl) {
-                setDefaultPublicHolidayUrl(payload.defaults.publicHolidaySourceUrl);
-              }
-            }}
-          />
-        </div>
-      ) : null}
-
       <SperrlisteTabs
         initialBlockedDays={initialBlockedDays}
         holidays={holidays}
@@ -67,6 +45,29 @@ export function SperrlistePageClient({
         freezeDays={settings.freezeDays}
         preferredWeekdays={settings.preferredWeekdays}
         exceptionWeekdays={settings.exceptionWeekdays}
+        actions={
+          canManageSettings ? (
+            <SperrlisteSettingsDialog
+              settings={settings}
+              defaultHolidaySourceUrl={defaultHolidayUrl}
+              defaultPublicHolidaySourceUrl={defaultPublicHolidayUrl}
+              onSettingsChange={(payload) => {
+                setSettings(payload.settings);
+                if (payload.holidays) {
+                  setHolidays(payload.holidays);
+                }
+                if (payload.defaults?.holidaySourceUrl) {
+                  setDefaultHolidayUrl(payload.defaults.holidaySourceUrl);
+                }
+                if (payload.defaults?.publicHolidaySourceUrl) {
+                  setDefaultPublicHolidayUrl(
+                    payload.defaults.publicHolidaySourceUrl,
+                  );
+                }
+              }}
+            />
+          ) : null
+        }
       />
     </div>
   );

--- a/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
@@ -27,7 +27,11 @@ export function SperrlisteSettingsDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" className="gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-auto gap-2 rounded-full border border-transparent px-5 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground shadow-none hover:border-primary/20 hover:bg-primary/10 hover:text-foreground sm:text-sm"
+        >
           <Settings2 className="h-4 w-4" aria-hidden />
           <span>Sperrlisten-Einstellungen</span>
         </Button>

--- a/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import { addDays, format } from "date-fns";
 import { de } from "date-fns/locale/de";
 
@@ -18,6 +18,7 @@ interface SperrlisteTabsProps {
   freezeDays?: number;
   preferredWeekdays?: number[];
   exceptionWeekdays?: number[];
+  actions?: ReactNode;
 }
 
 export function SperrlisteTabs({
@@ -27,6 +28,7 @@ export function SperrlisteTabs({
   freezeDays = 0,
   preferredWeekdays = [],
   exceptionWeekdays = [],
+  actions,
 }: SperrlisteTabsProps) {
   const formattedFreeze = useMemo(() => {
     if (!freezeDays || freezeDays <= 0) {
@@ -40,16 +42,23 @@ export function SperrlisteTabs({
 
   return (
     <Tabs defaultValue="personal" className="space-y-6">
-      <TabsList className="mb-6 flex w-full justify-start overflow-x-auto rounded-full bg-background/70 p-1 shadow-inner ring-1 ring-primary/10 backdrop-blur-sm sm:pr-0">
-        <TabsTrigger value="personal" className="gap-2 whitespace-nowrap px-5 py-2 text-xs font-semibold uppercase tracking-wide sm:text-sm">
-          <CalendarCheck2 className="h-4 w-4 text-muted-foreground/80" aria-hidden />
-          <span>Meine Sperrtermine</span>
-        </TabsTrigger>
-        <TabsTrigger value="overview" className="gap-2 whitespace-nowrap px-5 py-2 text-xs font-semibold uppercase tracking-wide sm:text-sm">
-          <UsersRound className="h-4 w-4 text-muted-foreground/80" aria-hidden />
-          <span>Übersicht</span>
-        </TabsTrigger>
-      </TabsList>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        {actions ? (
+          <div className="order-1 flex justify-end sm:order-2 sm:flex-none sm:justify-end">
+            {actions}
+          </div>
+        ) : null}
+        <TabsList className="order-2 flex w-full justify-start overflow-x-auto rounded-full bg-background/70 p-1 shadow-inner ring-1 ring-primary/10 backdrop-blur-sm sm:order-1 sm:w-auto sm:flex-1 sm:pr-0">
+          <TabsTrigger value="personal" className="gap-2 whitespace-nowrap px-5 py-2 text-xs font-semibold uppercase tracking-wide sm:text-sm">
+            <CalendarCheck2 className="h-4 w-4 text-muted-foreground/80" aria-hidden />
+            <span>Meine Sperrtermine</span>
+          </TabsTrigger>
+          <TabsTrigger value="overview" className="gap-2 whitespace-nowrap px-5 py-2 text-xs font-semibold uppercase tracking-wide sm:text-sm">
+            <UsersRound className="h-4 w-4 text-muted-foreground/80" aria-hidden />
+            <span>Übersicht</span>
+          </TabsTrigger>
+        </TabsList>
+      </div>
 
       <TabsContent value="personal" className="space-y-6">
         {formattedFreeze ? (


### PR DESCRIPTION
## Summary
- render the sperrliste settings dialog trigger inside the tab header so it aligns with "Meine Sperrtermine" and "Übersicht"
- expose an optional `actions` slot for `SperrlisteTabs` and adjust styles so the button matches the pill navigation

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: terminal session truncated by long progress output; see task log)*

------
https://chatgpt.com/codex/tasks/task_e_68e22ef3c798832db4b01218248b1b01