### PR TITLE
Revamp Sperrliste overview calendar

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
@@ -80,7 +80,6 @@ export function BlockOverview({
   return (
     <div className="space-y-6">
       <OverviewShell
-        currentMonth={currentMonth}
         monthLabel={data.monthLabel}
         membersCount={data.preparedMembers.length}
         totalBlockedDays={data.summary.total}

--- a/src/app/(members)/mitglieder/sperrliste/overview/desktop-timeline.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/desktop-timeline.tsx
@@ -1,7 +1,10 @@
-import { format, isSameMonth, isToday } from "date-fns";
+import type { ReactNode } from "react";
+
+import { format, isToday } from "date-fns";
 import { de } from "date-fns/locale/de";
 import { tv } from "tailwind-variants";
 
+import { Badge } from "@/components/ui/badge";
 import { UserAvatar } from "@/components/user-avatar";
 import { cn } from "@/lib/utils";
 import type { HolidayRange } from "@/types/holidays";
@@ -9,6 +12,7 @@ import type { HolidayRange } from "@/types/holidays";
 import type { BlockedDay } from "../block-calendar";
 import {
   type BlockOverviewSummary,
+  type DaySummary,
   type HolidaySegment,
   type PreparedMember,
   type VisibleDayInfo,
@@ -73,7 +77,6 @@ const staticCellStyles = tv({
 });
 
 interface DesktopTimelineProps {
-  currentMonth: Date;
   preparedMembers: PreparedMember[];
   visibleDayInfo: VisibleDayInfo[];
   holidaySegments: HolidaySegment[];
@@ -83,6 +86,7 @@ interface DesktopTimelineProps {
   sortedPreferredWeekdays: number[];
   preferredDayKeys: Set<string>;
   holidayMap: Map<string, HolidayRange[]>;
+  daySummaries: Map<string, DaySummary>;
   onSelectBlockedDay: (selection: {
     member: PreparedMember;
     entry: BlockedDay;
@@ -93,7 +97,6 @@ interface DesktopTimelineProps {
 }
 
 export function DesktopTimeline({
-  currentMonth,
   preparedMembers,
   visibleDayInfo,
   holidaySegments,
@@ -103,6 +106,7 @@ export function DesktopTimeline({
   sortedPreferredWeekdays,
   preferredDayKeys,
   holidayMap,
+  daySummaries,
   onSelectBlockedDay,
   formatCreatedAtLabel,
 }: DesktopTimelineProps) {
@@ -118,8 +122,8 @@ export function DesktopTimeline({
             >
               Mitglied
             </th>
-            {visibleDayInfo.map(({ day, key }, index) => {
-              const weekday = day.getDay();
+            {visibleDayInfo.map((info, index) => {
+              const { day, key, weekday, isoWeek, isWeekend, isCurrentMonth } = info;
               const isPreferredDay = preferredWeekdaySet.has(weekday);
               const isExceptionDay = exceptionWeekdaySet.has(weekday);
               const isPreferredExtra = !isPreferredDay && !isExceptionDay;
@@ -128,6 +132,40 @@ export function DesktopTimeline({
                 weekday === sortedPreferredWeekdays[0] &&
                 index !== 0;
               const isFirstOfMonth = format(day, "d") === "1";
+              const columnSummary = daySummaries.get(key);
+              const summaryBadges: ReactNode[] = [];
+
+              if (columnSummary?.blocked) {
+                summaryBadges.push(
+                  <Badge key="blocked" variant="destructive" size="sm">
+                    {columnSummary.blocked} gesperrt
+                  </Badge>,
+                );
+              }
+
+              if (columnSummary?.limited) {
+                summaryBadges.push(
+                  <Badge key="limited" variant="warning" size="sm">
+                    {columnSummary.limited} eingeschränkt
+                  </Badge>,
+                );
+              }
+
+              if (columnSummary?.preferred) {
+                summaryBadges.push(
+                  <Badge key="preferred" variant="success" size="sm">
+                    {columnSummary.preferred} bevorzugt
+                  </Badge>,
+                );
+              }
+
+              if (columnSummary?.holidayCount) {
+                summaryBadges.push(
+                  <Badge key="holiday" variant="info" size="sm">
+                    {columnSummary.holidayCount} Ferien
+                  </Badge>,
+                );
+              }
 
               return (
                 <th
@@ -139,9 +177,16 @@ export function DesktopTimeline({
                     isPreferredDay && "text-foreground",
                     isExceptionDay && !isPreferredDay && "text-muted-foreground",
                     isPreferredExtra && preferredDayKeys.has(key) && "text-emerald-500",
+                    isWeekend && "bg-muted/60",
+                    !isCurrentMonth && "opacity-80",
                   )}
                 >
                   <div className="flex flex-col items-center gap-1">
+                    {weekday === 1 ? (
+                      <span className="rounded-full bg-muted/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                        KW {isoWeek}
+                      </span>
+                    ) : null}
                     <span
                       className={cn(
                         "text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground/70",
@@ -164,6 +209,15 @@ export function DesktopTimeline({
                         {format(day, "MMM", { locale: de })}
                       </span>
                     ) : null}
+                    {summaryBadges.length ? (
+                      <div className="mt-2 flex flex-wrap justify-center gap-1">
+                        {summaryBadges}
+                      </div>
+                    ) : (
+                      <span className="mt-2 text-[10px] font-medium uppercase tracking-[0.2em] text-muted-foreground/60">
+                        Frei
+                      </span>
+                    )}
                   </div>
                 </th>
               );
@@ -229,18 +283,31 @@ export function DesktopTimeline({
                           ? `${stats.total} Sperrtermin${stats.total === 1 ? "" : "e"}`
                           : "Keine Sperrtermine"}
                       </div>
-                      {stats?.upcoming ? (
-                        <div className="text-sm leading-5 text-primary">{stats.upcoming} bevorstehend</div>
-                      ) : null}
+                      <div className="mt-2 flex flex-wrap gap-1">
+                        <Badge
+                          variant={stats?.total ? "destructive" : "muted"}
+                          size="sm"
+                          className="uppercase tracking-[0.16em]"
+                        >
+                          {stats?.total ?? 0} gesamt
+                        </Badge>
+                        <Badge
+                          variant={stats?.upcoming ? "info" : "muted"}
+                          size="sm"
+                          className="uppercase tracking-[0.16em]"
+                        >
+                          {stats?.upcoming ? `${stats.upcoming} bevorstehend` : "Keine neuen"}
+                        </Badge>
+                      </div>
                     </div>
                   </div>
                 </th>
-                {visibleDayInfo.map(({ day, key }, index) => {
+                {visibleDayInfo.map((info, index) => {
+                  const { day, key, weekday, isWeekend, isCurrentMonth } = info;
                   const entry = member.blockedMap.get(key);
                   const trimmedReason = entry?.reason?.trim() || undefined;
                   const hasReason = Boolean(trimmedReason);
                   const createdAtLabel = formatCreatedAtLabel(entry?.createdAt);
-                  const weekday = day.getDay();
                   const showDivider =
                     sortedPreferredWeekdays.length > 0 &&
                     weekday === sortedPreferredWeekdays[0] &&
@@ -294,7 +361,7 @@ export function DesktopTimeline({
                     status = "exceptionPlaceholder";
                   }
 
-                  const outsideMonth = !isSameMonth(day, currentMonth);
+                  const outsideMonth = !isCurrentMonth;
 
                   return (
                     <td
@@ -302,6 +369,7 @@ export function DesktopTimeline({
                       className={cn(
                         "min-w-[72px] border-b border-border/60 px-1 py-1 align-top",
                         showDivider && "border-l border-border/60",
+                        isWeekend && "bg-muted/30",
                       )}
                     >
                       {isBlocked && entry ? (

--- a/src/app/(members)/mitglieder/sperrliste/overview/mobile-timeline.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/mobile-timeline.tsx
@@ -11,6 +11,7 @@ import {
 import * as React from 'react';
 
 import { UserAvatar } from '@/components/user-avatar';
+import { Badge } from '@/components/ui/badge';
 import {
   Sheet,
   SheetContent,
@@ -38,6 +39,7 @@ import {
 } from './timeline-legend';
 import type {
   BlockOverviewSummary,
+  DaySummary,
   PreparedMember,
   VisibleDayInfo,
 } from './useBlockOverviewData';
@@ -124,6 +126,7 @@ type MobileTimelineProps = {
   visibleDayInfo: VisibleDayInfo[];
   holidayMap: Map<string, HolidayRange[]>;
   summary: BlockOverviewSummary;
+  daySummaries: Map<string, DaySummary>;
   onSelectBlockedDay: (selection: {
     member: PreparedMember;
     entry: BlockedDay;
@@ -138,6 +141,7 @@ export function MobileTimeline({
   visibleDayInfo,
   holidayMap,
   summary,
+  daySummaries,
   onSelectBlockedDay,
   formatCreatedAtLabel,
 }: MobileTimelineProps) {
@@ -174,11 +178,22 @@ export function MobileTimeline({
                       ? `${stats.total} Sperrtermin${stats.total === 1 ? '' : 'e'}`
                       : 'Keine Sperrtermine'}
                   </div>
-                  {stats?.upcoming ? (
-                    <div className="text-sm leading-5 text-primary">
-                      {stats.upcoming} bevorstehend
-                    </div>
-                  ) : null}
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    <Badge
+                      variant={stats?.total ? 'destructive' : 'muted'}
+                      size="sm"
+                      className="uppercase tracking-[0.16em]"
+                    >
+                      {stats?.total ?? 0} gesamt
+                    </Badge>
+                    <Badge
+                      variant={stats?.upcoming ? 'info' : 'muted'}
+                      size="sm"
+                      className="uppercase tracking-[0.16em]"
+                    >
+                      {stats?.upcoming ? `${stats.upcoming} bevorstehend` : 'Keine neuen'}
+                    </Badge>
+                  </div>
                 </div>
               </div>
 
@@ -196,7 +211,8 @@ export function MobileTimeline({
                   <ChevronRight className="h-4 w-4 text-muted-foreground/70" />
                 </div>
                 <div className="flex snap-x snap-mandatory gap-3 overflow-x-auto pb-2 pl-1 pr-6 [scrollbar-width:thin]">
-                  {visibleDayInfo.map(({ day, key }) => {
+                  {visibleDayInfo.map((info) => {
+                    const { day, key, isWeekend, isCurrentMonth, weekday } = info;
                     const entry = member.blockedMap.get(key);
                     const holidayEntries = holidayMap.get(key) ?? [];
                     const isHoliday = holidayEntries.length > 0;
@@ -206,6 +222,9 @@ export function MobileTimeline({
                     const trimmedReason = entry?.reason?.trim();
                     const hasReason = Boolean(trimmedReason);
                     const createdAtLabel = formatCreatedAtLabel(entry?.createdAt);
+                    const columnSummary = daySummaries.get(key);
+                    const summaryBadges: React.ReactNode[] = [];
+
                     const holidaySummary = holidayEntries
                       .map((holiday) =>
                         `${holiday.category === 'publicHoliday' ? 'Feiertag' : 'Ferien'}: ${holiday.title}`,
@@ -253,7 +272,41 @@ export function MobileTimeline({
                       isInteractive &&
                         'cursor-pointer transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                       isToday(day) && 'ring-2 ring-primary/70',
+                      isWeekend && !isInteractive && !isLimited && !isPreferred && !isHoliday && 'bg-muted/40',
+                      !isCurrentMonth && 'opacity-80',
                     );
+
+                    if (columnSummary?.blocked) {
+                      summaryBadges.push(
+                        <Badge key="blocked" variant="destructive" size="sm" className="uppercase">
+                          {columnSummary.blocked} gesperrt
+                        </Badge>,
+                      );
+                    }
+
+                    if (columnSummary?.limited) {
+                      summaryBadges.push(
+                        <Badge key="limited" variant="warning" size="sm" className="uppercase">
+                          {columnSummary.limited} eingeschränkt
+                        </Badge>,
+                      );
+                    }
+
+                    if (columnSummary?.preferred) {
+                      summaryBadges.push(
+                        <Badge key="preferred" variant="success" size="sm" className="uppercase">
+                          {columnSummary.preferred} bevorzugt
+                        </Badge>,
+                      );
+                    }
+
+                    if (columnSummary?.holidayCount) {
+                      summaryBadges.push(
+                        <Badge key="holiday" variant="info" size="sm" className="uppercase">
+                          {columnSummary.holidayCount} Ferien
+                        </Badge>,
+                      );
+                    }
 
                     const handleSelect = () => {
                       if (isInteractive && entry) {
@@ -289,13 +342,29 @@ export function MobileTimeline({
                           onClick={handleSelect}
                           onKeyDown={handleKeyDown}
                         >
-                          <div className="flex flex-col items-center gap-0.5">
-                            <span className="text-xs uppercase tracking-wide text-muted-foreground/80">
-                              {format(day, 'EE', { locale: de })}
-                            </span>
-                            <span className="text-sm font-semibold">
-                              {format(day, 'd', { locale: de })}
-                            </span>
+                          <div className="flex flex-col items-center gap-1">
+                            <div className="flex flex-col items-center gap-0.5">
+                              {weekday === 1 ? (
+                                <span className="rounded-full bg-muted/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                                  KW {format(day, 'I', { locale: de })}
+                                </span>
+                              ) : null}
+                              <span className="text-xs uppercase tracking-wide text-muted-foreground/80">
+                                {format(day, 'EE', { locale: de })}
+                              </span>
+                              <span className="text-sm font-semibold">
+                                {format(day, 'd', { locale: de })}
+                              </span>
+                            </div>
+                            {summaryBadges.length ? (
+                              <div className="flex flex-wrap justify-center gap-1">
+                                {summaryBadges}
+                              </div>
+                            ) : (
+                              <span className="text-[10px] font-medium uppercase tracking-[0.2em] text-muted-foreground/60">
+                                Frei
+                              </span>
+                            )}
                           </div>
                           <div className="flex flex-1 flex-col items-center justify-center">
                             {isInteractive && hasReason && trimmedReason ? (

--- a/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
@@ -14,6 +14,7 @@ import type { HolidayRange } from "@/types/holidays";
 import type { BlockedDay } from '../block-calendar';
 import {
   type BlockOverviewSummary,
+  type DaySummary,
   type HolidaySegment,
   type PreparedMember,
   type VisibleDayInfo,
@@ -33,7 +34,6 @@ type LegendItemProps = {
 };
 
 type OverviewShellProps = {
-  currentMonth: Date;
   monthLabel: string;
   membersCount: number;
   totalBlockedDays: number;
@@ -80,7 +80,6 @@ function LegendItem({ label, description, tone }: LegendItemProps) {
 }
 
 export function OverviewShell({
-  currentMonth,
   monthLabel,
   membersCount,
   totalBlockedDays,
@@ -146,11 +145,13 @@ export function OverviewShell({
     })
     .slice(0, 3);
 
+  const daySummaries = new Map<string, DaySummary>();
   let busiestDay: { key: string; date: Date; blocked: number; limited: number } | null = null;
 
   for (const dayInfo of visibleDayInfo) {
     let blockedCount = 0;
     let limitedCount = 0;
+    let preferredCount = 0;
 
     for (const member of preparedMembers) {
       const entry = member.blockedMap.get(dayInfo.key);
@@ -159,8 +160,19 @@ export function OverviewShell({
         blockedCount += 1;
       } else if (entry.kind === "LIMITED") {
         limitedCount += 1;
+      } else if (entry.kind === "PREFERRED") {
+        preferredCount += 1;
       }
     }
+
+    const summary: DaySummary = {
+      blocked: blockedCount,
+      limited: limitedCount,
+      preferred: preferredCount,
+      holidayCount: holidayMap.get(dayInfo.key)?.length ?? 0,
+    };
+
+    daySummaries.set(dayInfo.key, summary);
 
     if (blockedCount === 0 && limitedCount === 0) continue;
 
@@ -453,7 +465,6 @@ export function OverviewShell({
 
       <div className="hidden sm:block">
         <DesktopTimeline
-          currentMonth={currentMonth}
           preparedMembers={preparedMembers}
           visibleDayInfo={visibleDayInfo}
           holidaySegments={holidaySegments}
@@ -463,19 +474,21 @@ export function OverviewShell({
           sortedPreferredWeekdays={sortedPreferredWeekdays}
           preferredDayKeys={preferredDayKeys}
           holidayMap={holidayMap}
+          daySummaries={daySummaries}
           onSelectBlockedDay={onSelectBlockedDay}
           formatCreatedAtLabel={formatCreatedAtLabel}
         />
       </div>
 
-      <MobileTimeline
-        preparedMembers={preparedMembers}
-        visibleDayInfo={visibleDayInfo}
-        holidayMap={holidayMap}
-        summary={summary}
-        onSelectBlockedDay={onSelectBlockedDay}
-        formatCreatedAtLabel={formatCreatedAtLabel}
-      />
+        <MobileTimeline
+          preparedMembers={preparedMembers}
+          visibleDayInfo={visibleDayInfo}
+          holidayMap={holidayMap}
+          summary={summary}
+          daySummaries={daySummaries}
+          onSelectBlockedDay={onSelectBlockedDay}
+          formatCreatedAtLabel={formatCreatedAtLabel}
+        />
     </div>
   );
 }

--- a/src/app/(members)/mitglieder/sperrliste/overview/useBlockOverviewData.ts
+++ b/src/app/(members)/mitglieder/sperrliste/overview/useBlockOverviewData.ts
@@ -7,6 +7,8 @@ import {
   endOfMonth,
   endOfWeek,
   format,
+  getISOWeek,
+  isSameMonth,
   parseISO,
   startOfMonth,
   startOfToday,
@@ -44,6 +46,17 @@ export type PreparedMember = OverviewMember & {
 export type VisibleDayInfo = {
   day: Date;
   key: string;
+  weekday: number;
+  isoWeek: number;
+  isWeekend: boolean;
+  isCurrentMonth: boolean;
+};
+
+export type DaySummary = {
+  blocked: number;
+  limited: number;
+  preferred: number;
+  holidayCount: number;
 };
 
 export type HolidaySegment = {
@@ -212,15 +225,32 @@ export function useBlockOverviewData({
   const visibleDayInfo = useMemo(
     () =>
       daysInView
-        .map((day) => ({ day, key: format(day, DATE_FORMAT) }))
-        .filter(({ day, key }) => {
+        .map((day) => {
           const weekday = day.getDay();
-          const isPreferredDay = preferredWeekdaySet.has(weekday);
-          const isExceptionDay = exceptionWeekdaySet.has(weekday);
+          const key = format(day, DATE_FORMAT);
 
-          return isPreferredDay || isExceptionDay || preferredDayKeys.has(key);
+          return {
+            day,
+            key,
+            weekday,
+            isoWeek: getISOWeek(day),
+            isWeekend: weekday === 0 || weekday === 6,
+            isCurrentMonth: isSameMonth(day, currentMonth),
+          } satisfies VisibleDayInfo;
+        })
+        .filter((info) => {
+          const isPreferredDay = preferredWeekdaySet.has(info.weekday);
+          const isExceptionDay = exceptionWeekdaySet.has(info.weekday);
+
+          return isPreferredDay || isExceptionDay || preferredDayKeys.has(info.key);
         }),
-    [daysInView, preferredDayKeys, preferredWeekdaySet, exceptionWeekdaySet],
+    [
+      daysInView,
+      preferredDayKeys,
+      preferredWeekdaySet,
+      exceptionWeekdaySet,
+      currentMonth,
+    ],
   );
 
   const dayKeys = useMemo(() => visibleDayInfo.map((item) => item.key), [visibleDayInfo]);


### PR DESCRIPTION
## Summary
- add ISO week metadata and aggregate day summaries in the Sperrliste overview data so timelines can display richer context【F:src/app/(members)/mitglieder/sperrliste/overview/useBlockOverviewData.ts†L3-L204】
- refresh the desktop overview timeline with week badges, aggregated status chips, weekend styling, and per-member badges for total and upcoming blocks【F:src/app/(members)/mitglieder/sperrliste/overview/desktop-timeline.tsx†L1-L490】
- enhance the mobile timeline and overview shell to surface the new summaries, align statistics, and remove the obsolete currentMonth prop【F:src/app/(members)/mitglieder/sperrliste/overview/mobile-timeline.tsx†L1-L448】【F:src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx†L36-L493】【F:src/app/(members)/mitglieder/sperrliste/block-overview.tsx†L72-L128】

## Testing
- pnpm lint【d877ae†L1-L4】
- pnpm test【1d0145†L1-L19】
- CI=1 pnpm build【14ae69†L1-L79】

------
https://chatgpt.com/codex/tasks/task_e_68e23f61c424832d83ccc509f14225b7