### PR TITLE
Replace Kurzname with role size selection for casting roles

### DIFF
--- a/prisma/migrations/20260401090000_character_role_preference_code/migration.sql
+++ b/prisma/migrations/20260401090000_character_role_preference_code/migration.sql
@@ -1,0 +1,2 @@
+-- Add role preference code for casting roles
+ALTER TABLE "Character" ADD COLUMN "rolePreferenceCode" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -529,6 +529,7 @@ model Character {
   showId         String
   name           String
   shortName      String?
+  rolePreferenceCode String?
   description    String?
   notes          String?
   color          String?

--- a/src/app/(members)/mitglieder/produktionen/actions.ts
+++ b/src/app/(members)/mitglieder/produktionen/actions.ts
@@ -15,6 +15,7 @@ import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { ACTIVE_PRODUCTION_COOKIE, getActiveProduction } from "@/lib/active-production";
 import { setOnboardingWhatsAppLink } from "@/lib/onboarding-settings";
+import { listRolePreferenceDefinitions } from "@/lib/onboarding/role-preferences";
 
 export type ProductionActionResult =
   | { ok: true; message?: string }
@@ -34,6 +35,10 @@ type ReadOptions = {
   maxLength?: number;
   label?: string;
 };
+
+const ACTING_ROLE_PREFERENCE_CODES = new Set(
+  listRolePreferenceDefinitions("acting").map((definition) => definition.code),
+);
 
 function isString(value: FormDataEntryValue | null | undefined): value is string {
   return typeof value === "string";
@@ -55,6 +60,19 @@ function readOptionalString(formData: FormData, key: string, options?: ReadOptio
     );
   }
   return trimmed;
+}
+
+function readOptionalRolePreferenceCode(
+  formData: FormData,
+  key: string,
+  options?: ReadOptions,
+): string | undefined {
+  const value = readOptionalString(formData, key, options);
+  if (!value) return undefined;
+  if (!ACTING_ROLE_PREFERENCE_CODES.has(value)) {
+    throw new Error(`${options?.label ?? key} ist ungültig.`);
+  }
+  return value;
 }
 
 export async function setActiveProductionAction(formData: FormData): Promise<ProductionActionResult> {
@@ -1027,7 +1045,9 @@ export async function createCharacterAction(formData: FormData): Promise<void> {
     if (!show) throw new Error("Produktion wurde nicht gefunden.");
 
     const name = readString(formData, "name", { label: "Name", minLength: 2, maxLength: 120 });
-    const shortName = readOptionalString(formData, "shortName", { label: "Kurzname", maxLength: 40 });
+    const rolePreferenceCode = readOptionalRolePreferenceCode(formData, "rolePreferenceCode", {
+      label: "Rollengröße",
+    });
     const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 500 });
     const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 500 });
     const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
