### PR TITLE
Center onboarding wizard progress indicator

### DIFF
--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1097,7 +1097,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
         aria-label="Onboarding-Fortschritt"
         className="max-w-full overflow-x-auto rounded-xl border border-border/60 bg-background/80 px-3 py-2 shadow-sm sm:overflow-visible sm:border-none sm:bg-transparent sm:px-0 sm:py-0 sm:shadow-none"
       >
-        <ol className="flex list-none flex-wrap items-center gap-3 md:flex-nowrap">
+        <ol className="mx-auto flex list-none flex-wrap items-center gap-3 md:flex-nowrap lg:justify-center">
           {steps.map((item, index) => {
             const isActive = index === step;
             const isComplete = index < step;


### PR DESCRIPTION
## Summary
- center the onboarding wizard progress navigation so it stays aligned on wide screens

## Testing
- pnpm lint
- pnpm test
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e7993b87e8832da6e9e74316f3f391