### PR TITLE
Prevent Feedback & Support crash for invalid relative times

### DIFF
--- a/src/lib/__tests__/datetime.test.ts
+++ b/src/lib/__tests__/datetime.test.ts
@@ -28,6 +28,12 @@ describe("datetime utilities", () => {
 
       expect(formatRelativeFromNow(past, { now: reference })).toBe("vor 2 Stunden");
     });
+
+    it("falls back gracefully for invalid dates", () => {
+      const invalid = new Date("invalid");
+
+      expect(formatRelativeFromNow(invalid)).toBe("jetzt");
+    });
   });
 
   describe("formatRelativeBetween", () => {

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -88,8 +88,19 @@ export function formatRelativeBetween(
   const { formatter = DEFAULT_RELATIVE_TIME_FORMATTER, segments = RELATIVE_TIME_SEGMENTS, roundingMethod = Math.round } =
     options;
   const diffInSeconds = (target.getTime() - reference.getTime()) / 1000;
+
+  if (!Number.isFinite(diffInSeconds)) {
+    return formatter.format(0, "second");
+  }
+
   const { unit, value } = selectSegment(diffInSeconds, segments);
-  return formatter.format(roundingMethod(value), unit);
+  const rounded = roundingMethod(value);
+
+  if (!Number.isFinite(rounded)) {
+    return formatter.format(0, "second");
+  }
+
+  return formatter.format(rounded, unit);
 }
 
 export function formatRelativeFromNow(


### PR DESCRIPTION
## Summary
- guard `formatRelativeBetween` against invalid date differences so the Feedback & Support view no longer crashes when it receives malformed timestamps
- add a regression test ensuring `formatRelativeFromNow` falls back to "jetzt" for invalid inputs

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e24ad76534832d9fe2f6de1d6873f2