### PR TITLE
Remove newsletter CTA and references

### DIFF
--- a/docs/redesign-plan/README.md
+++ b/docs/redesign-plan/README.md
@@ -37,7 +37,7 @@ Dieser Plan übersetzt die Analyse des aktuellen Screenshots in umsetzbare Arbei
 - **Aufgaben:**
   - Feature-/Programmsektionen, Testimonials, FAQ und Kontaktbereich als modulare Komponenten bauen.
   - Bild- und Medienhandling (Optimized Images, Ratio-Wrapper) integrieren.
-  - Formular-Interaktionen (Newsletter, Kontakt) mit Validierung, Fehlermeldungen und Success States ergänzen.
+  - Formular-Interaktionen (Kontakt) mit Validierung, Fehlermeldungen und Success States ergänzen.
   - Animationen/Transitions sparsam implementieren (z. B. `framer-motion` oder CSS), Fokus auf Micro-Feedback.
 - **Deliverables:** Content-Komponenten mit Beispieldaten, dokumentierte Props & Usage-Beispiele, Responsiveness-Tests.
 - **Erfolgskriterien:** Nutzer finden Kerninformationen binnen <3 Klicks, Formulare erfüllen WCAG-Standards.

--- a/docs/redesign-plan/sprint-1-notes.md
+++ b/docs/redesign-plan/sprint-1-notes.md
@@ -24,7 +24,7 @@ Container-Padding folgt diesen Breakpoints (`1.5rem`, `2rem`, `3rem`).
 
 ## Navigationsrichtlinien
 - **Primäre Einträge** (`Über uns`, `Das Geheimnis`, `Chronik`) werden in `@/config/navigation.ts` verwaltet und zentral in Header & Footer verwendet.
-- **Sekundärbereich** fasst `Login`, `Newsletter`, `Impressum` zusammen und sitzt im Footer als Service-Spalte. CTA `Newsletter abonnieren` nutzt dasselbe Config-Objekt.
+- **Sekundärbereich** fasst `Login`, `Impressum` und weitere Service-Links zusammen und sitzt im Footer als Service-Spalte. CTA-Labels werden zentral über die Navigationskonfiguration gepflegt.
 - **Header-Verhalten**: Transparenter Header auf der Startseite, der beim Scrollen in eine dunkle, blur-basierte Variante mit Border übergeht. Desktop-Menü (`md`+) inline, Mobil (`< md`) als overlay Panel mit Escape/ClickOutside-Handling.
 - **Footer-Verlinkung**: Enthält Impressum & Kontakt sowie Build-Informationen. Kontaktinfos (`mailto`, Telefonnummer, Adresse) sind prominent in der Einleitung verankert.
 
@@ -36,6 +36,6 @@ Container-Padding folgt diesen Breakpoints (`1.5rem`, `2rem`, `3rem`).
 ## Barrierefreiheit
 - Skip-Link verweist auf `#main`, Landmark-Rollen bleiben (header/nav/main/footer).
 - Mobile Overlay fokussiert auf Escape/Outside Click, aktive Links haben `aria-current="page"`.
