### PR TITLE
Adjust members navigation to show profile below dashboard

### DIFF
--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -393,6 +393,12 @@ export const membersNavigation = [
         icon: DashboardIcon,
       },
       {
+        href: "/mitglieder/profil",
+        label: "Profil",
+        permissionKey: "mitglieder.profil",
+        icon: ProfileIcon,
+      },
+      {
         href: "/mitglieder/kalender",
         label: "Kalender",
         permissionKey: "mitglieder.kalender",
@@ -403,12 +409,6 @@ export const membersNavigation = [
         label: "Sperrliste",
         permissionKey: "mitglieder.sperrliste",
         icon: BlacklistIcon,
-      },
-      {
-        href: "/mitglieder/profil",
-        label: "Profil",
-        permissionKey: "mitglieder.profil",
-        icon: ProfileIcon,
       },
       {
         href: "/mitglieder/issues",


### PR DESCRIPTION
## Summary
- move the profile navigation entry directly beneath the dashboard link in the members area

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e23779ed08832d962698391f1182dd