### PR TITLE
Fix issues API auth handling

### DIFF
--- a/src/app/api/issues/[issueId]/comments/route.ts
+++ b/src/app/api/issues/[issueId]/comments/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/rbac";
+import { getSession } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { mapIssueDetail } from "../../utils";
 
@@ -8,7 +8,13 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ issueId: string }> },
 ) {
-  const session = await requireAuth();
+  const session = await getSession();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+  if (session.user.isDeactivated) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
   const [canView, canManage] = await Promise.all([
     hasPermission(session.user, "mitglieder.issues"),
     hasPermission(session.user, "mitglieder.issues.manage"),

--- a/src/app/api/issues/[issueId]/route.ts
+++ b/src/app/api/issues/[issueId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/rbac";
+import { getSession } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { isIssueCategory, isIssuePriority, isIssueStatus, isIssueVisibility } from "@/lib/issues";
 import { mapIssueDetail } from "../utils";
@@ -10,7 +10,13 @@ export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ issueId: string }> },
 ) {
-  const session = await requireAuth();
+  const session = await getSession();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+  if (session.user.isDeactivated) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
   const [canView, canManage] = await Promise.all([
     hasPermission(session.user, "mitglieder.issues"),
     hasPermission(session.user, "mitglieder.issues.manage"),
@@ -54,7 +60,13 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ issueId: string }> },
 ) {
-  const session = await requireAuth();
+  const session = await getSession();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+  if (session.user.isDeactivated) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
   const [canView, canManage] = await Promise.all([
     hasPermission(session.user, "mitglieder.issues"),
     hasPermission(session.user, "mitglieder.issues.manage"),

--- a/src/app/api/issues/__tests__/route.test.ts
+++ b/src/app/api/issues/__tests__/route.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { NextRequest } from "next/server";
+
+import { GET } from "../route";
+import { getSession } from "@/lib/rbac";
+import { hasPermission } from "@/lib/permissions";
+
+vi.mock("@/lib/rbac", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions", () => ({
+  hasPermission: vi.fn(),
+}));
+
+const prismaIssueMock = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  groupBy: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    issue: prismaIssueMock,
+  },
+}));
+
+vi.mock("@/app/api/issues/utils", () => ({
+  mapIssueSummary: vi.fn((issue: unknown) => issue),
+}));
+
+describe("GET /api/issues", () => {
+  const getSessionMock = vi.mocked(getSession);
+  const hasPermissionMock = vi.mocked(hasPermission);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when no session is present", async () => {
+    getSessionMock.mockResolvedValue(null);
+    const request = { url: "https://example.com/api/issues" } as NextRequest;
+
+    const response = await GET(request);
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Nicht autorisiert" });
+    expect(prismaIssueMock.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user is deactivated", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1", isDeactivated: true } });
+    const request = { url: "https://example.com/api/issues" } as NextRequest;
+
+    const response = await GET(request);
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Kein Zugriff" });
+  });
+
+  it("returns issues and counts for authorized users", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1", isDeactivated: false } });
+    hasPermissionMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    prismaIssueMock.findMany.mockResolvedValue([
+      {
+        id: "issue-1",
+        title: "Test",
+        description: "Description",
+        category: "general",
+        status: "open",
+        priority: "medium",
+        visibility: "public",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastActivityAt: new Date(),
+        resolvedAt: null,
+        createdById: "user-1",
+        updatedById: null,
+        createdBy: null,
+        updatedBy: null,
+        _count: { comments: 0 },
+      },
+    ]);
+    prismaIssueMock.groupBy.mockResolvedValue([
+      { status: "open", _count: { _all: 1 } },
+    ]);
+
+    const request = { url: "https://example.com/api/issues" } as NextRequest;
+    const response = await GET(request);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(body.issues).toHaveLength(1);
+    expect(body.counts).toEqual({ open: 1, in_progress: 0, resolved: 0, closed: 0 });
+  });
+});

--- a/src/app/api/issues/route.ts
+++ b/src/app/api/issues/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/rbac";
+import { getSession } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import {
   DEFAULT_ISSUE_CATEGORY,
@@ -18,7 +18,13 @@ import { extractIssuePlainText, mapIssueSummary, sanitizeIssueDescription } from
 const MAX_RESULTS = 100;
 
 export async function GET(request: NextRequest) {
-  const session = await requireAuth();
+  const session = await getSession();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+  if (session.user.isDeactivated) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
   const [canView, canManage] = await Promise.all([
     hasPermission(session.user, "mitglieder.issues"),
     hasPermission(session.user, "mitglieder.issues.manage"),
@@ -94,7 +100,13 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await requireAuth();
+  const session = await getSession();
+  if (!session?.user) {
+    return NextResponse.json({ error: "Nicht autorisiert" }, { status: 401 });
+  }
+  if (session.user.isDeactivated) {
+    return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });
+  }
   const allowed = await hasPermission(session.user, "mitglieder.issues");
   if (!allowed) {
     return NextResponse.json({ error: "Kein Zugriff" }, { status: 403 });

--- a/src/components/members/issues/issue-overview.tsx
+++ b/src/components/members/issues/issue-overview.tsx
@@ -133,14 +133,29 @@ export function IssueOverview({ initialIssues, initialCounts, breadcrumbs }: Iss
       const query = params.toString();
       const response = await fetch(`/api/issues${query ? `?${query}` : ""}`, {
         cache: "no-store",
+        credentials: "include",
+        redirect: "follow",
       });
+      if (response.status === 401) {
+        throw new Error("Bitte melde dich erneut an, um den Feedback-Bereich zu nutzen.");
+      }
+      if (response.status === 403) {
+        throw new Error("Kein Zugriff auf den Feedback-Bereich.");
+      }
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        throw new Error("Unerwartete Antwort vom Server erhalten.");
+      }
       const data = await response.json().catch(() => null);
       if (!response.ok) {
         throw new Error(data?.error ?? "Anliegen konnten nicht geladen werden");
       }
-      const nextIssues = Array.isArray(data?.issues) ? (data.issues as IssueSummary[]) : [];
-      setIssues(nextIssues);
-      setCounts(normalizeCounts(data?.counts as IssueStatusCounts));
+      if (!data || typeof data !== "object" || !Array.isArray((data as { issues?: unknown }).issues)) {
+        throw new Error("Antwort des Servers konnte nicht verarbeitet werden.");
+      }
+      const payload = data as { issues: IssueSummary[]; counts?: Partial<IssueStatusCounts> };
+      setIssues(Array.isArray(payload.issues) ? payload.issues : []);
+      setCounts(normalizeCounts(payload.counts));
     } catch (err) {
       console.error("[IssueOverview] load", err);
       toast.error(err instanceof Error ? err.message : "Anliegen konnten nicht geladen werden");


### PR DESCRIPTION
## Summary
- return JSON errors from issues API routes when a session is missing or deactivated and reuse permission checks
- harden the Feedback & Support overview fetcher to detect auth/response problems and surface helpful toasts
- cover the issues listing endpoint with unit tests to guard the new auth behaviour

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e250dd2340832db811832353e5a21c