### PR TITLE
Fix onboarding ranking schema by including candidate emails

### DIFF
--- a/src/lib/onboarding/dashboard-service.ts
+++ b/src/lib/onboarding/dashboard-service.ts
@@ -281,6 +281,7 @@ function evaluateCandidateForRole(
 interface CandidateInput {
   userId: string;
   name: string;
+  email: string | null;
   focus: OnboardingFocus | null;
   interests: string[];
   experienceYears: number | null;
@@ -419,6 +420,7 @@ async function computeOnboardingDashboardData(
               name: true,
               firstName: true,
               lastName: true,
+              email: true,
               dateOfBirth: true,
               photoConsent: {
                 select: {
@@ -745,6 +747,7 @@ async function computeOnboardingDashboardData(
     return {
       userId: profile.user.id,
       name: fullName,
+      email: profile.user.email ?? null,
       focus: profile.focus,
       interests: userInterestMap.get(profile.user.id) ?? [],
       experienceYears,
@@ -848,6 +851,7 @@ async function computeOnboardingDashboardData(
         return {
           userId: candidate.userId,
           name: candidate.name,
+          email: candidate.email,
           focus: candidate.focus,
           normalizedShare: roundTo(metrics.share, 3),
           score: roundTo(metrics.score, 3),


### PR DESCRIPTION
## Summary
- request the email field when loading onboarding profiles
- attach the email to ranking candidates so dashboard parsing succeeds

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e666e0c40c832db492deaf7fa80944