### PR TITLE
Fix upcoming department lists map mutation

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
@@ -198,22 +198,20 @@ export default async function ProduktionsGewerkePage({ searchParams }: PageProps
     tasksByDepartment.set(entry.departmentId, current);
   }
 
-  const upcomingTasksByDepartment = new Map<string, typeof upcomingTasksRaw>();
+  type UpcomingTask = (typeof upcomingTasksRaw)[number];
+  const upcomingTasksByDepartment = new Map<string, UpcomingTask[]>();
   for (const task of upcomingTasksRaw) {
     const existing = upcomingTasksByDepartment.get(task.departmentId) ?? [];
-    if (existing.length < 3) {
-      existing.push(task);
-    }
-    upcomingTasksByDepartment.set(task.departmentId, existing);
+    const updated = existing.length < 3 ? [...existing, task] : existing;
+    upcomingTasksByDepartment.set(task.departmentId, updated);
   }
 
-  const upcomingEventsByDepartment = new Map<string, typeof upcomingEventsRaw>();
+  type UpcomingEvent = (typeof upcomingEventsRaw)[number];
+  const upcomingEventsByDepartment = new Map<string, UpcomingEvent[]>();
   for (const event of upcomingEventsRaw) {
     const existing = upcomingEventsByDepartment.get(event.departmentId) ?? [];
-    if (existing.length < 3) {
-      existing.push(event);
-    }
-    upcomingEventsByDepartment.set(event.departmentId, existing);
+    const updated = existing.length < 3 ? [...existing, event] : existing;
+    upcomingEventsByDepartment.set(event.departmentId, updated);
   }
 
   const selectedDepartment = selectedSlug


### PR DESCRIPTION
## Summary
- avoid mutating readonly arrays when building upcoming department task and event maps
- create typed helper aliases so maps always store mutable copies limited to three items

## Testing
- pnpm lint
- pnpm test *(fails: website-settings.test.ts expects different background token values)*
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_69011e93ea04832d9653b3778237f136