### PR TITLE
feat: add sperrliste export csv

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
-import { addMonths, format, startOfMonth } from 'date-fns';
+import { useMemo, useState } from 'react';
+import { addDays, addMonths, eachDayOfInterval, format, startOfMonth, startOfToday } from 'date-fns';
 import { de } from 'date-fns/locale/de';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
@@ -12,12 +13,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { formatWeekdayList, getWeekdayLabel, sortWeekdays, type WeekdayValue } from '@/lib/weekdays';
+import { toast } from 'sonner';
 
 import type { HolidayRange } from '@/types/holidays';
 
 import type { BlockedDay } from './block-calendar';
 import { OverviewShell } from './overview/overview-shell';
 import {
+  DATE_FORMAT,
   formatCreatedAtLabel,
   useBlockOverviewData,
   type OverviewMember,
@@ -31,18 +35,45 @@ type SelectedBlockedDay = {
   holidayEntries: HolidayRange[];
 };
 
+type ExportDay = {
+  date: Date;
+  key: string;
+  header: string;
+  title: string;
+};
+
+type ExportRow = {
+  member: PreparedMember;
+  entries: (BlockedDay | null)[];
+};
+
 export type { OverviewMember } from './overview/useBlockOverviewData';
+
+function normaliseReason(value: string | null | undefined) {
+  if (!value) {
+    return '';
+  }
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function escapeCsvValue(value: string) {
+  const needsQuotes = value.includes(';') || value.includes('"') || value.includes('\n');
+  const escaped = value.replace(/"/g, '""');
+  return needsQuotes ? `"${escaped}"` : escaped;
+}
 
 export function BlockOverview({
   members,
   holidays = [],
   preferredWeekdays = [],
   exceptionWeekdays = [],
+  canExport = false,
 }: {
   members: OverviewMember[];
   holidays?: HolidayRange[];
   preferredWeekdays?: number[];
   exceptionWeekdays?: number[];
+  canExport?: boolean;
 }) {
   const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()));
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -55,6 +86,75 @@ export function BlockOverview({
     exceptionWeekdays,
     currentMonth,
   });
+
+  const importantWeekdays = useMemo(
+    () => sortWeekdays([...preferredWeekdays, ...exceptionWeekdays]),
+    [preferredWeekdays, exceptionWeekdays],
+  );
+
+  const importantWeekdaySummary = useMemo(
+    () => (importantWeekdays.length ? formatWeekdayList(importantWeekdays) : null),
+    [importantWeekdays],
+  );
+
+  const exportWindow = useMemo(() => {
+    if (!importantWeekdays.length) {
+      return null;
+    }
+    const start = startOfToday();
+    const end = addDays(start, 13);
+    const weekdaySet = new Set(importantWeekdays);
+    const days: ExportDay[] = eachDayOfInterval({ start, end })
+      .filter((day) => weekdaySet.has(day.getDay() as WeekdayValue))
+      .map((day) => {
+        const weekday = day.getDay() as WeekdayValue;
+        return {
+          date: day,
+          key: format(day, DATE_FORMAT),
+          header: `${getWeekdayLabel(weekday, 'short')} ${format(day, 'dd.MM.', { locale: de })}`,
+          title: format(day, 'EEEE, d. MMMM yyyy', { locale: de }),
+        };
+      });
+
+    if (!days.length) {
+      return null;
+    }
+
+    return { start, end, days };
+  }, [importantWeekdays]);
+
+  const exportRows = useMemo<ExportRow[]>(() => {
+    if (!exportWindow) {
+      return [];
+    }
+
+    return data.preparedMembers
+      .map<ExportRow | null>((member) => {
+        const entries = exportWindow.days.map((day) => {
+          const entry = member.blockedMap.get(day.key);
+          if (!entry || entry.kind !== 'BLOCKED') {
+            return null;
+          }
+          return entry;
+        });
+
+        if (entries.every((entry) => entry === null)) {
+          return null;
+        }
+
+        return { member, entries };
+      })
+      .filter((row): row is ExportRow => row !== null);
+  }, [data.preparedMembers, exportWindow]);
+
+  const exportRangeLabel = useMemo(() => {
+    if (!exportWindow) {
+      return null;
+    }
+    return `${format(exportWindow.start, 'dd.MM.yyyy')} – ${format(exportWindow.end, 'dd.MM.yyyy')}`;
+  }, [exportWindow]);
+
+  const exportDisabled = !exportWindow || exportRows.length === 0;
 
   const selectedBlockedCreatedAtLabel = selectedBlockedDay
     ? formatCreatedAtLabel(selectedBlockedDay.entry.createdAt)
@@ -69,6 +169,49 @@ export function BlockOverview({
     setDetailsOpen(true);
   };
 
+  const handleExportTable = () => {
+    if (!exportWindow || exportRows.length === 0) {
+      toast.warning('Keine Sperrtermine auf wichtigen Tagen im ausgewählten Zeitraum gefunden.');
+      return;
+    }
+
+    try {
+      const header = ['Mitglied', 'E-Mail', ...exportWindow.days.map((day) => day.header)];
+      const csvRows = [
+        header,
+        ...exportRows.map(({ member, entries }) => {
+          const cells = entries.map((entry) => {
+            if (!entry) {
+              return '';
+            }
+            const reason = normaliseReason(entry.reason);
+            return reason || 'gesperrt';
+          });
+          return [member.displayName, member.email ?? '', ...cells];
+        }),
+      ];
+
+      const csvContent = csvRows.map((row) => row.map((value) => escapeCsvValue(value)).join(';')).join('\n');
+      const blob = new Blob([`\uFEFF${csvContent}`], {
+        type: 'text/csv;charset=utf-8;',
+      });
+      const url = URL.createObjectURL(blob);
+      const fileName = `sperrliste-wichtige-tage-${format(exportWindow.start, 'yyyyMMdd')}-${format(exportWindow.end, 'yyyyMMdd')}.csv`;
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      link.rel = 'noopener';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+      toast.success('Export wurde gestartet.');
+    } catch (error) {
+      console.error(error);
+      toast.error('Export konnte nicht erstellt werden.');
+    }
+  };
+
   if (!data.preparedMembers.length) {
     return (
       <div className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
@@ -79,6 +222,43 @@ export function BlockOverview({
 
   return (
     <div className="space-y-6">
+      {canExport ? (
+        <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1 text-sm text-muted-foreground">
+              {exportWindow ? (
+                <>
+                  <p>
+                    Zeitraum: {exportRangeLabel ?? '–'}. Berücksichtigte Tage:{' '}
+                    {importantWeekdaySummary ?? '–'}.
+                  </p>
+                  {exportRows.length === 0 ? (
+                    <p>Aktuell liegen keine Sperrtermine auf diesen Tagen in den nächsten zwei Wochen vor.</p>
+                  ) : (
+                    <p>
+                      Mitglieder mit Sperrterminen: {exportRows.length}{' '}
+                      {exportRows.length === 1 ? 'Person' : 'Personen'}.
+                    </p>
+                  )}
+                </>
+              ) : (
+                <p>
+                  Lege wichtige Probentage in den Sperrlisten-Einstellungen fest, um einen Export zu ermöglichen.
+                </p>
+              )}
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleExportTable}
+              disabled={exportDisabled}
+              className="sm:w-auto"
+            >
+              CSV exportieren
+            </Button>
+          </div>
+        </div>
+      ) : null}
       <OverviewShell
         monthLabel={data.monthLabel}
         membersCount={data.preparedMembers.length}

--- a/src/app/(members)/mitglieder/sperrliste/page-client.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page-client.tsx
@@ -16,6 +16,7 @@ interface SperrlistePageClientProps {
   overviewMembers: OverviewMember[];
   initialSettings: ClientSperrlisteSettings;
   canManageSettings: boolean;
+  canExport: boolean;
   defaultHolidaySourceUrl: string;
   defaultPublicHolidaySourceUrl: string;
 }
@@ -26,6 +27,7 @@ export function SperrlistePageClient({
   overviewMembers,
   initialSettings,
   canManageSettings,
+  canExport,
   defaultHolidaySourceUrl,
   defaultPublicHolidaySourceUrl,
 }: SperrlistePageClientProps) {
@@ -45,6 +47,7 @@ export function SperrlistePageClient({
         freezeDays={settings.freezeDays}
         preferredWeekdays={settings.preferredWeekdays}
         exceptionWeekdays={settings.exceptionWeekdays}
+        canExport={canExport}
         actions={
           canManageSettings ? (
             <SperrlisteSettingsDialog

--- a/src/app/(members)/mitglieder/sperrliste/page.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/page.tsx
@@ -31,7 +31,13 @@ export default async function SperrlistePage() {
   const settingsRecord = await readSperrlisteSettings();
   const resolvedSettingsBefore = resolveSperrlisteSettings(settingsRecord);
 
-  const [personalBlockedDays, holidayRanges, overviewUsers, canManageSettings] = await Promise.all([
+  const [
+    personalBlockedDays,
+    holidayRanges,
+    overviewUsers,
+    canManageSettings,
+    canExport,
+  ] = await Promise.all([
     prisma.blockedDay.findMany({
       where: { userId },
       orderBy: { date: "asc" },
@@ -63,6 +69,7 @@ export default async function SperrlistePage() {
       },
     }),
     hasPermission(session.user, "mitglieder.sperrliste.settings"),
+    hasPermission(session.user, "mitglieder.sperrliste.export"),
   ]);
 
   const refreshedSettingsRecord = await readSperrlisteSettings();
@@ -113,6 +120,7 @@ export default async function SperrlistePage() {
         overviewMembers={overviewMembers}
         initialSettings={clientSettings}
         canManageSettings={canManageSettings}
+        canExport={canExport}
         defaultHolidaySourceUrl={defaultHolidaySourceUrl}
         defaultPublicHolidaySourceUrl={defaultPublicHolidaySourceUrl}
       />

--- a/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
@@ -18,6 +18,7 @@ interface SperrlisteTabsProps {
   freezeDays?: number;
   preferredWeekdays?: number[];
   exceptionWeekdays?: number[];
+  canExport?: boolean;
   actions?: ReactNode;
 }
 
@@ -28,6 +29,7 @@ export function SperrlisteTabs({
   freezeDays = 0,
   preferredWeekdays = [],
   exceptionWeekdays = [],
+  canExport = false,
   actions,
 }: SperrlisteTabsProps) {
   const formattedFreeze = useMemo(() => {
@@ -81,6 +83,7 @@ export function SperrlisteTabs({
           holidays={holidays}
           preferredWeekdays={preferredWeekdays}
           exceptionWeekdays={exceptionWeekdays}
+          canExport={canExport}
         />
       </TabsContent>
     </Tabs>

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -208,6 +208,13 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     category: "membership",
   },
   {
+    key: "mitglieder.sperrliste.export",
+    label: "Sperrlisten-Export herunterladen",
+    description:
+      "CSV-Übersichten der nächsten zwei Wochen für die wichtigsten Probentage exportieren.",
+    category: "membership",
+  },
+  {
     key: "mitglieder.website.settings",
     label: "Website-Einstellungen verwalten",
     description:

--- a/src/types/d3-cloud.d.ts
+++ b/src/types/d3-cloud.d.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module "d3-cloud" {
+  export type Word = any;
+
+  export interface CloudLayout<T = any> {
+    size(size: [number, number]): CloudLayout<T>;
+    words(words: T[]): CloudLayout<T>;
+    padding(padding: number): CloudLayout<T>;
+    rotate(rotate: (datum: T, index?: number) => number): CloudLayout<T>;
+    font(font: string | ((datum: T) => string)): CloudLayout<T>;
+    fontStyle(style: string | ((datum: T) => string)): CloudLayout<T>;
+    fontWeight(weight: string | number | ((datum: T) => string | number)): CloudLayout<T>;
+    fontSize(fontSize: (datum: T) => number): CloudLayout<T>;
+    spiral(name: string | ((size: [number, number]) => (theta: number) => [number, number])): CloudLayout<T>;
+    random(random: number | (() => number)): CloudLayout<T>;
+    on(event: string, listener: (words: T[], bounds?: [number, number]) => void): CloudLayout<T>;
+    start(): CloudLayout<T>;
+    stop(): CloudLayout<T>;
+  }
+
+  const cloud: <T = any>() => CloudLayout<T>;
+  export default cloud;
+}


### PR DESCRIPTION
## Summary
- add a CSV export card to the Sperrliste overview that lists members blocked on important days within the next two weeks
- gate the export feature behind a dedicated permission and surface it through the Sperrliste tabs
- declare a minimal d3-cloud module type to satisfy the build tooling

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e525ad4fdc832d840695d01c3c09c9