### PR TITLE
Fix Sperrliste settings overload and clean lint warnings

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/overview/TimelineView.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/TimelineView.tsx
@@ -1,15 +1,13 @@
 import React, { useMemo, useEffect, useCallback } from "react";
 
-import { 
-  CalendarStarIcon, 
-  CheckIcon, 
-  ClockAlertIcon, 
-  ClockIcon, 
-  StarIcon, 
-  UmbrellaIcon, 
-  XCircleIcon 
+import {
+  CalendarStarIcon,
+  CheckIcon,
+  ClockAlertIcon,
+  StarIcon,
+  UmbrellaIcon,
+  XCircleIcon
 } from "./icons";
-import { IconButton } from "./ui-components";
 import { TimelineCell } from "./timeline-cell";
 import { getHolidaySpans, selectDayBuckets, groupPeopleByType } from "./data-helpers";
 import type { DayColumn, HolidayIndicator, OverviewPerson, PersonGroup } from "./types";

--- a/src/app/(members)/mitglieder/sperrliste/overview/desktop-table.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/desktop-table.tsx
@@ -184,10 +184,9 @@ export function DesktopTable({
               <>
                 {/* Schauspieler Gruppe */}
                 {groupedPeople.actors.map((p, idx) => (
-                  <PersonRow 
+                  <PersonRow
                     key={p.id}
                     person={p}
-                    dayCols={dayCols}
                     compact={compact}
                     isFirstInGroup={idx === 0}
                     groupSize={groupedPeople.actors.length}
@@ -198,10 +197,9 @@ export function DesktopTable({
                 
                 {/* Beides Gruppe (Schauspieler & Gewerke) */}
                 {groupedPeople.both.map((p, idx) => (
-                  <PersonRow 
+                  <PersonRow
                     key={p.id}
                     person={p}
-                    dayCols={dayCols}
                     compact={compact}
                     isFirstInGroup={idx === 0}
                     groupSize={groupedPeople.both.length}
@@ -212,10 +210,9 @@ export function DesktopTable({
                 
                 {/* Gewerke Gruppe */}
                 {groupedPeople.crew.map((p, idx) => (
-                  <PersonRow 
+                  <PersonRow
                     key={p.id}
                     person={p}
-                    dayCols={dayCols}
                     compact={compact}
                     isFirstInGroup={idx === 0}
                     groupSize={groupedPeople.crew.length}
@@ -229,15 +226,15 @@ export function DesktopTable({
               /* Gefilterte Liste ohne Gruppierungs-Header */
               filteredPeople.map((p) => (
                 <tr key={p.id} className="border-b border-slate-200/60">
-                  <th 
-                    scope="row" 
+                  <th
+                    scope="row"
                     className="sticky left-0 z-10 w-[220px] sm:w-[260px] min-w-[220px] border-r border-slate-200/70 bg-white backdrop-blur shadow-sm px-3 py-2 text-left"
                   >
                     <PersonInfo person={p} />
                   </th>
-                  {p.days.map((cell, i) => (
+                  {p.days.map((cell) => (
                     <td key={`${p.id}-${cell.dayKey}`} className="h-20 px-1.5 py-1.5 align-top whitespace-normal break-words">
-                      <Cell cell={cell} compact={compact} inTable={true} />
+                      <Cell cell={cell} compact={compact} />
                     </td>
                   ))}
                 </tr>
@@ -256,7 +253,6 @@ export function DesktopTable({
 
 type PersonRowProps = {
   person: OverviewPerson;
-  dayCols: DayColumn[];
   compact: boolean;
   isFirstInGroup: boolean;
   groupSize: number;
@@ -265,13 +261,12 @@ type PersonRowProps = {
   isLastGroup?: boolean;
 };
 
-function PersonRow({ 
-  person, 
-  dayCols, 
-  compact, 
-  isFirstInGroup, 
-  groupSize, 
-  groupLabel, 
+function PersonRow({
+  person,
+  compact,
+  isFirstInGroup,
+  groupSize,
+  groupLabel,
   groupColor,
   isLastGroup = false
 }: PersonRowProps) {
@@ -310,9 +305,9 @@ function PersonRow({
       >
         <PersonInfo person={person} groupColor={groupColor} />
       </th>
-      {person.days.map((cell, i) => (
+      {person.days.map((cell) => (
         <td key={`${person.id}-${cell.dayKey}`} className="h-20 px-1.5 py-1.5 align-top whitespace-normal break-words">
-          <Cell cell={cell} compact={compact} inTable={true} />
+          <Cell cell={cell} compact={compact} />
         </td>
       ))}
     </tr>

--- a/src/app/(members)/mitglieder/sperrliste/overview/table-cell.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/table-cell.tsx
@@ -10,13 +10,12 @@ import type { OverviewPersonDay } from "./types";
 type CellProps = {
   cell: OverviewPersonDay;
   compact?: boolean;
-  inTable?: boolean;
 };
 
 /**
  * Cell-Komponente für die Tabellen-Ansicht (memoized für Performance)
  */
-const CellComponent = ({ cell, compact = false, inTable = false }: CellProps) => {
+const CellComponent = ({ cell, compact = false }: CellProps) => {
   const baseClasses = `flex flex-col justify-center h-16 w-full rounded-lg px-2.5 text-left text-[12px] font-medium overflow-hidden ${
     compact ? "leading-4" : ""
   }`;

--- a/src/lib/sperrliste-settings.ts
+++ b/src/lib/sperrliste-settings.ts
@@ -229,7 +229,6 @@ type ReadSperrlisteSettingsOptions =
   | ReadSperrlisteSettingsOptionsWithMeta
   | ReadSperrlisteSettingsOptionsWithoutMeta;
 
-export async function readSperrlisteSettings(): Promise<SperrlisteSettingsRecord>;
 export async function readSperrlisteSettings(
   options: ReadSperrlisteSettingsOptionsWithMeta,
 ): Promise<ReadSperrlisteSettingsMeta>;
@@ -238,7 +237,7 @@ export async function readSperrlisteSettings(
 ): Promise<SperrlisteSettingsRecord>;
 export async function readSperrlisteSettings(
   options?: ReadSperrlisteSettingsOptions,
-) {
+): Promise<SperrlisteSettingsRecord | ReadSperrlisteSettingsMeta> {
   if (!databaseEnabled()) {
     const record = cloneRecord(DEV_SPERRLISTE_SETTINGS_RECORD_FIXTURE);
     if (options?.withMeta) {


### PR DESCRIPTION
## Summary
- adjust `readSperrlisteSettings` overloads so the implementation signature matches TypeScript expectations
- remove unused icons, props, and parameters from the Sperrliste overview timeline and table to satisfy lint rules
- streamline the table cell component by dropping an unused flag

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ea7ac0216c832da11a3145729a678f