### PR TITLE
Refactor onboarding ranking layout

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
@@ -45,144 +45,216 @@ type RankingTabProps = {
 
 type Domain = "acting" | "crew";
 
+type CandidatePreference = {
+  roleId: string;
+  label: string;
+  share: number;
+  rank: number;
+};
 
+type CandidateAggregate = {
+  userId: string;
+  name: string;
+  email: string | null;
+  focus: "acting" | "tech" | "both" | null;
+  score: number;
+  confidence: number;
+  experienceYears: number | null;
+  interests: string[];
+  background: string | null;
+  notes: string | null;
+  bestRank: number | null;
+  preferences: Record<Domain, CandidatePreference[]>;
+};
 
-function CandidateCard({
-  candidate,
+function PreferenceColumn({
+  domain,
+  preferences,
+  isActive,
 }: {
-  candidate: OnboardingDashboardData["ranking"]["roles"][number]["candidates"][number];
+  domain: Domain;
+  preferences: CandidatePreference[];
+  isActive: boolean;
 }) {
-  const shareLabel = percentageFormatter.format(candidate.normalizedShare * 100);
-  const confidencePercentage = Math.round(candidate.confidence * 100);
-  const interestPreview = candidate.interests.slice(0, 3);
-  const remainingInterests = candidate.interests.length - interestPreview.length;
-
   return (
-    <div className="group relative rounded-lg border border-border/50 bg-card p-3 transition-all hover:border-border hover:shadow-sm">
-      {/* Header mit Name und Rang */}
-      <div className="mb-2 flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-primary/10 text-[10px] font-bold text-primary">
-              {candidate.rank}
-            </span>
-            <h4 className="truncate text-sm font-semibold text-foreground">{candidate.name}</h4>
-          </div>
-          
-          {/* Kompakte Metriken */}
-          <div className="mt-1 space-y-0.5">
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="font-medium">{shareLabel}% Präferenz</span>
-              <span className="text-muted-foreground/60">•</span>
-              <span>Score {scoreFormatter.format(candidate.score)}</span>
-              <span className="text-muted-foreground/60">•</span>
-              <span>{numberFormatter.format(confidencePercentage)}% Sicherheit</span>
-            </div>
-            {candidate.email && (
-              <div className="text-xs text-muted-foreground">
-                <span className="font-mono">{candidate.email}</span>
-              </div>
-            )}
-          </div>
-        </div>
-        
-        {/* Fokus Badge */}
-        {candidate.focus && (
-          <Badge variant={focusVariant[candidate.focus]} size="sm" className="shrink-0">
-            {focusLabel[candidate.focus]}
-          </Badge>
+    <div
+      className={`rounded-xl border p-3 shadow-sm transition-colors ${
+        isActive ? "border-primary/60 bg-primary/5" : "border-border/60 bg-muted/30"
+      }`}
+    >
+      <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <span>{domain === "acting" ? "Acting" : "Gewerk"}</span>
+        {preferences.length > 0 && (
+          <span>{percentageFormatter.format(preferences[0].share * 100)}%</span>
         )}
       </div>
-
-      {/* Eigenschaften kompakt */}
-      <div className="space-y-2">
-        {/* Erfahrung und Interessen in einer Zeile */}
-        <div className="flex flex-wrap items-center gap-1.5">
-          {candidate.experienceYears !== null && (
-            <Badge variant="secondary" size="sm">
-              {candidate.experienceYears === 0 ? "Neu" : `${candidate.experienceYears}J`}
-            </Badge>
-          )}
-          {interestPreview.map((interest) => (
-            <Badge key={interest} variant="muted" size="sm" className="text-[10px]">
-              {interest}
-            </Badge>
-          ))}
-          {remainingInterests > 0 && (
-            <Badge variant="ghost" size="sm" className="text-[10px]">
-              +{remainingInterests}
-            </Badge>
-          )}
-        </div>
-
-        {/* Weitere Präferenzen kompakter */}
-        {candidate.otherPreferences.length > 0 && (
-          <div className="flex flex-wrap gap-1 text-[10px] text-muted-foreground">
-            {candidate.otherPreferences.slice(0, 3).map((pref) => (
-              <span key={`${pref.domain}-${pref.roleId}`} className="rounded bg-muted/50 px-1.5 py-0.5">
-                #{pref.rank} {pref.label} ({percentageFormatter.format(pref.normalizedShare * 100)}%)
-              </span>
+      {preferences.length === 0 ? (
+        <p className="mt-4 text-[11px] text-muted-foreground/80">
+          Keine Präferenzen vorhanden.
+        </p>
+      ) : (
+        <>
+          <ol className="mt-3 space-y-1.5">
+            {preferences.slice(0, 3).map((pref, index) => (
+              <li
+                key={`${domain}-${pref.roleId}`}
+                className="flex items-center justify-between gap-3 rounded-lg bg-background/70 px-2.5 py-1.5 text-xs"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <span
+                    className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold ${
+                      index === 0 ? "bg-primary/15 text-primary" : "bg-muted text-foreground/80"
+                    }`}
+                  >
+                    {index + 1}
+                  </span>
+                  <span className="truncate font-medium text-foreground">{pref.label}</span>
+                </div>
+                <span className="shrink-0 text-[11px] text-muted-foreground">
+                  {percentageFormatter.format(pref.share * 100)}%
+                </span>
+              </li>
             ))}
-            {candidate.otherPreferences.length > 3 && (
-              <span className="rounded bg-muted/30 px-1.5 py-0.5">+{candidate.otherPreferences.length - 3}</span>
-            )}
-          </div>
-        )}
-
-        {/* Background/Notes sehr kompakt */}
-        {(candidate.background || candidate.notes) && (
-          <div className="space-y-1 text-[11px] text-muted-foreground">
-            {candidate.background && (
-              <p className="line-clamp-1">
-                <span className="font-medium text-foreground/70">BG:</span> {candidate.background}
-              </p>
-            )}
-            {candidate.notes && (
-              <p className="line-clamp-1">
-                <span className="font-medium text-foreground/70">Note:</span> {candidate.notes}
-              </p>
-            )}
-          </div>
-        )}
-      </div>
+          </ol>
+          {preferences.length > 3 && (
+            <p className="mt-2 text-[10px] text-muted-foreground/80">
+              +{preferences.length - 3} weitere Präferenzen
+            </p>
+          )}
+        </>
+      )}
     </div>
   );
 }
 
-function RoleColumn({
-  domain,
-  role,
-}: {
-  domain: Domain;
-  role: OnboardingDashboardData["ranking"]["roles"][number];
-}) {
+function CandidateCard({ candidate, activeDomain }: { candidate: CandidateAggregate; activeDomain: Domain }) {
+  const experienceLabel =
+    candidate.experienceYears === null
+      ? null
+      : candidate.experienceYears === 0
+        ? "Neu im Bereich"
+        : `${candidate.experienceYears} Jahre Erfahrung`;
+  const securityLabel = `${numberFormatter.format(Math.round(candidate.confidence * 100))}% Sicherheit`;
+
   return (
-    <Card className="h-full border-border/40">
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-sm font-semibold text-foreground">
-            {role.label}
-          </CardTitle>
-          <Badge variant="muted" size="sm" className="text-[10px]">
-            {role.demand} Personen
-          </Badge>
-        </div>
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
-          Ranking nach {domain === "acting" ? "Rollengrößen" : "Gewerken"}
-        </p>
-      </CardHeader>
-      <CardContent className="space-y-2 pt-0">
-        {role.candidates.length === 0 ? (
-          <div className="flex h-20 items-center justify-center">
-            <p className="text-xs text-muted-foreground">Keine Kandidat:innen</p>
+    <Card className="min-w-[320px] max-w-[360px] border-border/50">
+      <CardHeader className="pb-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              {candidate.bestRank !== null && (
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[11px] font-semibold text-primary">
+                  #{candidate.bestRank}
+                </span>
+              )}
+              <CardTitle className="truncate text-base font-semibold text-foreground">
+                {candidate.name}
+              </CardTitle>
+            </div>
+            {candidate.email && (
+              <p className="mt-1 truncate text-xs text-muted-foreground">{candidate.email}</p>
+            )}
           </div>
-        ) : (
-          role.candidates.map((candidate) => (
-            <CandidateCard key={candidate.userId} candidate={candidate} />
-          ))
+          {candidate.focus && (
+            <Badge variant={focusVariant[candidate.focus]} size="sm" className="shrink-0">
+              {focusLabel[candidate.focus]}
+            </Badge>
+          )}
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+          {experienceLabel && (
+            <span className="rounded-full bg-muted/60 px-2 py-0.5 font-medium text-foreground/80">
+              {experienceLabel}
+            </span>
+          )}
+          <span className="rounded-full bg-muted/40 px-2 py-0.5 font-medium text-foreground/80">
+            Score {scoreFormatter.format(candidate.score)}
+          </span>
+          <span className="rounded-full bg-muted/40 px-2 py-0.5 font-medium text-foreground/80">
+            {securityLabel}
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-0">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <PreferenceColumn
+            domain="acting"
+            preferences={candidate.preferences.acting}
+            isActive={activeDomain === "acting"}
+          />
+          <PreferenceColumn
+            domain="crew"
+            preferences={candidate.preferences.crew}
+            isActive={activeDomain === "crew"}
+          />
+        </div>
+        {candidate.interests.length > 0 && (
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Tags</p>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {candidate.interests.map((interest) => (
+                <Badge
+                  key={interest}
+                  variant="outline"
+                  size="sm"
+                  className="border-border/60 bg-background px-2 py-0 text-[11px]"
+                >
+                  {interest}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+        {(candidate.background || candidate.notes) && (
+          <div className="space-y-2 text-[12px]">
+            {candidate.background && (
+              <p className="text-muted-foreground">
+                <span className="font-semibold text-foreground/80">Background:</span> {candidate.background}
+              </p>
+            )}
+            {candidate.notes && (
+              <div className="rounded-lg border border-dashed border-border/60 bg-muted/40 p-2 text-muted-foreground">
+                <span className="font-semibold text-foreground/80">Notiz:</span> {candidate.notes}
+              </div>
+            )}
+          </div>
         )}
       </CardContent>
     </Card>
+  );
+}
+
+function DomainSection({
+  domain,
+  candidates,
+}: {
+  domain: Domain;
+  candidates: CandidateAggregate[];
+}) {
+  const label = domain === "acting" ? "Acting Talente" : "Crew Talente";
+
+  if (candidates.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-border/60 bg-muted/20 p-6 text-sm text-muted-foreground">
+        Keine Kandidat:innen für {label} verfügbar.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between text-sm">
+        <h3 className="font-semibold text-foreground">{label}</h3>
+        <span className="text-xs text-muted-foreground">{candidates.length} Profile</span>
+      </div>
+      <div className="overflow-x-auto">
+        <div className="flex gap-4 pb-2">
+          {candidates.map((candidate) => (
+            <CandidateCard key={`${domain}-${candidate.userId}`} candidate={candidate} activeDomain={domain} />
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -215,6 +287,107 @@ export function RankingTab({ ranking }: RankingTabProps) {
     }
   }, [actingRoles.length, crewRoles.length, domain]);
 
+  const candidateAggregates = useMemo(() => {
+    const map = new Map<string, CandidateAggregate>();
+
+    for (const role of ranking.roles) {
+      for (const candidate of role.candidates) {
+        let entry = map.get(candidate.userId);
+
+        if (!entry) {
+          entry = {
+            userId: candidate.userId,
+            name: candidate.name,
+            email: candidate.email,
+            focus: candidate.focus,
+            score: candidate.score,
+            confidence: candidate.confidence,
+            experienceYears: candidate.experienceYears,
+            interests: [...new Set(candidate.interests)],
+            background: candidate.background,
+            notes: candidate.notes,
+            bestRank: candidate.rank,
+            preferences: {
+              acting: [],
+              crew: [],
+            },
+          } satisfies CandidateAggregate;
+          map.set(candidate.userId, entry);
+        } else {
+          entry.email = entry.email ?? candidate.email;
+          entry.focus = entry.focus ?? candidate.focus;
+          entry.score = Math.max(entry.score, candidate.score);
+          entry.confidence = Math.max(entry.confidence, candidate.confidence);
+          entry.experienceYears =
+            entry.experienceYears === null
+              ? candidate.experienceYears
+              : candidate.experienceYears === null
+                ? entry.experienceYears
+                : Math.max(entry.experienceYears, candidate.experienceYears);
+          entry.interests = Array.from(new Set([...entry.interests, ...candidate.interests]));
+          entry.background = entry.background ?? candidate.background;
+          entry.notes = entry.notes ?? candidate.notes;
+          entry.bestRank = entry.bestRank === null ? candidate.rank : Math.min(entry.bestRank, candidate.rank);
+        }
+
+        const addPreference = (prefDomain: Domain, pref: CandidatePreference) => {
+          const list = entry!.preferences[prefDomain];
+          const existingIndex = list.findIndex((item) => item.roleId === pref.roleId);
+          if (existingIndex === -1) {
+            list.push(pref);
+          } else if (list[existingIndex].share < pref.share) {
+            list[existingIndex] = pref;
+          }
+        };
+
+        addPreference(role.domain, {
+          roleId: role.roleId,
+          label: role.label,
+          share: candidate.normalizedShare,
+          rank: candidate.rank,
+        });
+
+        for (const otherPreference of candidate.otherPreferences) {
+          addPreference(otherPreference.domain, {
+            roleId: otherPreference.roleId,
+            label: otherPreference.label,
+            share: otherPreference.normalizedShare,
+            rank: otherPreference.rank,
+          });
+        }
+      }
+    }
+
+    const aggregates = Array.from(map.values());
+
+    for (const aggregate of aggregates) {
+      aggregate.preferences.acting.sort((a, b) => b.share - a.share);
+      aggregate.preferences.crew.sort((a, b) => b.share - a.share);
+    }
+
+    return aggregates;
+  }, [ranking.roles]);
+
+  const actingCandidates = useMemo(
+    () =>
+      candidateAggregates
+        .filter((candidate) => candidate.preferences.acting.length > 0)
+        .slice()
+        .sort(
+          (a, b) => (b.preferences.acting[0]?.share ?? 0) - (a.preferences.acting[0]?.share ?? 0),
+        ),
+    [candidateAggregates],
+  );
+
+  const crewCandidates = useMemo(
+    () =>
+      candidateAggregates
+        .filter((candidate) => candidate.preferences.crew.length > 0)
+        .slice()
+        .sort((a, b) => (b.preferences.crew[0]?.share ?? 0) - (a.preferences.crew[0]?.share ?? 0)),
+    [candidateAggregates],
+  );
+
   return (
     <Tabs value={domain} onValueChange={(value) => setDomain(value as Domain)} className="space-y-6">
       <TabsList className="w-fit bg-muted/40">
@@ -228,21 +401,19 @@ export function RankingTab({ ranking }: RankingTabProps) {
           </p>
         ) : (
           <>
-            {/* Spiderdiagramm für Acting-Präferenzen */}
             <RoleSpiderChart
               title="Acting Rollenpräferenzen"
               subtitle="Verteilung der Rollengrößen nach Präferenzstärke"
               data={actingRoles.map((role) => ({
                 label: role.label,
-                value: role.candidates.reduce((sum, c) => sum + c.normalizedShare, 0) / Math.max(role.candidates.length, 1) * 100
+                value:
+                  (role.candidates.reduce((sum, c) => sum + c.normalizedShare, 0) /
+                    Math.max(role.candidates.length, 1)) *
+                  100,
               }))}
             />
-            
-            <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
-              {actingRoles.map((role) => (
-                <RoleColumn key={role.roleId} role={role} domain="acting" />
-              ))}
-            </div>
+
+            <DomainSection domain="acting" candidates={actingCandidates} />
           </>
         )}
       </TabsContent>
@@ -253,21 +424,19 @@ export function RankingTab({ ranking }: RankingTabProps) {
           </p>
         ) : (
           <>
-            {/* Spiderdiagramm für Crew-Präferenzen */}
             <RoleSpiderChart
               title="Crew Rollenpräferenzen"
               subtitle="Verteilung der Gewerke nach Präferenzstärke"
               data={crewRoles.map((role) => ({
                 label: role.label,
-                value: role.candidates.reduce((sum, c) => sum + c.normalizedShare, 0) / Math.max(role.candidates.length, 1) * 100
+                value:
+                  (role.candidates.reduce((sum, c) => sum + c.normalizedShare, 0) /
+                    Math.max(role.candidates.length, 1)) *
+                  100,
               }))}
             />
-            
-            <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
-              {crewRoles.map((role) => (
-                <RoleColumn key={role.roleId} role={role} domain="crew" />
-              ))}
-            </div>
+
+            <DomainSection domain="crew" candidates={crewCandidates} />
           </>
         )}
       </TabsContent>


### PR DESCRIPTION
## Summary
- rebuild the onboarding ranking tab around compact profile cards with horizontal scrolling rows per domain
- aggregate role preferences per candidate so cards show acting and crew highlights side by side with tags and notes
- keep existing spider charts while replacing role columns by modernized candidate cards

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e671353000832d89c142f4e4d5ebe7