### PR TITLE
Exclude blocked members from rehearsal invite list

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
@@ -154,6 +154,9 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
   const groupedMembers = useMemo(() => {
     const map = new Map<string, MemberOption[]>();
     for (const member of members) {
+      if (blockedUserIds.has(member.id)) {
+        continue;
+      }
       const primaryRole = member.role ?? "member";
       const list = map.get(primaryRole) ?? [];
       list.push(member);
@@ -163,7 +166,7 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
     return orderedRoles
       .map((role) => [role, map.get(role) ?? []] as const)
       .filter(([, list]) => list.length > 0);
-  }, [members]);
+  }, [blockedUserIds, members]);
 
   const selectedSet = useMemo(() => new Set(selectedInvitees), [selectedInvitees]);
 
@@ -206,6 +209,16 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
   useEffect(() => {
     fetchBlockedForDate(date).catch(() => null);
   }, [date, fetchBlockedForDate]);
+
+  useEffect(() => {
+    setSelectedInvitees((prev) => {
+      const filtered = prev.filter((id) => !blockedUserIds.has(id));
+      if (filtered.length === prev.length) {
+        return prev;
+      }
+      return filtered;
+    });
+  }, [blockedUserIds]);
 
   const skipInitialSave = useRef(true);
 


### PR DESCRIPTION
## Summary
- hide blocked members from the rehearsal invite list for the selected date
- automatically remove blocked members from already selected invitees to keep data clean

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e563470f2c832d807b4cc3781b1c56