### PR TITLE
Fix issue overview dialog trigger usage

### DIFF
--- a/src/components/members/issues/issue-overview.tsx
+++ b/src/components/members/issues/issue-overview.tsx
@@ -20,7 +20,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import {
   ISSUE_CATEGORY_BADGE_CLASSES,
@@ -242,11 +241,7 @@ export function IssueOverview({ initialIssues, initialCounts, breadcrumbs }: Iss
           title="Feedback & Support"
           description="Melde Probleme, Bugs oder Verbesserungsvorschläge und verfolge den Bearbeitungsstand im Mitglieder-Issue-Board."
           breadcrumbs={breadcrumbs}
-          actions={
-            <DialogTrigger asChild>
-              <Button>Neues Anliegen melden</Button>
-            </DialogTrigger>
-          }
+          actions={<Button onClick={() => setCreateOpen(true)}>Neues Anliegen melden</Button>}
           status={statusSummary}
         />
         <DialogContent className="max-w-2xl">


### PR DESCRIPTION
## Summary
- open the issue creation dialog using explicit state updates so the trigger no longer renders outside the dialog context
- remove the unused `DialogTrigger` import from the issue overview component

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e2ddb87e20832da82b9f104aaaed23