### PR TITLE
Expand onboarding heatmap width on desktop

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/global-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/global-tab.tsx
@@ -110,6 +110,7 @@ export function GlobalOverviewTab({ data, participants }: GlobalOverviewTabProps
           coverage={data.roleCoverage.crew}
         />
         <RoleHeatmap
+          className="lg:col-span-2"
           data={data.roleHeatmap}
           subtitle="Intensität der Doppel-Präferenzen acting × crew"
           title="Heatmap"

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/role-heatmap.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/role-heatmap.tsx
@@ -10,6 +10,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import type { z } from "zod";
 
 import { heatmapCellSchema } from "@/lib/onboarding/dashboard-schemas";
+import { cn } from "@/lib/utils";
 
 type HeatmapCell = z.infer<typeof heatmapCellSchema>;
 
@@ -17,9 +18,10 @@ type RoleHeatmapProps = {
   title?: string;
   data: HeatmapCell[];
   subtitle?: string;
+  className?: string;
 };
 
-export function RoleHeatmap({ title = "Kombinationen", data, subtitle }: RoleHeatmapProps) {
+export function RoleHeatmap({ title = "Kombinationen", data, subtitle, className }: RoleHeatmapProps) {
   const axes = useMemo(() => {
     const acting = Array.from(new Set(data.map((cell) => cell.x))).sort();
     const crew = Array.from(new Set(data.map((cell) => cell.y))).sort();
@@ -44,7 +46,7 @@ export function RoleHeatmap({ title = "Kombinationen", data, subtitle }: RoleHea
   }, [maxValue]);
 
   return (
-    <Card className="h-full">
+    <Card className={cn("h-full", className)}>
       <CardHeader className="space-y-1">
         <CardTitle className="text-base font-semibold tracking-tight sm:text-lg">{title}</CardTitle>
         {subtitle ? <p className="text-sm text-muted-foreground">{subtitle}</p> : null}


### PR DESCRIPTION
## Summary
- allow the onboarding role heatmap card to accept custom layout classes
- span the heatmap across two columns on large screens to guarantee more horizontal space

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build > build.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68e4ce70143c832daf766f0f050bcf01