### PR TITLE
Remove duplicate email display in members table

### DIFF
--- a/src/components/members/members-table.tsx
+++ b/src/components/members/members-table.tsx
@@ -161,7 +161,6 @@ export function MembersTable({
                             </Badge>
                           )}
                         </div>
-                        <div className="text-xs text-muted-foreground">{u.email || "—"}</div>
                         <div className="mt-2 flex flex-wrap gap-1">
                           {sorted.map((r) => (
                             <span
@@ -231,7 +230,6 @@ export function MembersTable({
                                   </Badge>
                                 )}
                               </div>
-                              <div className="text-xs text-muted-foreground">{u.email || "—"}</div>
                             </div>
                           </div>
                         </td>


### PR DESCRIPTION
## Summary
- remove the redundant email line from the mobile cards in the members table
- remove the duplicate email label under the name column now that the dedicated email column already shows it

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e539c65b98832d98e1d2820dcd5580