### PR TITLE
Add shared interest suggestions hook for onboarding and profile

### DIFF
--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -56,6 +56,7 @@ import { MAX_INTERESTS_PER_USER } from "@/data/profile";
 import { ALLERGY_LEVEL_STYLES } from "@/data/allergy-styles";
 import { UserAvatar } from "@/components/user-avatar";
 import { useOnboardingBackgroundData } from "@/components/onboarding/use-onboarding-background-data";
+import { useInterestSuggestions } from "@/hooks/useInterestSuggestions";
 import {
   getRolePreferenceDescription,
   getRolePreferenceTitle,
@@ -2444,29 +2445,42 @@ function InterestsSection({ interests, onInterestsChange }: InterestsSectionProp
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const { suggestions: interestSuggestions, loading: suggestionsLoading } = useInterestSuggestions();
+  const availableInterestSuggestions = useMemo(() => {
+    const selected = new Set(state.items.map((item) => item.toLowerCase()));
+    return interestSuggestions
+      .filter((suggestion) => suggestion.name && !selected.has(suggestion.name.toLowerCase()))
+      .slice(0, 12);
+  }, [interestSuggestions, state.items]);
 
   useEffect(() => {
     setState({ items: interests, dirty: false });
   }, [interests]);
 
-  const addInterest = () => {
+  const tryAddInterest = (rawValue: string) => {
     setError(null);
-    const parsed = interestSchema.safeParse(input);
+    const parsed = interestSchema.safeParse(rawValue);
     if (!parsed.success) {
       setError(parsed.error.issues[0]?.message ?? "Ungültiges Interesse");
-      return;
+      return false;
     }
     const value = parsed.data;
     if (state.items.length >= MAX_INTERESTS_PER_USER) {
       setError(`Maximal ${MAX_INTERESTS_PER_USER} Interessen erlaubt.`);
-      return;
+      return false;
     }
     if (state.items.some((entry) => entry.toLowerCase() === value.toLowerCase())) {
       setError("Dieses Interesse ist bereits erfasst.");
-      return;
+      return false;
     }
     setState((prev) => ({ items: [...prev.items, value], dirty: true }));
-    setInput("");
+    return true;
+  };
+
+  const addInterest = () => {
+    if (tryAddInterest(input)) {
+      setInput("");
+    }
   };
 
   const removeInterest = (interest: string) => {
@@ -2552,6 +2566,37 @@ function InterestsSection({ interests, onInterestsChange }: InterestsSectionProp
                 </span>
               ))
             )}
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Beliebte Tags</p>
+            <div className="flex flex-wrap gap-2">
+              {suggestionsLoading ? (
+                <span className="text-xs text-muted-foreground">Lade Vorschläge …</span>
+              ) : availableInterestSuggestions.length > 0 ? (
+                availableInterestSuggestions.map((suggestion) => (
+                  <button
+                    key={suggestion.name}
+                    type="button"
+                    className="flex items-center gap-2 rounded-full border border-border/70 px-3 py-1 text-xs text-muted-foreground transition hover:border-primary hover:text-primary"
+                    onClick={() => {
+                      if (tryAddInterest(suggestion.name)) {
+                        setInput("");
+                      }
+                    }}
+                  >
+                    <span>{suggestion.name}</span>
+                    {suggestion.usage > 0 ? (
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                        {suggestion.usage}
+                      </span>
+                    ) : null}
+                  </button>
+                ))
+              ) : (
+                <span className="text-xs text-muted-foreground">Keine Vorschläge verfügbar.</span>
+              )}
+            </div>
           </div>
 
           <div className="flex justify-between gap-2">

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -21,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useInterestSuggestions } from "@/hooks/useInterestSuggestions";
 import { cn } from "@/lib/utils";
 import { listRolePreferenceDefinitions } from "@/lib/onboarding/role-preferences";
 import {
@@ -127,11 +128,6 @@ type PreferenceSummaryEntry = {
   label: string;
   isCustom: boolean;
   domain: "acting" | "crew";
-};
-
-type InterestSuggestion = {
-  name: string;
-  usage: number;
 };
 
 type DietaryEntry = {
@@ -301,8 +297,10 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
   const [documentError, setDocumentError] = useState<string | null>(null);
   const [documentMode, setDocumentMode] = useState<"upload" | "signature">("upload");
   const [signatureDataUrl, setSignatureDataUrl] = useState<string | null>(null);
-  const [availableInterests, setAvailableInterests] = useState<InterestSuggestion[]>([]);
-  const [interestsLoading, setInterestsLoading] = useState(false);
+  const {
+    suggestions: interestSuggestions,
+    loading: interestsLoading,
+  } = useInterestSuggestions();
   const [form, setForm] = useState(() => createInitialFormState(variant));
   const {
     backgroundSuggestions,
@@ -333,49 +331,6 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
   });
 
   const notesHelpId = useId();
-
-  useEffect(() => {
-    let cancelled = false;
-    const loadInterests = async () => {
-      setInterestsLoading(true);
-      try {
-        const response = await fetch("/api/onboarding/interests", { cache: "no-store" });
-        const data = await response.json().catch(() => null);
-        if (!cancelled && Array.isArray(data?.interests)) {
-          const entries = data.interests
-            .map((entry: unknown): InterestSuggestion | null => {
-              if (typeof entry === "string") {
-                return { name: entry, usage: 0 } satisfies InterestSuggestion;
-              }
-              if (entry && typeof entry === "object") {
-                const record = entry as { name?: unknown; usage?: unknown };
-                const name = typeof record.name === "string" ? record.name : null;
-                if (!name) return null;
-                const usage = typeof record.usage === "number" && Number.isFinite(record.usage)
-                  ? record.usage
-                  : 0;
-                return { name, usage } satisfies InterestSuggestion;
-              }
-              return null;
-            })
-            .filter(
-              (entry: InterestSuggestion | null): entry is InterestSuggestion => Boolean(entry?.name),
-            );
-          setAvailableInterests(entries);
-        }
-      } catch {
-        if (!cancelled) {
-          setAvailableInterests([]);
-        }
-      } finally {
-        if (!cancelled) setInterestsLoading(false);
-      }
-    };
-    void loadInterests();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const age = useMemo(() => calculateAge(form.dateOfBirth || null), [form.dateOfBirth]);
   const isMinor = age !== null && age < 18;
@@ -462,10 +417,10 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
 
   const availableInterestSuggestions = useMemo(() => {
     const selected = new Set(form.interests.map((item) => item.toLowerCase()));
-    return availableInterests
+    return interestSuggestions
       .filter((interest) => interest.name && !selected.has(interest.name.toLowerCase()))
       .slice(0, 12);
-  }, [availableInterests, form.interests]);
+  }, [interestSuggestions, form.interests]);
 
   const addInterestToForm = useCallback(
     (interest: string) => {

--- a/src/hooks/useInterestSuggestions.ts
+++ b/src/hooks/useInterestSuggestions.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { parseInterestSuggestions, type InterestSuggestion } from "@/lib/interests";
+
+type Options = {
+  immediate?: boolean;
+  initial?: InterestSuggestion[];
+};
+
+function isAbortError(error: unknown): error is DOMException {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+export function useInterestSuggestions(options?: Options) {
+  const { immediate = true, initial = [] } = options ?? {};
+  const [suggestions, setSuggestions] = useState<InterestSuggestion[]>(initial);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      setLoading(true);
+      try {
+        const response = await fetch("/api/onboarding/interests", { cache: "no-store", signal });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const data = await response.json().catch(() => null);
+        if (signal?.aborted) {
+          return;
+        }
+        const parsed = parseInterestSuggestions(data);
+        setSuggestions(parsed);
+        setError(null);
+      } catch (error) {
+        if (isAbortError(error)) {
+          return;
+        }
+        console.error("[useInterestSuggestions]", error);
+        setError("Vorschläge konnten nicht geladen werden.");
+        if (!signal?.aborted) {
+          setSuggestions([]);
+        }
+      } finally {
+        if (!signal?.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!immediate) {
+      return undefined;
+    }
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => {
+      controller.abort();
+    };
+  }, [immediate, load]);
+
+  const refresh = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  return { suggestions, loading, error, refresh } as const;
+}

--- a/src/lib/interests.ts
+++ b/src/lib/interests.ts
@@ -1,0 +1,61 @@
+export type InterestSuggestion = {
+  name: string;
+  usage: number;
+};
+
+function toSuggestion(entry: unknown): InterestSuggestion | null {
+  if (typeof entry === "string") {
+    const name = entry.trim();
+    if (!name) {
+      return null;
+    }
+    return { name, usage: 0 } satisfies InterestSuggestion;
+  }
+
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+
+  const record = entry as { name?: unknown; usage?: unknown };
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  if (!name) {
+    return null;
+  }
+
+  const usage =
+    typeof record.usage === "number" && Number.isFinite(record.usage) && record.usage >= 0
+      ? Math.floor(record.usage)
+      : 0;
+
+  return { name, usage } satisfies InterestSuggestion;
+}
+
+export function parseInterestSuggestions(payload: unknown): InterestSuggestion[] {
+  const list: unknown[] = Array.isArray(payload)
+    ? payload
+    : payload && typeof payload === "object" && Array.isArray((payload as { interests?: unknown }).interests)
+      ? ((payload as { interests: unknown[] }).interests ?? [])
+      : [];
+
+  const seen = new Set<string>();
+  const suggestions: InterestSuggestion[] = [];
+
+  for (const entry of list) {
+    const suggestion = toSuggestion(entry);
+    if (!suggestion) {
+      continue;
+    }
+    const normalized = suggestion.name.trim();
+    if (!normalized) {
+      continue;
+    }
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    suggestions.push({ name: normalized, usage: suggestion.usage });
+  }
+
+  return suggestions;
+}


### PR DESCRIPTION
## Summary
- add a shared interest suggestion parser and hook that fetches `/api/onboarding/interests`
- update the onboarding wizard to consume the new hook instead of bespoke fetch logic
- surface the top interest suggestions in the profile interest editor using the shared hook

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e779b5aa54832da47438be9cf4e03b