### PR TITLE
Align total members metric styling with online card

### DIFF
--- a/src/components/members-dashboard.tsx
+++ b/src/components/members-dashboard.tsx
@@ -19,7 +19,6 @@ import { useMembersPermissions } from "@/components/members/permissions-context"
 import { PageHeader, PageHeaderDescription, PageHeaderStatus, PageHeaderTitle } from "@/design-system/patterns";
 import {
   Users,
-  Activity,
   Calendar,
   Wifi,
   WifiOff,
@@ -471,8 +470,8 @@ export function MembersDashboard({ permissions: permissionsProp }: MembersDashbo
         label: "Mitglieder gesamt",
         value: numberFormatter.format(stats.totalMembers),
         hint: "inkl. Ensemble und Technik",
-        icon: <Activity className="h-4 w-4" />,
-        tone: "neutral",
+        icon: <Users className="h-4 w-4" />,
+        tone: "positive",
       },
       {
         key: "rehearsals",


### PR DESCRIPTION
## Summary
- update the Mitglieder-gesamt dashboard metric to reuse the positive styling used by the online metric
- remove the unused Activity icon import from the dashboard component

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e563e04d04832d9dd79fba13702a04