### PR TITLE
Refactor permissions UI into responsive matrix

### DIFF
--- a/src/components/members/permissions/permission-explorer.tsx
+++ b/src/components/members/permissions/permission-explorer.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { type Dispatch, type SetStateAction, useMemo, useState } from "react";
+import { Fragment, type Dispatch, type SetStateAction, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { Filter, Layers, Search, ShieldCheck } from "lucide-react";
-import { PermissionDetailDrawer } from "@/components/members/permissions/permission-detail-drawer";
+import { toast } from "sonner";
 import type {
   DepartmentGrantState,
   PermissionWorkbenchDepartment,
@@ -15,9 +13,7 @@ import type {
   PermissionWorkbenchRole,
   RoleGrantState,
 } from "@/components/members/permissions/permission-workbench-client";
-
-const FILTER_BUTTON_CLASS =
-  "w-full justify-between rounded-lg border border-border/70 bg-background/70 px-3 py-2 text-left text-sm font-medium text-foreground transition hover:border-primary/40 hover:bg-primary/5 hover:text-primary";
+import { ROLE_LABELS } from "@/lib/roles";
 
 type PermissionExplorerProps = {
   permissions: PermissionWorkbenchPermission[];
@@ -28,19 +24,20 @@ type PermissionExplorerProps = {
   departmentGrants: DepartmentGrantState;
   setRoleGrants: Dispatch<SetStateAction<RoleGrantState>>;
   setDepartmentGrants: Dispatch<SetStateAction<DepartmentGrantState>>;
-  unassignedCount: number;
 };
 
-type AssignmentStats = {
-  roleCount: number;
-  departmentCount: number;
-};
+type MatrixTarget = "role" | "department";
 
-type CategorySummary = {
-  key: string;
+type GroupedPermission = {
+  categoryKey: string;
   label: string;
-  total: number;
+  permissions: PermissionWorkbenchPermission[];
 };
+
+type MutableGrantState = Record<string, Set<string>>;
+
+const makeCellKey = (targetType: MatrixTarget, targetId: string, permissionKey: string) =>
+  `${targetType}:${targetId}:${permissionKey}`;
 
 export function PermissionExplorer({
   permissions,
@@ -51,362 +48,341 @@ export function PermissionExplorer({
   departmentGrants,
   setRoleGrants,
   setDepartmentGrants,
-  unassignedCount,
 }: PermissionExplorerProps) {
   const [searchTerm, setSearchTerm] = useState("");
-  const [activeCategories, setActiveCategories] = useState<Set<string>>(new Set());
-  const [onlyUnassigned, setOnlyUnassigned] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selectedPermissionKey, setSelectedPermissionKey] = useState<string | null>(null);
-  const [focusedPermissionKey, setFocusedPermissionKey] = useState<string | null>(null);
-
-  const permissionMap = useMemo(() => {
-    const map = new Map<string, PermissionWorkbenchPermission>();
-    for (const permission of permissions) {
-      map.set(permission.key, permission);
-    }
-    return map;
-  }, [permissions]);
-
-  const categorySummaries = useMemo<CategorySummary[]>(() => {
-    const summaryMap = new Map<string, CategorySummary>();
-    for (const permission of permissions) {
-      if (!summaryMap.has(permission.categoryKey)) {
-        summaryMap.set(permission.categoryKey, {
-          key: permission.categoryKey,
-          label: permission.categoryLabel,
-          total: 0,
-        });
-      }
-      summaryMap.get(permission.categoryKey)!.total += 1;
-    }
-    return Array.from(summaryMap.values()).sort((a, b) => a.label.localeCompare(b.label, "de"));
-  }, [permissions]);
-
-  const assignmentStats = useMemo(() => {
-    const stats = new Map<string, AssignmentStats>();
-    for (const permission of permissions) {
-      stats.set(permission.key, { roleCount: 0, departmentCount: 0 });
-    }
-    for (const role of roles) {
-      const grants = roleGrants[role.id];
-      if (!grants) continue;
-      for (const permissionKey of grants) {
-        const entry = stats.get(permissionKey);
-        if (!entry) {
-          stats.set(permissionKey, { roleCount: 1, departmentCount: 0 });
-        } else {
-          entry.roleCount += 1;
-        }
-      }
-    }
-    for (const department of departments) {
-      const grants = departmentGrants[department.id];
-      if (!grants) continue;
-      for (const permissionKey of grants) {
-        const entry = stats.get(permissionKey);
-        if (!entry) {
-          stats.set(permissionKey, { roleCount: 0, departmentCount: 1 });
-        } else {
-          entry.departmentCount += 1;
-        }
-      }
-    }
-    return stats;
-  }, [permissions, roles, roleGrants, departments, departmentGrants]);
+  const [pendingCells, setPendingCells] = useState<Set<string>>(new Set());
 
   const filteredPermissions = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
+    if (!term) return permissions;
     return permissions.filter((permission) => {
-      if (activeCategories.size > 0 && !activeCategories.has(permission.categoryKey)) {
-        return false;
-      }
-      if (term) {
-        const haystacks = [permission.key, permission.label, permission.description, permission.categoryLabel]
-          .filter(Boolean)
-          .map((value) => value!.toString().toLowerCase());
-        const matches = haystacks.some((value) => value.includes(term));
-        if (!matches) return false;
-      }
-      if (onlyUnassigned) {
-        const stats = assignmentStats.get(permission.key);
-        if (stats && (stats.roleCount > 0 || stats.departmentCount > 0)) {
-          return false;
-        }
-      }
-      return true;
+      const haystacks = [
+        permission.key,
+        permission.label,
+        permission.description ?? "",
+        permission.categoryLabel,
+      ].map((value) => value.toLowerCase());
+      return haystacks.some((value) => value.includes(term));
     });
-  }, [permissions, activeCategories, searchTerm, onlyUnassigned, assignmentStats]);
+  }, [permissions, searchTerm]);
 
-  const groupedPermissions = useMemo(() => {
-    const groups = new Map<string, { label: string; permissions: PermissionWorkbenchPermission[] }>();
+  const groupedPermissions = useMemo<GroupedPermission[]>(() => {
+    const groups = new Map<string, GroupedPermission>();
     for (const permission of filteredPermissions) {
       if (!groups.has(permission.categoryKey)) {
         groups.set(permission.categoryKey, {
+          categoryKey: permission.categoryKey,
           label: permission.categoryLabel,
           permissions: [],
         });
       }
       groups.get(permission.categoryKey)!.permissions.push(permission);
     }
-    return Array.from(groups.entries()).map(([categoryKey, value]) => ({
-      categoryKey,
-      label: value.label,
-      permissions: value.permissions,
-    }));
+    return Array.from(groups.values());
   }, [filteredPermissions]);
 
-  const focusedPermission =
-    (focusedPermissionKey ? permissionMap.get(focusedPermissionKey) : null) ??
-    (selectedPermissionKey ? permissionMap.get(selectedPermissionKey) : null) ??
-    filteredPermissions[0] ??
-    null;
-
-  const handleCategoryToggle = (categoryKey: string) => {
-    setActiveCategories((current) => {
+  const updatePendingCells = (cellKey: string, pending: boolean) => {
+    setPendingCells((current) => {
       const next = new Set(current);
-      if (next.has(categoryKey)) {
-        next.delete(categoryKey);
-      } else {
-        next.add(categoryKey);
-      }
+      if (pending) next.add(cellKey);
+      else next.delete(cellKey);
       return next;
     });
   };
 
-  const handleClearFilters = () => {
-    setActiveCategories(new Set());
-    setOnlyUnassigned(false);
-    setSearchTerm("");
+  const mutateGrant = async (
+    targetType: MatrixTarget,
+    targetId: string,
+    permissionKey: string,
+    grant: boolean,
+  ) => {
+    const state: MutableGrantState = (targetType === "role" ? roleGrants : departmentGrants) as MutableGrantState;
+    const setState: Dispatch<SetStateAction<MutableGrantState>> =
+      targetType === "role"
+        ? (setRoleGrants as Dispatch<SetStateAction<MutableGrantState>>)
+        : (setDepartmentGrants as Dispatch<SetStateAction<MutableGrantState>>);
+
+    const previous = new Set(state[targetId] ?? []);
+    const cellKey = makeCellKey(targetType, targetId, permissionKey);
+
+    setState((current) => {
+      const next: MutableGrantState = { ...current };
+      const updated = new Set(current[targetId] ?? []);
+      if (grant) {
+        updated.add(permissionKey);
+      } else {
+        updated.delete(permissionKey);
+      }
+      next[targetId] = updated;
+      return next;
+    });
+
+    updatePendingCells(cellKey, true);
+
+    try {
+      const response = await fetch("/api/permissions/definitions", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targetType, targetId, permissionKey, grant }),
+      });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error || "Speichern fehlgeschlagen");
+      }
+    } catch (error) {
+      setState((current) => {
+        const next: MutableGrantState = { ...current };
+        next[targetId] = previous;
+        return next;
+      });
+      toast.error("Änderung konnte nicht gespeichert werden", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      updatePendingCells(cellKey, false);
+    }
   };
 
-  const handleOpenDrawer = (permissionKey: string) => {
-    setSelectedPermissionKey(permissionKey);
-    setDrawerOpen(true);
-  };
+  const renderMatrix = (
+    targetType: MatrixTarget,
+    title: string,
+    description: string,
+    emptyMessage: string,
+  ) => {
+    const columns = targetType === "role" ? roles : departments;
 
-  const activeFilters = activeCategories.size + (onlyUnassigned ? 1 : 0) + (searchTerm.trim() ? 1 : 0);
+    return (
+      <section key={targetType} className="space-y-4">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold">{title}</h3>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        {columns.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+            {emptyMessage}
+          </div>
+        ) : groupedPermissions.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
+            Keine Rechte passen zu deiner Suche.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-border/70 shadow-sm">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px] border-separate border-spacing-0 text-sm">
+                <thead>
+                  <tr className="bg-muted/40">
+                    <th
+                      scope="col"
+                      className="sticky left-0 z-20 min-w-[260px] bg-muted/40 px-4 py-3 text-left text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+                    >
+                      Recht
+                    </th>
+                    {columns.map((column) => (
+                      <th
+                        key={column.id}
+                        scope="col"
+                        className="min-w-[150px] border-l border-border/60 px-3 py-3 text-center text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+                      >
+                        {targetType === "role" ? (
+                          <div className="flex flex-col items-center gap-1 text-center">
+                            <span className="font-medium">{(column as PermissionWorkbenchRole).name}</span>
+                            {(column as PermissionWorkbenchRole).systemRole ? (
+                              <span className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+                                {(column as PermissionWorkbenchRole).systemRole}
+                              </span>
+                            ) : null}
+                          </div>
+                        ) : (
+                          <div className="flex flex-col items-center gap-1 text-center">
+                            <span className="font-medium">{(column as PermissionWorkbenchDepartment).name}</span>
+                            {(column as PermissionWorkbenchDepartment).slug ? (
+                              <span className="text-[11px] uppercase tracking-[0.2em] text-muted-foreground">
+                                {(column as PermissionWorkbenchDepartment).slug}
+                              </span>
+                            ) : null}
+                            {(column as PermissionWorkbenchDepartment).requiresJoinApproval ? (
+                              <Badge variant="warning" size="sm">
+                                Zustimmung nötig
+                              </Badge>
+                            ) : null}
+                          </div>
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {groupedPermissions.map((group) => (
+                    <Fragment key={`${targetType}-${group.categoryKey}`}>
+                      <tr>
+                        <th
+                          scope="colgroup"
+                          colSpan={columns.length + 1}
+                          className="bg-muted/60 px-4 py-2 text-left text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+                        >
+                          {group.label}
+                        </th>
+                      </tr>
+                      {group.permissions.map((permission) => (
+                        <tr key={`${targetType}-${permission.key}`} className="bg-background">
+                          <th
+                            scope="row"
+                            className="sticky left-0 z-10 bg-background px-4 py-3 text-left align-top text-sm"
+                          >
+                            <div className="space-y-1">
+                              <span className="font-medium">{permission.label}</span>
+                              <div className="space-y-1 text-xs text-muted-foreground">
+                                <span className="font-mono uppercase tracking-[0.2em] text-muted-foreground/80">
+                                  {permission.key}
+                                </span>
+                                {permission.description ? (
+                                  <p className="leading-relaxed text-foreground/80">{permission.description}</p>
+                                ) : null}
+                              </div>
+                            </div>
+                          </th>
+                          {columns.map((column) => {
+                            if (targetType === "role") {
+                              const role = column as PermissionWorkbenchRole;
+                              const granted = roleGrants[role.id]?.has(permission.key) ?? false;
+                              const pending = pendingCells.has(makeCellKey("role", role.id, permission.key));
+                              return (
+                                <td
+                                  key={role.id}
+                                  className="border-l border-border/60 px-3 py-2 text-center align-middle"
+                                >
+                                  <Button
+                                    type="button"
+                                    size="sm"
+                                    variant={granted ? "default" : "outline"}
+                                    className={cn(
+                                      "h-9 w-full whitespace-normal text-xs",
+                                      pending && "opacity-60",
+                                    )}
+                                    aria-pressed={granted}
+                                    aria-label={`${permission.label} für ${role.name} ${
+                                      granted ? "deaktivieren" : "aktivieren"
+                                    }`}
+                                    title={granted ? "Recht entziehen" : "Recht gewähren"}
+                                    disabled={pending}
+                                    onClick={() => void mutateGrant("role", role.id, permission.key, !granted)}
+                                  >
+                                    {granted ? "Aktiv" : "Inaktiv"}
+                                  </Button>
+                                </td>
+                              );
+                            }
+                            const department = column as PermissionWorkbenchDepartment;
+                            const granted = departmentGrants[department.id]?.has(permission.key) ?? false;
+                            const pending = pendingCells.has(
+                              makeCellKey("department", department.id, permission.key),
+                            );
+                            return (
+                              <td
+                                key={department.id}
+                                className="border-l border-border/60 px-3 py-2 text-center align-middle"
+                              >
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant={granted ? "secondary" : "outline"}
+                                  className={cn(
+                                    "h-9 w-full whitespace-normal text-xs",
+                                    pending && "opacity-60",
+                                  )}
+                                  aria-pressed={granted}
+                                  aria-label={`${permission.label} für ${department.name} ${
+                                    granted ? "deaktivieren" : "aktivieren"
+                                  }`}
+                                  title={granted ? "Recht entziehen" : "Recht gewähren"}
+                                  disabled={pending}
+                                  onClick={() =>
+                                    void mutateGrant("department", department.id, permission.key, !granted)
+                                  }
+                                >
+                                  {granted ? "Aktiv" : "Inaktiv"}
+                                </Button>
+                              </td>
+                            );
+                          })}
+                        </tr>
+                      ))}
+                    </Fragment>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
+    );
+  };
 
   return (
-    <div className="grid gap-6 xl:grid-cols-[220px_minmax(0,1fr)_300px]">
-      <aside className="space-y-4 xl:sticky xl:top-24">
-        <div className="rounded-xl border border-border/80 bg-card/60 p-4 shadow-sm">
-          <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-            <span>Filter</span>
-            <Filter className="h-4 w-4" aria-hidden />
-          </div>
-          <div className="mt-3 space-y-3">
-            <div className="space-y-1">
-              <label className="text-xs font-semibold text-muted-foreground">Suche</label>
-              <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  value={searchTerm}
-                  onChange={(event) => setSearchTerm(event.target.value)}
-                  placeholder="Rechte durchsuchen…"
-                  className="pl-9"
-                  spellCheck={false}
-                />
-              </div>
-            </div>
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-                <span>Kategorien</span>
-                <Layers className="h-4 w-4" aria-hidden />
-              </div>
-              <div className="grid gap-2">
-                {categorySummaries.map((category) => {
-                  const isActive = activeCategories.has(category.key);
-                  return (
-                    <button
-                      key={category.key}
-                      type="button"
-                      className={cn(
-                        FILTER_BUTTON_CLASS,
-                        isActive && "border-primary bg-primary/10 text-primary shadow-sm",
-                      )}
-                      onClick={() => handleCategoryToggle(category.key)}
-                    >
-                      <span>{category.label}</span>
-                      <Badge variant={isActive ? "default" : "muted"} size="sm">
-                        {category.total}
-                      </Badge>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-            <div className="space-y-2">
-              <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-                <span>Besonderes</span>
-                <ShieldCheck className="h-4 w-4" aria-hidden />
-              </div>
-              <button
-                type="button"
-                className={cn(
-                  FILTER_BUTTON_CLASS,
-                  onlyUnassigned && "border-primary bg-primary/10 text-primary shadow-sm",
-                )}
-                onClick={() => setOnlyUnassigned((current) => !current)}
-              >
-                <span>Nur ungeplante Rechte</span>
-                <Badge variant={onlyUnassigned ? "default" : "muted"} size="sm">
-                  {unassignedCount}
-                </Badge>
-              </button>
-            </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="w-full justify-center"
-              disabled={activeFilters === 0}
-              onClick={handleClearFilters}
-            >
-              Filter zurücksetzen
-            </Button>
-          </div>
-        </div>
-      </aside>
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h2 className="text-xl font-semibold">Rechte-Matrix</h2>
+        <p className="text-sm text-muted-foreground">
+          Schalte Rechte per Klick frei oder entziehe sie wieder. Die Matrix funktioniert auf allen Bildschirmgrößen
+          dank horizontal scrollbarer Tabellen.
+        </p>
+      </header>
 
-      <div className="space-y-6">
-        {groupedPermissions.length === 0 ? (
-          <Card className="border-dashed bg-muted/40 text-center">
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                {activeFilters > 0
-                  ? "Keine Rechte passen zu den aktuellen Filtern."
-                  : "Keine Rechte gefunden."}
-              </p>
-            </CardContent>
-          </Card>
-        ) : null}
-        {groupedPermissions.map((group) => (
-          <section key={group.categoryKey} className="space-y-3">
-            <div className="flex items-center gap-3">
-              <div className="h-px flex-1 bg-border/50" aria-hidden />
-              <div className="text-[11px] font-semibold uppercase tracking-[0.35em] text-muted-foreground">
-                {group.label}
-              </div>
-              <div className="h-px flex-1 bg-border/50" aria-hidden />
-            </div>
-            <div className="grid gap-3 md:grid-cols-2">
-              {group.permissions.map((permission) => {
-                const stats = assignmentStats.get(permission.key) ?? { roleCount: 0, departmentCount: 0 };
-                const isActive = selectedPermissionKey === permission.key;
-                const isFocused = focusedPermissionKey === permission.key;
-                return (
-                  <Card
-                    key={permission.key}
-                    className={cn(
-                      "relative cursor-pointer border-border/80 bg-card/70 transition hover:border-primary/50 hover:shadow-md",
-                      (isActive || isFocused) && "border-primary/70 shadow-lg",
-                    )}
-                    onMouseEnter={() => setFocusedPermissionKey(permission.key)}
-                    onMouseLeave={() => setFocusedPermissionKey((current) => (current === permission.key ? null : current))}
-                    onClick={() => handleOpenDrawer(permission.key)}
-                  >
-                    <CardHeader>
-                      <CardTitle className="flex flex-col gap-1 text-base">
-                        <span>{permission.label}</span>
-                        <span className="text-xs font-normal text-muted-foreground">{permission.key}</span>
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3 text-sm">
-                      {permission.description ? (
-                        <p className="text-muted-foreground">{permission.description}</p>
-                      ) : null}
-                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                        <Badge variant={stats.roleCount > 0 ? "default" : "muted"} size="sm">
-                          {stats.roleCount} Rollen
-                        </Badge>
-                        <Badge variant={stats.departmentCount > 0 ? "secondary" : "muted"} size="sm">
-                          {stats.departmentCount} Gewerke
-                        </Badge>
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })}
-            </div>
-          </section>
-        ))}
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Filter</span>
+          <p className="text-sm text-muted-foreground">
+            Suche nach Rechtstitel, Schlüssel oder Beschreibung, um die Matrix einzugrenzen.
+          </p>
+        </div>
+        <div className="md:w-80">
+          <Input
+            placeholder="Rechte durchsuchen…"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            aria-label="Rechte durchsuchen"
+          />
+        </div>
       </div>
 
-      <aside className="hidden xl:block">
-        <div className="sticky top-24 space-y-4">
-          <div className="rounded-xl border border-border/80 bg-card/60 p-5 shadow-sm">
-            <div className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">
-              Detailansicht
-            </div>
-            {focusedPermission ? (
-              <div className="mt-4 space-y-3">
-                <div>
-                  <p className="text-sm font-semibold text-foreground">{focusedPermission.label}</p>
-                  <p className="text-xs text-muted-foreground">{focusedPermission.key}</p>
-                </div>
-                {focusedPermission.description ? (
-                  <p className="text-sm text-muted-foreground">{focusedPermission.description}</p>
-                ) : null}
-                <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                  <Badge variant="muted" size="sm">
-                    {focusedPermission.categoryLabel}
-                  </Badge>
-                  {(() => {
-                    const stats = assignmentStats.get(focusedPermission.key) ?? {
-                      roleCount: 0,
-                      departmentCount: 0,
-                    };
-                    return (
-                      <>
-                        <Badge variant={stats.roleCount > 0 ? "default" : "muted"} size="sm">
-                          {stats.roleCount} Rollen
-                        </Badge>
-                        <Badge variant={stats.departmentCount > 0 ? "secondary" : "muted"} size="sm">
-                          {stats.departmentCount} Gewerke
-                        </Badge>
-                      </>
-                    );
-                  })()}
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="w-full"
-                  onClick={() => focusedPermission && handleOpenDrawer(focusedPermission.key)}
-                >
-                  Zuweisungen öffnen
-                </Button>
-              </div>
-            ) : (
-              <p className="mt-4 text-sm text-muted-foreground">
-                Wähle ein Recht aus, um Details zu sehen und Zuweisungen zu bearbeiten.
-              </p>
-            )}
-          </div>
-          <div className="rounded-xl border border-border/80 bg-card/40 p-4 text-xs text-muted-foreground">
-            <p className="font-semibold uppercase tracking-[0.3em]">Hinweis</p>
-            <p className="mt-2 leading-relaxed">
-              Owner und Admin verfügen automatisch über vollständigen Zugriff auf alle Rechte. Individuelle
-              Zuweisungen werden über Rollen und Gewerke gesteuert.
-            </p>
-          </div>
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">Systemrollen</h3>
+          <p className="text-sm text-muted-foreground">
+            Owner und Admin besitzen automatisch Vollzugriff und erscheinen deshalb nicht in der Matrix.
+          </p>
         </div>
-      </aside>
+        <div className="flex flex-wrap gap-2">
+          {systemRoles.length === 0 ? (
+            <Badge variant="muted" size="sm">Keine Systemrollen registriert.</Badge>
+          ) : (
+            systemRoles.map((role) => {
+              const label = role.systemRole
+                ? ROLE_LABELS[role.systemRole as keyof typeof ROLE_LABELS] ?? role.name
+                : role.name;
+              return (
+                <Badge key={role.id} variant="muted" size="sm" className="font-medium">
+                  {label}
+                </Badge>
+              );
+            })
+          )}
+        </div>
+      </section>
 
-      <PermissionDetailDrawer
-        open={drawerOpen && Boolean(selectedPermissionKey)}
-        onOpenChange={setDrawerOpen}
-        permission={selectedPermissionKey ? permissionMap.get(selectedPermissionKey) ?? null : null}
-        systemRoles={systemRoles}
-        roles={roles}
-        departments={departments}
-        roleGrants={roleGrants}
-        departmentGrants={departmentGrants}
-        setRoleGrants={setRoleGrants}
-        setDepartmentGrants={setDepartmentGrants}
-      />
+      {renderMatrix(
+        "role",
+        "Rollen-Matrix",
+        "Aktiviere die benötigten Rechte für jede Rolle mit einem Klick.",
+        "Noch keine eigenen Rollen angelegt.",
+      )}
+
+      {renderMatrix(
+        "department",
+        "Gewerke-Matrix",
+        "Lege fest, welche Gewerke Zugriff auf einzelne Rechte erhalten.",
+        "Keine Gewerke vorhanden.",
+      )}
     </div>
   );
 }

--- a/src/components/members/permissions/permission-workbench-client.tsx
+++ b/src/components/members/permissions/permission-workbench-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PermissionExplorer } from "@/components/members/permissions/permission-explorer";
 import { RoleAdministrationPanel } from "@/components/members/permissions/role-administration-panel";
@@ -66,27 +66,6 @@ export function PermissionWorkbenchClient({
   );
   const [activeTab, setActiveTab] = useState("permissions");
 
-  const assignedPermissions = useMemo(() => {
-    const permissionsWithAssignments = new Set<string>();
-    for (const set of Object.values(roleGrants)) {
-      if (!set) continue;
-      for (const permissionKey of set) {
-        permissionsWithAssignments.add(permissionKey);
-      }
-    }
-    for (const set of Object.values(departmentGrants)) {
-      if (!set) continue;
-      for (const permissionKey of set) {
-        permissionsWithAssignments.add(permissionKey);
-      }
-    }
-    return permissionsWithAssignments;
-  }, [roleGrants, departmentGrants]);
-
-  const unassignedCount = useMemo(() => {
-    return permissions.reduce((count, permission) => (assignedPermissions.has(permission.key) ? count : count + 1), 0);
-  }, [permissions, assignedPermissions]);
-
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
       <TabsList>
@@ -104,7 +83,6 @@ export function PermissionWorkbenchClient({
           departmentGrants={departmentGrants}
           setRoleGrants={setRoleGrants}
           setDepartmentGrants={setDepartmentGrants}
-          unassignedCount={unassignedCount}
         />
       </TabsContent>
       <TabsContent value="roles">


### PR DESCRIPTION
## Summary
- replace the permissions explorer with a responsive matrix table that works across breakpoints
- surface system role information and simplify filters to a single search field
- keep role and department assignment updates inline with optimistic updates

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e2e2142f00832db17c9bc35046809e