### PR TITLE
Improve mobile Sperrliste layout

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-calendar.tsx
@@ -12,7 +12,14 @@ import {
 import { addDays, format, parseISO, startOfMonth, isValid } from "date-fns";
 import { de } from "date-fns/locale/de";
 import { toast } from "sonner";
-import { CalendarDays, ChevronDown, CircleX, Clock, Star } from "lucide-react";
+import {
+  ArrowLeftRight,
+  CalendarDays,
+  ChevronDown,
+  CircleX,
+  Clock,
+  Star,
+} from "lucide-react";
 
 import {
   MonthCalendar,
@@ -1107,6 +1114,13 @@ export function BlockCalendar({
     </div>
   );
 
+  const mobileScrollHint = (
+    <div className="flex items-center gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-xs font-medium text-primary dark:border-primary/30 dark:bg-primary/10 sm:hidden">
+      <ArrowLeftRight className="h-4 w-4" aria-hidden />
+      <span>Wische seitlich, um weitere Tage zu sehen.</span>
+    </div>
+  );
+
   const handleCreate = async () => {
     if (!selectedDateKey) return;
     const trimmed = reason.trim();
@@ -1235,6 +1249,7 @@ export function BlockCalendar({
         renderDay={renderCalendarDay}
         additionalContent={
           <>
+            {mobileScrollHint}
             {rehearsalHint}
             {selectionPanel}
             {holidayDescription}

--- a/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/settings-dialog.tsx
@@ -30,10 +30,11 @@ export function SperrlisteSettingsDialog({
         <Button
           variant="ghost"
           size="sm"
-          className="h-auto gap-2 rounded-full border border-transparent px-5 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground shadow-none hover:border-primary/20 hover:bg-primary/10 hover:text-foreground sm:text-sm"
+          className="h-auto w-full justify-center gap-2 rounded-full border border-transparent px-5 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground shadow-none hover:border-primary/20 hover:bg-primary/10 hover:text-foreground sm:w-auto sm:justify-start sm:text-sm"
         >
           <Settings2 className="h-4 w-4" aria-hidden />
-          <span>Sperrlisten-Einstellungen</span>
+          <span className="sm:hidden">Einstellungen</span>
+          <span className="hidden sm:inline">Sperrlisten-Einstellungen</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[90vh] overflow-hidden border-0 bg-transparent p-0 sm:max-w-5xl">

--- a/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
@@ -44,19 +44,25 @@ export function SperrlisteTabs({
 
   return (
     <Tabs defaultValue="personal" className="space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         {actions ? (
-          <div className="order-1 flex justify-end sm:order-2 sm:flex-none sm:justify-end">
-            {actions}
+          <div className="order-1 w-full sm:order-2 sm:w-auto">
+            <div className="flex w-full justify-end sm:justify-end">{actions}</div>
           </div>
         ) : null}
-        <TabsList className="order-2 flex w-full justify-start overflow-x-auto rounded-full bg-background/70 p-1 shadow-inner ring-1 ring-primary/10 backdrop-blur-sm sm:order-1 sm:w-auto sm:flex-1 sm:pr-0">
-          <TabsTrigger value="personal" className="gap-2 whitespace-nowrap px-5 py-2 text-xs font-semibold uppercase tracking-wide sm:text-sm">
-            <CalendarCheck2 className="h-4 w-4 text-muted-foreground/80" aria-hidden />
-            <span>Meine Sperrtermine</span>
+        <TabsList className="order-2 flex w-full gap-2 overflow-hidden rounded-2xl border border-border/60 bg-background/80 p-1.5 shadow-sm ring-1 ring-border/60 backdrop-blur-sm sm:order-1 sm:w-auto sm:flex-1 sm:overflow-visible">
+          <TabsTrigger
+            value="personal"
+            className="flex-1 justify-center gap-1.5 whitespace-nowrap rounded-xl px-4 py-2 text-xs font-semibold uppercase tracking-wide sm:flex-none sm:justify-center sm:px-5 sm:text-sm"
+          >
+            <CalendarCheck2 className="hidden h-4 w-4 text-muted-foreground/80 sm:block" aria-hidden />
+            <span className="sm:min-w-[10ch]">Meine Sperrtermine</span>
           </TabsTrigger>
-          <TabsTrigger value="overview" className="gap-2 whitespace-nowrap px-5 py-2 text-xs font-semibold uppercase tracking-wide sm:text-sm">
-            <UsersRound className="h-4 w-4 text-muted-foreground/80" aria-hidden />
+          <TabsTrigger
+            value="overview"
+            className="flex-1 justify-center gap-1.5 whitespace-nowrap rounded-xl px-4 py-2 text-xs font-semibold uppercase tracking-wide sm:flex-none sm:justify-center sm:px-5 sm:text-sm"
+          >
+            <UsersRound className="hidden h-4 w-4 text-muted-foreground/80 sm:block" aria-hidden />
             <span>Übersicht</span>
           </TabsTrigger>
         </TabsList>

--- a/src/components/calendar/month-calendar.tsx
+++ b/src/components/calendar/month-calendar.tsx
@@ -108,7 +108,7 @@ export function MonthCalendar({
   showWeekNumbers = true,
   className,
   contentClassName,
-  minGridWidthClassName = "min-w-full sm:min-w-[640px] lg:min-w-[720px]",
+  minGridWidthClassName = "min-w-[540px] sm:min-w-[640px] lg:min-w-[720px]",
   dayClassName,
   additionalContent,
 }: MonthCalendarProps) {


### PR DESCRIPTION
## Summary
- allow the calendar grid to keep generous column widths on phones and add a swipe hint for the Sperrliste page
- rework the Sperrliste tabs header so actions and triggers size correctly on narrow screens
- adjust the settings trigger button copy/layout for mobile and update the shared calendar min width

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e55ac62a64832d9869048fb6307418