### PR TITLE
Improve SMTP autodetect with DNS lookups

### DIFF
--- a/src/app/(members)/mitglieder/server-einstellungen/actions.ts
+++ b/src/app/(members)/mitglieder/server-einstellungen/actions.ts
@@ -16,6 +16,10 @@ import {
   type ClientServerSettings,
   type ServerSettingsInput,
 } from "@/lib/server-settings";
+import {
+  autoDetectMailServerSettings,
+  type MailServerSuggestion,
+} from "@/lib/server-settings-autodetect";
 
 const EMAIL_SCHEMA = z.string().email();
 
@@ -277,4 +281,62 @@ export async function testMailServerConnectionAction(
       message: message ?? "Verbindung zum SMTP-Server konnte nicht aufgebaut werden.",
     };
   }
+}
+
+export type AutoDetectMailServerResult =
+  | { success: true; suggestion: MailServerSuggestion }
+  | {
+      success: false;
+      error: "not_authorized" | "validation_failed" | "not_found";
+      fieldErrors?: FieldErrors;
+      message?: string;
+    };
+
+export async function autoDetectMailServerSettingsAction(
+  input: Partial<Record<keyof ServerSettingsInput, unknown>>,
+): Promise<AutoDetectMailServerResult> {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "mitglieder.server.settings");
+  if (!allowed) {
+    return { success: false, error: "not_authorized" };
+  }
+
+  const parsed = validateServerSettingsPayload(input);
+  if (!parsed.success) {
+    return { success: false, error: "validation_failed", fieldErrors: parsed.fieldErrors };
+  }
+
+  const data = parsed.data;
+
+  const mailHost = data.mailHost ?? null;
+  const mailFromAddress = data.mailFromAddress ?? null;
+  const mailUsername = data.mailUsername ?? null;
+
+  if (!mailHost && !mailFromAddress) {
+    return {
+      success: false,
+      error: "validation_failed",
+      fieldErrors: {
+        mailHost: ["Bitte gib einen SMTP-Server oder eine Absenderadresse an."],
+        mailFromAddress: ["Bitte gib eine Absenderadresse an oder trage den SMTP-Server ein."],
+      },
+      message: "Es fehlen Angaben zur automatischen Erkennung.",
+    };
+  }
+
+  const suggestion = await autoDetectMailServerSettings({
+    email: mailFromAddress,
+    host: mailHost,
+    username: mailUsername,
+  });
+
+  if (!suggestion) {
+    return {
+      success: false,
+      error: "not_found",
+      message: "Es konnten keine passenden SMTP-Einstellungen ermittelt werden.",
+    };
+  }
+
+  return { success: true, suggestion };
 }

