### PR TITLE
Improve permissions workbench clarity

### DIFF
--- a/src/components/members/permissions/permission-explorer.tsx
+++ b/src/components/members/permissions/permission-explorer.tsx
@@ -50,12 +50,28 @@ export function PermissionExplorer({
   setDepartmentGrants,
 }: PermissionExplorerProps) {
   const [searchTerm, setSearchTerm] = useState("");
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [pendingCells, setPendingCells] = useState<Set<string>>(new Set());
+
+  const categoryOptions = useMemo(() => {
+    const entries = new Map<string, string>();
+    for (const permission of permissions) {
+      if (!entries.has(permission.categoryKey)) {
+        entries.set(permission.categoryKey, permission.categoryLabel);
+      }
+    }
+    return Array.from(entries.entries())
+      .map(([key, label]) => ({ key, label }))
+      .sort((a, b) => a.label.localeCompare(b.label, "de"));
+  }, [permissions]);
 
   const filteredPermissions = useMemo(() => {
     const term = searchTerm.trim().toLowerCase();
-    if (!term) return permissions;
     return permissions.filter((permission) => {
+      if (selectedCategories.length > 0 && !selectedCategories.includes(permission.categoryKey)) {
+        return false;
+      }
+      if (!term) return true;
       const haystacks = [
         permission.key,
         permission.label,
@@ -64,7 +80,7 @@ export function PermissionExplorer({
       ].map((value) => value.toLowerCase());
       return haystacks.some((value) => value.includes(term));
     });
-  }, [permissions, searchTerm]);
+  }, [permissions, searchTerm, selectedCategories]);
 
   const groupedPermissions = useMemo<GroupedPermission[]>(() => {
     const groups = new Map<string, GroupedPermission>();
@@ -80,6 +96,62 @@ export function PermissionExplorer({
     }
     return Array.from(groups.values());
   }, [filteredPermissions]);
+
+  const roleAssignmentStats = useMemo(() => {
+    const totals = Object.values(roleGrants).reduce(
+      (accumulator, grants) => {
+        const size = grants.size;
+        return {
+          assignments: accumulator.assignments + size,
+          populatedTargets: accumulator.populatedTargets + (size > 0 ? 1 : 0),
+        };
+      },
+      { assignments: 0, populatedTargets: 0 },
+    );
+    const potential = permissions.length * roles.length;
+    const coverage = potential > 0 ? totals.assignments / potential : 0;
+    const average = roles.length > 0 ? totals.assignments / roles.length : 0;
+    return { ...totals, coverage, average };
+  }, [permissions.length, roleGrants, roles.length]);
+
+  const departmentAssignmentStats = useMemo(() => {
+    const totals = Object.values(departmentGrants).reduce(
+      (accumulator, grants) => {
+        const size = grants.size;
+        return {
+          assignments: accumulator.assignments + size,
+          populatedTargets: accumulator.populatedTargets + (size > 0 ? 1 : 0),
+        };
+      },
+      { assignments: 0, populatedTargets: 0 },
+    );
+    const potential = permissions.length * departments.length;
+    const coverage = potential > 0 ? totals.assignments / potential : 0;
+    const average = departments.length > 0 ? totals.assignments / departments.length : 0;
+    return { ...totals, coverage, average };
+  }, [departmentGrants, departments.length, permissions.length]);
+
+  const hasActiveFilter = selectedCategories.length > 0 || searchTerm.trim().length > 0;
+
+  const toggleCategory = (categoryKey: string) => {
+    setSelectedCategories((current) =>
+      current.includes(categoryKey)
+        ? current.filter((value) => value !== categoryKey)
+        : [...current, categoryKey],
+    );
+  };
+
+  const clearFilters = () => {
+    setSearchTerm("");
+    setSelectedCategories([]);
+  };
+
+  const formatPercent = (value: number) =>
+    new Intl.NumberFormat("de-DE", {
+      style: "percent",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(value);
 
   const updatePendingCells = (cellKey: string, pending: boolean) => {
     setPendingCells((current) => {
@@ -328,23 +400,6 @@ export function PermissionExplorer({
         </p>
       </header>
 
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div className="space-y-1">
-          <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Filter</span>
-          <p className="text-sm text-muted-foreground">
-            Suche nach Rechtstitel, Schlüssel oder Beschreibung, um die Matrix einzugrenzen.
-          </p>
-        </div>
-        <div className="md:w-80">
-          <Input
-            placeholder="Rechte durchsuchen…"
-            value={searchTerm}
-            onChange={(event) => setSearchTerm(event.target.value)}
-            aria-label="Rechte durchsuchen"
-          />
-        </div>
-      </div>
-
       <section className="space-y-3">
         <div className="space-y-1">
           <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">Systemrollen</h3>
@@ -368,6 +423,97 @@ export function PermissionExplorer({
             })
           )}
         </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-muted-foreground">Überblick</h3>
+          <p className="text-sm text-muted-foreground">
+            Nutze die Kennzahlen, um schnell zu sehen, wie stark Rollen und Gewerke bereits mit Rechten belegt sind.
+          </p>
+        </div>
+        <dl className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Rechte sichtbar</dt>
+            <dd className="text-xl font-semibold">
+              {filteredPermissions.length.toLocaleString("de-DE")}
+            </dd>
+            <dd className="text-xs text-muted-foreground">
+              von insgesamt {permissions.length.toLocaleString("de-DE")} Definitionen
+            </dd>
+          </div>
+          <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Rollenzuweisungen</dt>
+            <dd className="text-xl font-semibold">
+              {roleAssignmentStats.assignments.toLocaleString("de-DE")}
+            </dd>
+            <dd className="text-xs text-muted-foreground">
+              {roleAssignmentStats.populatedTargets.toLocaleString("de-DE")} von {roles.length.toLocaleString("de-DE")} Rollen aktiv · {formatPercent(roleAssignmentStats.coverage)} Abdeckung
+            </dd>
+          </div>
+          <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Gewerkezuteilungen</dt>
+            <dd className="text-xl font-semibold">
+              {departmentAssignmentStats.assignments.toLocaleString("de-DE")}
+            </dd>
+            <dd className="text-xs text-muted-foreground">
+              {departmentAssignmentStats.populatedTargets.toLocaleString("de-DE")} von {departments.length.toLocaleString("de-DE")} Gewerken aktiv · {formatPercent(departmentAssignmentStats.coverage)} Abdeckung
+            </dd>
+          </div>
+          <div className="rounded-lg border border-border/60 bg-muted/10 p-4">
+            <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Durchschnitt pro Ziel</dt>
+            <dd className="text-xl font-semibold">
+              {roleAssignmentStats.average.toLocaleString("de-DE", { maximumFractionDigits: 1 })}
+            </dd>
+            <dd className="text-xs text-muted-foreground">
+              Rechte pro Rolle · {departmentAssignmentStats.average.toLocaleString("de-DE", { maximumFractionDigits: 1 })} pro Gewerk
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-foreground">Filter</span>
+            <p className="text-sm text-muted-foreground">
+              Suche nach Rechtstitel, Schlüssel oder Beschreibung oder schränke die Anzeige nach Kategorien ein.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 md:w-auto md:flex-row md:items-center">
+            <Input
+              placeholder="Rechte durchsuchen…"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              aria-label="Rechte durchsuchen"
+              className="md:w-72"
+            />
+            {hasActiveFilter ? (
+              <Button type="button" variant="ghost" size="sm" onClick={clearFilters}>
+                Filter zurücksetzen
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        {categoryOptions.length > 1 ? (
+          <div className="flex flex-wrap gap-2">
+            {categoryOptions.map((category) => {
+              const active = selectedCategories.includes(category.key);
+              return (
+                <Button
+                  key={category.key}
+                  type="button"
+                  variant={active ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => toggleCategory(category.key)}
+                  aria-pressed={active}
+                >
+                  {category.label}
+                </Button>
+              );
+            })}
+          </div>
+        ) : null}
       </section>
 
       {renderMatrix(


### PR DESCRIPTION
## Summary
- add category-based filtering controls and reset action to the permissions explorer
- surface overview metrics for role and department assignments to clarify current coverage

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e40d268a0c832d9dfe5770bebf0884