### PR TITLE
feat: add Sperrliste PDF export for important days

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
@@ -78,6 +78,7 @@ export function BlockOverview({
   const [currentMonth, setCurrentMonth] = useState(() => startOfMonth(new Date()));
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [selectedBlockedDay, setSelectedBlockedDay] = useState<SelectedBlockedDay | null>(null);
+  const [isExportingPdf, setIsExportingPdf] = useState(false);
 
   const data = useBlockOverviewData({
     members,
@@ -169,6 +170,106 @@ export function BlockOverview({
     setDetailsOpen(true);
   };
 
+  const extractFilenameFromDisposition = (disposition: string | null) => {
+    if (!disposition) return null;
+    const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utf8Match?.[1]) {
+      try {
+        return decodeURIComponent(utf8Match[1]);
+      } catch {
+        return utf8Match[1];
+      }
+    }
+    const quotedMatch = disposition.match(/filename="([^"\\]*(?:\\.[^"\\]*)*)"/i);
+    if (quotedMatch?.[1]) {
+      return quotedMatch[1].replace(/\\"/g, "").replace(/\\/g, "").trim();
+    }
+    const simpleMatch = disposition.match(/filename=([^;]+)/i);
+    if (simpleMatch?.[1]) {
+      return simpleMatch[1].replace(/"/g, "").trim();
+    }
+    return null;
+  };
+
+  const handleExportPdf = async () => {
+    if (!exportWindow || exportRows.length === 0) {
+      toast.warning('Keine Sperrtermine auf wichtigen Tagen im ausgewählten Zeitraum gefunden.');
+      return;
+    }
+
+    setIsExportingPdf(true);
+    try {
+      const pdfPayload = {
+        generatedAt: new Date().toISOString(),
+        range: {
+          start: exportWindow.start.toISOString(),
+          end: exportWindow.end.toISOString(),
+          label: exportRangeLabel,
+        },
+        summary: {
+          memberCount: exportRows.length,
+          importantWeekdays: importantWeekdaySummary,
+        },
+        days: exportWindow.days.map((day) => ({
+          key: day.key,
+          label: day.header,
+          title: day.title,
+        })),
+        members: exportRows.map(({ member, entries }) => ({
+          name: member.displayName,
+          email: member.email ?? null,
+          entries: exportWindow.days.map((day, index) => {
+            const entry = entries[index];
+            if (!entry) {
+              return { dayKey: day.key, value: null };
+            }
+            const reason = normaliseReason(entry.reason);
+            return { dayKey: day.key, value: reason || 'gesperrt' };
+          }),
+        })),
+      };
+
+      const response = await fetch('/api/pdfs/sperrliste-wichtige-tage', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(pdfPayload),
+      });
+
+      if (!response.ok) {
+        const errorPayload = await response.json().catch(() => null);
+        throw new Error(errorPayload?.error ?? 'PDF konnte nicht erstellt werden.');
+      }
+
+      const blob = await response.blob();
+      const disposition = response.headers.get('content-disposition');
+      const filenameFromHeader = extractFilenameFromDisposition(disposition);
+      let filename =
+        filenameFromHeader?.trim() ||
+        `sperrliste-wichtige-tage-${format(exportWindow.start, 'yyyyMMdd')}-${format(exportWindow.end, 'yyyyMMdd')}.pdf`;
+      filename = filename.replace(/[\\/]/g, '_').replace(/[\r\n]/g, '').trim();
+      if (!filename.toLowerCase().endsWith('.pdf')) {
+        filename = `${filename}.pdf`;
+      }
+
+      const downloadUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = downloadUrl;
+      link.download = filename;
+      link.rel = 'noopener';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(downloadUrl);
+      toast.success('PDF wurde heruntergeladen.');
+    } catch (error) {
+      console.error(error);
+      const message = error instanceof Error ? error.message : 'PDF konnte nicht erstellt werden.';
+      toast.error(message);
+    } finally {
+      setIsExportingPdf(false);
+    }
+  };
+
   const handleExportTable = () => {
     if (!exportWindow || exportRows.length === 0) {
       toast.warning('Keine Sperrtermine auf wichtigen Tagen im ausgewählten Zeitraum gefunden.');
@@ -224,7 +325,7 @@ export function BlockOverview({
     <div className="space-y-6">
       {canExport ? (
         <div className="rounded-lg border border-border/60 bg-muted/40 p-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1 text-sm text-muted-foreground">
               {exportWindow ? (
                 <>
@@ -247,15 +348,27 @@ export function BlockOverview({
                 </p>
               )}
             </div>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleExportTable}
-              disabled={exportDisabled}
-              className="sm:w-auto"
-            >
-              CSV exportieren
-            </Button>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleExportTable}
+                disabled={exportDisabled}
+                className="sm:w-auto"
+              >
+                CSV exportieren
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleExportPdf}
+                disabled={exportDisabled || isExportingPdf}
+                aria-busy={isExportingPdf}
+                className="sm:w-auto"
+              >
+                PDF exportieren
+              </Button>
+            </div>
           </div>
         </div>
       ) : null}

--- a/src/lib/pdf/templates/index.ts
+++ b/src/lib/pdf/templates/index.ts
@@ -1,8 +1,9 @@
 import type { PdfTemplate } from "../types";
 import { onboardingInviteTemplate } from "./onboarding-invite";
 import { onboardingStatisticsTemplate } from "./onboarding-statistics";
+import { sperrlisteImportantDaysTemplate } from "./sperrliste-wichtige-tage";
 
-const templates = [onboardingInviteTemplate, onboardingStatisticsTemplate] as const;
+const templates = [onboardingInviteTemplate, onboardingStatisticsTemplate, sperrlisteImportantDaysTemplate] as const;
 
 const templateMap = new Map<string, PdfTemplate<unknown>>();
 for (const template of templates) {

--- a/src/lib/pdf/templates/sperrliste-wichtige-tage.ts
+++ b/src/lib/pdf/templates/sperrliste-wichtige-tage.ts
@@ -1,0 +1,294 @@
+import { z } from "zod";
+
+import type { PdfTemplate } from "../types";
+
+const daySchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  title: z.string(),
+});
+
+const entrySchema = z.object({
+  dayKey: z.string(),
+  value: z.string().nullable(),
+});
+
+const memberSchema = z.object({
+  name: z.string(),
+  email: z.string().nullable(),
+  entries: z.array(entrySchema),
+});
+
+const sperrlisteImportantDaysSchema = z
+  .object({
+    generatedAt: z.string().datetime(),
+    range: z.object({
+      start: z.string().datetime(),
+      end: z.string().datetime(),
+      label: z.string().nullable(),
+    }),
+    summary: z.object({
+      memberCount: z.number().int().nonnegative(),
+      importantWeekdays: z.string().nullable(),
+    }),
+    days: z.array(daySchema),
+    members: z.array(memberSchema),
+  })
+  .superRefine((data, ctx) => {
+    data.members.forEach((member, memberIndex) => {
+      if (member.entries.length !== data.days.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["members", memberIndex, "entries"],
+          message: "entries length must match number of days",
+        });
+      }
+    });
+  });
+
+export type SperrlisteImportantDaysPdfData = z.infer<typeof sperrlisteImportantDaysSchema>;
+
+const dateFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "long" });
+const dateTimeFormatter = new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" });
+
+function ensurePageSpace(doc: PDFKit.PDFDocument, neededHeight: number) {
+  const bottom = doc.page.height - doc.page.margins.bottom;
+  if (doc.y + neededHeight <= bottom) {
+    return;
+  }
+  doc.addPage();
+  doc.x = doc.page.margins.left;
+  doc.y = doc.page.margins.top;
+}
+
+function formatDateForFilename(value: string) {
+  try {
+    return value.slice(0, 10).replace(/-/g, "");
+  } catch {
+    return "unknown";
+  }
+}
+
+function buildRangeLabel(range: SperrlisteImportantDaysPdfData["range"]) {
+  try {
+    const start = new Date(range.start);
+    const end = new Date(range.end);
+    return `${dateFormatter.format(start)} – ${dateFormatter.format(end)}`;
+  } catch {
+    return null;
+  }
+}
+
+function drawTable(
+  doc: PDFKit.PDFDocument,
+  headers: readonly string[],
+  rows: readonly (readonly string[])[],
+  columnWidths: readonly number[],
+) {
+  if (!rows.length) {
+    return;
+  }
+
+  const paddingX = 6;
+  const paddingY = 4;
+  const startX = doc.page.margins.left;
+  const columnPositions = columnWidths.reduce<number[]>((positions, width, index) => {
+    const previous = index === 0 ? startX : positions[index - 1] + columnWidths[index - 1];
+    positions.push(previous);
+    return positions;
+  }, []);
+  const totalWidth = columnWidths.reduce((sum, value) => sum + value, 0);
+  const bottom = doc.page.height - doc.page.margins.bottom;
+
+  const computeRowHeight = (cells: readonly string[], font: string, fontSize: number) => {
+    doc.font(font).fontSize(fontSize);
+    return cells.reduce((max, cell, cellIndex) => {
+      const width = Math.max(columnWidths[cellIndex] - paddingX * 2, 32);
+      const height = doc.heightOfString(cell, { width, align: "left" }) + paddingY * 2;
+      return Math.max(max, height);
+    }, 0);
+  };
+
+  const drawHeaderRow = () => {
+    const headerHeight = computeRowHeight(headers, "Helvetica-Bold", 9);
+    ensurePageSpace(doc, headerHeight + 6);
+
+    doc.save();
+    doc.rect(startX, doc.y, totalWidth, headerHeight).fill("#f3f4f6");
+    doc.restore();
+
+    doc.font("Helvetica-Bold").fontSize(9).fillColor("#111827");
+    headers.forEach((header, index) => {
+      const x = columnPositions[index] + paddingX;
+      const width = Math.max(columnWidths[index] - paddingX * 2, 32);
+      doc.text(header, x, doc.y + paddingY, { width, align: "left" });
+    });
+    doc.y += headerHeight;
+    doc.moveTo(startX, doc.y).lineTo(startX + totalWidth, doc.y).strokeColor("#d1d5db").lineWidth(0.5).stroke();
+  };
+
+  const drawDataRow = (row: readonly string[], index: number) => {
+    const rowHeight = computeRowHeight(row, "Helvetica", 9);
+    if (doc.y + rowHeight > bottom) {
+      doc.addPage();
+      doc.x = doc.page.margins.left;
+      doc.y = doc.page.margins.top;
+      drawHeaderRow();
+    }
+
+    if (index % 2 === 1) {
+      doc.save();
+      doc.rect(startX, doc.y, totalWidth, rowHeight).fill("#f9fafb");
+      doc.restore();
+    }
+
+    doc.font("Helvetica").fontSize(9).fillColor("#1f2937");
+    row.forEach((cell, cellIndex) => {
+      const x = columnPositions[cellIndex] + paddingX;
+      const width = Math.max(columnWidths[cellIndex] - paddingX * 2, 32);
+      doc.text(cell, x, doc.y + paddingY, { width, align: "left" });
+    });
+
+    doc.y += rowHeight;
+    doc.moveTo(startX, doc.y).lineTo(startX + totalWidth, doc.y).strokeColor("#e5e7eb").lineWidth(0.5).stroke();
+  };
+
+  drawHeaderRow();
+  rows.forEach((row, index) => {
+    drawDataRow(row, index);
+  });
+  doc.moveDown(0.6);
+}
+
+export const sperrlisteImportantDaysTemplate: PdfTemplate<SperrlisteImportantDaysPdfData> = {
+  id: "sperrliste-wichtige-tage",
+  label: "Sperrliste · Wichtige Probentage",
+  description:
+    "Zeigt Sperrtermine der wichtigsten Probentage im Zwei-Wochen-Fenster als kompakt formatiertes Tabellen-PDF.",
+  filename: (data) => {
+    const start = formatDateForFilename(data.range.start);
+    const end = formatDateForFilename(data.range.end);
+    return `sperrliste-wichtige-tage-${start}-${end}.pdf`;
+  },
+  async render(doc, data) {
+    doc.font("Helvetica-Bold").fontSize(18).fillColor("#111827").text("Sperrliste · Wichtige Probentage");
+    doc.moveDown(0.2);
+
+    const generatedAt = new Date(data.generatedAt);
+    doc
+      .font("Helvetica")
+      .fontSize(10)
+      .fillColor("#4b5563")
+      .text(`Generiert am ${dateTimeFormatter.format(generatedAt)}`);
+    doc.moveDown(0.6);
+
+    const effectiveRangeLabel = data.range.label ?? buildRangeLabel(data.range) ?? "–";
+    doc.font("Helvetica").fontSize(11).fillColor("#1f2937").text(`Zeitraum: ${effectiveRangeLabel}`);
+    doc.moveDown(0.1);
+
+    if (data.summary.importantWeekdays) {
+      doc.font("Helvetica").fontSize(11).fillColor("#1f2937").text(`Berücksichtigte Tage: ${data.summary.importantWeekdays}`);
+      doc.moveDown(0.1);
+    }
+
+    doc
+      .font("Helvetica")
+      .fontSize(11)
+      .fillColor("#1f2937")
+      .text(`Mitglieder mit Sperrterminen: ${data.summary.memberCount}`);
+    doc.moveDown(0.8);
+
+    if (!data.days.length || !data.members.length || data.summary.memberCount === 0) {
+      doc
+        .font("Helvetica")
+        .fontSize(11)
+        .fillColor("#4b5563")
+        .text("Für den angegebenen Zeitraum liegen keine Sperrtermine auf wichtigen Tagen vor.");
+      return;
+    }
+
+    const availableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+    const dayCount = data.days.length;
+    const minNameWidth = 120;
+    const minEmailWidth = 120;
+    const minDayWidth = 56;
+    const absoluteMinNameWidth = 90;
+    const absoluteMinEmailWidth = 90;
+    const absoluteMinDayWidth = 36;
+
+    let nameWidth = minNameWidth;
+    let emailWidth = minEmailWidth;
+    let dayWidth = minDayWidth;
+
+    const minimalTotal = nameWidth + emailWidth + dayWidth * dayCount;
+    if (minimalTotal > availableWidth) {
+      const excess = minimalTotal - availableWidth;
+      const adjustableName = Math.max(0, nameWidth - absoluteMinNameWidth);
+      const adjustableEmail = Math.max(0, emailWidth - absoluteMinEmailWidth);
+      const adjustableDay = Math.max(0, dayWidth - absoluteMinDayWidth) * dayCount;
+      const adjustableTotal = adjustableName + adjustableEmail + adjustableDay;
+
+      if (adjustableTotal > 0) {
+        const ratio = Math.min(1, excess / adjustableTotal);
+        nameWidth -= adjustableName * ratio;
+        emailWidth -= adjustableEmail * ratio;
+        dayWidth -= Math.max(0, dayWidth - absoluteMinDayWidth) * ratio;
+      }
+
+      const adjustedTotal = nameWidth + emailWidth + dayWidth * dayCount;
+      if (adjustedTotal > availableWidth && adjustedTotal > 0) {
+        const scale = availableWidth / adjustedTotal;
+        nameWidth *= scale;
+        emailWidth *= scale;
+        dayWidth *= scale;
+      }
+    } else {
+      const extra = availableWidth - minimalTotal;
+      const weightName = 1.2;
+      const weightEmail = 1.1;
+      const weightDay = dayCount > 0 ? 0.9 * dayCount : 0;
+      const weightSum = weightName + weightEmail + weightDay;
+      if (weightSum > 0) {
+        nameWidth += (weightName / weightSum) * extra;
+        emailWidth += (weightEmail / weightSum) * extra;
+        if (dayCount > 0) {
+          dayWidth += ((weightDay / weightSum) * extra) / dayCount;
+        }
+      }
+    }
+
+    nameWidth = Math.max(0, nameWidth);
+    emailWidth = Math.max(0, emailWidth);
+    dayWidth = Math.max(0, dayWidth);
+
+    const columnWidths = [nameWidth, emailWidth, ...Array(dayCount).fill(dayWidth)];
+
+    const headers: string[] = ["Mitglied", "E-Mail", ...data.days.map((day) => day.label)];
+    const dayLookup = new Map(data.days.map((day, index) => [day.key, index] as const));
+
+    const rows = data.members.map((member) => {
+      const cells = Array<string>(dayCount).fill("");
+      member.entries.forEach((entry, entryIndex) => {
+        const columnIndex = dayLookup.get(entry.dayKey) ?? entryIndex;
+        if (columnIndex < dayCount) {
+          cells[columnIndex] = entry.value && entry.value.trim() ? entry.value.trim() : "gesperrt";
+        }
+      });
+      return [member.name, member.email?.trim() || "–", ...cells] as const;
+    });
+
+    doc.font("Helvetica-Bold").fontSize(12).fillColor("#111827").text("Sperrtermine im Überblick");
+    doc.moveDown(0.4);
+
+    drawTable(doc, headers, rows, columnWidths);
+
+    doc
+      .font("Helvetica")
+      .fontSize(9)
+      .fillColor("#6b7280")
+      .text(
+        "Hinweis: Leere Felder bedeuten keine Sperre am jeweiligen Tag. Der Eintrag 'gesperrt' weist auf eine Sperre ohne näheren Grund hin.",
+      );
+  },
+  schema: sperrlisteImportantDaysSchema,
+};


### PR DESCRIPTION
## Summary
- add a PDF export button to the Sperrliste overview and send the prepared data to the PDF API
- implement a formatted Sperrliste "wichtige Tage" PDF template and register it in the template registry

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e538e0e8ec832da167532b3b2db427