--- a/src/app/(members)/mitglieder/server-einstellungen/server-settings-content.tsx
+++ b/src/app/(members)/mitglieder/server-einstellungen/server-settings-content.tsx
@@ -13,8 +13,10 @@ import type { ClientServerSettings } from "@/lib/server-settings";
 import {
   saveServerSettingsAction,
   testMailServerConnectionAction,
+  autoDetectMailServerSettingsAction,
   type SaveServerSettingsResult,
   type TestMailServerResult,
+  type AutoDetectMailServerResult,
 } from "./actions";
 
 type ServerSettingsFormValues = {
@@ -69,10 +71,12 @@ export function ServerSettingsContent({ initialSettings }: ServerSettingsContent
   const [testFeedback, setTestFeedback] = useState<TestFeedback>(null);
   const [lastUpdated, setLastUpdated] = useState<string | null>(initialSettings.updatedAt);
   const [passwordPersisted, setPasswordPersisted] = useState<boolean>(initialSettings.mailPasswordSet);
+  const [autoDetectInfo, setAutoDetectInfo] = useState<string | null>(null);
   const passwordHintId = useId();
 
   const [isSaving, startSaving] = useTransition();
   const [isTesting, startTesting] = useTransition();
+  const [isAutodetecting, startAutodetect] = useTransition();
 
   const lastUpdatedLabel = useMemo(() => {
     if (!lastUpdated) {
@@ -100,12 +104,21 @@ export function ServerSettingsContent({ initialSettings }: ServerSettingsContent
       const value = event.target.value;
       setFormState((previous) => ({ ...previous, [field]: value }));
       clearFieldError(field);
+      if (
+        field === "mailHost" ||
+        field === "mailPort" ||
+        field === "mailUsername" ||
+        field === "mailFromAddress"
+      ) {
+        setAutoDetectInfo(null);
+      }
     };
 
   const handleSecureChange = (event: ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked;
     setFormState((previous) => ({ ...previous, mailSecure: checked }));
     clearFieldError("mailSecure");
+    setAutoDetectInfo(null);
   };
 
   const handlePasswordChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -160,6 +173,7 @@ export function ServerSettingsContent({ initialSettings }: ServerSettingsContent
       setPasswordState({ mode: "preserve", value: "" });
       setFieldErrors({});
       setTestFeedback(null);
+      setAutoDetectInfo(null);
       setLastUpdated(result.settings.updatedAt);
       setPasswordPersisted(result.settings.mailPasswordSet);
       toast.success("Servereinstellungen gespeichert.");
@@ -239,6 +253,63 @@ export function ServerSettingsContent({ initialSettings }: ServerSettingsContent
     });
   };
 
+  const applyAutoDetectResult = (result: AutoDetectMailServerResult) => {
+    if (result.success) {
+      setFormState((previous) => ({
+        ...previous,
+        mailHost: result.suggestion.mailHost,
+        mailPort: String(result.suggestion.mailPort ?? ""),
+        mailSecure: result.suggestion.mailSecure,
+        mailUsername: result.suggestion.mailUsername ?? previous.mailUsername,
+      }));
+      setFieldErrors((previous) => {
+        const next = { ...previous };
+        delete next.mailHost;
+        delete next.mailPort;
+        delete next.mailSecure;
+        delete next.mailUsername;
+        return next;
+      });
+      const providerSuffix = result.suggestion.provider ? ` (${result.suggestion.provider})` : "";
+      const confidenceLabel = (() => {
+        switch (result.suggestion.confidence) {
+          case "high":
+            return `Vorkonfiguration${providerSuffix} erkannt.`;
+          case "medium":
+            return `Vorschlag anhand der vorhandenen Angaben${providerSuffix}.`;
+          default:
+            return `Generischer Vorschlag basierend auf der Domain${providerSuffix}.`;
+        }
+      })();
+      setAutoDetectInfo(confidenceLabel);
+      toast.success("SMTP-Einstellungen wurden vorausgefüllt.");
+      return;
+    }
+
+    if (result.error === "not_authorized") {
+      toast.error("Du darfst diese Einstellungen nicht ändern.");
+      return;
+    }
+
+    if (isValidationError(result) && result.fieldErrors) {
+      setFieldErrors(result.fieldErrors);
+      toast.error("Bitte prüfe die markierten Felder.");
+      return;
+    }
+
+    const message = result.message ?? "Die SMTP-Einstellungen konnten nicht automatisch erkannt werden.";
+    toast.error(message);
+  };
+
+  const handleAutoDetect = () => {
+    setAutoDetectInfo(null);
+    startAutodetect(async () => {
+      const payload = buildPayload();
+      const result = await autoDetectMailServerSettingsAction(payload);
+      applyAutoDetectResult(result);
+    });
+  };
+
   const renderFieldErrors = (field: keyof FieldErrors) => {
     const messages = fieldErrors[field];
     if (!messages?.length) {
@@ -287,6 +358,21 @@ export function ServerSettingsContent({ initialSettings }: ServerSettingsContent
                 onChange={handleTextChange("mailHost")}
                 placeholder="smtp.example.org"
               />
+              <div className="flex flex-wrap items-center gap-2 pt-1">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAutoDetect}
+                  disabled={isAutodetecting || isSaving || isTesting}
+                  data-state={isAutodetecting ? "loading" : undefined}
+                >
+                  Automatisch erkennen
+                </Button>
+                {autoDetectInfo ? (
+                  <span className="text-xs text-muted-foreground">{autoDetectInfo}</span>
+                ) : null}
+              </div>
               {renderFieldErrors("mailHost")}
             </div>
             <div className="space-y-2">

--- a/src/lib/__tests__/server-settings-autodetect.test.ts
+++ b/src/lib/__tests__/server-settings-autodetect.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveMx, resolveSrv } from "node:dns/promises";
+
+import { autoDetectMailServerSettings } from "@/lib/server-settings-autodetect";
+
+vi.mock("node:dns/promises", () => ({
+  resolveSrv: vi.fn(),
+  resolveMx: vi.fn(),
+}));
+
+const mockedResolveSrv = vi.mocked(resolveSrv);
+const mockedResolveMx = vi.mocked(resolveMx);
+
+function dnsNotFoundError() {
+  const error = new Error("not found");
+  (error as NodeJS.ErrnoException).code = "ENOTFOUND";
+  return error;
+}
+
+describe("autoDetectMailServerSettings", () => {
+  beforeEach(() => {
+    mockedResolveSrv.mockImplementation(async () => {
+      throw dnsNotFoundError();
+    });
+    mockedResolveMx.mockImplementation(async () => {
+      throw dnsNotFoundError();
+    });
+  });
+
+  it("returns a known provider configuration for Gmail", async () => {
+    const result = await autoDetectMailServerSettings({ email: "user@gmail.com" });
+
+    expect(result).not.toBeNull();
+    expect(result?.mailHost).toBe("smtp.gmail.com");
+    expect(result?.mailPort).toBe(465);
+    expect(result?.mailSecure).toBe(true);
+    expect(result?.mailUsername).toBe("user@gmail.com");
+    expect(result?.confidence).toBe("high");
+  });
+
+  it("prefers the provided host and marks the confidence as medium", async () => {
+    const result = await autoDetectMailServerSettings({
+      host: "mail.custom-domain.test",
+      email: "admin@custom-domain.test",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.mailHost).toBe("mail.custom-domain.test");
+    expect(result?.mailPort).toBe(587);
+    expect(result?.mailSecure).toBe(false);
+    expect(result?.confidence).toBe("medium");
+  });
+
+  it("falls back to a generic smtp-domain suggestion when no provider matches", async () => {
+    const result = await autoDetectMailServerSettings({ email: "team@example.org" });
+
+    expect(result).not.toBeNull();
+    expect(result?.mailHost).toBe("smtp.example.org");
+    expect(result?.mailPort).toBe(587);
+    expect(result?.mailSecure).toBe(false);
+    expect(result?.confidence).toBe("low");
+  });
+
+  it("uses SRV records when available", async () => {
+    mockedResolveSrv.mockImplementation(async (record: string) => {
+      if (record === "_submission._tcp.example.org") {
+        return [
+          { name: "smtp.example.org.", port: 587, priority: 0, weight: 10 },
+          { name: "smtp-backup.example.org.", port: 587, priority: 10, weight: 1 },
+        ];
+      }
+      throw dnsNotFoundError();
+    });
+
+    const result = await autoDetectMailServerSettings({ email: "info@example.org" });
+
+    expect(result).not.toBeNull();
+    expect(result?.mailHost).toBe("smtp.example.org");
+    expect(result?.mailPort).toBe(587);
+    expect(result?.mailSecure).toBe(false);
+    expect(result?.confidence).toBe("high");
+  });
+
+  it("falls back to MX records when no SRV record is present", async () => {
+    mockedResolveMx.mockResolvedValue([
+      { exchange: "mx-primary.example.org.", priority: 0 },
+      { exchange: "mx-backup.example.org.", priority: 10 },
+    ]);
+
+    const result = await autoDetectMailServerSettings({ email: "sender@example.org" });
+
+    expect(mockedResolveSrv).toHaveBeenCalled();
+    expect(result).not.toBeNull();
+    expect(result?.mailHost).toBe("mx-primary.example.org");
+    expect(result?.mailPort).toBe(587);
+    expect(result?.mailSecure).toBe(false);
+    expect(result?.confidence).toBe("medium");
+  });
+});
+

--- a/src/lib/server-settings-autodetect.ts
+++ b/src/lib/server-settings-autodetect.ts
@@ -1,0 +1,379 @@
+import { resolveMx, resolveSrv } from "node:dns/promises";
+import { z } from "zod";
+
+const EMAIL_SCHEMA = z.string().email();
+
+type UsernameStrategy = "email" | "preserve";
+
+type KnownProvider = {
+  name: string;
+  domains: string[];
+  host: string;
+  port: number;
+  secure: boolean;
+  usernameStrategy?: UsernameStrategy;
+};
+
+const KNOWN_PROVIDERS: KnownProvider[] = [
+  {
+    name: "Google Mail",
+    domains: ["gmail.com", "googlemail.com"],
+    host: "smtp.gmail.com",
+    port: 465,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "Microsoft 365 / Outlook",
+    domains: ["outlook.com", "hotmail.com", "live.com", "office365.com", "office.com"],
+    host: "smtp.office365.com",
+    port: 587,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "GMX",
+    domains: ["gmx.de", "gmx.net"],
+    host: "mail.gmx.net",
+    port: 587,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "WEB.DE",
+    domains: ["web.de"],
+    host: "smtp.web.de",
+    port: 587,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "Yahoo Mail",
+    domains: ["yahoo.com", "yahoo.de", "ymail.com"],
+    host: "smtp.mail.yahoo.com",
+    port: 465,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "iCloud Mail",
+    domains: ["icloud.com", "me.com", "mac.com"],
+    host: "smtp.mail.me.com",
+    port: 587,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "Posteo",
+    domains: ["posteo.de"],
+    host: "posteo.de",
+    port: 465,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "IONOS",
+    domains: ["ionos.de", "ionos.com", "1und1.de", "1und1.com"],
+    host: "smtp.ionos.de",
+    port: 587,
+    secure: true,
+    usernameStrategy: "email",
+  },
+  {
+    name: "Strato",
+    domains: ["strato.de", "strato.com"],
+    host: "smtp.strato.de",
+    port: 465,
+    secure: true,
+    usernameStrategy: "email",
+  },
+];
+
+const DEFAULT_PORT = 587;
+const DNS_LOOKUP_ERROR_CODES = new Set([
+  "ENODATA",
+  "ENOTFOUND",
+  "ENOENT",
+  "NOTIMP",
+  "REFUSED",
+  "SERVFAIL",
+  "TIMEOUT",
+]);
+
+type SrvService = "_submission" | "_smtps" | "_smtp";
+
+export type MailServerSuggestion = {
+  mailHost: string;
+  mailPort: number;
+  mailSecure: boolean;
+  mailUsername: string | null;
+  confidence: "high" | "medium" | "low";
+  provider: string | null;
+};
+
+type AutoDetectInput = {
+  email?: string | null;
+  host?: string | null;
+  username?: string | null;
+};
+
+function normaliseEmail(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = EMAIL_SCHEMA.safeParse(trimmed.toLowerCase());
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data;
+}
+
+function extractDomainFromEmail(email: string | null | undefined): string | null {
+  const parsed = normaliseEmail(email);
+  if (!parsed) {
+    return null;
+  }
+  const [, domain = null] = parsed.split("@");
+  return domain;
+}
+
+function normaliseHost(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+  const withoutProtocol = trimmed.replace(/^https?:\/\//, "");
+  const [host] = withoutProtocol.split("/");
+  if (!host) {
+    return null;
+  }
+  return host.split(":")[0] ?? null;
+}
+
+function collectDomainCandidates(email: string | null, host: string | null): string[] {
+  const candidates = new Set<string>();
+  if (email) {
+    const domain = extractDomainFromEmail(email);
+    if (domain) {
+      candidates.add(domain);
+    }
+  }
+
+  if (host) {
+    const normalisedHost = normaliseHost(host);
+    if (normalisedHost) {
+      const parts = normalisedHost.split(".");
+      for (let index = 0; index < parts.length - 1; index += 1) {
+        const candidate = parts.slice(index).join(".");
+        if (candidate) {
+          candidates.add(candidate);
+        }
+      }
+    }
+  }
+
+  return Array.from(candidates);
+}
+
+function resolveKnownProvider(domainCandidates: string[]): KnownProvider | null {
+  for (const provider of KNOWN_PROVIDERS) {
+    for (const candidate of domainCandidates) {
+      if (provider.domains.includes(candidate)) {
+        return provider;
+      }
+    }
+  }
+  return null;
+}
+
+function determineUsername(
+  strategy: UsernameStrategy | undefined,
+  fallbackEmail: string | null,
+  providedUsername: string | null | undefined,
+): string | null {
+  if (strategy === "email") {
+    return fallbackEmail ?? providedUsername ?? null;
+  }
+  if (providedUsername && providedUsername.trim()) {
+    return providedUsername.trim();
+  }
+  return fallbackEmail ?? null;
+}
+
+async function safeResolveSrv(record: string) {
+  try {
+    return await resolveSrv(record);
+  } catch (error) {
+    const code =
+      typeof error === "object" && error && "code" in error ? (error as { code?: string }).code : undefined;
+    if (code && DNS_LOOKUP_ERROR_CODES.has(code)) {
+      return [];
+    }
+    return [];
+  }
+}
+
+async function safeResolveMx(domain: string) {
+  try {
+    return await resolveMx(domain);
+  } catch (error) {
+    const code =
+      typeof error === "object" && error && "code" in error ? (error as { code?: string }).code : undefined;
+    if (code && DNS_LOOKUP_ERROR_CODES.has(code)) {
+      return [];
+    }
+    return [];
+  }
+}
+
+function normaliseDnsTarget(target: string): string {
+  return target.replace(/\.$/, "");
+}
+
+function sortByPriority<T extends { priority: number; weight?: number }>(records: T[]): T[] {
+  return [...records].sort((a, b) => {
+    if (a.priority !== b.priority) {
+      return a.priority - b.priority;
+    }
+    const weightA = a.weight ?? 0;
+    const weightB = b.weight ?? 0;
+    return weightB - weightA;
+  });
+}
+
+function determineSecureFromService(service: SrvService): boolean {
+  if (service === "_smtps") {
+    return true;
+  }
+  return false;
+}
+
+async function resolveSrvSuggestion(
+  domainCandidates: string[],
+  email: string | null,
+  username: string | null | undefined,
+): Promise<MailServerSuggestion | null> {
+  const services: SrvService[] = ["_submission", "_smtps", "_smtp"];
+
+  for (const domain of domainCandidates) {
+    for (const service of services) {
+      const records = await safeResolveSrv(`${service}._tcp.${domain}`);
+      if (!records || records.length === 0) {
+        continue;
+      }
+
+      const [best] = sortByPriority(records);
+      if (!best) {
+        continue;
+      }
+
+      const host = normaliseDnsTarget(best.name);
+      if (!host) {
+        continue;
+      }
+
+      const secure = determineSecureFromService(service);
+      return {
+        mailHost: host,
+        mailPort: best.port ?? DEFAULT_PORT,
+        mailSecure: secure,
+        mailUsername: determineUsername(undefined, email, username ?? null),
+        confidence: "high",
+        provider: null,
+      };
+    }
+  }
+
+  return null;
+}
+
+async function resolveMxSuggestion(
+  domainCandidates: string[],
+  email: string | null,
+  username: string | null | undefined,
+): Promise<MailServerSuggestion | null> {
+  for (const domain of domainCandidates) {
+    const records = await safeResolveMx(domain);
+    if (!records || records.length === 0) {
+      continue;
+    }
+
+    const [best] = sortByPriority(records);
+    if (!best || !best.exchange) {
+      continue;
+    }
+
+    const host = normaliseDnsTarget(best.exchange);
+    if (!host) {
+      continue;
+    }
+
+    return {
+      mailHost: host,
+      mailPort: DEFAULT_PORT,
+      mailSecure: false,
+      mailUsername: determineUsername(undefined, email, username ?? null),
+      confidence: "medium",
+      provider: null,
+    };
+  }
+
+  return null;
+}
+
+export async function autoDetectMailServerSettings(
+  input: AutoDetectInput,
+): Promise<MailServerSuggestion | null> {
+  const email = normaliseEmail(input.email ?? null);
+  const host = normaliseHost(input.host ?? null);
+  const domainCandidates = collectDomainCandidates(email, host);
+  const provider = resolveKnownProvider(domainCandidates);
+
+  if (provider) {
+    return {
+      mailHost: provider.host,
+      mailPort: provider.port,
+      mailSecure: provider.secure,
+      mailUsername: determineUsername(provider.usernameStrategy, email, input.username ?? null),
+      confidence: "high",
+      provider: provider.name,
+    };
+  }
+
+  const dnsSrvSuggestion = await resolveSrvSuggestion(domainCandidates, email, input.username ?? null);
+  if (dnsSrvSuggestion) {
+    return dnsSrvSuggestion;
+  }
+
+  const dnsMxSuggestion = await resolveMxSuggestion(domainCandidates, email, input.username ?? null);
+  if (dnsMxSuggestion) {
+    return dnsMxSuggestion;
+  }
+
+  const emailDomain = extractDomainFromEmail(email);
+  const suggestionHost = host ?? (emailDomain ? `smtp.${emailDomain}` : null);
+
+  if (!suggestionHost) {
+    return null;
+  }
+
+  const confidence: MailServerSuggestion["confidence"] = host ? "medium" : emailDomain ? "low" : "low";
+  const username = determineUsername(undefined, email, input.username ?? null);
+
+  return {
+    mailHost: suggestionHost,
+    mailPort: DEFAULT_PORT,
+    mailSecure: false,
+    mailUsername: username,
+    confidence,
+    provider: null,
+  };
+}
+


### PR DESCRIPTION
## Summary
- extend the SMTP auto-detection helper to consult DNS SRV and MX records when no provider preset matches
- update the server settings action to await the asynchronous detection result
- add unit coverage for DNS-based suggestions alongside the existing heuristics

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e4d02281a0832d97d8aae756338749