-- Newsletter-CTA im Footer besitzt ausreichenden Kontrast (> 4.5:1) und border-dashed-Indikator.
+- Footer-CTAs behalten ausreichenden Kontrast (> 4.5:1) und eine visuelle Hervorhebung.
 
 Diese Richtlinien bilden die Basis für Sprint 2 (Token & Komponenten), ohne bestehende Seitenlogik zu beeinträchtigen.

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -41,7 +41,7 @@ export default async function Home() {
     {
       question: "Wann startet der Ticketverkauf?",
       answer:
-        "Der genaue Starttermin wird in Kürze bekannt gegeben. Trag dich am besten in unseren Newsletter ein oder folge uns auf Social Media, damit du den Verkaufsbeginn und mögliche Frühbucheraktionen nicht verpasst.",
+        "Der genaue Starttermin wird in Kürze bekannt gegeben. Folge uns auf Social Media, damit du den Verkaufsbeginn und mögliche Frühbucheraktionen nicht verpasst.",
     },
     {
       question: "Benötige ich Vorkenntnisse, um das Stück zu genießen?",

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,11 +1,7 @@
 import Link from "next/link";
 
 import { BuildInfoTimestamp } from "@/components/build-info-timestamp";
-import {
-  ctaNavigation,
-  primaryNavigation,
-  secondaryNavigation,
-} from "@/config/navigation";
+import { primaryNavigation, secondaryNavigation } from "@/config/navigation";
 
 type CommitInfo = {
   short: string;
@@ -60,17 +56,6 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
             </div>
 
             <div className="mt-6 flex flex-col gap-6 sm:mt-8 sm:flex-row sm:items-start sm:gap-8">
-              <div>
-                <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Newsletter</p>
-                <Link
-                  href={ctaNavigation.href}
-                  className="mt-2 inline-flex items-center gap-2 rounded-full border border-dashed border-primary/60 bg-primary/10 px-5 py-2.5 text-sm font-semibold text-primary transition-colors hover:border-primary hover:bg-primary/15"
-                >
-                  {ctaNavigation.label}
-                  <span aria-hidden className="text-base">→</span>
-                </Link>
-              </div>
-
               <div>
                 <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Folge uns</p>
                 <div className="mt-2 flex items-center gap-3">

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -13,7 +13,7 @@ import { usePathname } from "next/navigation";
 
 import { NotificationBell } from "@/components/notification-bell";
 import { UserNav } from "@/components/user-nav";
-import { ctaNavigation, primaryNavigation } from "@/config/navigation";
+import { primaryNavigation } from "@/config/navigation";
 import { cn } from "@/lib/utils";
 import {
   Sheet,
@@ -81,11 +81,6 @@ const drawerLinkGroupStyles = {
   "--drawer-link-gap": HEADER_SPACING.mobile.linkGroupGap,
 } as CSSProperties;
 
-const drawerFooterStyles = {
-  "--drawer-footer-space": HEADER_SPACING.mobile.footerSpace,
-  "--drawer-footer-padding-top": HEADER_SPACING.mobile.footerPaddingTop,
-} as CSSProperties;
-
 const drawerLinkPaddingStyles = {
   paddingInline: HEADER_SPACING.mobile.linkPaddingInline,
   paddingBlock: HEADER_SPACING.mobile.linkPaddingBlock,
@@ -93,11 +88,6 @@ const drawerLinkPaddingStyles = {
 
 const drawerLinkDescriptionStyles = {
   marginTop: HEADER_SPACING.mobile.linkDescriptionMarginTop,
-} satisfies CSSProperties;
-
-const drawerCtaPaddingStyles = {
-  paddingInline: HEADER_SPACING.mobile.ctaPaddingInline,
-  paddingBlock: HEADER_SPACING.mobile.ctaPaddingBlock,
 } satisfies CSSProperties;
 
 const heroGradientStyles = {
@@ -327,21 +317,10 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
           })}
         </div>
 
-        <div
-          style={drawerFooterStyles}
-          className="mt-auto space-y-[var(--drawer-footer-space)] border-t border-border/60 pt-[var(--drawer-footer-padding-top)] text-sm text-muted-foreground"
-        >
-          <span className="block text-xs uppercase tracking-[0.12em] text-foreground/70">
-            Bleib verbunden
+        <div className="mt-auto text-xs text-muted-foreground">
+          <span className="block uppercase tracking-[0.12em] text-foreground/70">
+            Gute Unterhaltung!
           </span>
-          <Link
-            href={ctaNavigation.href}
-            style={drawerCtaPaddingStyles}
-            className="block rounded-lg border border-dashed border-primary/50 bg-primary/10 text-foreground transition-colors hover:border-primary hover:bg-primary/20"
-            onClick={() => setOpen(false)}
-          >
-            {ctaNavigation.label}
-          </Link>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -33,16 +33,7 @@ export const secondaryNavigation: NavigationItem[] = [
     href: "/login",
   },
   {
-    label: "Newsletter",
-    href: "/onboarding",
-  },
-  {
     label: "Impressum",
     href: "/impressum",
   },
 ];
-
-export const ctaNavigation = {
-  label: "Newsletter abonnieren",
-  href: "/onboarding",
-};

--- a/src/lib/analytics/__tests__/aggregate-session-metrics.test.ts
+++ b/src/lib/analytics/__tests__/aggregate-session-metrics.test.ts
@@ -66,7 +66,7 @@ describe("aggregateSessionMetrics", () => {
         path: "/landing",
         referrer: null,
         referrerDomain: null,
-        utmSource: "newsletter",
+        utmSource: "mailing",
         utmMedium: "email",
         utmCampaign: "winter-sale",
         utmTerm: null,

--- a/src/lib/analytics/aggregate-session-metrics.ts
+++ b/src/lib/analytics/aggregate-session-metrics.ts
@@ -134,7 +134,7 @@ function normalizeChannel(rawChannel: string | null | undefined): string {
     return "Direct";
   }
 
-  if (["email", "newsletter"].includes(normalized)) {
+  if (["email"].includes(normalized)) {
     return "E-Mail";
   }
   if (["social", "social_media", "social-media", "facebook", "instagram", "twitter", "linkedin"].includes(normalized)) {


### PR DESCRIPTION
## Summary
- remove the newsletter CTA from the navigation config, header, and footer
- update homepage FAQ copy and analytics handling to avoid newsletter terminology
- adjust redesign documentation to drop newsletter-specific guidance

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e24affeac4832db1bb0846f4560a79