### PR TITLE
Fix onboarding radar chart scaling

### DIFF
--- a/src/app/dashboard/onboarding/[onboardingId]/_components/role-spider-chart.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/role-spider-chart.tsx
@@ -110,7 +110,9 @@ export function RoleSpiderChart({
       };
     }
 
-    const computedMax = Math.max(...data.map((entry) => entry.maxValue ?? entry.value), 1);
+    const hasExplicitMax = data.some((entry) => entry.maxValue !== undefined);
+    const values = data.map((entry) => entry.maxValue ?? entry.value);
+    const computedMax = Math.max(...values, hasExplicitMax ? 1 : 100);
     const mapped: ChartEntry[] = data.map((entry) => ({
       label: entry.label,
       value: entry.value,


### PR DESCRIPTION
## Summary
- ensure the onboarding radar chart always normalizes to a 100% scale when no explicit maximum is provided
- keep support for custom max values by still honoring per-entry `maxValue` overrides

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: Module not found: Can't resolve 'react-easy-crop' and related CSS)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e170b0c4832db5e123992f2fc18b