### PR TITLE
Add onboarding talent detail modal

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { OnboardingDashboardData } from "@/lib/onboarding/dashboard-schemas";
 import { RoleSpiderChart } from "./role-spider-chart";
+import { TalentDetailDialog } from "./talent-detail-dialog";
+import type {
+  CandidateAggregate,
+  CandidatePreference,
+  Domain,
+  HighlightContext,
+  RoleCandidate,
+  RoleGroup,
+  RoleSummary,
+} from "./ranking-types";
 
 const domainLabels: Record<"acting" | "crew", string> = {
   acting: "Acting & Rollengrößen",
@@ -41,37 +51,6 @@ const scoreFormatter = new Intl.NumberFormat("de-DE", {
 
 type RankingTabProps = {
   ranking: OnboardingDashboardData["ranking"];
-};
-
-type Domain = "acting" | "crew";
-
-type CandidatePreference = {
-  roleId: string;
-  label: string;
-  share: number;
-  rank: number;
-};
-
-type CandidateAggregate = {
-  userId: string;
-  name: string;
-  email: string | null;
-  focus: "acting" | "tech" | "both" | null;
-  score: number;
-  confidence: number;
-  experienceYears: number | null;
-  interests: string[];
-  background: string | null;
-  notes: string | null;
-  preferences: Record<Domain, CandidatePreference[]>;
-};
-
-type HighlightContext = {
-  domain: Domain;
-  roleId: string;
-  label: string;
-  rank: number;
-  share: number;
 };
 
 function PreferenceList({
@@ -133,9 +112,11 @@ function PreferenceList({
 function CandidateCard({
   candidate,
   highlight,
+  onSelectCandidate,
 }: {
   candidate: CandidateAggregate;
   highlight: HighlightContext;
+  onSelectCandidate: (candidate: CandidateAggregate, highlight: HighlightContext) => void;
 }) {
   const experienceLabel =
     candidate.experienceYears === null
@@ -162,7 +143,13 @@ function CandidateCard({
               </span>
             </div>
             <CardTitle className="text-base font-semibold text-foreground">
-              {candidate.name}
+              <button
+                type="button"
+                onClick={() => onSelectCandidate(candidate, highlight)}
+                className="rounded-md text-left text-base font-semibold text-foreground transition hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              >
+                {candidate.name}
+              </button>
             </CardTitle>
             {candidate.email && (
               <p className="text-xs text-muted-foreground break-words">{candidate.email}</p>
@@ -237,26 +224,15 @@ function CandidateCard({
   );
 }
 
-type RoleCandidate = {
-  candidate: CandidateAggregate;
-  highlight: HighlightContext;
-};
-
-type RoleGroup = {
-  roleId: string;
-  label: string;
+function DomainSection({
+  domain,
+  groups,
+  onSelectCandidate,
+}: {
   domain: Domain;
-  candidates: RoleCandidate[];
-};
-
-type RoleSummary = {
-  roleId: string;
-  label: string;
-  domain: Domain;
-  averageShare: number;
-};
-
-function DomainSection({ domain, groups }: { domain: Domain; groups: RoleGroup[] }) {
+  groups: RoleGroup[];
+  onSelectCandidate: (candidate: CandidateAggregate, highlight: HighlightContext) => void;
+}) {
   const label = domain === "acting" ? "Acting Talente" : "Crew Talente";
 
   if (groups.length === 0) {
@@ -283,6 +259,7 @@ function DomainSection({ domain, groups }: { domain: Domain; groups: RoleGroup[]
                 key={`${group.roleId}-${candidate.userId}`}
                 candidate={candidate}
                 highlight={highlight}
+                onSelectCandidate={onSelectCandidate}
               />
             ))}
           </div>
@@ -294,6 +271,17 @@ function DomainSection({ domain, groups }: { domain: Domain; groups: RoleGroup[]
 
 export function RankingTab({ ranking }: RankingTabProps) {
   const [domain, setDomain] = useState<Domain>("acting");
+  const [selectedCandidate, setSelectedCandidate] = useState<{
+    candidate: CandidateAggregate;
+    highlight: HighlightContext;
+  } | null>(null);
+
+  const handleSelectCandidate = useCallback(
+    (candidate: CandidateAggregate, highlight: HighlightContext) => {
+      setSelectedCandidate({ candidate, highlight });
+    },
+    [],
+  );
 
   const roleSummaries = useMemo<RoleSummary[]>(() => {
     return ranking.roles.map((role) => {
@@ -486,12 +474,13 @@ export function RankingTab({ ranking }: RankingTabProps) {
   );
 
   return (
-    <Tabs value={domain} onValueChange={(value) => setDomain(value as Domain)} className="space-y-6">
-      <TabsList className="w-fit bg-muted/40">
-        <TabsTrigger value="acting">Acting</TabsTrigger>
-        <TabsTrigger value="crew">Crew</TabsTrigger>
-      </TabsList>
-      <TabsContent value="acting" className="mt-0 space-y-4">
+    <>
+      <Tabs value={domain} onValueChange={(value) => setDomain(value as Domain)} className="space-y-6">
+        <TabsList className="w-fit bg-muted/40">
+          <TabsTrigger value="acting">Acting</TabsTrigger>
+          <TabsTrigger value="crew">Crew</TabsTrigger>
+        </TabsList>
+        <TabsContent value="acting" className="mt-0 space-y-4">
         {actingRoleSummaries.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             Keine Daten für {domainLabels.acting} verfügbar.
@@ -507,11 +496,15 @@ export function RankingTab({ ranking }: RankingTabProps) {
               }))}
             />
 
-            <DomainSection domain="acting" groups={actingGroups} />
+            <DomainSection
+              domain="acting"
+              groups={actingGroups}
+              onSelectCandidate={handleSelectCandidate}
+            />
           </>
         )}
-      </TabsContent>
-      <TabsContent value="crew" className="mt-0 space-y-4">
+        </TabsContent>
+        <TabsContent value="crew" className="mt-0 space-y-4">
         {crewRoleSummaries.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             Keine Daten für {domainLabels.crew} verfügbar.
@@ -527,10 +520,26 @@ export function RankingTab({ ranking }: RankingTabProps) {
               }))}
             />
 
-            <DomainSection domain="crew" groups={crewGroups} />
+            <DomainSection
+              domain="crew"
+              groups={crewGroups}
+              onSelectCandidate={handleSelectCandidate}
+            />
           </>
         )}
-      </TabsContent>
-    </Tabs>
+        </TabsContent>
+      </Tabs>
+
+      <TalentDetailDialog
+        open={selectedCandidate !== null}
+        candidate={selectedCandidate?.candidate ?? null}
+        highlight={selectedCandidate?.highlight ?? null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedCandidate(null);
+          }
+        }}
+      />
+    </>
   );
 }

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-types.ts
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-types.ts
@@ -1,0 +1,49 @@
+export type Domain = "acting" | "crew";
+
+export type CandidatePreference = {
+  roleId: string;
+  label: string;
+  share: number;
+  rank: number;
+};
+
+export type CandidateAggregate = {
+  userId: string;
+  name: string;
+  email: string | null;
+  focus: "acting" | "tech" | "both" | null;
+  score: number;
+  confidence: number;
+  experienceYears: number | null;
+  interests: string[];
+  background: string | null;
+  notes: string | null;
+  preferences: Record<Domain, CandidatePreference[]>;
+};
+
+export type HighlightContext = {
+  domain: Domain;
+  roleId: string;
+  label: string;
+  rank: number;
+  share: number;
+};
+
+export type RoleCandidate = {
+  candidate: CandidateAggregate;
+  highlight: HighlightContext;
+};
+
+export type RoleGroup = {
+  roleId: string;
+  label: string;
+  domain: Domain;
+  candidates: RoleCandidate[];
+};
+
+export type RoleSummary = {
+  roleId: string;
+  label: string;
+  domain: Domain;
+  averageShare: number;
+};

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/role-spider-chart.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/role-spider-chart.tsx
@@ -14,6 +14,7 @@ type RoleSpiderChartProps = {
   title?: string;
   subtitle?: string;
   size?: number;
+  accentColor?: string;
 };
 
 const percentFormatter = new Intl.NumberFormat("de-DE", { maximumFractionDigits: 0 });
@@ -23,8 +24,10 @@ export function RoleSpiderChart({
   title = "Rollenpräferenzen",
   subtitle = "Verteilung der Rollengrößen-Präferenzen",
   size = 220,
+  accentColor,
 }: RoleSpiderChartProps) {
   const chartId = useId();
+  const accent = accentColor ?? "hsl(var(--primary))";
 
   const { pathData, labels, maxValue, center, radius, angleStep, points } = useMemo(() => {
     if (data.length === 0) {
@@ -122,15 +125,15 @@ export function RoleSpiderChart({
         <svg width={size} height={size} className="overflow-visible" role="img" aria-label={title}>
           <defs>
             <linearGradient id={`spider-fill-${chartId}`} x1="0" x2="0" y1="0" y2="1">
-              <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity="0.45" />
-              <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity="0.15" />
+              <stop offset="0%" stopColor={accent} stopOpacity="0.45" />
+              <stop offset="100%" stopColor={accent} stopOpacity="0.15" />
             </linearGradient>
             <linearGradient id={`spider-stroke-${chartId}`} x1="0" x2="1" y1="0" y2="1">
-              <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity="0.7" />
-              <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity="0.4" />
+              <stop offset="0%" stopColor={accent} stopOpacity="0.7" />
+              <stop offset="100%" stopColor={accent} stopOpacity="0.4" />
             </linearGradient>
             <filter id={`spider-shadow-${chartId}`} x="-20%" y="-20%" width="140%" height="140%">
-              <feDropShadow dx="0" dy="8" stdDeviation="12" floodColor="hsl(var(--primary))" floodOpacity="0.12" />
+              <feDropShadow dx="0" dy="8" stdDeviation="12" floodColor={accent} floodOpacity="0.12" />
             </filter>
           </defs>
 
@@ -177,7 +180,7 @@ export function RoleSpiderChart({
             />
           ))}
 
-          <circle cx={center} cy={center} r={4} fill="hsl(var(--primary))" fillOpacity={0.6} />
+          <circle cx={center} cy={center} r={4} fill={accent} fillOpacity={0.6} />
 
           <path
             d={pathData}
@@ -195,14 +198,14 @@ export function RoleSpiderChart({
                 cy={point.y}
                 r={3.5}
                 fill="hsl(var(--background))"
-                stroke="hsl(var(--primary))"
+                stroke={accent}
                 strokeWidth={1.5}
               />
               <circle
                 cx={point.x}
                 cy={point.y}
                 r={1.4}
-                fill="hsl(var(--primary))"
+                fill={accent}
               />
             </g>
           ))}

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/talent-detail-dialog.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/talent-detail-dialog.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+import { RoleSpiderChart } from "./role-spider-chart";
+import type { CandidateAggregate, HighlightContext } from "./ranking-types";
+
+const percentageFormatter = new Intl.NumberFormat("de-DE", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
+const scoreFormatter = new Intl.NumberFormat("de-DE", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const securityFormatter = new Intl.NumberFormat("de-DE", {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+function PreferenceDetail({
+  domain,
+  preferences,
+}: {
+  domain: "acting" | "crew";
+  preferences: CandidateAggregate["preferences"]["acting"];
+}) {
+  return (
+    <div className="rounded-xl border border-border/60 bg-background/80 p-4">
+      <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <span>{domain === "acting" ? "Acting" : "Gewerk"}</span>
+        {preferences.length > 0 && (
+          <span>{percentageFormatter.format(preferences[0].share * 100)}%</span>
+        )}
+      </div>
+      {preferences.length === 0 ? (
+        <p className="mt-3 text-[12px] text-muted-foreground/80">
+          Keine Präferenzen hinterlegt.
+        </p>
+      ) : (
+        <ol className="mt-3 space-y-2 text-sm">
+          {preferences.map((preference, index) => (
+            <li
+              key={`${domain}-${preference.roleId}`}
+              className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/40 px-3 py-2"
+            >
+              <div className="flex items-center gap-2">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-background text-[11px] font-semibold text-muted-foreground">
+                  #{preference.rank}
+                </span>
+                <div className="space-y-0.5">
+                  <p className="text-sm font-semibold text-foreground/90">{preference.label}</p>
+                  <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/80">
+                    {domain === "acting" ? "Acting" : "Crew"} #{index + 1}
+                  </p>
+                </div>
+              </div>
+              <span className="shrink-0 text-sm font-semibold text-foreground/80">
+                {percentageFormatter.format(preference.share * 100)}%
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+export function TalentDetailDialog({
+  candidate,
+  highlight,
+  open,
+  onOpenChange,
+}: {
+  candidate: CandidateAggregate | null;
+  highlight: HighlightContext | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const actingPreferences = candidate?.preferences.acting ?? [];
+  const crewPreferences = candidate?.preferences.crew ?? [];
+
+  const actingSpiderData = actingPreferences.map((preference) => ({
+    label: preference.label,
+    value: preference.share * 100,
+  }));
+
+  const crewSpiderData = crewPreferences.map((preference) => ({
+    label: preference.label,
+    value: preference.share * 100,
+  }));
+
+  const confidence = candidate
+    ? `${securityFormatter.format(candidate.confidence * 100)}%`
+    : null;
+
+  const score = candidate ? scoreFormatter.format(candidate.score) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader className="space-y-2">
+          <DialogTitle className="text-2xl font-semibold text-foreground">
+            {candidate?.name ?? "Talentprofil"}
+          </DialogTitle>
+          <DialogDescription>
+            Detailansicht der Onboarding-Präferenzen und Hintergründe.
+          </DialogDescription>
+          {highlight && (
+            <div className="flex flex-wrap items-center gap-2 pt-1 text-xs">
+              <Badge variant="muted" size="sm" className="font-semibold uppercase tracking-wide">
+                {highlight.label}
+              </Badge>
+              <Badge variant="outline" size="sm">
+                #{highlight.rank}
+              </Badge>
+              <span className="rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 font-medium text-foreground/80">
+                {percentageFormatter.format(highlight.share * 100)}% Präferenzanteil
+              </span>
+            </div>
+          )}
+        </DialogHeader>
+
+        {candidate ? (
+          <div className="space-y-6">
+            <section className="grid gap-4 text-sm text-muted-foreground sm:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+                  Kontakt
+                </p>
+                <p className={cn("font-medium text-foreground", !candidate.email && "text-muted-foreground/70")}>
+                  {candidate.email ?? "Keine E-Mail hinterlegt"}
+                </p>
+              </div>
+              <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+                  Fokus & Sicherheit
+                </p>
+                <div className="flex flex-wrap items-center gap-2">
+                  {candidate.focus && (
+                    <Badge variant="secondary" size="sm" className="font-semibold uppercase tracking-wide">
+                      {candidate.focus === "acting"
+                        ? "Fokus Acting"
+                        : candidate.focus === "tech"
+                          ? "Fokus Technik"
+                          : "Fokus Acting + Crew"}
+                    </Badge>
+                  )}
+                  {score && (
+                    <span className="rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 font-medium text-foreground/80">
+                      Score {score}
+                    </span>
+                  )}
+                  {confidence && (
+                    <span className="rounded-full border border-border/60 bg-muted/30 px-2 py-0.5 font-medium text-foreground/80">
+                      {confidence} Sicherheit
+                    </span>
+                  )}
+                  {candidate.experienceYears !== null && (
+                    <span className="rounded-full border border-border/60 bg-muted/30 px-2 py-0.5 font-medium text-foreground/80">
+                      {candidate.experienceYears === 0
+                        ? "Neu im Bereich"
+                        : `${candidate.experienceYears} Jahre Erfahrung`}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            <Separator />
+
+            {candidate.interests.length > 0 && (
+              <section className="space-y-3">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Interessen & Tags</h3>
+                <div className="flex flex-wrap gap-2">
+                  {candidate.interests.map((interest) => (
+                    <Badge
+                      key={interest}
+                      variant="outline"
+                      size="sm"
+                      className="border-border/60 bg-background/80 px-2 py-0 text-[11px] font-medium"
+                    >
+                      {interest}
+                    </Badge>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {(candidate.background || candidate.notes) && (
+              <section className="grid gap-4 text-sm text-muted-foreground lg:grid-cols-2">
+                {candidate.background && (
+                  <div className="space-y-2 rounded-xl border border-border/60 bg-muted/40 p-4">
+                    <h3 className="text-sm font-semibold text-foreground">Background</h3>
+                    <p className="leading-relaxed text-muted-foreground/90">{candidate.background}</p>
+                  </div>
+                )}
+                {candidate.notes && (
+                  <div className="space-y-2 rounded-xl border border-dashed border-border/60 bg-background/80 p-4">
+                    <h3 className="text-sm font-semibold text-foreground">Notizen aus dem Onboarding</h3>
+                    <p className="leading-relaxed text-muted-foreground/90">{candidate.notes}</p>
+                  </div>
+                )}
+              </section>
+            )}
+
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Präferenzradar
+              </h3>
+              <div className="grid gap-4 lg:grid-cols-2">
+                <div className="space-y-3">
+                  <RoleSpiderChart
+                    title="Acting Präferenzen"
+                    subtitle="Stärken der favorisierten Rollen"
+                    data={actingSpiderData}
+                    accentColor="var(--chart-3)"
+                    size={260}
+                  />
+                  <PreferenceDetail domain="acting" preferences={actingPreferences} />
+                </div>
+                <div className="space-y-3">
+                  <RoleSpiderChart
+                    title="Crew Präferenzen"
+                    subtitle="Verteilung der Gewerke"
+                    data={crewSpiderData}
+                    accentColor="var(--chart-4)"
+                    size={260}
+                  />
+                  <PreferenceDetail domain="crew" preferences={crewPreferences} />
+                </div>
+              </div>
+            </section>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">Keine Profildaten verfügbar.</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add a talent detail dialog for onboarding ranking entries with formatted insights
- allow clicking a candidate name to open modal showing stats and domain-specific spider charts
- refactor shared ranking types and support custom accents in the radar chart component

## Testing
- pnpm lint
- pnpm test
- pnpm build > build.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68e6b2433238832db7cba7ac0902383f