### PR TITLE
Use Recharts for onboarding spider chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-dom": "19.1.1",
     "react-hook-form": "^7.62.0",
     "react-quill-new": "^3.6.0",
+    "recharts": "^3.2.1",
     "sanitize-html": "^2.13.0",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       react-quill-new:
         specifier: ^3.6.0
         version: 3.6.0(quill-delta@5.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      recharts:
+        specifier: ^3.2.1
+        version: 3.2.1(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react-is@17.0.2)(react@19.1.1)(redux@5.0.1)
       sanitize-html:
         specifier: ^2.13.0
         version: 2.17.0
@@ -1381,6 +1384,17 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@reduxjs/toolkit@2.9.0':
+    resolution: {integrity: sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.52.0':
     resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
     cpu: [arm]
@@ -1844,8 +1858,23 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
   '@types/d3-cloud@1.2.9':
     resolution: {integrity: sha512-5EWJvnlCrqTThGp8lYHx+DL00sOjx2HTlXH1WRe93k5pfOIhPQaL63NttaKYIbT7bTXp/USiunjNS/N4ipttIQ==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
 
   '@types/d3-scale-chromatic@3.1.0':
     resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
@@ -1853,8 +1882,14 @@ packages:
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/d3@3.5.53':
     resolution: {integrity: sha512-8yKQA9cAS6+wGsJpBysmnhlaaxlN42Qizqkw+h2nILSlS+MAG2z4JdO6p+PJrJ+ACvimkmLJL281h157e52psQ==}
@@ -1900,6 +1935,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.43.0':
     resolution: {integrity: sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==}
@@ -2390,12 +2428,20 @@ packages:
   d3-dispatch@1.0.6:
     resolution: {integrity: sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==}
 
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
   d3-format@3.1.0:
     resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
     engines: {node: '>=12'}
 
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
 
   d3-scale-chromatic@3.1.0:
@@ -2406,12 +2452,20 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
 
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
   d3-time-format@4.1.0:
     resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
     engines: {node: '>=12'}
 
   d3-time@3.1.0:
     resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
@@ -2465,6 +2519,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -2631,6 +2688,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.40.0:
+    resolution: {integrity: sha512-8o6w0KFmU0CiIl0/Q/BCEOabF2IJaELM1T2PWj6e8KqzHv1gdx+7JtFnDwOx1kJH/isJ5NwlDG1nCr1HrRF94Q==}
 
   esbuild@0.25.10:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
@@ -3025,6 +3085,9 @@ packages:
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
+
+  immer@10.1.3:
+    resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
 
   immutable@4.3.7:
     resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
@@ -3873,6 +3936,18 @@ packages:
       react: ^16 || ^17 || ^18 || ^19
       react-dom: ^16 || ^17 || ^18 || ^19
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -3911,9 +3986,25 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  recharts@3.2.1:
+    resolution: {integrity: sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -3936,6 +4027,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4211,6 +4305,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -4341,6 +4438,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -4348,6 +4450,9 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -5783,6 +5888,18 @@ snapshots:
     dependencies:
       react: 19.1.1
 
+  '@reduxjs/toolkit@2.9.0(react-redux@9.2.0(@types/react@19.1.13)(react@19.1.1)(redux@5.0.1))(react@19.1.1)':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@standard-schema/utils': 0.3.0
+      immer: 10.1.3
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.1.1
+      react-redux: 9.2.0(@types/react@19.1.13)(react@19.1.1)(redux@5.0.1)
+
   '@rollup/rollup-android-arm-eabi@4.52.0':
     optional: true
 
@@ -6296,9 +6413,21 @@ snapshots:
     dependencies:
       '@types/node': 24.5.2
 
+  '@types/d3-array@3.2.2': {}
+
   '@types/d3-cloud@1.2.9':
     dependencies:
       '@types/d3': 3.5.53
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
 
   '@types/d3-scale-chromatic@3.1.0': {}
 
@@ -6306,7 +6435,13 @@ snapshots:
     dependencies:
       '@types/d3-time': 3.0.4
 
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
   '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/d3@3.5.53': {}
 
@@ -6354,6 +6489,8 @@ snapshots:
       htmlparser2: 8.0.2
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.36.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -6883,11 +7020,15 @@ snapshots:
 
   d3-dispatch@1.0.6: {}
 
+  d3-ease@3.0.1: {}
+
   d3-format@3.1.0: {}
 
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
 
   d3-scale-chromatic@3.1.0:
     dependencies:
@@ -6902,6 +7043,10 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
 
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-time-format@4.1.0:
     dependencies:
       d3-time: 3.1.0
@@ -6909,6 +7054,8 @@ snapshots:
   d3-time@3.1.0:
     dependencies:
       d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -6950,6 +7097,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -7183,6 +7332,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.40.0: {}
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -7689,6 +7840,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
+
+  immer@10.1.3: {}
 
   immutable@4.3.7: {}
 
@@ -8480,6 +8633,15 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
+  react-redux@9.2.0(@types/react@19.1.13)(react@19.1.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.1.1
+      use-sync-external-store: 1.6.0(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.1.13)(react@19.1.1):
     dependencies:
       react: 19.1.1
@@ -8511,10 +8673,36 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  recharts@3.2.1(@types/react@19.1.13)(react-dom@19.1.1(react@19.1.1))(react-is@17.0.2)(react@19.1.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.9.0(react-redux@9.2.0(@types/react@19.1.13)(react@19.1.1)(redux@5.0.1))(react@19.1.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.40.0
+      eventemitter3: 5.0.1
+      immer: 10.1.3
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.1.13)(react@19.1.1)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.1.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -8543,6 +8731,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -8918,6 +9108,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -9075,9 +9267,30 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.13
 
+  use-sync-external-store@1.6.0(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+
   uuid@8.3.2: {}
 
   vary@1.1.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1):
     dependencies:

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/role-spider-chart.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/role-spider-chart.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+} from "recharts";
+import type { TickItemTextProps } from "recharts/types/polar/PolarAngleAxis";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 type RolePreference = {
@@ -19,6 +29,19 @@ type RoleSpiderChartProps = {
 
 const percentFormatter = new Intl.NumberFormat("de-DE", { maximumFractionDigits: 0 });
 const FALLBACK_ACCENT = "oklch(0.66 0.18 63.3)";
+
+function parseCoordinate(value: number | string | undefined): number {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  return 0;
+}
 
 function normalizeCssColor(value: string | null | undefined): string | null {
   if (!value) {
@@ -60,86 +83,99 @@ function useResolvedAccentColor(accentColor?: string): string {
   return resolvedAccent;
 }
 
+type ChartEntry = {
+  label: string;
+  value: number;
+  maxValue: number;
+};
+
 export function RoleSpiderChart({
   data,
   title = "Rollenpräferenzen",
   subtitle = "Verteilung der Rollengrößen-Präferenzen",
-  size = 220,
+  size = 240,
   accentColor,
 }: RoleSpiderChartProps) {
   const chartId = useId();
   const accent = useResolvedAccentColor(accentColor);
 
-  const { pathData, labels, maxValue, center, radius, angleStep, points } = useMemo(() => {
+  const { chartData, maxValue } = useMemo(() => {
     if (data.length === 0) {
-      const fallbackCenter = size / 2;
-      const fallbackRadius = (size - 72) / 2;
       return {
-        pathData: "",
-        labels: [],
+        chartData: [] as ChartEntry[],
         maxValue: 1,
-        center: fallbackCenter,
-        radius: fallbackRadius,
-        angleStep: 0,
-        points: [],
       };
     }
 
-    const max = Math.max(...data.map((entry) => entry.maxValue ?? entry.value));
-    const computedCenter = size / 2;
-    const computedRadius = (size - 72) / 2;
-    const computedAngleStep = (2 * Math.PI) / data.length;
+    const computedMax = Math.max(...data.map((entry) => entry.maxValue ?? entry.value), 1);
+    const mapped: ChartEntry[] = data.map((entry) => ({
+      label: entry.label,
+      value: entry.value,
+      maxValue: entry.maxValue ?? computedMax,
+    }));
 
-    const calculatedPoints = data.map((item, index) => {
-      const angle = index * computedAngleStep - Math.PI / 2;
-      const normalizedValue = max === 0 ? 0 : (item.value / max) * computedRadius;
-      const x = computedCenter + normalizedValue * Math.cos(angle);
-      const y = computedCenter + normalizedValue * Math.sin(angle);
-      const axisX = computedCenter + computedRadius * Math.cos(angle);
-      const axisY = computedCenter + computedRadius * Math.sin(angle);
+    return { chartData: mapped, maxValue: computedMax };
+  }, [data]);
 
-      return {
-        x,
-        y,
-        axisX,
-        axisY,
-        angle,
-        value: item.value,
-        label: item.label,
-      };
-    });
+  const renderAngleTick = useCallback(
+    ({ payload, x, y }: TickItemTextProps) => {
+      if (!payload || !payload.payload) {
+        return <g />;
+      }
 
-    const path =
-      calculatedPoints.length > 0
-        ? `M${calculatedPoints.map((point) => `${point.x},${point.y}`).join("L")}Z`
-        : "";
+      const entry = payload.payload as ChartEntry;
+      const center = size / 2;
+      const xCoord = parseCoordinate(x);
+      const yCoord = parseCoordinate(y);
+      const textAnchor =
+        xCoord > center + 6
+          ? "start"
+          : xCoord < center - 6
+            ? "end"
+            : ("middle" as const);
+      const labelWidth = 120;
+      const labelHeight = 34;
+      const rectX =
+        textAnchor === "end" ? -labelWidth : textAnchor === "middle" ? -labelWidth / 2 : 0;
 
-    const calculatedLabels = calculatedPoints.map((point) => {
-      const labelRadius = computedRadius + 26;
-      const x = computedCenter + labelRadius * Math.cos(point.angle);
-      const y = computedCenter + labelRadius * Math.sin(point.angle);
+      return (
+        <g transform={`translate(${xCoord}, ${yCoord})`}>
+          <rect
+            x={rectX}
+            y={-labelHeight / 2}
+            width={labelWidth}
+            height={labelHeight}
+            rx={8}
+            fill="hsl(var(--background))"
+            opacity={0.92}
+            stroke="hsl(var(--border))"
+            strokeWidth={0.5}
+          />
+          <text
+            x={0}
+            y={-4}
+            textAnchor={textAnchor}
+            className="text-[10px] font-semibold fill-foreground"
+            dominantBaseline="middle"
+          >
+            {payload.value as string}
+          </text>
+          <text
+            x={0}
+            y={8}
+            textAnchor={textAnchor}
+            className="text-[9px] font-medium fill-muted-foreground"
+            dominantBaseline="middle"
+          >
+            {`${percentFormatter.format(entry.value)}%`}
+          </text>
+        </g>
+      );
+    },
+    [size],
+  );
 
-      return {
-        x,
-        y,
-        angle: point.angle,
-        label: point.label,
-        value: point.value,
-      };
-    });
-
-    return {
-      pathData: path,
-      labels: calculatedLabels,
-      maxValue: max,
-      center: computedCenter,
-      radius: computedRadius,
-      angleStep: computedAngleStep,
-      points: calculatedPoints,
-    };
-  }, [data, size]);
-
-  if (data.length === 0) {
+  if (chartData.length === 0) {
     return (
       <Card className="h-full">
         <CardHeader>
@@ -153,8 +189,7 @@ export function RoleSpiderChart({
     );
   }
 
-  const ringSteps = 4;
-  const ringFactors = Array.from({ length: ringSteps }, (_, index) => (index + 1) / ringSteps);
+  const radialTicks = 4;
 
   return (
     <Card className="h-full">
@@ -163,159 +198,58 @@ export function RoleSpiderChart({
         {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
       </CardHeader>
       <CardContent className="flex items-center justify-center p-6">
-        <svg width={size} height={size} className="overflow-visible" role="img" aria-label={title}>
-          <defs>
-            <linearGradient id={`spider-fill-${chartId}`} x1="0" x2="0" y1="0" y2="1">
-              <stop offset="0%" stopColor={accent} stopOpacity="0.45" />
-              <stop offset="100%" stopColor={accent} stopOpacity="0.15" />
-            </linearGradient>
-            <linearGradient id={`spider-stroke-${chartId}`} x1="0" x2="1" y1="0" y2="1">
-              <stop offset="0%" stopColor={accent} stopOpacity="0.7" />
-              <stop offset="100%" stopColor={accent} stopOpacity="0.4" />
-            </linearGradient>
-            <filter id={`spider-shadow-${chartId}`} x="-20%" y="-20%" width="140%" height="140%">
-              <feDropShadow dx="0" dy="8" stdDeviation="12" floodColor={accent} floodOpacity="0.12" />
-            </filter>
-          </defs>
+        <div className="w-full" style={{ maxWidth: size, height: size }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <RadarChart
+              data={chartData}
+              cx="50%"
+              cy="50%"
+              outerRadius="70%"
+              startAngle={-90}
+              endAngle={270}
+            >
+              <defs>
+                <linearGradient id={`spider-fill-${chartId}`} x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0%" stopColor={accent} stopOpacity={0.45} />
+                  <stop offset="100%" stopColor={accent} stopOpacity={0.15} />
+                </linearGradient>
+                <linearGradient id={`spider-stroke-${chartId}`} x1="0" x2="1" y1="0" y2="1">
+                  <stop offset="0%" stopColor={accent} stopOpacity={0.7} />
+                  <stop offset="100%" stopColor={accent} stopOpacity={0.4} />
+                </linearGradient>
+              </defs>
 
-          <circle
-            cx={center}
-            cy={center}
-            r={radius + 18}
-            fill="hsl(var(--muted) / 0.18)"
-            stroke="hsl(var(--border))"
-            strokeWidth="0.75"
-          />
-
-          {ringFactors.map((factor, index) => {
-            const ringRadius = radius * factor;
-            const ringPoints = Array.from({ length: data.length }, (_, pointIndex) => {
-              const angle = pointIndex * angleStep - Math.PI / 2;
-              const x = center + ringRadius * Math.cos(angle);
-              const y = center + ringRadius * Math.sin(angle);
-              return `${x},${y}`;
-            }).join(" ");
-
-            return (
-              <polygon
-                key={`ring-${factor}`}
-                points={ringPoints}
-                fill={index % 2 === 0 ? "hsl(var(--background))" : "hsl(var(--muted) / 0.1)"}
+              <PolarGrid
+                radialLines
+                gridType="polygon"
                 stroke="hsl(var(--border))"
-                strokeWidth="0.75"
-                opacity={factor === 1 ? 0.75 : 0.45}
+                strokeOpacity={0.4}
               />
-            );
-          })}
-
-          {points.map((point) => (
-            <line
-              key={`axis-${point.label}`}
-              x1={center}
-              y1={center}
-              x2={point.axisX}
-              y2={point.axisY}
-              stroke="hsl(var(--border))"
-              strokeWidth="0.75"
-              strokeOpacity={0.35}
-            />
-          ))}
-
-          <circle cx={center} cy={center} r={4} fill={accent} fillOpacity={0.6} />
-
-          <path
-            d={pathData}
-            fill={`url(#spider-fill-${chartId})`}
-            stroke={`url(#spider-stroke-${chartId})`}
-            strokeWidth={2}
-            strokeLinejoin="round"
-            filter={`url(#spider-shadow-${chartId})`}
-          />
-
-          {points.map((point) => (
-            <g key={`point-${point.label}`}>
-              <circle
-                cx={point.x}
-                cy={point.y}
-                r={3.5}
-                fill="hsl(var(--background))"
-                stroke={accent}
-                strokeWidth={1.5}
+              <PolarAngleAxis
+                dataKey="label"
+                tick={renderAngleTick}
+                tickLine={false}
+                axisLine={false}
               />
-              <circle
-                cx={point.x}
-                cy={point.y}
-                r={1.4}
-                fill={accent}
+              <PolarRadiusAxis
+                angle={90}
+                domain={[0, maxValue]}
+                tickCount={radialTicks}
+                tickFormatter={(value) => `${percentFormatter.format(value)}%`}
+                tick={{ className: "text-[9px] fill-muted-foreground" }}
+                axisLine={false}
               />
-            </g>
-          ))}
-
-          {ringFactors.map((factor) => {
-            const ringValue = maxValue * factor;
-            return (
-              <text
-                key={`ring-label-${factor}`}
-                x={center}
-                y={center - radius * factor - 6}
-                textAnchor="middle"
-                className="text-[9px] fill-muted-foreground"
-              >
-                {`${percentFormatter.format(ringValue)}%`}
-              </text>
-            );
-          })}
-
-          {labels.map((label, index) => {
-            let textAnchor: "start" | "middle" | "end" = "middle";
-            if (label.x > center + 6) textAnchor = "start";
-            else if (label.x < center - 6) textAnchor = "end";
-
-            const valueLabel = `${percentFormatter.format(label.value)}%`;
-            const labelWidth = 120;
-            const labelHeight = 34;
-            const rectX =
-              textAnchor === "end"
-                ? -labelWidth
-                : textAnchor === "middle"
-                  ? -labelWidth / 2
-                  : 0;
-
-            return (
-              <g key={`label-${index}`} transform={`translate(${label.x}, ${label.y})`}>
-                <rect
-                  x={rectX}
-                  y={-labelHeight / 2}
-                  width={labelWidth}
-                  height={labelHeight}
-                  rx={8}
-                  fill="hsl(var(--background))"
-                  opacity={0.92}
-                  stroke="hsl(var(--border))"
-                  strokeWidth={0.5}
-                />
-                <text
-                  x={0}
-                  y={-4}
-                  textAnchor={textAnchor}
-                  className="text-[10px] font-semibold fill-foreground"
-                  dominantBaseline="middle"
-                >
-                  {label.label}
-                </text>
-                <text
-                  x={0}
-                  y={8}
-                  textAnchor={textAnchor}
-                  className="text-[9px] font-medium fill-muted-foreground"
-                  dominantBaseline="middle"
-                >
-                  {valueLabel}
-                </text>
-              </g>
-            );
-          })}
-        </svg>
+              <Radar
+                name="Präferenz"
+                dataKey="value"
+                stroke={`url(#spider-stroke-${chartId})`}
+                strokeWidth={2}
+                fill={`url(#spider-fill-${chartId})`}
+                fillOpacity={1}
+              />
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- replace the handcrafted SVG-based spider chart with a Recharts RadarChart implementation and keep the existing card layout and labels
- resolve accent colours safely and render custom ticks that preserve the previous label/value styling
- add the Recharts dependency to package.json/pnpm-lock.yaml

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e6c1e2df74832d852152727507df72