### PR TITLE
Fix Sperrliste PDF row alignment

### DIFF
--- a/src/lib/pdf/templates/sperrliste-wichtige-tage.ts
+++ b/src/lib/pdf/templates/sperrliste-wichtige-tage.ts
@@ -165,6 +165,7 @@ function drawTable(
     doc.rect(startX, doc.y, totalWidth, headerHeight).fill("#f3f4f6");
     doc.restore();
 
+    const rowTop = doc.y;
     headerCells.forEach((cell, index) => {
       const x = columnPositions[index] + paddingX;
       const width = Math.max(columnWidths[index] - paddingX * 2, 32);
@@ -172,12 +173,14 @@ function drawTable(
       const fontSize = cell.style.fontSize ?? 9;
       const align = resolveAlign(cell.style);
       doc.font(font).fontSize(fontSize).fillColor(cell.style.textColor ?? "#111827");
-      doc.text(cell.text, x, doc.y + paddingY, {
+      doc.text(cell.text, x, rowTop + paddingY, {
         width,
         align,
         lineBreak: false,
         ellipsis: true,
       });
+      doc.y = rowTop;
+      doc.x = startX;
     });
     doc.y += headerHeight;
     doc.moveTo(startX, doc.y).lineTo(startX + totalWidth, doc.y).strokeColor("#d1d5db").lineWidth(0.5).stroke();
@@ -209,6 +212,7 @@ function drawTable(
       doc.restore();
     }
 
+    const rowTop = doc.y;
     cells.forEach((cell, cellIndex) => {
       const x = columnPositions[cellIndex];
       const width = Math.max(columnWidths[cellIndex], 32);
@@ -228,12 +232,14 @@ function drawTable(
         .font(font)
         .fontSize(fontSize)
         .fillColor(textColor)
-        .text(cell.text, x + paddingX, doc.y + paddingY, {
+        .text(cell.text, x + paddingX, rowTop + paddingY, {
           width: textWidth,
           align,
           lineBreak: false,
           ellipsis: true,
         });
+      doc.y = rowTop;
+      doc.x = startX;
     });
 
     doc.y += rowHeight;


### PR DESCRIPTION
## Summary
- prevent PDFKit from shifting the cursor between cells when rendering the Sperrliste table
- keep header and data cell text aligned by resetting the drawing position after each write

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e66d074624832d8fcac8b2156a47c2