### PR TITLE
Align Sperrlisten overview with design tokens

### DIFF
--- a/src/app/(members)/mitglieder/sperrliste/overview/SperrlistenV2.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/SperrlistenV2.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import "./sperrliste-styles.css";
+import { Button } from "@/components/ui/button";
+
 import { DesktopCalendar } from "./DesktopCalendar";
 import { DesktopTable } from "./desktop-table";
 import { MobileByDay } from "./MobileByDay";
@@ -105,21 +107,29 @@ export default function SperrlistenV2({
   }, [handleKeyDown]);
 
   return (
-    <div className="min-h-dvh bg-background text-foreground">
+    <div className="sperrlisten-overview min-h-dvh bg-background text-foreground">
       <main className="mx-auto space-y-4 p-4 sm:p-6" role="main" aria-label="Sperrlistenübersicht">
         <header className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
           <div className="space-y-1">
             <h1 className="text-lg font-semibold sm:text-xl" id="page-title">Sperrlistenübersicht</h1>
             <div className="flex flex-wrap gap-2 text-xs" role="status" aria-live="polite">
-              {month && <span className="rounded px-2 py-1 text-blue-800 bg-blue-100">{month.label}</span>}
-              <span className="rounded px-2 py-1 text-sky-800 bg-sky-100">Zeitraum</span>
-              <span className="rounded px-2 py-1 text-gray-800 bg-gray-100">{dayCols.length} Tage</span>
+              {month && (
+                <span className="inline-flex items-center rounded-full border border-primary/40 bg-primary/15 px-2.5 py-1 font-medium text-primary">
+                  {month.label}
+                </span>
+              )}
+              <span className="inline-flex items-center rounded-full border border-info/40 bg-info/18 px-2.5 py-1 font-medium text-info">
+                Zeitraum
+              </span>
+              <span className="inline-flex items-center rounded-full border border-muted/60 bg-muted/40 px-2.5 py-1 font-medium text-muted-foreground">
+                {dayCols.length} Tage
+              </span>
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             {/* Monatswechsel-Handler (nur wenn verfügbar) */}
             {(onPreviousMonth || onNextMonth) && (
-              <div className="flex items-center gap-1 rounded-xl border border-slate-200/70 bg-white/80 p-1 shadow-sm" role="group" aria-label="Monatsnavigation">
+              <div className="flex items-center gap-1 rounded-xl border border-border/60 bg-card/80 p-1 shadow-sm backdrop-blur" role="group" aria-label="Monatsnavigation">
                 {onPreviousMonth && (
                   <IconButton aria-label="Vorheriger Monat" onClick={onPreviousMonth}>
                     &larr;
@@ -132,7 +142,7 @@ export default function SperrlistenV2({
                 )}
                 <button
                   type="button"
-                  className="ml-1 inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white/70 px-2.5 py-1 text-sm font-medium hover:bg-white transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                  className="ml-1 inline-flex items-center gap-2 rounded-lg border border-border/60 bg-card/70 px-2.5 py-1 text-sm font-medium text-muted-foreground transition-colors hover:bg-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   aria-label="Zu heute springen"
                   onClick={handleJumpToToday}
                 >
@@ -140,11 +150,11 @@ export default function SperrlistenV2({
                 </button>
               </div>
             )}
-            
-            <div className="flex overflow-hidden rounded-xl border border-slate-200 bg-white" role="group" aria-label="Personenfilter">
+
+            <div className="flex overflow-hidden rounded-xl border border-border/60 bg-card shadow-sm" role="group" aria-label="Personenfilter">
               <button
                 type="button"
-                className={`px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${personFilter === "all" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${personFilter === "all" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setPersonFilter("all")}
                 aria-pressed={personFilter === "all"}
                 aria-label={`Alle Personen anzeigen (${groupedCounts.total})`}
@@ -153,7 +163,7 @@ export default function SperrlistenV2({
               </button>
               <button
                 type="button"
-                className={`border-l border-slate-200 px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${personFilter === "actors" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`border-l border-border/60 px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${personFilter === "actors" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setPersonFilter("actors")}
                 aria-pressed={personFilter === "actors"}
                 aria-label={`Schauspieler anzeigen (${groupedCounts.actors})`}
@@ -162,7 +172,7 @@ export default function SperrlistenV2({
               </button>
               <button
                 type="button"
-                className={`border-l border-slate-200 px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${personFilter === "crew" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`border-l border-border/60 px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${personFilter === "crew" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setPersonFilter("crew")}
                 aria-pressed={personFilter === "crew"}
                 aria-label={`Gewerke anzeigen (${groupedCounts.crew})`}
@@ -171,7 +181,7 @@ export default function SperrlistenV2({
               </button>
               <button
                 type="button"
-                className={`border-l border-slate-200 px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${personFilter === "both" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`border-l border-border/60 px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${personFilter === "both" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setPersonFilter("both")}
                 aria-pressed={personFilter === "both"}
                 aria-label={`Beides anzeigen (${groupedCounts.both})`}
@@ -180,7 +190,7 @@ export default function SperrlistenV2({
               </button>
               <button
                 type="button"
-                className={`border-l border-slate-200 px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${personFilter === "other" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`border-l border-border/60 px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${personFilter === "other" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setPersonFilter("other")}
                 aria-pressed={personFilter === "other"}
                 aria-label={`Sonstige anzeigen (${groupedCounts.other})`}
@@ -188,10 +198,10 @@ export default function SperrlistenV2({
                 Sonstige ({groupedCounts.other})
               </button>
             </div>
-            <div className="hidden overflow-hidden rounded-xl border border-slate-200 bg-white sm:flex" role="group" aria-label="Ansichtsauswahl">
+            <div className="hidden overflow-hidden rounded-xl border border-border/60 bg-card shadow-sm sm:flex" role="group" aria-label="Ansichtsauswahl">
               <button
                 type="button"
-                className={`px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${view === "calendar" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${view === "calendar" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setView("calendar")}
                 aria-pressed={view === "calendar"}
                 aria-label="Kalenderansicht (Tastenkombination: Strg+1)"
@@ -200,7 +210,7 @@ export default function SperrlistenV2({
               </button>
               <button
                 type="button"
-                className={`border-l border-slate-200 px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${view === "table" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`border-l border-border/60 px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${view === "table" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setView("table")}
                 aria-pressed={view === "table"}
                 aria-label="Tabellenansicht (Tastenkombination: Strg+2)"
@@ -209,7 +219,7 @@ export default function SperrlistenV2({
               </button>
               <button
                 type="button"
-                className={`border-l border-slate-200 px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500 ${view === "timeline" ? "bg-slate-50 text-slate-900" : "text-slate-600 hover:bg-slate-50"}`}
+                className={`border-l border-border/60 px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${view === "timeline" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/40"}`}
                 onClick={() => setView("timeline")}
                 aria-pressed={view === "timeline"}
                 aria-label="Timeline-Ansicht (Tastenkombination: Strg+3)"
@@ -228,30 +238,30 @@ export default function SperrlistenV2({
 
         {/* Kompakte Mobile-Legende (nur sm:hidden) - analog Spielplatz */}
         <section className="sm:hidden">
-          <div className="rounded-xl border border-slate-200/70 bg-gradient-to-r from-slate-50 to-white px-3 py-2 shadow-sm">
-            <div className="flex items-center justify-between gap-3 text-[10px]">
+          <div className="rounded-xl border border-border/60 bg-card/80 px-3 py-2 text-muted-foreground shadow-sm backdrop-blur">
+            <div className="flex items-center justify-between gap-3 text-[10px] text-muted-foreground">
               <div className="flex items-center gap-3">
                 <div className="flex items-center gap-1">
-                  <div className="h-3 w-3 rounded-full bg-green-100 border border-green-200" />
-                  <span className="text-slate-600">Frei</span>
+                  <div className="h-3 w-3 rounded-full border border-[hsl(var(--success)/0.35)] bg-[hsl(var(--success)/0.18)]" />
+                  <span>Frei</span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <div className="h-3 w-3 rounded-full bg-orange-100 border border-orange-200" />
-                  <span className="text-slate-600">Begrenzt</span>
+                  <div className="h-3 w-3 rounded-full border border-[hsl(var(--warning)/0.35)] bg-[hsl(var(--warning)/0.2)]" />
+                  <span>Begrenzt</span>
                 </div>
                 <div className="flex items-center gap-1">
-                  <div className="h-3 w-3 rounded-full bg-red-100 border border-red-200" />
-                  <span className="text-slate-600">Gesperrt</span>
+                  <div className="h-3 w-3 rounded-full border border-[hsl(var(--destructive)/0.35)] bg-[hsl(var(--destructive)/0.2)]" />
+                  <span>Gesperrt</span>
                 </div>
               </div>
-              <div className="flex items-center gap-2 border-l border-slate-300 pl-3">
+              <div className="flex items-center gap-2 border-l border-border/60 pl-3">
                 <div className="flex items-center gap-0.5">
                   <CalendarStarIcon className="h-3 w-3 text-amber-500" />
-                  <span className="text-slate-600">Feiertag</span>
+                  <span>Feiertag</span>
                 </div>
                 <div className="flex items-center gap-0.5">
                   <UmbrellaIcon className="h-3 w-3 text-sky-500" />
-                  <span className="text-slate-600">Ferien</span>
+                  <span>Ferien</span>
                 </div>
               </div>
             </div>
@@ -311,14 +321,14 @@ export default function SperrlistenV2({
           />
         )}
 
-        <button
+        <Button
           type="button"
-          className="self-end rounded bg-primary px-4 py-2 text-white shadow hover:bg-primary/80 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+          className="self-end"
           onClick={onExportPdf}
           aria-label="Sperrlistenübersicht als PDF exportieren"
         >
           PDF exportieren
-        </button>
+        </Button>
       </main>
     </div>
   );

--- a/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/overview-shell.tsx
@@ -6,12 +6,7 @@ import { de } from "date-fns/locale/de";
 import {
   ArrowLeft,
   ArrowRight,
-  CalendarDays,
   Clock,
-  Sparkles,
-  Sun,
-  Umbrella,
-  Users2,
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -19,7 +14,6 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Heading, Text } from "@/components/ui/typography";
-import { cn } from "@/lib/utils";
 import { getNameInitials } from "@/lib/names";
 import { formatWeekdayList, type WeekdayValue } from "@/lib/weekdays";
 import type { HolidayRange } from "@/types/holidays";
@@ -31,7 +25,6 @@ import type {
   VisibleDayInfo,
 } from "./useBlockOverviewData";
 import type {
-  DayBucket,
   DayColumn,
   HolidayIndicator,
   OverviewPerson,
@@ -74,26 +67,11 @@ function normaliseReason(value: string | null | undefined) {
   return trimmed || null;
 }
 
-function selectDayBuckets(
-  people: OverviewPerson[],
-  dayCols: DayColumn[],
-  holidays: HolidayIndicator[],
-): DayBucket[] {
-  return dayCols.map((column, index) => {
-    const entries = people.map((person) => ({ person, cell: person.days[index] }));
-    const available = entries.filter((entry) => entry.cell.type === "free" || entry.cell.type === "preferred");
-    const limited = entries.filter((entry) => entry.cell.type === "limited");
-    const blocked = entries.filter((entry) => entry.cell.type === "block");
-    const holiday = holidays.find((indicator) => indicator.dayIndex === index) ?? null;
-    return { column, available, limited, blocked, holiday } satisfies DayBucket;
-  });
-}
-
 export function OverviewShell({
   monthLabel,
   summary,
-  holidaysInRangeCount,
-  busiestMember,
+  holidaysInRangeCount: _holidaysInRangeCount,
+  busiestMember: _busiestMember,
   preferredDescription,
   exceptionDescription,
   preparedMembers,
@@ -106,6 +84,8 @@ export function OverviewShell({
   onSelectBlockedDay,
 }: OverviewShellProps) {
   const numberFormatter = useMemo(() => new Intl.NumberFormat("de-DE"), []);
+  void _holidaysInRangeCount;
+  void _busiestMember;
 
   const dayCols = useMemo<DayColumn[]>(() => {
     return visibleDayInfo.map((info) => {
@@ -214,27 +194,12 @@ export function OverviewShell({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [dayCols, highlightedDay, view]);
 
-  const filteredPeople = useMemo(() => {
-    if (personFilter === "all") return people;
-    return people.filter((person) => person.group === personFilter);
-  }, [people, personFilter]);
-
   const groupedPeople = useMemo(() => {
     const actors = people.filter((person) => person.group === "actors");
     const crew = people.filter((person) => person.group === "crew");
     const both = people.filter((person) => person.group === "both" || person.group === "other");
     return { actors, crew, both };
   }, [people]);
-
-  const activePeople = personFilter === "all" ? people : filteredPeople;
-  const dayBuckets = useMemo(
-    () => selectDayBuckets(activePeople, dayCols, holidayIndicators),
-    [activePeople, dayCols, holidayIndicators],
-  );
-
-  const membersCount = people.length;
-  const totalBlockedDays = summary.total;
-  const upcomingBlockedDays = summary.upcoming;
 
   const monthRangeLabel = useMemo(() => {
     if (!dayCols.length) return null;
@@ -261,59 +226,6 @@ export function OverviewShell({
     if (!uniqueWeekdays.length) return "–";
     return formatWeekdayList(uniqueWeekdays, { style: "short" });
   }, [dayCols]);
-
-  const stats = useMemo(
-    () => [
-      {
-        title: "Mitglieder im Überblick",
-        value: numberFormatter.format(membersCount),
-        hint:
-          membersCount === 1
-            ? "Eine Person in der Übersicht"
-            : `${numberFormatter.format(membersCount)} Personen in der Übersicht`,
-        icon: <Users2 className="h-5 w-5" aria-hidden />,
-      },
-      {
-        title: "Sperrtermine gesamt",
-        value: numberFormatter.format(totalBlockedDays),
-        hint:
-          totalBlockedDays === 1
-            ? "Ein Sperrtermin im Zeitraum"
-            : `${numberFormatter.format(totalBlockedDays)} Sperrtermine im Zeitraum`,
-        icon: <CalendarDays className="h-5 w-5" aria-hidden />,
-      },
-      {
-        title: "Anstehende Sperrtermine",
-        value: numberFormatter.format(upcomingBlockedDays),
-        hint:
-          upcomingBlockedDays === 1
-            ? "Ein Termin ab heute"
-            : `${numberFormatter.format(upcomingBlockedDays)} Termine ab heute`,
-        icon: <Clock className="h-5 w-5" aria-hidden />,
-      },
-      {
-        title: "Ferien & Feiertage",
-        value: numberFormatter.format(holidaysInRangeCount),
-        hint: holidaysInRangeCount === 1 ? "Ein relevanter Tag" : `${holidaysInRangeCount} relevante Tage`,
-        icon: <Umbrella className="h-5 w-5" aria-hidden />,
-      },
-    ],
-    [
-      holidaysInRangeCount,
-      membersCount,
-      numberFormatter,
-      totalBlockedDays,
-      upcomingBlockedDays,
-    ],
-  );
-
-  const busiestHint = useMemo(() => {
-    if (!busiestMember) {
-      return "Sobald Sperrtermine vorliegen, erscheint hier der Spitzenreiter.";
-    }
-    const totalLabel = numberFormatter.format(busiestMember.total);
-    return `${busiestMember.name} · ${totalLabel} Sperrtermin${busiestMember.total === 1 ? "" : "e"}`;
-  }, [busiestMember, numberFormatter]);
 
   return (
     <div className="min-h-dvh bg-muted/20 text-foreground">

--- a/src/app/(members)/mitglieder/sperrliste/overview/sperrliste-styles.css
+++ b/src/app/(members)/mitglieder/sperrliste/overview/sperrliste-styles.css
@@ -141,3 +141,144 @@
     background-color: hsl(var(--muted-foreground) / 0.5);
   }
 }
+
+@layer components {
+  .sperrlisten-overview {
+    color-scheme: light dark;
+  }
+
+  .sperrlisten-overview .bg-white,
+  .sperrlisten-overview .bg-white\/95,
+  .sperrlisten-overview .bg-white\/90,
+  .sperrlisten-overview .bg-white\/85,
+  .sperrlisten-overview .bg-white\/80,
+  .sperrlisten-overview .bg-white\/75,
+  .sperrlisten-overview .bg-white\/70,
+  .sperrlisten-overview .bg-white\/60,
+  .sperrlisten-overview .bg-white\/50 {
+    background-color: hsl(var(--card)) !important;
+  }
+
+  .sperrlisten-overview .bg-slate-50,
+  .sperrlisten-overview .bg-slate-50\/30,
+  .sperrlisten-overview .bg-slate-50\/80,
+  .sperrlisten-overview .bg-slate-100,
+  .sperrlisten-overview .bg-gray-100 {
+    background-color: hsl(var(--muted) / 0.4) !important;
+  }
+
+  .sperrlisten-overview .border-slate-100,
+  .sperrlisten-overview .border-slate-200,
+  .sperrlisten-overview .border-slate-200\/70,
+  .sperrlisten-overview .border-slate-300,
+  .sperrlisten-overview .border-gray-200,
+  .sperrlisten-overview .border-gray-300 {
+    border-color: hsl(var(--border) / 0.6) !important;
+  }
+
+  .sperrlisten-overview .text-slate-900,
+  .sperrlisten-overview .text-slate-800,
+  .sperrlisten-overview .text-slate-700,
+  .sperrlisten-overview .text-gray-800 {
+    color: hsl(var(--foreground)) !important;
+  }
+
+  .sperrlisten-overview .text-slate-600,
+  .sperrlisten-overview .text-slate-500,
+  .sperrlisten-overview .text-slate-400,
+  .sperrlisten-overview .text-gray-600 {
+    color: hsl(var(--muted-foreground)) !important;
+  }
+
+  .sperrlisten-overview .bg-green-100,
+  .sperrlisten-overview .bg-green-100\/80,
+  .sperrlisten-overview .from-green-50,
+  .sperrlisten-overview .from-green-50\/80,
+  .sperrlisten-overview .to-green-100\/50 {
+    background-color: hsl(var(--success) / 0.18) !important;
+    --tw-gradient-from: hsl(var(--success) / 0.18) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), hsl(var(--success) / 0.05) !important;
+  }
+
+  .sperrlisten-overview .text-green-700,
+  .sperrlisten-overview .text-green-700\/90,
+  .sperrlisten-overview .text-green-700\/80,
+  .sperrlisten-overview .border-green-200,
+  .sperrlisten-overview .border-green-200\/70,
+  .sperrlisten-overview .border-green-200\/80 {
+    color: hsl(var(--success)) !important;
+    border-color: hsl(var(--success) / 0.4) !important;
+  }
+
+  .sperrlisten-overview .bg-orange-100,
+  .sperrlisten-overview .bg-orange-100\/80,
+  .sperrlisten-overview .from-orange-50,
+  .sperrlisten-overview .from-orange-50\/80,
+  .sperrlisten-overview .to-orange-100\/50 {
+    background-color: hsl(var(--warning) / 0.2) !important;
+    --tw-gradient-from: hsl(var(--warning) / 0.2) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), hsl(var(--warning) / 0.06) !important;
+  }
+
+  .sperrlisten-overview .text-orange-700,
+  .sperrlisten-overview .text-orange-700\/90,
+  .sperrlisten-overview .border-orange-200,
+  .sperrlisten-overview .border-orange-200\/70 {
+    color: hsl(var(--warning)) !important;
+    border-color: hsl(var(--warning) / 0.45) !important;
+  }
+
+  .sperrlisten-overview .bg-red-100,
+  .sperrlisten-overview .bg-red-100\/80,
+  .sperrlisten-overview .from-red-50,
+  .sperrlisten-overview .from-red-50\/80,
+  .sperrlisten-overview .to-red-100\/50 {
+    background-color: hsl(var(--destructive) / 0.18) !important;
+    --tw-gradient-from: hsl(var(--destructive) / 0.18) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), hsl(var(--destructive) / 0.06) !important;
+  }
+
+  .sperrlisten-overview .text-red-700,
+  .sperrlisten-overview .text-red-700\/90,
+  .sperrlisten-overview .border-red-200,
+  .sperrlisten-overview .border-red-200\/70 {
+    color: hsl(var(--destructive)) !important;
+    border-color: hsl(var(--destructive) / 0.45) !important;
+  }
+
+  .sperrlisten-overview .bg-sky-100,
+  .sperrlisten-overview .bg-sky-100\/80,
+  .sperrlisten-overview .from-sky-100,
+  .sperrlisten-overview .to-sky-200,
+  .sperrlisten-overview .from-sky-400,
+  .sperrlisten-overview .to-sky-500 {
+    background-color: hsl(var(--info) / 0.18) !important;
+    --tw-gradient-from: hsl(var(--info)) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), color-mix(in srgb, hsl(var(--info)) 80%, transparent) !important;
+    --tw-gradient-to: color-mix(in srgb, hsl(var(--info)) 70%, transparent) !important;
+  }
+
+  .sperrlisten-overview .text-sky-700,
+  .sperrlisten-overview .text-sky-700\/90,
+  .sperrlisten-overview .text-blue-800,
+  .sperrlisten-overview .border-blue-500,
+  .sperrlisten-overview .border-blue-400 {
+    color: hsl(var(--info)) !important;
+    border-color: hsl(var(--info) / 0.55) !important;
+  }
+
+  .sperrlisten-overview .bg-blue-50,
+  .sperrlisten-overview .bg-blue-50\/80,
+  .sperrlisten-overview .from-blue-50,
+  .sperrlisten-overview .to-blue-100\/50 {
+    background-color: hsl(var(--primary) / 0.18) !important;
+    --tw-gradient-from: hsl(var(--primary) / 0.2) !important;
+    --tw-gradient-stops: var(--tw-gradient-from), hsl(var(--primary) / 0.06) !important;
+  }
+
+  .sperrlisten-overview .ring-blue-500\/30,
+  .sperrlisten-overview .ring-blue-400\/30,
+  .sperrlisten-overview .ring-blue-200\/50 {
+    --tw-ring-color: hsl(var(--ring) / 0.3) !important;
+  }
+}

--- a/src/app/(members)/mitglieder/sperrliste/overview/ui-components.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/ui-components.tsx
@@ -5,6 +5,8 @@
 
 import React from "react";
 
+import { cn } from "@/lib/utils";
+
 // ============================================================================
 // Badge
 // ============================================================================
@@ -22,15 +24,19 @@ type BadgeProps = {
  */
 export function Badge({ children, tone = "default", className = "" }: BadgeProps) {
   const palettes: Record<BadgeTone, string> = {
-    info: "border-sky-200 bg-sky-100/80 text-sky-700",
-    danger: "border-red-200 bg-red-100/80 text-red-700",
-    ok: "border-green-200 bg-green-100/80 text-green-700",
-    default: "border-slate-200 bg-white/80 text-slate-600",
+    info: "border-info/40 bg-info/15 text-info",
+    danger: "border-destructive/40 bg-destructive/20 text-destructive",
+    ok: "border-success/40 bg-success/15 text-success",
+    default: "border-border/60 bg-card/75 text-muted-foreground",
   };
 
   return (
     <span
-      className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] ${palettes[tone]} ${className}`}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]",
+        palettes[tone],
+        className,
+      )}
     >
       {children}
     </span>
@@ -50,7 +56,10 @@ export function IconButton({ children, className = "", ...props }: IconButtonPro
   return (
     <button
       {...props}
-      className={`inline-flex h-9 w-9 items-center justify-center rounded-full text-slate-500 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 ${className}`}
+      className={cn(
+        "inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 bg-card/70 text-muted-foreground transition hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className,
+      )}
     >
       {children}
     </button>
@@ -75,21 +84,31 @@ type StatusBadgeProps = {
  */
 export function StatusBadge({ icon, count, tone, compact = false }: StatusBadgeProps) {
   const colors: Record<StatusBadgeTone, string> = {
-    ok: "bg-green-100 text-green-700 border-green-300",
-    warn: "bg-orange-100 text-orange-700 border-orange-300",
-    danger: "bg-red-100 text-red-700 border-red-300",
+    ok: "border-success/40 bg-success/15 text-success",
+    warn: "border-warning/40 bg-warning/15 text-warning",
+    danger: "border-destructive/40 bg-destructive/15 text-destructive",
   };
 
   if (compact) {
     return (
-      <div className={`flex items-center justify-center rounded-md border px-1 py-0.5 text-[10px] font-bold ${colors[tone]}`}>
+      <div
+        className={cn(
+          "flex items-center justify-center rounded-md border px-1 py-0.5 text-[10px] font-semibold",
+          colors[tone],
+        )}
+      >
         <span>{count}</span>
       </div>
     );
   }
 
   return (
-    <div className={`flex items-center gap-1 rounded-lg border px-1.5 py-0.5 text-[10px] font-bold shadow-sm ${colors[tone]}`}>
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-lg border px-1.5 py-0.5 text-[10px] font-semibold shadow-sm",
+        colors[tone],
+      )}
+    >
       {icon}
       <span>{count}</span>
     </div>
@@ -110,13 +129,18 @@ type MiniChipProps = {
  */
 export function MiniChip({ count, tone }: MiniChipProps) {
   const colorMap: Record<StatusBadgeTone, string> = {
-    ok: "bg-green-100/80 text-green-700 border-green-200",
-    warn: "bg-orange-100/80 text-orange-700 border-orange-200",
-    danger: "bg-red-100/80 text-red-700 border-red-200",
+    ok: "border-success/35 bg-success/15 text-success",
+    warn: "border-warning/35 bg-warning/15 text-warning",
+    danger: "border-destructive/35 bg-destructive/15 text-destructive",
   };
 
   return (
-    <span className={`inline-flex min-w-5 items-center justify-center rounded-md border px-1 text-[10px] ${colorMap[tone]}`}>
+    <span
+      className={cn(
+        "inline-flex min-w-5 items-center justify-center rounded-md border px-1 text-[10px] font-medium",
+        colorMap[tone],
+      )}
+    >
       {count}
     </span>
   );
@@ -145,9 +169,14 @@ type NoteProps = {
  */
 export function Note({ title, children, className = "" }: NoteProps) {
   return (
-    <article className={`rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-sm ${className}`}>
-      <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{title}</h3>
-      <p className="mt-1 text-sm leading-6 text-slate-700">{children}</p>
+    <article
+      className={cn(
+        "rounded-2xl border border-border/60 bg-card/80 p-4 text-sm leading-6 text-card-foreground shadow-sm backdrop-blur",
+        className,
+      )}
+    >
+      <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{title}</h3>
+      <p className="mt-1 text-sm leading-6 text-foreground/85">{children}</p>
     </article>
   );
 }
@@ -171,18 +200,18 @@ type KpiProps = {
  */
 export function Kpi({ icon, title, value, hint, tone = "default" }: KpiProps) {
   const bgMap: Record<KpiTone, string> = {
-    danger: "bg-red-100/80 text-red-700",
-    info: "bg-sky-100/80 text-sky-700",
-    default: "bg-blue-100/80 text-blue-700",
+    danger: "bg-destructive/15 text-destructive",
+    info: "bg-info/18 text-info",
+    default: "bg-primary/15 text-primary",
   };
 
   return (
-    <article className="flex items-start gap-3 rounded-2xl border border-slate-200/70 bg-white/80 p-4 shadow-sm">
-      <span className={`flex h-11 w-11 items-center justify-center rounded-full ${bgMap[tone]}`}>{icon}</span>
+    <article className="flex items-start gap-3 rounded-2xl border border-border/60 bg-card/80 p-4 text-card-foreground shadow-sm backdrop-blur">
+      <span className={cn("flex h-11 w-11 items-center justify-center rounded-full", bgMap[tone])}>{icon}</span>
       <div className="min-w-0">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">{title}</p>
-        <p className="truncate text-lg font-semibold sm:text-xl">{value}</p>
-        {hint && <p className="text-xs leading-5 text-slate-600">{hint}</p>}
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{title}</p>
+        <p className="truncate text-lg font-semibold text-foreground sm:text-xl">{value}</p>
+        {hint && <p className="text-xs leading-5 text-foreground/80">{hint}</p>}
       </div>
     </article>
   );


### PR DESCRIPTION
## Summary
- update Sperrlisten overview UI controls to use design system tokens and components for consistent light/dark styling
- refresh shared Sperrlisten UI helpers to rely on semantic colors and blurred card surfaces
- add scoped CSS overrides to remap legacy color utilities to the design token palette in the overview

## Testing
- pnpm lint
- pnpm test
- pnpm build *(fails: workbox binary unavailable in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68ea98cd7f20832db9545810c06e3d98