### PR TITLE
Fix members layout width on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,8 +161,9 @@
     margin-inline: auto;
     --members-max-width: calc(var(--layout-max-width) + 2 * var(--layout-gutter));
     --members-container-padding-inline: var(--layout-gutter);
-    max-width: var(--members-max-width);
+    max-width: 100%;
     padding-inline: var(--members-container-padding-inline);
+    box-sizing: border-box;
   }
 
   .members-container--width-sm {
@@ -212,6 +213,12 @@
 
     .members-container--padding-relaxed {
       --members-container-padding-inline: 2rem;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .members-container {
+      max-width: var(--members-max-width);
     }
   }
 


### PR DESCRIPTION
## Summary
- clamp the members content container to the viewport on smaller screens
- add border-box sizing so padding adjustments do not introduce overflow

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: Module not found 'react-easy-crop' / 'react-easy-crop/react-easy-crop.css')*

------
https://chatgpt.com/codex/tasks/task_e_68e8d165a970832da96f5c79869da1c3