@@ -1041,7 +1061,7 @@ export async function createCharacterAction(formData: FormData): Promise<void> {
       data: {
         showId,
         name,
-        shortName: shortName ?? null,
+        rolePreferenceCode: rolePreferenceCode ?? null,
         description: description ?? null,
         notes: notes ?? null,
         color: color ?? null,
@@ -1085,7 +1105,9 @@ export async function updateCharacterAction(formData: FormData): Promise<void> {
     if (!character) throw new Error("Rolle wurde nicht gefunden.");
 
     const name = readString(formData, "name", { label: "Name", minLength: 2, maxLength: 120 });
-    const shortName = readOptionalString(formData, "shortName", { label: "Kurzname", maxLength: 40 });
+    const rolePreferenceCode = readOptionalRolePreferenceCode(formData, "rolePreferenceCode", {
+      label: "Rollengröße",
+    });
     const description = readOptionalString(formData, "description", { label: "Beschreibung", maxLength: 500 });
     const notes = readOptionalString(formData, "notes", { label: "Notiz", maxLength: 500 });
     const color = parseColor(readOptionalString(formData, "color", { label: "Farbe", maxLength: 20 }));
@@ -1094,7 +1116,7 @@ export async function updateCharacterAction(formData: FormData): Promise<void> {
       where: { id: characterId },
       data: {
         name,
-        shortName: shortName ?? null,
+        rolePreferenceCode: rolePreferenceCode ?? null,
         description: description ?? null,
         notes: notes ?? null,
         color: color ?? null,

--- a/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
@@ -9,6 +9,7 @@ import { hasPermission } from "@/lib/permissions";
 import { getActiveProduction } from "@/lib/active-production";
 import { getUserDisplayName } from "@/lib/names";
 import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
+import { getRolePreferenceTitle, listRolePreferenceDefinitions } from "@/lib/onboarding/role-preferences";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -55,6 +56,7 @@ type Character = {
   id: string;
   name: string;
   shortName: string | null;
+  rolePreferenceCode: string | null;
   description: string | null;
   notes: string | null;
   color: string | null;
@@ -66,6 +68,7 @@ type ExportCharacter = {
   id: string;
   name: string;
   shortName: string | null;
+  rolePreferenceCode: string | null;
   description: string | null;
   notes: string | null;
   color: string | null;
@@ -100,6 +103,8 @@ const CASTING_ORDER: CharacterCastingType[] = [
   CharacterCastingType.primary,
   CharacterCastingType.alternate,
 ];
+
+const ROLE_PREFERENCE_OPTIONS = listRolePreferenceDefinitions("acting");
 
 const DESCRIPTION_PREVIEW_LENGTH = 100;
 
@@ -275,8 +280,15 @@ function CreateCharacterDialog({ showId, users }: { showId: string; users: Displ
               <Input name="name" placeholder="z.B. Protagonist" minLength={2} maxLength={120} required />
             </div>
             <div className="space-y-1">
-              <label className="text-sm font-medium">Kurzname</label>
-              <Input name="shortName" placeholder="Kurzlabel" maxLength={40} />
+              <label className="text-sm font-medium">Rollengröße</label>
+              <select name="rolePreferenceCode" className={selectSmallClassName} defaultValue="">
+                <option value="">Keine Rollengröße</option>
+                {ROLE_PREFERENCE_OPTIONS.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.title}
+                  </option>
+                ))}
+              </select>
             </div>
             <div className="space-y-1 md:col-span-2">
               <label className="text-sm font-medium">Beschreibung</label>
@@ -399,9 +411,9 @@ function CharacterCard({ character, users }: { character: Character; users: Disp
             <div className="min-w-0 space-y-1">
               <div className="flex flex-wrap items-center gap-2">
                 <CardTitle className="text-lg font-semibold">{character.name}</CardTitle>
-                {character.shortName ? (
+                {character.rolePreferenceCode ? (
                   <span className="rounded-full bg-muted/70 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {character.shortName}
+                    {getRolePreferenceTitle(character.rolePreferenceCode)}
                   </span>
                 ) : null}
               </div>
@@ -432,6 +444,9 @@ function CharacterCard({ character, users }: { character: Character; users: Disp
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          {character.rolePreferenceCode ? null : (
+            <span className="rounded-full bg-muted/50 px-2 py-1">Keine Rollengröße</span>
+          )}
           {character.description ? null : <span className="rounded-full bg-muted/50 px-2 py-1">Ohne Beschreibung</span>}
           {hasCastings ? null : (
             <span className="rounded-full bg-destructive/10 px-2 py-1 text-destructive">Nicht besetzt</span>
@@ -535,8 +550,19 @@ function UpdateCharacterDialog({ character }: { character: Character }) {
               <Input name="name" defaultValue={character.name} minLength={2} maxLength={120} required />
             </div>
             <div className="space-y-1">
-              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Kurzname</label>
-              <Input name="shortName" defaultValue={character.shortName ?? ""} maxLength={40} />
+              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Rollengröße</label>
+              <select
+                name="rolePreferenceCode"
+                className={selectSmallClassName}
+                defaultValue={character.rolePreferenceCode ?? ""}
+              >
+                <option value="">Keine Rollengröße</option>
+                {ROLE_PREFERENCE_OPTIONS.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.title}
+                  </option>
+                ))}
+              </select>
             </div>
             <div className="space-y-1 md:col-span-2">
               <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Beschreibung</label>
@@ -622,6 +648,7 @@ export default async function ProduktionsBesetzungPage({ searchParams }: PagePro
             id: true,
             name: true,
             shortName: true,
+            rolePreferenceCode: true,
             description: true,
             notes: true,
             color: true,
@@ -672,6 +699,7 @@ export default async function ProduktionsBesetzungPage({ searchParams }: PagePro
       ? [
           character.name,
           character.shortName,
+          character.rolePreferenceCode ? getRolePreferenceTitle(character.rolePreferenceCode) : null,
           character.description,
           character.notes,
           ...character.castings.map((casting) => formatUserName(casting.user)),
@@ -689,6 +717,7 @@ export default async function ProduktionsBesetzungPage({ searchParams }: PagePro
     id: character.id,
     name: character.name,
     shortName: character.shortName,
+    rolePreferenceCode: character.rolePreferenceCode,
     description: character.description,
     notes: character.notes,
     color: character.color,


### PR DESCRIPTION
### Motivation
- Replace the short label (`Kurzname`) field on casting roles with a selectable role-size so roles can be classified as Schnupper/Mittlere/Große/etc. as used in onboarding role categories.
- Persist the selected role-size on `Character` so UI, search and exports can surface the chosen category consistently.
- Validate submitted role-size values against the onboarding definitions to avoid invalid codes.

### Description
- Added a nullable `rolePreferenceCode` field to the `Character` model and created a migration `20260401090000_character_role_preference_code` to add the column in the database.
- In `src/app/(members)/mitglieder/produktionen/actions.ts` added `ACTING_ROLE_PREFERENCE_CODES`, a `readOptionalRolePreferenceCode` helper and wired reading/validation and persistence of `rolePreferenceCode` in `createCharacterAction` and `updateCharacterAction`.
- Updated the casting page UI `src/app/(members)/mitglieder/produktionen/besetzung/page.tsx` to replace `shortName` inputs with a `rolePreferenceCode` `<select>` populated from `listRolePreferenceDefinitions("acting")`, show the selected role-size on role cards via `getRolePreferenceTitle`, and include the role-size in search/export payloads.
- Adjusted export payload and GraphQL/Prisma selects to include `rolePreferenceCode` where applicable.

### Testing
- Ran `pnpm lint` (no blocking errors encountered during the rollout).
- Ran unit tests with `pnpm test` / Vitest where all tests ran and passed (`123 tests passed`).
- Ran `pnpm build` which failed due to missing client dependencies unrelated to this change: missing `@radix-ui/react-dropdown-menu` and `@radix-ui/react-popover` reported by the bundler; the build failure prevented a full production build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975fb0ae1e4832d8d037b69acced3ee)