### PR TITLE
Add DNS lookup to mail server autodetect

### DIFF
--- a/src/app/(members)/mitglieder/server-einstellungen/actions.ts
+++ b/src/app/(members)/mitglieder/server-einstellungen/actions.ts
@@ -324,7 +324,7 @@ export async function autoDetectMailServerSettingsAction(
     };
   }
 
-  const suggestion = autoDetectMailServerSettings({
+  const suggestion = await autoDetectMailServerSettings({
     email: mailFromAddress,
     host: mailHost,
     username: mailUsername,

--- a/src/lib/__tests__/server-settings-autodetect.test.ts
+++ b/src/lib/__tests__/server-settings-autodetect.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { resolveMx } from "node:dns/promises";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { autoDetectMailServerSettings } from "@/lib/server-settings-autodetect";
 
+vi.mock("node:dns/promises", () => ({
+  resolveMx: vi.fn(),
+}));
+
+const resolveMxMock = vi.mocked(resolveMx);
+
+beforeEach(() => {
+  resolveMxMock.mockReset();
+});
+
 describe("autoDetectMailServerSettings", () => {
-  it("returns a known provider configuration for Gmail", () => {
-    const result = autoDetectMailServerSettings({ email: "user@gmail.com" });
+  it("returns a known provider configuration for Gmail", async () => {
+    const result = await autoDetectMailServerSettings({ email: "user@gmail.com" });
 
     expect(result).not.toBeNull();
     expect(result?.mailHost).toBe("smtp.gmail.com");
@@ -12,10 +23,11 @@ describe("autoDetectMailServerSettings", () => {
     expect(result?.mailSecure).toBe(true);
     expect(result?.mailUsername).toBe("user@gmail.com");
     expect(result?.confidence).toBe("high");
+    expect(resolveMxMock).not.toHaveBeenCalled();
   });
 
-  it("prefers the provided host and marks the confidence as medium", () => {
-    const result = autoDetectMailServerSettings({
+  it("prefers the provided host and marks the confidence as medium", async () => {
+    const result = await autoDetectMailServerSettings({
       host: "mail.custom-domain.test",
       email: "admin@custom-domain.test",
     });
@@ -25,10 +37,29 @@ describe("autoDetectMailServerSettings", () => {
     expect(result?.mailPort).toBe(587);
     expect(result?.mailSecure).toBe(false);
     expect(result?.confidence).toBe("medium");
+    expect(resolveMxMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to a generic smtp-domain suggestion when no provider matches", () => {
-    const result = autoDetectMailServerSettings({ email: "team@example.org" });
+  it("resolves the MX records when available", async () => {
+    resolveMxMock.mockResolvedValueOnce([
+      { exchange: "mx1.example.org", priority: 20 },
+      { exchange: "mx0.example.org", priority: 10 },
+    ]);
+
+    const result = await autoDetectMailServerSettings({ email: "team@example.org" });
+
+    expect(resolveMxMock).toHaveBeenCalledWith("example.org");
+    expect(result).not.toBeNull();
+    expect(result?.mailHost).toBe("mx0.example.org");
+    expect(result?.mailPort).toBe(587);
+    expect(result?.mailSecure).toBe(false);
+    expect(result?.confidence).toBe("medium");
+  });
+
+  it("falls back to a generic smtp-domain suggestion when no provider matches", async () => {
+    resolveMxMock.mockResolvedValue([]);
+
+    const result = await autoDetectMailServerSettings({ email: "team@example.org" });
 
     expect(result).not.toBeNull();
     expect(result?.mailHost).toBe("smtp.example.org");

--- a/src/lib/server-settings-autodetect.ts
+++ b/src/lib/server-settings-autodetect.ts
@@ -1,3 +1,5 @@
+import { resolveMx } from "node:dns/promises";
+
 import { z } from "zod";
 
 const EMAIL_SCHEMA = z.string().email();
@@ -89,6 +91,43 @@ const KNOWN_PROVIDERS: KnownProvider[] = [
 ];
 
 const DEFAULT_PORT = 587;
+
+function sortMxRecords(records: Awaited<ReturnType<typeof resolveMx>>): string | null {
+  if (!records?.length) {
+    return null;
+  }
+
+  const sorted = [...records].sort((a, b) => a.priority - b.priority);
+  for (const record of sorted) {
+    const host = record.exchange?.trim();
+    if (host) {
+      return host.toLowerCase();
+    }
+  }
+
+  return null;
+}
+
+async function resolveMailHostFromDns(domainCandidates: string[]): Promise<string | null> {
+  for (const candidate of domainCandidates) {
+    try {
+      const records = await resolveMx(candidate);
+      const host = sortMxRecords(records);
+      if (host) {
+        return host;
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  return null;
+}
 
 export type MailServerSuggestion = {
   mailHost: string;
@@ -195,7 +234,7 @@ function determineUsername(
   return fallbackEmail ?? null;
 }
 
-export function autoDetectMailServerSettings(input: AutoDetectInput): MailServerSuggestion | null {
+export async function autoDetectMailServerSettings(input: AutoDetectInput): Promise<MailServerSuggestion | null> {
   const email = normaliseEmail(input.email ?? null);
   const host = normaliseHost(input.host ?? null);
   const domainCandidates = collectDomainCandidates(email, host);
@@ -212,14 +251,38 @@ export function autoDetectMailServerSettings(input: AutoDetectInput): MailServer
     };
   }
 
+  if (host) {
+    return {
+      mailHost: host,
+      mailPort: DEFAULT_PORT,
+      mailSecure: false,
+      mailUsername: determineUsername(undefined, email, input.username ?? null),
+      confidence: "medium",
+      provider: null,
+    };
+  }
+
+  const dnsHost = await resolveMailHostFromDns(domainCandidates);
+
+  if (dnsHost) {
+    return {
+      mailHost: dnsHost,
+      mailPort: DEFAULT_PORT,
+      mailSecure: false,
+      mailUsername: determineUsername(undefined, email, input.username ?? null),
+      confidence: "medium",
+      provider: null,
+    };
+  }
+
   const emailDomain = extractDomainFromEmail(email);
-  const suggestionHost = host ?? (emailDomain ? `smtp.${emailDomain}` : null);
+  const suggestionHost = emailDomain ? `smtp.${emailDomain}` : null;
 
   if (!suggestionHost) {
     return null;
   }
 
-  const confidence: MailServerSuggestion["confidence"] = host ? "medium" : emailDomain ? "low" : "low";
+  const confidence: MailServerSuggestion["confidence"] = "low";
   const username = determineUsername(undefined, email, input.username ?? null);
 
   return {


### PR DESCRIPTION
## Summary
- add DNS MX lookups to the SMTP auto-detection utility and return medium-confidence suggestions when records exist
- keep existing host-based suggestions while awaiting the async auto-detection result in the server settings action
- extend the autodetect test suite with mocked DNS resolution scenarios

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build *(fails: missing `d3-cloud` module types in unrelated dashboard onboarding code)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d95ffd60832dac64450cb62cb691