### PR TITLE
Refine Sperrliste controls and expand overview insights

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -945,30 +945,27 @@ export function BlockCalendar({
   ) : null;
 
   const holidayHeaderToggle = (
-    <label
+    <button
+      type="button"
+      onClick={() => setShowHolidays((prev) => !prev)}
       className={cn(
-        "flex cursor-pointer select-none items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition",
+        "flex select-none items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950",
         showHolidays
-          ? "border-sky-300 bg-sky-50 text-sky-900 shadow-sm hover:bg-sky-100 dark:border-sky-500/60 dark:bg-sky-500/20 dark:text-sky-50 dark:hover:bg-sky-500/30"
-          : "border-border/60 bg-background/80 text-muted-foreground hover:border-sky-200 hover:text-foreground dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:bg-slate-900/60",
+          ? "border-sky-300 bg-sky-50 text-sky-900 shadow-sm hover:bg-sky-100 focus-visible:ring-offset-background dark:border-sky-500/60 dark:bg-sky-500/20 dark:text-sky-50 dark:hover:bg-sky-500/30"
+          : "border-border/60 bg-background/80 text-muted-foreground hover:border-sky-200 hover:text-foreground focus-visible:ring-offset-background dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:bg-slate-900/60",
       )}
+      aria-pressed={showHolidays}
     >
-      <input
-        type="checkbox"
-        checked={showHolidays}
-        onChange={(event) => setShowHolidays(event.target.checked)}
-        className="h-4 w-4 accent-sky-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:accent-sky-400"
-      />
       <span className="flex items-center gap-1.5">
         <CalendarDays className="h-4 w-4" aria-hidden />
-        <span>Ferien &amp; Feiertage anzeigen</span>
+        <span>{showHolidays ? "Ferien & Feiertage eingeblendet" : "Ferien & Feiertage anzeigen"}</span>
       </span>
-    </label>
+    </button>
   );
 
   const holidayDescription = (
     <p className="text-xs leading-5 text-muted-foreground">
-      Schulferien und gesetzliche Feiertage werden im Kalender hervorgehoben. Über das Kästchen oben kannst du sie bei Bedarf ausblenden.
+      Schulferien und gesetzliche Feiertage werden im Kalender hervorgehoben. Über den Schalter oben blendest du sie bei Bedarf aus.
     </p>
   );
 
@@ -1203,6 +1200,7 @@ export function BlockCalendar({
         onMonthChange={handleMonthChange}
         transitionDirection={enterDir}
         subtitle="Tippe auf einen Tag, um ihn zu sperren, einzuschränken oder als bevorzugt zu markieren."
+        headerActionsPlacement="left"
         headerActions={
           <div className="flex flex-wrap items-center gap-2">
             {holidayHeaderToggle}

--- a/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
@@ -1,8 +1,15 @@
-'use client';
-import { ChevronLeft, ChevronRight, Sparkles } from 'lucide-react';
+"use client";
+import {
+  differenceInCalendarDays,
+  format as formatDate,
+  parseISO,
+  startOfToday,
+} from "date-fns";
+import { de } from "date-fns/locale/de";
+import { ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 
-import { Button } from '@/components/ui/button';
-import type { HolidayRange } from '@/types/holidays';
+import { Button } from "@/components/ui/button";
+import type { HolidayRange } from "@/types/holidays";
 
 import type { BlockedDay } from '../block-calendar';
 import {
@@ -56,6 +63,8 @@ type OverviewShellProps = {
   formatCreatedAtLabel: (createdAt?: string | null) => string | null;
 };
 
+const DATE_FORMAT = "yyyy-MM-dd";
+
 function LegendItem({ label, description, tone }: LegendItemProps) {
   const styles = timelineToneStyles({ tone });
 
@@ -95,76 +104,335 @@ export function OverviewShell({
   onSelectBlockedDay,
   formatCreatedAtLabel,
 }: OverviewShellProps) {
+  const today = startOfToday();
+  const todayKey = formatDate(today, DATE_FORMAT);
+  const memberSummaries = preparedMembers.map((member) => {
+    const stats = summary.totals.get(member.id) ?? { total: 0, upcoming: 0 };
+    const upcomingBlocked = member.blockedDays
+      .filter((entry) => entry.kind === "BLOCKED" && entry.date >= todayKey)
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    return {
+      member,
+      stats,
+      nextUpcomingDate: upcomingBlocked[0]?.date ?? null,
+    };
+  });
+
+  const membersWithBlocks = memberSummaries.filter((item) => item.stats.total > 0).length;
+  const membersWithUpcoming = memberSummaries.filter((item) => item.stats.upcoming > 0).length;
+  const averageBlocksPerMember = membersCount > 0 ? summary.total / membersCount : 0;
+  const averageUpcomingPerMember = membersCount > 0 ? summary.upcoming / membersCount : 0;
+  const numberFormatter = new Intl.NumberFormat("de-DE", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+
+  const formattedAverageBlocks = numberFormatter.format(averageBlocksPerMember);
+  const formattedAverageUpcoming = numberFormatter.format(averageUpcomingPerMember);
+
+  const topUpcomingMembers = memberSummaries
+    .filter((item) => item.stats.upcoming > 0)
+    .sort((a, b) => {
+      if (b.stats.upcoming === a.stats.upcoming) {
+        if (a.nextUpcomingDate && b.nextUpcomingDate) {
+          return a.nextUpcomingDate.localeCompare(b.nextUpcomingDate);
+        }
+        if (a.nextUpcomingDate) return -1;
+        if (b.nextUpcomingDate) return 1;
+        return a.member.displayName.localeCompare(b.member.displayName);
+      }
+      return b.stats.upcoming - a.stats.upcoming;
+    })
+    .slice(0, 3);
+
+  let busiestDay: { key: string; date: Date; blocked: number; limited: number } | null = null;
+
+  for (const dayInfo of visibleDayInfo) {
+    let blockedCount = 0;
+    let limitedCount = 0;
+
+    for (const member of preparedMembers) {
+      const entry = member.blockedMap.get(dayInfo.key);
+      if (!entry) continue;
+      if (entry.kind === "BLOCKED") {
+        blockedCount += 1;
+      } else if (entry.kind === "LIMITED") {
+        limitedCount += 1;
+      }
+    }
+
+    if (blockedCount === 0 && limitedCount === 0) continue;
+
+    if (
+      !busiestDay ||
+      blockedCount > busiestDay.blocked ||
+      (blockedCount === busiestDay.blocked && limitedCount > busiestDay.limited) ||
+      (blockedCount === busiestDay.blocked &&
+        limitedCount === busiestDay.limited &&
+        dayInfo.key < busiestDay.key)
+    ) {
+      busiestDay = {
+        key: dayInfo.key,
+        date: dayInfo.day,
+        blocked: blockedCount,
+        limited: limitedCount,
+      };
+    }
+  }
+
+  const busiestDayLabel = busiestDay
+    ? formatDate(busiestDay.date, "EEEE, d. MMMM", { locale: de })
+    : null;
+  const busiestDaySummary = busiestDay
+    ? [
+        `${busiestDay.blocked} ${busiestDay.blocked === 1 ? "Sperre" : "Sperren"}`,
+        busiestDay.limited
+          ? `${busiestDay.limited} Einschränkung${busiestDay.limited === 1 ? "" : "en"}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" · ")
+    : "Keine Konflikte im Fokuszeitraum.";
+  const busiestDayIsUpcoming = busiestDay ? busiestDay.key >= todayKey : false;
+
+  const uniqueHolidayEntries = new Map<string, HolidayRange>();
+  holidayMap.forEach((entries) => {
+    for (const entry of entries) {
+      if (!uniqueHolidayEntries.has(entry.id)) {
+        uniqueHolidayEntries.set(entry.id, entry);
+      }
+    }
+  });
+
+  const sortedHolidays = Array.from(uniqueHolidayEntries.values()).sort((a, b) =>
+    a.startDate.localeCompare(b.startDate),
+  );
+  const nextHoliday =
+    sortedHolidays.find((entry) => entry.endDate >= todayKey) ?? null;
+  const nextHolidayStart = nextHoliday ? parseISO(nextHoliday.startDate) : null;
+  const nextHolidayEnd = nextHoliday ? parseISO(nextHoliday.endDate) : null;
+  const holidayCountdown =
+    nextHolidayStart && Number.isFinite(nextHolidayStart.getTime())
+      ? differenceInCalendarDays(nextHolidayStart, today)
+      : null;
+  const holidayTimingLabel =
+    nextHoliday && nextHolidayStart && nextHolidayEnd
+      ? holidayCountdown !== null && holidayCountdown > 0
+        ? `in ${holidayCountdown} ${holidayCountdown === 1 ? "Tag" : "Tagen"}`
+        : differenceInCalendarDays(nextHolidayEnd, today) >= 0
+          ? "läuft aktuell"
+          : null
+      : null;
+  const nextHolidayLabel =
+    nextHolidayStart && Number.isFinite(nextHolidayStart.getTime())
+      ? formatDate(nextHolidayStart, "d. MMMM yyyy", { locale: de })
+      : null;
+
+  const overviewNarrative: string[] = [];
+
+  if (membersWithBlocks) {
+    overviewNarrative.push(
+      `${membersWithBlocks} von ${membersCount} Mitgliedern haben aktuell ${summary.total} gesperrte Tage eingetragen.`,
+    );
+  } else {
+    overviewNarrative.push("Noch keine Sperrtermine im ausgewählten Zeitraum.");
+  }
+
+  if (busiestMember) {
+    overviewNarrative.push(
+      `Die meisten Sperrtermine meldet ${busiestMember.name} (${busiestMember.total}).`,
+    );
+  }
+
+  if (busiestDayLabel) {
+    overviewNarrative.push(
+      `${busiestDayIsUpcoming ? "Der nächste Engpass" : "Der größte Engpass"} ${
+        busiestDayIsUpcoming ? "steht" : "lag"
+      } am ${busiestDayLabel} (${busiestDaySummary}).`,
+    );
+  }
+
+  if (nextHoliday && nextHolidayLabel) {
+    overviewNarrative.push(
+      `Nächste Ferienphase: ${nextHoliday.title} ab ${nextHolidayLabel}${
+        holidayTimingLabel ? ` (${holidayTimingLabel})` : ""
+      }.`,
+    );
+  } else if (!holidaysInRangeCount) {
+    overviewNarrative.push("Im Fokuszeitraum liegen keine Ferien oder Feiertage.");
+  }
+
   return (
     <div className="space-y-6">
       <div className="overflow-hidden rounded-3xl border border-primary/20 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 p-6 text-slate-100 shadow-xl dark:border-primary/30">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex-1">
             <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.4em] text-primary/80">
               <Sparkles className="h-4 w-4" aria-hidden />
               Übersicht
             </div>
-            <h2 className="mt-2 text-2xl font-semibold leading-tight sm:text-3xl">{monthLabel}</h2>
-            <p className="mt-2 max-w-xl text-sm text-slate-300">
-              Alle Sperrtermine des Teams in einer kompakten Zeitachse – ideal, um Engpässe früh zu erkennen.
-            </p>
-          </div>
-          <div className="flex flex-col gap-2 sm:items-end">
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                className="h-10 w-10 rounded-full border-slate-600/50 bg-slate-900/60 text-slate-100 hover:border-primary/60 hover:text-primary"
-                onClick={onPrev}
-                aria-label="Vorheriger Monat"
-              >
-                <ChevronLeft className="h-5 w-5" aria-hidden />
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                className="h-10 w-10 rounded-full border-slate-600/50 bg-slate-900/60 text-slate-100 hover:border-primary/60 hover:text-primary"
-                onClick={onNext}
-                aria-label="Nächster Monat"
-              >
-                <ChevronRight className="h-5 w-5" aria-hidden />
-              </Button>
+            <div className="mt-2 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="text-2xl font-semibold leading-tight sm:text-3xl">{monthLabel}</h2>
+                <p className="mt-2 max-w-3xl text-sm text-slate-300">
+                  {overviewNarrative.join(" ")}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 self-start sm:self-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-10 w-10 rounded-full border-slate-600/50 bg-slate-900/60 text-slate-100 hover:border-primary/60 hover:text-primary"
+                  onClick={onPrev}
+                  aria-label="Vorheriger Monat"
+                >
+                  <ChevronLeft className="h-5 w-5" aria-hidden />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-10 w-10 rounded-full border-slate-600/50 bg-slate-900/60 text-slate-100 hover:border-primary/60 hover:text-primary"
+                  onClick={onNext}
+                  aria-label="Nächster Monat"
+                >
+                  <ChevronRight className="h-5 w-5" aria-hidden />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="rounded-full bg-white/10 text-xs font-medium text-slate-200 hover:bg-white/20"
+                  onClick={onReset}
+                >
+                  Heute
+                </Button>
+              </div>
             </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="rounded-full bg-white/10 text-xs font-medium text-slate-200 hover:bg-white/20"
-              onClick={onReset}
-            >
-              Heute
-            </Button>
-          </div>
-        </div>
 
-        <div className="mt-5 grid gap-2 text-[13px] leading-5 sm:grid-cols-3">
-          <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">Teammitglieder</div>
-            <div className="mt-1 text-lg font-semibold sm:text-xl">{membersCount}</div>
-          </div>
-          <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">Gesperrte Tage</div>
-            <div className="mt-1 flex flex-col gap-1 text-lg font-semibold sm:text-xl">
-              <span>{totalBlockedDays}</span>
-              <span className="text-[11px] font-medium text-slate-300/80 line-clamp-1">
-                {upcomingBlockedDays} bevorstehend
-              </span>
-            </div>
-          </div>
-          <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">Ferien &amp; Feiertage in der Ansicht</div>
-            <div className="mt-1 flex flex-col gap-1 text-lg font-semibold sm:text-xl">
-              <span>{holidaysInRangeCount}</span>
-              <span className="text-[11px] font-medium text-slate-300/80 line-clamp-2">
-                {busiestMember ? `Top-Sperren: ${busiestMember.name} (${busiestMember.total})` : 'Keine Häufungen'}
-              </span>
+            <dl className="mt-5 grid gap-3 text-[13px] leading-5 sm:grid-cols-2 xl:grid-cols-4">
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
+                <dt className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">
+                  Teammitglieder
+                </dt>
+                <dd className="mt-1 text-lg font-semibold sm:text-xl">{membersCount}</dd>
+                <dd className="text-[11px] font-medium text-slate-300/80 line-clamp-2">
+                  {membersWithBlocks} mit Sperrterminen
+                </dd>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
+                <dt className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">
+                  Sperrtermine im Fokus
+                </dt>
+                <dd className="mt-1 flex flex-col gap-1 text-lg font-semibold sm:text-xl">
+                  <span>{totalBlockedDays}</span>
+                  <span className="text-[11px] font-medium text-slate-300/80 line-clamp-1">
+                    {upcomingBlockedDays} bevorstehend
+                  </span>
+                </dd>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
+                <dt className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">
+                  Mitglieder mit kommenden Sperren
+                </dt>
+                <dd className="mt-1 flex flex-col gap-1 text-lg font-semibold sm:text-xl">
+                  <span>{membersWithUpcoming}</span>
+                  <span className="text-[11px] font-medium text-slate-300/80 line-clamp-1">
+                    Ø {formattedAverageUpcoming} Sperren pro Mitglied
+                  </span>
+                </dd>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-inner">
+                <dt className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">
+                  Ferien &amp; Feiertage
+                </dt>
+                <dd className="mt-1 flex flex-col gap-1 text-lg font-semibold sm:text-xl">
+                  <span>{holidaysInRangeCount}</span>
+                  <span className="text-[11px] font-medium text-slate-300/80 line-clamp-2">
+                    {nextHoliday && nextHolidayLabel
+                      ? `Nächste Phase: ${nextHoliday.title}`
+                      : averageBlocksPerMember > 0
+                        ? `Ø ${formattedAverageBlocks} Sperren gesamt`
+                        : "Keine Quellen aktiv"}
+                  </span>
+                </dd>
+              </div>
+            </dl>
+
+            <div className="mt-6 grid gap-4 lg:grid-cols-2">
+              <div className="rounded-xl border border-white/10 bg-white/5 p-4 shadow-inner">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">
+                  Engpass-Analyse
+                </div>
+                {busiestDay ? (
+                  <div className="mt-3 space-y-2 text-slate-200">
+                    <p className="text-base font-semibold">
+                      {busiestDayIsUpcoming ? "Nächster Engpass" : "Größter Engpass"}
+                    </p>
+                    <p className="text-sm text-slate-300">
+                      {busiestDayLabel} · {busiestDaySummary}
+                    </p>
+                  </div>
+                ) : (
+                  <p className="mt-3 text-sm text-slate-300">
+                    Bisher wurden keine Sperrtermine im Fokuszeitraum hinterlegt.
+                  </p>
+                )}
+                {nextHoliday && nextHolidayLabel ? (
+                  <div className="mt-4 space-y-1 text-xs text-slate-300/90">
+                    <span className="font-semibold uppercase tracking-wide text-slate-200">
+                      Ferien &amp; Feiertage
+                    </span>
+                    <p>
+                      {nextHoliday.title} ab {nextHolidayLabel}
+                      {holidayTimingLabel ? ` · ${holidayTimingLabel}` : ""}
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+              <div className="rounded-xl border border-white/10 bg-white/5 p-4 shadow-inner">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.3em] text-slate-300/80">
+                  Top-betroffene Mitglieder
+                </div>
+                {topUpcomingMembers.length ? (
+                  <ul className="mt-3 space-y-2">
+                    {topUpcomingMembers.map((item) => {
+                      const nextDate = item.nextUpcomingDate
+                        ? parseISO(item.nextUpcomingDate)
+                        : null;
+                      const nextDateLabel =
+                        nextDate && Number.isFinite(nextDate.getTime())
+                          ? formatDate(nextDate, "d. MMM yyyy", { locale: de })
+                          : null;
+
+                      return (
+                        <li
+                          key={item.member.id}
+                          className="rounded-lg border border-white/10 bg-white/10 px-3 py-2 text-sm leading-6 text-slate-200"
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="font-medium">{item.member.displayName}</span>
+                            <span className="text-xs font-semibold uppercase tracking-wide text-primary/80">
+                              {item.stats.upcoming} bevorstehend
+                            </span>
+                          </div>
+                          <div className="text-xs text-slate-300">
+                            {nextDateLabel
+                              ? `Nächster Sperrtermin am ${nextDateLabel}`
+                              : "Keine konkreten Termine im Fokuszeitraum."}
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <p className="mt-3 text-sm text-slate-300">
+                    Es stehen aktuell keine kommenden Sperrtermine an.
+                  </p>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/calendar/month-calendar.tsx
+++ b/src/components/calendar/month-calendar.tsx
@@ -66,6 +66,7 @@ export interface MonthCalendarProps {
   title?: ReactNode;
   subtitle?: ReactNode;
   headerActions?: ReactNode;
+  headerActionsPlacement?: "left" | "right";
   todayLabel?: string;
   showTodayButton?: boolean;
   showWeekNumbers?: boolean;
@@ -97,6 +98,7 @@ export function MonthCalendar({
   title,
   subtitle,
   headerActions,
+  headerActionsPlacement = "right",
   todayLabel = "Heute",
   showTodayButton = true,
   showWeekNumbers = true,
@@ -224,18 +226,25 @@ export function MonthCalendar({
 
   return (
     <div className={cn("w-full rounded-xl border bg-card shadow-sm", className)}>
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b bg-muted/40 px-4 py-3">
-        <div className="space-y-1">
-          {typeof headerTitle === "string" ? (
-            <h2 className="text-xl font-semibold">{headerTitle}</h2>
-          ) : (
-            headerTitle
-          )}
-          {subtitle ? (
-            <p className="text-sm text-muted-foreground">{subtitle}</p>
+      <div className="flex flex-wrap items-center gap-3 border-b bg-muted/40 px-4 py-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
+          <div className="space-y-1">
+            {typeof headerTitle === "string" ? (
+              <h2 className="text-xl font-semibold">{headerTitle}</h2>
+            ) : (
+              headerTitle
+            )}
+            {subtitle ? (
+              <p className="text-sm text-muted-foreground">{subtitle}</p>
+            ) : null}
+          </div>
+          {headerActionsPlacement === "left" && headerActions ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {headerActions}
+            </div>
           ) : null}
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           {showTodayButton ? (
             <Button type="button" variant="outline" size="sm" onClick={goToday}>
               {todayLabel}
@@ -259,7 +268,7 @@ export function MonthCalendar({
               <ChevronRight className="h-4 w-4" />
             </button>
           </div>
-          {headerActions}
+          {headerActionsPlacement === "right" ? headerActions : null}
         </div>
       </div>
       <div className="overflow-x-auto">


### PR DESCRIPTION
## Summary
- turn the holiday visibility control on the Sperrliste calendar into a dedicated toggle button and keep it beside the multi-select action by adding a header actions placement option to the shared MonthCalendar
- expand the Sperrliste overview hero section with richer computed insights, including key metrics, narrative context, an engpass analysis, and a list of the most affected members

## Testing
- pnpm lint
- pnpm test *(fails in the full suite; server-analytics-content and create-production-form were re-run individually with longer timeouts and passed)*
- VITEST_POOL=threads VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 pnpm test -- --run 'src/app/(members)/mitglieder/server-analytics/__tests__/server-analytics-content.test.tsx' --test-timeout=10000
- VITEST_POOL=threads VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 pnpm test -- --run 'src/app/(members)/mitglieder/produktionen/__tests__/create-production-form.test.tsx'
- pnpm build *(timed out while creating the optimized build; command aborted after a prolonged wait)*

------
https://chatgpt.com/codex/tasks/task_e_68e2301ef4cc832d942ca5604b651aa2