### PR TITLE
Align Sperrliste calendar toolbar layout

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -944,15 +944,23 @@ export function BlockCalendar({
     </div>
   ) : null;
 
+  const headerToggleBase =
+    "flex select-none items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500 dark:focus-visible:ring-offset-slate-950";
+  const headerToggleInactive =
+    "border-border/60 bg-background/80 text-muted-foreground hover:border-sky-200 hover:text-foreground focus-visible:ring-offset-background dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:bg-slate-900/60";
+  const holidayToggleActive =
+    "border-sky-300 bg-sky-50 text-sky-900 shadow-sm hover:bg-sky-100 focus-visible:ring-offset-background dark:border-sky-500/60 dark:bg-sky-500/20 dark:text-sky-50 dark:hover:bg-sky-500/30";
+  const selectionToggleActive =
+    "border-primary/50 bg-primary/10 text-primary shadow-sm hover:bg-primary/15 focus-visible:ring-primary focus-visible:ring-offset-background dark:border-primary/40 dark:bg-primary/15 dark:text-primary-foreground dark:hover:bg-primary/20 dark:focus-visible:ring-primary";
+
   const holidayHeaderToggle = (
     <button
       type="button"
       onClick={() => setShowHolidays((prev) => !prev)}
       className={cn(
-        "flex select-none items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950",
-        showHolidays
-          ? "border-sky-300 bg-sky-50 text-sky-900 shadow-sm hover:bg-sky-100 focus-visible:ring-offset-background dark:border-sky-500/60 dark:bg-sky-500/20 dark:text-sky-50 dark:hover:bg-sky-500/30"
-          : "border-border/60 bg-background/80 text-muted-foreground hover:border-sky-200 hover:text-foreground focus-visible:ring-offset-background dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-200 dark:hover:bg-slate-900/60",
+        headerToggleBase,
+        "w-full justify-center sm:w-auto sm:justify-start",
+        showHolidays ? holidayToggleActive : headerToggleInactive,
       )}
       aria-pressed={showHolidays}
     >
@@ -960,6 +968,21 @@ export function BlockCalendar({
         <CalendarDays className="h-4 w-4" aria-hidden />
         <span>{showHolidays ? "Ferien & Feiertage eingeblendet" : "Ferien & Feiertage anzeigen"}</span>
       </span>
+    </button>
+  );
+
+  const selectionModeToggle = (
+    <button
+      type="button"
+      onClick={handleToggleSelectionMode}
+      className={cn(
+        headerToggleBase,
+        "w-full justify-center sm:w-auto sm:justify-start",
+        selectionMode ? selectionToggleActive : headerToggleInactive,
+      )}
+      aria-pressed={selectionMode}
+    >
+      {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
     </button>
   );
 
@@ -1200,19 +1223,12 @@ export function BlockCalendar({
         onMonthChange={handleMonthChange}
         transitionDirection={enterDir}
         subtitle="Tippe auf einen Tag, um ihn zu sperren, einzuschränken oder als bevorzugt zu markieren."
-        headerActionsPlacement="left"
+        headerActionsPlacement="right"
+        navigationPlacement="left"
         headerActions={
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {selectionModeToggle}
             {holidayHeaderToggle}
-            <Button
-              type="button"
-              variant={selectionMode ? "default" : "outline"}
-              size="sm"
-              onClick={handleToggleSelectionMode}
-              className="w-full sm:w-auto"
-            >
-              {selectionMode ? "Auswahl beenden" : "Mehrfachauswahl"}
-            </Button>
           </div>
         }
         renderDay={renderCalendarDay}

--- a/src/components/calendar/month-calendar.tsx
+++ b/src/components/calendar/month-calendar.tsx
@@ -67,6 +67,7 @@ export interface MonthCalendarProps {
   subtitle?: ReactNode;
   headerActions?: ReactNode;
   headerActionsPlacement?: "left" | "right";
+  navigationPlacement?: "left" | "right";
   todayLabel?: string;
   showTodayButton?: boolean;
   showWeekNumbers?: boolean;
@@ -99,6 +100,7 @@ export function MonthCalendar({
   subtitle,
   headerActions,
   headerActionsPlacement = "right",
+  navigationPlacement = "right",
   todayLabel = "Heute",
   showTodayButton = true,
   showWeekNumbers = true,
@@ -224,52 +226,70 @@ export function MonthCalendar({
     ? "grid grid-cols-7 gap-1 sm:grid-cols-[64px_repeat(7,minmax(0,1fr))] sm:gap-1.5"
     : "grid grid-cols-7 gap-1 sm:gap-1.5";
 
+  const navigationControls = (
+    <div className="flex flex-wrap items-center gap-2">
+      {showTodayButton ? (
+        <Button type="button" variant="outline" size="sm" onClick={goToday}>
+          {todayLabel}
+        </Button>
+      ) : null}
+      <div className="flex items-center rounded-md border">
+        <button
+          type="button"
+          onClick={goPrevMonth}
+          className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+          aria-label="Vorheriger Monat"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={goNextMonth}
+          className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
+          aria-label="Nächster Monat"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+
+  const hasRightActions = headerActionsPlacement === "right" && Boolean(headerActions);
+
   return (
     <div className={cn("w-full rounded-xl border bg-card shadow-sm", className)}>
       <div className="flex flex-wrap items-center gap-3 border-b bg-muted/40 px-4 py-3">
         <div className="flex min-w-0 flex-1 flex-col gap-3">
-          <div className="space-y-1">
-            {typeof headerTitle === "string" ? (
-              <h2 className="text-xl font-semibold">{headerTitle}</h2>
-            ) : (
-              headerTitle
+          <div
+            className={cn(
+              "flex min-w-0 flex-col gap-3",
+              navigationPlacement === "left"
+                ? "sm:flex-row sm:items-center sm:justify-between"
+                : undefined
             )}
-            {subtitle ? (
-              <p className="text-sm text-muted-foreground">{subtitle}</p>
-            ) : null}
+          >
+            <div className="min-w-0 space-y-1">
+              {typeof headerTitle === "string" ? (
+                <h2 className="text-xl font-semibold">{headerTitle}</h2>
+              ) : (
+                headerTitle
+              )}
+              {subtitle ? (
+                <p className="text-sm text-muted-foreground">{subtitle}</p>
+              ) : null}
+            </div>
+            {navigationPlacement === "left" ? navigationControls : null}
           </div>
           {headerActionsPlacement === "left" && headerActions ? (
-            <div className="flex flex-wrap items-center gap-2">
-              {headerActions}
-            </div>
+            <div className="flex flex-wrap items-center gap-2">{headerActions}</div>
           ) : null}
         </div>
-        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
-          {showTodayButton ? (
-            <Button type="button" variant="outline" size="sm" onClick={goToday}>
-              {todayLabel}
-            </Button>
-          ) : null}
-          <div className="flex items-center rounded-md border">
-            <button
-              type="button"
-              onClick={goPrevMonth}
-              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
-              aria-label="Vorheriger Monat"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-            <button
-              type="button"
-              onClick={goNextMonth}
-              className="p-2 text-sm text-muted-foreground transition hover:text-foreground"
-              aria-label="Nächster Monat"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
+        {navigationPlacement === "right" || hasRightActions ? (
+          <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
+            {navigationPlacement === "right" ? navigationControls : null}
+            {hasRightActions ? headerActions : null}
           </div>
-          {headerActionsPlacement === "right" ? headerActions : null}
-        </div>
+        ) : null}
       </div>
       <div className="overflow-x-auto">
         <div


### PR DESCRIPTION
## Summary
- move the holiday toggle and multi-selection controls to the right-hand header rail in the Sperrliste calendar and style the selection toggle to match
- extend the shared MonthCalendar component with configurable navigation placement so the Today button and month arrows sit on the left for the Sperrliste view

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e23e76c108832da301b4a29f130d5d