### PR TITLE
Improve member calendar styling

### DIFF
--- a/src/app/(members)/mitglieder/kalender/calendar-client.tsx
+++ b/src/app/(members)/mitglieder/kalender/calendar-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ComponentProps } from "react";
+import type { ComponentProps, CSSProperties } from "react";
 import {
   addDays,
   addWeeks,
@@ -59,6 +59,10 @@ type CalendarEventWithDates = Omit<MemberCalendarEvent, "start" | "end"> & {
 type BigCalendarEvent = CalendarEventWithDates & {
   start: Date;
   end: Date;
+};
+
+type CalendarEventStyle = CSSProperties & {
+  "--member-calendar-accent"?: string;
 };
 
 const AGENDA_RANGE_DAYS = 60;
@@ -266,18 +270,18 @@ export function CalendarClient({ initialDate, calendars, events, summary }: Cale
     (event) => {
       const source = calendarMap.get(event.calendarId);
       const accentColor = source?.color;
+      const style: CalendarEventStyle = {};
+
+      if (accentColor) {
+        style["--member-calendar-accent"] = accentColor;
+      }
+
       return {
         className: cn(
           "member-calendar-event",
           event.allDay ? "member-calendar-event--all-day" : "member-calendar-event--timed",
         ),
-        style: {
-          backgroundColor: "var(--color-card)",
-          border: `1px solid ${accentColor ?? "var(--border)"}`,
-          color: "var(--color-foreground)",
-          borderRadius: "1rem",
-          padding: 0,
-        },
+        style,
       };
     },
     [calendarMap],
@@ -469,31 +473,39 @@ function CalendarEventContent({ event, calendarMap }: CalendarEventComponentProp
     : `${format(event.startDate, "HH:mm", { locale: de })} – ${format(event.endDate, "HH:mm", { locale: de })}`;
 
   return (
-    <div className="flex h-full flex-col justify-between gap-2 rounded-[0.9rem] bg-background/95 p-2 text-xs">
+    <div className="member-calendar-event-content flex h-full flex-col justify-between gap-2 rounded-[0.9rem] bg-background/95 p-2 text-xs">
       <div className="space-y-1">
-        <p className="line-clamp-2 text-sm font-semibold leading-tight" style={accentColor ? { color: accentColor } : undefined}>
+        <p
+          className="member-calendar-event-title line-clamp-2 text-sm font-semibold leading-tight"
+          style={accentColor ? { color: accentColor } : undefined}
+        >
           {event.title}
         </p>
-        <p className="text-[11px] text-muted-foreground">{timeLabel}</p>
+        <p className="member-calendar-event-meta text-[11px] text-muted-foreground">{timeLabel}</p>
         {event.location ? (
-          <p className="flex items-center gap-1 text-[11px] text-muted-foreground">
+          <p className="member-calendar-event-location flex items-center gap-1 text-[11px] text-muted-foreground">
             <MapPin className="h-3 w-3" /> {event.location}
           </p>
         ) : null}
-        {note ? <p className="line-clamp-2 text-[11px] text-muted-foreground/90">{note}</p> : null}
+        {note ? (
+          <p className="member-calendar-event-note line-clamp-2 text-[11px] text-muted-foreground/90">{note}</p>
+        ) : null}
       </div>
       <div className="flex flex-wrap gap-1">
         {attendance ? (
           <Badge
             variant="outline"
-            className="rounded-full px-2 py-0 text-[10px]"
+            className="member-calendar-event-attendance-badge rounded-full px-2 py-0 text-[10px]"
             style={accentColor ? { borderColor: accentColor, color: accentColor } : undefined}
           >
             {attendance}
           </Badge>
         ) : null}
         {badge ? (
-          <Badge variant={resolveBadgeVariant(badge.tone)} className="rounded-full px-2 py-0 text-[10px]">
+          <Badge
+            variant={resolveBadgeVariant(badge.tone)}
+            className="member-calendar-event-badge rounded-full px-2 py-0 text-[10px]"
+          >
             {badge.label}
           </Badge>
         ) : null}
@@ -510,22 +522,25 @@ function AgendaEventContent({ event, calendarMap }: CalendarEventComponentProps)
   const badge = event.metadata?.badge ?? null;
 
   return (
-    <div className="flex flex-col gap-2 rounded-2xl border border-border/60 bg-background/85 px-3 py-2 text-xs">
+    <div className="member-calendar-agenda-event flex flex-col gap-2 rounded-2xl border border-border/60 bg-background/85 px-3 py-2 text-xs">
       <div className="flex items-start justify-between gap-2">
         <div className="space-y-1">
-          <p className="text-sm font-semibold" style={accentColor ? { color: accentColor } : undefined}>
+          <p
+            className="member-calendar-event-title text-sm font-semibold"
+            style={accentColor ? { color: accentColor } : undefined}
+          >
             {event.title}
           </p>
-          <p className="text-[11px] text-muted-foreground">
+          <p className="member-calendar-event-meta text-[11px] text-muted-foreground">
             {format(event.startDate, "EEEE, d. MMMM yyyy", { locale: de })}
           </p>
-          <p className="text-[11px] text-muted-foreground">
+          <p className="member-calendar-event-meta text-[11px] text-muted-foreground">
             {event.allDay
               ? "Ganztägig"
               : `${format(event.startDate, "HH:mm", { locale: de })} – ${format(event.endDate, "HH:mm", { locale: de })}`}
           </p>
           {event.location ? (
-            <p className="flex items-center gap-1 text-[11px] text-muted-foreground">
+            <p className="member-calendar-event-location flex items-center gap-1 text-[11px] text-muted-foreground">
               <MapPin className="h-3 w-3" /> {event.location}
             </p>
           ) : null}
@@ -533,22 +548,25 @@ function AgendaEventContent({ event, calendarMap }: CalendarEventComponentProps)
         {source ? (
           <Badge
             variant="outline"
-            className="h-fit rounded-full px-2 py-0 text-[10px]"
+            className="member-calendar-agenda-source-badge h-fit rounded-full px-2 py-0 text-[10px]"
             style={accentColor ? { borderColor: accentColor, color: accentColor } : undefined}
           >
             {source.label}
           </Badge>
         ) : null}
       </div>
-      {note ? <p className="text-[11px] text-muted-foreground/90">{note}</p> : null}
+      {note ? <p className="member-calendar-event-note text-[11px] text-muted-foreground/90">{note}</p> : null}
       <div className="flex flex-wrap gap-1">
         {attendance ? (
-          <Badge variant="secondary" className="rounded-full px-2 py-0 text-[10px]">
+          <Badge variant="secondary" className="member-calendar-event-badge rounded-full px-2 py-0 text-[10px]">
             {attendance}
           </Badge>
         ) : null}
         {badge ? (
-          <Badge variant={resolveBadgeVariant(badge.tone)} className="rounded-full px-2 py-0 text-[10px]">
+          <Badge
+            variant={resolveBadgeVariant(badge.tone)}
+            className="member-calendar-event-badge rounded-full px-2 py-0 text-[10px]"
+          >
             {badge.label}
           </Badge>
         ) : null}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -129,58 +129,207 @@
 }
 
 @layer components {
+  .member-calendar {
+    --member-calendar-border: color-mix(in srgb, var(--color-border) 72%, transparent);
+    --member-calendar-surface: color-mix(in srgb, var(--color-card) 92%, transparent);
+    --member-calendar-surface-subtle: color-mix(in srgb, var(--color-card) 86%, transparent);
+    --member-calendar-muted: color-mix(in srgb, var(--color-muted-foreground) 70%, transparent);
+    @apply relative overflow-hidden rounded-[1.75rem];
+    border: 1px solid var(--member-calendar-border);
+    background: var(--member-calendar-surface);
+    backdrop-filter: blur(12px);
+  }
+
   .member-calendar .rbc-calendar {
     @apply text-foreground;
+    padding: clamp(0.75rem, 1.6vw, 1.25rem);
   }
 
   .member-calendar .rbc-toolbar {
     display: none;
   }
 
-  .member-calendar .rbc-header {
-    @apply border-border/60 text-xs font-semibold uppercase tracking-wide text-muted-foreground;
-    background-color: color-mix(in srgb, var(--color-card) 70%, transparent);
+  .member-calendar .rbc-time-view,
+  .member-calendar .rbc-month-view,
+  .member-calendar .rbc-agenda-view {
+    border-radius: 1.5rem;
+    border: 1px solid color-mix(in srgb, var(--member-calendar-border) 85%, transparent);
+    background: color-mix(in srgb, var(--member-calendar-surface) 82%, transparent);
+    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--member-calendar-border) 45%, transparent);
+    padding: clamp(0.5rem, 1vw, 0.75rem);
   }
 
-  .member-calendar .rbc-header + .rbc-header,
-  .member-calendar .rbc-month-row + .rbc-month-row,
   .member-calendar .rbc-time-header,
   .member-calendar .rbc-time-content,
   .member-calendar .rbc-timeslot-group,
   .member-calendar .rbc-agenda-view table thead > tr > th,
   .member-calendar .rbc-agenda-view table tbody > tr + tr {
-    border-color: color-mix(in srgb, var(--color-border) 80%, transparent);
+    border-color: color-mix(in srgb, var(--member-calendar-border) 80%, transparent);
   }
 
-  .member-calendar .rbc-time-view,
-  .member-calendar .rbc-month-view,
-  .member-calendar .rbc-agenda-view {
-    background-color: color-mix(in srgb, var(--color-card) 85%, transparent);
+  .member-calendar .rbc-time-content {
+    border-radius: 1.25rem;
+    background: color-mix(in srgb, var(--member-calendar-surface-subtle) 88%, transparent);
+    scrollbar-width: thin;
+  }
+
+  .member-calendar .rbc-time-content::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .member-calendar .rbc-time-content::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .member-calendar .rbc-time-content::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--member-calendar-border) 60%, transparent);
+    border-radius: 9999px;
   }
 
   .member-calendar .rbc-time-gutter,
   .member-calendar .rbc-agenda-view table thead > tr {
-    background-color: color-mix(in srgb, var(--color-card) 75%, transparent);
+    background: color-mix(in srgb, var(--member-calendar-surface) 78%, transparent);
+  }
+
+  .member-calendar .rbc-time-gutter .rbc-timeslot-group {
+    border-color: transparent;
+  }
+
+  .member-calendar .rbc-header {
+    @apply text-xs font-semibold uppercase tracking-wide;
+    color: color-mix(in srgb, var(--member-calendar-muted) 90%, var(--color-foreground));
+    background: color-mix(in srgb, var(--member-calendar-surface) 70%, transparent);
+    padding-block: 0.75rem;
+  }
+
+  .member-calendar .rbc-time-header > .rbc-allday-cell,
+  .member-calendar .rbc-allday-cell {
+    background: color-mix(in srgb, var(--member-calendar-surface) 82%, transparent);
   }
 
   .member-calendar .rbc-today {
-    background-color: color-mix(in srgb, var(--color-primary) 15%, transparent);
+    background: color-mix(in srgb, var(--color-primary) 16%, transparent);
   }
 
   .member-calendar .rbc-off-range-bg {
-    background-color: color-mix(in srgb, var(--color-muted) 45%, transparent);
+    background: color-mix(in srgb, var(--color-muted) 45%, transparent);
   }
 
   .member-calendar .rbc-off-range {
-    color: color-mix(in srgb, var(--color-muted-foreground) 70%, transparent);
+    color: color-mix(in srgb, var(--member-calendar-muted) 80%, transparent);
+  }
+
+  .member-calendar .rbc-current-time-indicator {
+    background: var(--color-primary);
+    height: 2px;
   }
 
   .member-calendar .member-calendar-event {
-    box-shadow: none;
+    --member-calendar-accent: var(--color-primary);
+    border-radius: 1rem;
+    border: 1px solid color-mix(in srgb, var(--member-calendar-accent) 52%, transparent);
+    background: color-mix(in srgb, var(--member-calendar-accent) 6%, var(--color-background) 94%);
+    color: color-mix(in srgb, var(--color-foreground) 95%, transparent);
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--member-calendar-accent) 25%, transparent);
+    padding: 0;
+    transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease,
+      transform 150ms ease;
+  }
+
+  .member-calendar .member-calendar-event.member-calendar-event--all-day {
+    background: color-mix(in srgb, var(--member-calendar-accent) 10%, var(--color-background) 90%);
+    border-style: dashed;
+  }
+
+  .member-calendar .member-calendar-event:hover,
+  .member-calendar .member-calendar-event:focus-within,
+  .member-calendar .rbc-event.rbc-selected.member-calendar-event {
+    border-color: color-mix(in srgb, var(--member-calendar-accent) 75%, transparent);
+    background: color-mix(in srgb, var(--member-calendar-accent) 12%, var(--color-background) 88%);
+    box-shadow: 0 8px 20px -12px color-mix(in srgb, var(--member-calendar-accent) 70%, transparent);
   }
 
   .member-calendar .member-calendar-event .rbc-event-content {
     height: 100%;
+  }
+
+  .member-calendar .member-calendar-event-content {
+    background: color-mix(in srgb, var(--color-background) 95%, transparent);
+    transition: background-color 150ms ease, color 150ms ease;
+  }
+
+  .member-calendar .member-calendar-event:hover .member-calendar-event-content,
+  .member-calendar .member-calendar-event:focus-within .member-calendar-event-content {
+    background: color-mix(in srgb, var(--member-calendar-accent) 8%, var(--color-background) 92%);
+  }
+
+  .member-calendar .member-calendar-event-title {
+    color: color-mix(in srgb, var(--member-calendar-accent) 80%, var(--color-foreground));
+  }
+
+  .member-calendar .member-calendar-event-meta {
+    color: color-mix(in srgb, var(--member-calendar-muted) 88%, transparent);
+  }
+
+  .member-calendar .member-calendar-event-location {
+    color: color-mix(in srgb, var(--member-calendar-muted) 80%, transparent);
+  }
+
+  .member-calendar .member-calendar-event-location svg {
+    color: color-mix(in srgb, var(--member-calendar-accent) 70%, transparent);
+  }
+
+  .member-calendar .member-calendar-event-note {
+    color: color-mix(in srgb, var(--member-calendar-muted) 75%, transparent);
+  }
+
+  .member-calendar .member-calendar-event-attendance-badge {
+    border-color: color-mix(in srgb, var(--member-calendar-accent) 50%, transparent);
+    color: color-mix(in srgb, var(--member-calendar-accent) 80%, var(--color-foreground));
+    background: color-mix(in srgb, var(--member-calendar-accent) 10%, transparent);
+  }
+
+  .member-calendar .member-calendar-event-badge {
+    background: color-mix(in srgb, var(--member-calendar-accent) 12%, transparent);
+    color: color-mix(in srgb, var(--member-calendar-accent) 90%, var(--color-foreground));
+  }
+
+  .member-calendar .member-calendar-agenda-source-badge {
+    border-color: color-mix(in srgb, var(--member-calendar-accent) 40%, transparent);
+    color: color-mix(in srgb, var(--member-calendar-accent) 85%, var(--color-foreground));
+    background: color-mix(in srgb, var(--member-calendar-accent) 8%, transparent);
+  }
+
+  .member-calendar .member-calendar-agenda-event {
+    border-color: color-mix(in srgb, var(--member-calendar-border) 70%, transparent);
+    background: color-mix(in srgb, var(--member-calendar-surface) 88%, transparent);
+  }
+
+  .member-calendar .rbc-agenda-view table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  .member-calendar .rbc-agenda-view table thead > tr > th {
+    @apply text-xs font-semibold uppercase tracking-wide;
+    padding: 0.75rem 1rem;
+    background: color-mix(in srgb, var(--member-calendar-surface) 70%, transparent);
+    color: color-mix(in srgb, var(--member-calendar-muted) 85%, var(--color-foreground));
+  }
+
+  .member-calendar .rbc-agenda-view table tbody > tr > td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--member-calendar-border) 70%, transparent);
+    background: transparent;
+  }
+
+  .member-calendar .rbc-agenda-view table tbody > tr:last-of-type > td {
+    border-bottom: none;
+  }
+
+  .member-calendar .rbc-agenda-view table tbody > tr:hover > td {
+    background: color-mix(in srgb, var(--member-calendar-accent) 6%, var(--color-background) 94%);
   }
 
   .member-calendar .rbc-agenda-empty {


### PR DESCRIPTION
## Summary
- use a dedicated CSS variable in the calendar client to theme react-big-calendar events and badge helpers
- refresh the member calendar styles to match the site’s design tokens, including view chrome, scrollbars, and agenda layout

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e40afb8c90832dbba9bd9fe081a45e