### PR TITLE
Besetzung: Client-seitige Filter/Sortierung und Szenen-Toolbar verbessern

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/besetzung/casting-list-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/casting-list-client.tsx
@@ -1,0 +1,495 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CharacterCastingType } from "@prisma/client";
+import { ArrowDownAZ, ArrowUpAZ, ChevronDown, FilterX, Pencil, Plus, Trash2, UserRoundCheck } from "lucide-react";
+
+import { getRolePreferenceTitle } from "@/lib/onboarding/role-preferences";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import {
+  assignCharacterCastingAction,
+  deleteCharacterAction,
+  removeCharacterCastingAction,
+  updateCharacterAction,
+} from "../actions";
+import {
+  CASTING_ORDER,
+  DESCRIPTION_PREVIEW_LENGTH,
+  ROLE_PREFERENCE_OPTIONS,
+  type Character,
+  type CharacterCasting,
+  type DisplayUser,
+  formatUserName,
+  getCastingLabel,
+  getCastingOrderIndex,
+  resolveRoleSizeLabel,
+  selectSmallClassName,
+  truncateText,
+} from "./casting-utils";
+
+type Props = {
+  characters: Character[];
+  users: DisplayUser[];
+  currentPath: string;
+};
+
+type RoleSizeFilterValue = "all" | "none" | (typeof ROLE_PREFERENCE_OPTIONS)[number]["code"];
+
+type SortDirection = "asc" | "desc";
+
+function CastingAssignments({ castings, currentPath }: { castings: CharacterCasting[]; currentPath: string }) {
+  const sortedCastings = [...castings].sort((a, b) => getCastingOrderIndex(a.type) - getCastingOrderIndex(b.type));
+
+  if (sortedCastings.length === 0) {
+    return <p className="text-sm text-muted-foreground">Noch keine Besetzung zugeordnet.</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {sortedCastings.map((casting) => (
+        <div key={casting.id} className="rounded-lg border border-border/70 bg-background/80 p-2 text-sm shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="font-medium">{formatUserName(casting.user)}</p>
+              <p className="text-xs text-muted-foreground">{getCastingLabel(casting.type)}</p>
+              {casting.notes ? <p className="text-xs text-muted-foreground">Notiz: {casting.notes}</p> : null}
+            </div>
+            <form action={removeCharacterCastingAction} method="post">
+              <input type="hidden" name="castingId" value={casting.id} />
+              <input type="hidden" name="redirectPath" value={currentPath} />
+              <Button
+                type="submit"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Besetzung entfernen"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </form>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AssignCastingDialog({ characterId, users, currentPath }: { characterId: string; users: DisplayUser[]; currentPath: string }) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" className="h-9 w-9" aria-label="Besetzung hinzufügen">
+          <Plus className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Mitglied zuordnen</DialogTitle>
+          <DialogDescription>
+            Weise dieser Rolle ein Mitglied zu und lege Besetzungsart sowie optionale Notizen fest.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="grid gap-3" action={assignCharacterCastingAction} method="post">
+          <input type="hidden" name="characterId" value={characterId} />
+          <input type="hidden" name="redirectPath" value={currentPath} />
+          <div className="space-y-1">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Mitglied</label>
+            <select name="userId" className={selectSmallClassName} required>
+              <option value="">Mitglied auswählen</option>
+              {users.map((user) => (
+                <option key={user.id} value={user.id}>
+                  {formatUserName(user)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Besetzungsart</label>
+            <select name="type" className={selectSmallClassName} defaultValue={CharacterCastingType.primary}>
+              {CASTING_ORDER.map((type) => (
+                <option key={type} value={type}>
+                  {getCastingLabel(type)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+            <Input name="notes" maxLength={200} placeholder="optional" />
+          </div>
+          <DialogFooter className="sm:justify-end">
+            <DialogClose asChild>
+              <Button type="button" variant="ghost">
+                Abbrechen
+              </Button>
+            </DialogClose>
+            <DialogClose asChild>
+              <Button type="submit">Mitglied besetzen</Button>
+            </DialogClose>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function UpdateCharacterDialog({ character, currentPath }: { character: Character; currentPath: string }) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" className="h-9 w-9" aria-label="Rolle bearbeiten">
+          <Pencil className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Rolle bearbeiten</DialogTitle>
+          <DialogDescription>Aktualisiere die Stammdaten der Rolle und speichere deine Änderungen.</DialogDescription>
+        </DialogHeader>
+        <form action={updateCharacterAction} method="post" className="grid gap-3">
+          <input type="hidden" name="characterId" value={character.id} />
+          <input type="hidden" name="redirectPath" value={currentPath} />
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-1">
+              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
+              <Input name="name" defaultValue={character.name} minLength={2} maxLength={120} required />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Rollengröße</label>
+              <select
+                name="rolePreferenceCode"
+                className={selectSmallClassName}
+                defaultValue={character.rolePreferenceCode ?? ""}
+              >
+                <option value="">Keine Rollengröße</option>
+                {ROLE_PREFERENCE_OPTIONS.map((option) => (
+                  <option key={option.code} value={option.code}>
+                    {option.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Beschreibung</label>
+              <Textarea name="description" rows={2} maxLength={500} defaultValue={character.description ?? ""} />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Farbe</label>
+              <input
+                type="color"
+                name="color"
+                defaultValue={character.color ?? "#7c3aed"}
+                className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
+              />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
+              <Textarea name="notes" rows={2} maxLength={500} defaultValue={character.notes ?? ""} />
+            </div>
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="submit" variant="outline">
+                Rolle aktualisieren
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CharacterCard({ character, users, currentPath }: { character: Character; users: DisplayUser[]; currentPath: string }) {
+  const hasCastings = character.castings.length > 0;
+  const sortedCastings = [...character.castings].sort(
+    (a, b) => getCastingOrderIndex(a.type) - getCastingOrderIndex(b.type),
+  );
+  const roleSizeLabel = resolveRoleSizeLabel(character.rolePreferenceCode);
+
+  return (
+    <Card
+      id={`role-${character.id}`}
+      key={character.id}
+      className={cn(
+        "min-w-0 w-full overflow-hidden border border-border/70",
+        !hasCastings && "border-destructive/60",
+      )}
+    >
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex min-w-0 flex-1 items-start gap-3">
+            <span
+              className="mt-1 h-10 w-1.5 rounded-full"
+              style={{ backgroundColor: character.color ?? "#8b5cf6" }}
+              aria-hidden
+            />
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <CardTitle className="break-words text-lg font-semibold">{character.name}</CardTitle>
+              </div>
+              <dl className="grid gap-1 text-xs text-muted-foreground">
+                <div className="flex flex-wrap gap-2">
+                  <dt className="font-semibold text-foreground/80">Rollengröße</dt>
+                  <dd>{roleSizeLabel}</dd>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <dt className="font-semibold text-foreground/80">Beschreibung</dt>
+                  <dd>
+                    {character.description
+                      ? truncateText(character.description, DESCRIPTION_PREVIEW_LENGTH)
+                      : "Ohne Beschreibung"}
+                  </dd>
+                </div>
+                {character.notes ? (
+                  <div className="flex flex-wrap gap-2">
+                    <dt className="font-semibold text-foreground/80">Notiz</dt>
+                    <dd>{character.notes}</dd>
+                  </div>
+                ) : null}
+              </dl>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <AssignCastingDialog characterId={character.id} users={users} currentPath={currentPath} />
+            <UpdateCharacterDialog character={character} currentPath={currentPath} />
+            <form action={deleteCharacterAction} method="post">
+              <input type="hidden" name="characterId" value={character.id} />
+              <input type="hidden" name="redirectPath" value={currentPath} />
+              <Button type="submit" variant="ghost" size="icon" className="h-9 w-9" aria-label="Rolle entfernen">
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </form>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          {hasCastings ? null : (
+            <span className="rounded-full bg-destructive/10 px-2 py-1 text-destructive">Nicht besetzt</span>
+          )}
+        </div>
+        <details className="group rounded-lg border border-border/60 bg-muted/40">
+          <summary className="flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-xs font-semibold text-foreground">
+            <span className="flex items-center gap-2">
+              <span>Besetzung</span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] font-semibold text-muted-foreground">
+                <UserRoundCheck className="h-3 w-3" aria-hidden />
+                {sortedCastings.length}
+              </span>
+            </span>
+            <ChevronDown className="h-4 w-4 text-muted-foreground transition duration-200 group-open:rotate-180" aria-hidden />
+          </summary>
+          <div className="space-y-2 border-t border-border/60 px-3 py-3">
+            <CastingAssignments castings={sortedCastings} currentPath={currentPath} />
+          </div>
+        </details>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CastingListClient({ characters, users, currentPath }: Props) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const [castingType, setCastingType] = useState<"all" | CharacterCastingType>("all");
+  const [roleSizeFilter, setRoleSizeFilter] = useState<RoleSizeFilterValue>("all");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+  const filteredCharacters = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    const matchesRoleSize = (character: Character) => {
+      if (roleSizeFilter === "all") return true;
+      if (roleSizeFilter === "none") return !character.rolePreferenceCode;
+      return character.rolePreferenceCode === roleSizeFilter;
+    };
+
+    const matchesCastingType = (character: Character) =>
+      castingType === "all" ? true : character.castings.some((casting) => casting.type === castingType);
+
+    const matchesSearch = (character: Character) => {
+      if (!normalizedSearch) return true;
+      return [
+        character.name,
+        character.shortName,
+        character.rolePreferenceCode ? getRolePreferenceTitle(character.rolePreferenceCode) : null,
+        character.description,
+        character.notes,
+        ...character.castings.map((casting) => formatUserName(casting.user)),
+      ].some((value) => value?.toLowerCase().includes(normalizedSearch));
+    };
+
+    return characters
+      .filter((character) => matchesSearch(character) && matchesCastingType(character) && matchesRoleSize(character))
+      .sort((a, b) => {
+        const aHasRole = Boolean(a.rolePreferenceCode);
+        const bHasRole = Boolean(b.rolePreferenceCode);
+
+        if (aHasRole !== bHasRole) {
+          return aHasRole ? -1 : 1;
+        }
+
+        const aLabel = a.rolePreferenceCode ? getRolePreferenceTitle(a.rolePreferenceCode) : "";
+        const bLabel = b.rolePreferenceCode ? getRolePreferenceTitle(b.rolePreferenceCode) : "";
+
+        const comparison = aLabel.localeCompare(bLabel, "de");
+        return sortDirection === "asc" ? comparison : -comparison;
+      });
+  }, [characters, castingType, roleSizeFilter, searchTerm, sortDirection]);
+
+  const unassignedCharacters = filteredCharacters.filter((character) => character.castings.length === 0);
+
+  const clearFilters = () => {
+    setSearchTerm("");
+    setCastingType("all");
+    setRoleSizeFilter("all");
+    setSortDirection("asc");
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-border/70 bg-card/60 p-3 shadow-sm">
+        <div className="grid gap-3 lg:grid-cols-[2fr_1fr_1fr_auto] lg:items-center">
+          <div className="space-y-1">
+            <label className="sr-only" htmlFor="casting-search">
+              Suche
+            </label>
+            <Input
+              id="casting-search"
+              name="q"
+              placeholder="Nach Rollen oder Personen suchen"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="sr-only" htmlFor="casting-type">
+              Besetzungsart
+            </label>
+            <select
+              id="casting-type"
+              name="castingType"
+              className={selectSmallClassName}
+              value={castingType}
+              onChange={(event) => setCastingType(event.target.value as "all" | CharacterCastingType)}
+            >
+              <option value="all">Alle Besetzungen</option>
+              {CASTING_ORDER.map((type) => (
+                <option key={type} value={type}>
+                  {getCastingLabel(type)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="sr-only" htmlFor="role-size">
+              Rollengröße
+            </label>
+            <select
+              id="role-size"
+              name="roleSize"
+              className={selectSmallClassName}
+              value={roleSizeFilter}
+              onChange={(event) => setRoleSizeFilter(event.target.value as RoleSizeFilterValue)}
+            >
+              <option value="all">Alle Rollengrößen</option>
+              <option value="none">Keine Rollengröße</option>
+              {ROLE_PREFERENCE_OPTIONS.map((option) => (
+                <option key={option.code} value={option.code}>
+                  {option.title}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              aria-label={sortDirection === "asc" ? "Rollengröße A bis Z sortieren" : "Rollengröße Z bis A sortieren"}
+              onClick={() => setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"))}
+            >
+              {sortDirection === "asc" ? <ArrowDownAZ className="h-4 w-4" /> : <ArrowUpAZ className="h-4 w-4" />}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Filter und Suche entfernen"
+              onClick={clearFilters}
+            >
+              <FilterX className="h-4 w-4" aria-hidden />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {unassignedCharacters.length > 0 ? (
+        <div
+          className="rounded-2xl border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive shadow-sm"
+          role="status"
+        >
+          <p className="font-semibold">
+            {unassignedCharacters.length === 1 ? "Diese Rolle ist noch nicht besetzt." : "Mehrere Rollen sind noch nicht besetzt."}
+          </p>
+          <p className="text-xs text-destructive/80">
+            Klicke auf eine Rolle, um direkt zur Karte zu springen und ein Mitglied zuzuordnen.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {unassignedCharacters.map((character) => (
+              <Button
+                key={character.id}
+                asChild
+                variant="outline"
+                size="sm"
+                className="border-destructive/60 text-destructive hover:bg-destructive/10 hover:text-destructive"
+              >
+                <a href={`#role-${character.id}`}>{character.name}</a>
+              </Button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <section className="space-y-3">
+        {characters.length === 0 ? (
+          <Card>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Noch keine Rollen angelegt. Nutze den Button „Rolle anlegen“, um die erste Figur zu erstellen.
+              </p>
+            </CardContent>
+          </Card>
+        ) : filteredCharacters.length === 0 ? (
+          <Card>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Keine Rollen erfüllen aktuell die ausgewählten Filter oder Suchbegriffe.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]">
+            {filteredCharacters.map((character) => (
+              <CharacterCard key={character.id} character={character} users={users} currentPath={currentPath} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/produktionen/besetzung/casting-utils.ts
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/casting-utils.ts
@@ -1,0 +1,89 @@
+import { CharacterCastingType } from "@prisma/client";
+
+import { getUserDisplayName } from "@/lib/names";
+import { getRolePreferenceTitle, listRolePreferenceDefinitions } from "@/lib/onboarding/role-preferences";
+
+export type DisplayUser = {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  name: string | null;
+  email: string | null;
+};
+
+export type CharacterCasting = {
+  id: string;
+  type: CharacterCastingType;
+  notes: string | null;
+  user: DisplayUser | null;
+};
+
+export type Character = {
+  id: string;
+  name: string;
+  shortName: string | null;
+  rolePreferenceCode: string | null;
+  description: string | null;
+  notes: string | null;
+  color: string | null;
+  order: number | null;
+  castings: CharacterCasting[];
+};
+
+export type ExportCharacter = {
+  id: string;
+  name: string;
+  shortName: string | null;
+  rolePreferenceCode: string | null;
+  description: string | null;
+  notes: string | null;
+  color: string | null;
+  castings: Array<{
+    id: string;
+    type: CharacterCastingType;
+    notes: string | null;
+    userName: string;
+  }>;
+};
+
+export const CASTING_LABELS: Partial<Record<CharacterCastingType, string>> = {
+  primary: "Primär",
+  alternate: "Sekundär",
+};
+
+export const CASTING_ORDER: CharacterCastingType[] = [
+  CharacterCastingType.primary,
+  CharacterCastingType.alternate,
+];
+
+export const ROLE_PREFERENCE_OPTIONS = listRolePreferenceDefinitions("acting");
+
+export const DESCRIPTION_PREVIEW_LENGTH = 100;
+
+export const selectSmallClassName =
+  "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+export function formatUserName(user?: DisplayUser | null) {
+  if (!user) return "Unbekannt";
+  return getUserDisplayName(user, "Unbekannt");
+}
+
+export function getCastingLabel(type: CharacterCastingType) {
+  return CASTING_LABELS[type] ?? "Weitere";
+}
+
+export function getCastingOrderIndex(type: CharacterCastingType) {
+  const index = CASTING_ORDER.indexOf(type);
+  return index === -1 ? CASTING_ORDER.length : index;
+}
+
+export function truncateText(value: string, maxLength: number) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength).trimEnd()}…`;
+}
+
+export function resolveRoleSizeLabel(rolePreferenceCode: string | null) {
+  return rolePreferenceCode ? getRolePreferenceTitle(rolePreferenceCode) : "Keine Rollengröße";
+}

--- a/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/besetzung/page.tsx
@@ -1,18 +1,14 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { CharacterCastingType } from "@prisma/client";
-import { BadgeCheck, ChevronDown, Filter, FilterX, Pencil, Plus, Trash2, UserRoundCheck, Users } from "lucide-react";
+import { BadgeCheck, UserRoundCheck, Users } from "lucide-react";
 
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { getActiveProduction } from "@/lib/active-production";
-import { getUserDisplayName } from "@/lib/names";
 import { membersNavigationBreadcrumb } from "@/lib/members-breadcrumbs";
-import { getRolePreferenceTitle, listRolePreferenceDefinitions } from "@/lib/onboarding/role-preferences";
-import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -29,63 +25,17 @@ import { PageHeader } from "@/components/members/page-header";
 import { ProductionWorkspaceEmptyState } from "@/components/production/workspace-empty-state";
 import { CastingExportDialog } from "@/components/production/casting-export-dialog";
 
+import { CastingListClient } from "./casting-list-client";
 import {
-  assignCharacterCastingAction,
-  createCharacterAction,
-  deleteCharacterAction,
-  removeCharacterCastingAction,
-  updateCharacterAction,
-} from "../actions";
-
-type DisplayUser = {
-  id: string;
-  firstName?: string | null;
-  lastName?: string | null;
-  name: string | null;
-  email: string | null;
-};
-
-type CharacterCasting = {
-  id: string;
-  type: CharacterCastingType;
-  notes: string | null;
-  user: DisplayUser | null;
-};
-
-type Character = {
-  id: string;
-  name: string;
-  shortName: string | null;
-  rolePreferenceCode: string | null;
-  description: string | null;
-  notes: string | null;
-  color: string | null;
-  order: number | null;
-  castings: CharacterCasting[];
-};
-
-type ExportCharacter = {
-  id: string;
-  name: string;
-  shortName: string | null;
-  rolePreferenceCode: string | null;
-  description: string | null;
-  notes: string | null;
-  color: string | null;
-  castings: Array<{
-    id: string;
-    type: CharacterCastingType;
-    notes: string | null;
-    userName: string;
-  }>;
-};
-
-type PageProps = {
-  searchParams?: Promise<{
-    q?: string | string[] | null;
-    castingType?: string | string[] | null;
-  }>;
-};
+  CASTING_ORDER,
+  ROLE_PREFERENCE_OPTIONS,
+  type DisplayUser,
+  type ExportCharacter,
+  formatUserName,
+  getCastingLabel,
+  selectSmallClassName,
+} from "./casting-utils";
+import { createCharacterAction } from "../actions";
 
 type HeaderStat = {
   label: string;
@@ -94,45 +44,7 @@ type HeaderStat = {
   hint?: string;
 };
 
-const CASTING_LABELS: Partial<Record<CharacterCastingType, string>> = {
-  primary: "Primär",
-  alternate: "Sekundär",
-};
-
-const CASTING_ORDER: CharacterCastingType[] = [
-  CharacterCastingType.primary,
-  CharacterCastingType.alternate,
-];
-
-const ROLE_PREFERENCE_OPTIONS = listRolePreferenceDefinitions("acting");
-
-const DESCRIPTION_PREVIEW_LENGTH = 100;
-
-const selectSmallClassName =
-  "h-9 w-full rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
-
 const currentPath = "/mitglieder/produktionen/besetzung";
-
-function formatUserName(user?: DisplayUser | null) {
-  if (!user) return "Unbekannt";
-  return getUserDisplayName(user, "Unbekannt");
-}
-
-function getCastingLabel(type: CharacterCastingType) {
-  return CASTING_LABELS[type] ?? "Weitere";
-}
-
-function getCastingOrderIndex(type: CharacterCastingType) {
-  const index = CASTING_ORDER.indexOf(type);
-  return index === -1 ? CASTING_ORDER.length : index;
-}
-
-function truncateText(value: string, maxLength: number) {
-  if (value.length <= maxLength) {
-    return value;
-  }
-  return `${value.slice(0, maxLength).trimEnd()}…`;
-}
 
 function CastingTypeSelect({
   defaultValue,
@@ -198,58 +110,6 @@ function HeaderStats({
         </div>
       </div>
     </div>
-  );
-}
-
-function CastingFilters({ searchTerm, castingType }: { searchTerm: string; castingType: string }) {
-  return (
-    <form className="rounded-2xl border border-border/70 bg-card/60 p-3 shadow-sm" method="get" action={currentPath}>
-      <div className="grid gap-3 lg:grid-cols-[2fr_1fr_auto] lg:items-center">
-        <div className="space-y-1">
-          <label className="sr-only" htmlFor="casting-search">
-            Suche
-          </label>
-          <Input
-            id="casting-search"
-            name="q"
-            placeholder="Nach Rollen oder Personen suchen"
-            defaultValue={searchTerm}
-            className="h-9 text-sm"
-          />
-        </div>
-        <div className="space-y-1">
-          <label className="sr-only" htmlFor="casting-type">
-            Besetzungsart
-          </label>
-          <select
-            id="casting-type"
-            name="castingType"
-            className={selectSmallClassName}
-            defaultValue={castingType}
-          >
-            <option value="all">Alle Besetzungen</option>
-            {CASTING_ORDER.map((type) => (
-              <option key={type} value={type}>
-                {getCastingLabel(type)}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="flex items-center justify-end gap-2">
-          <Button type="submit" size="sm">
-            Suche
-          </Button>
-          <Button type="submit" variant="outline" size="icon" aria-label="Filter anwenden">
-            <Filter className="h-4 w-4" aria-hidden />
-          </Button>
-          <Button type="button" variant="ghost" size="icon" asChild aria-label="Filter und Suche entfernen">
-            <Link href={currentPath}>
-              <FilterX className="h-4 w-4" aria-hidden />
-            </Link>
-          </Button>
-        </div>
-      </div>
-    </form>
   );
 }
 
@@ -339,255 +199,7 @@ function CreateCharacterDialog({ showId, users }: { showId: string; users: Displ
   );
 }
 
-function CastingAssignments({
-  castings,
-}: {
-  castings: CharacterCasting[];
-}) {
-  const sortedCastings = [...castings].sort((a, b) => getCastingOrderIndex(a.type) - getCastingOrderIndex(b.type));
-
-  if (sortedCastings.length === 0) {
-    return <p className="text-sm text-muted-foreground">Noch keine Besetzung zugeordnet.</p>;
-  }
-
-  return (
-    <div className="space-y-2">
-      {sortedCastings.map((casting) => (
-        <div key={casting.id} className="rounded-lg border border-border/70 bg-background/80 p-2 text-sm shadow-sm">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div>
-              <p className="font-medium">{formatUserName(casting.user)}</p>
-              <p className="text-xs text-muted-foreground">{getCastingLabel(casting.type)}</p>
-              {casting.notes ? <p className="text-xs text-muted-foreground">Notiz: {casting.notes}</p> : null}
-            </div>
-            <form action={removeCharacterCastingAction} method="post">
-              <input type="hidden" name="castingId" value={casting.id} />
-              <input type="hidden" name="redirectPath" value={currentPath} />
-              <Button
-                type="submit"
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                aria-label="Besetzung entfernen"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </form>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function CharacterCard({ character, users }: { character: Character; users: DisplayUser[] }) {
-  const hasCastings = character.castings.length > 0;
-  const sortedCastings = [...character.castings].sort(
-    (a, b) => getCastingOrderIndex(a.type) - getCastingOrderIndex(b.type),
-  );
-
-  return (
-    <Card
-      id={`role-${character.id}`}
-      key={character.id}
-      className={cn(
-        "min-w-0 w-full overflow-hidden border border-border/70",
-        !hasCastings && "border-destructive/60",
-      )}
-    >
-      <CardContent className="space-y-3">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="flex min-w-0 flex-1 items-start gap-3">
-            <span
-              className="mt-1 h-10 w-1.5 rounded-full"
-              style={{ backgroundColor: character.color ?? "#8b5cf6" }}
-              aria-hidden
-            />
-            <div className="min-w-0 space-y-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <CardTitle className="break-words text-lg font-semibold">{character.name}</CardTitle>
-                {character.rolePreferenceCode ? (
-                  <span className="max-w-full rounded-full bg-muted/70 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {getRolePreferenceTitle(character.rolePreferenceCode)}
-                  </span>
-                ) : null}
-              </div>
-              {character.description ? (
-                <p className="text-sm text-muted-foreground">
-                  {truncateText(character.description, DESCRIPTION_PREVIEW_LENGTH)}
-                </p>
-              ) : null}
-              {character.notes ? <p className="text-xs text-muted-foreground">Notiz: {character.notes}</p> : null}
-            </div>
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <AssignCastingDialog characterId={character.id} users={users} />
-            <UpdateCharacterDialog character={character} />
-            <form action={deleteCharacterAction} method="post">
-              <input type="hidden" name="characterId" value={character.id} />
-              <input type="hidden" name="redirectPath" value={currentPath} />
-              <Button
-                type="submit"
-                variant="ghost"
-                size="icon"
-                className="h-9 w-9"
-                aria-label="Rolle entfernen"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            </form>
-          </div>
-        </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          {character.rolePreferenceCode ? null : (
-            <span className="rounded-full bg-muted/50 px-2 py-1">Keine Rollengröße</span>
-          )}
-          {character.description ? null : <span className="rounded-full bg-muted/50 px-2 py-1">Ohne Beschreibung</span>}
-          {hasCastings ? null : (
-            <span className="rounded-full bg-destructive/10 px-2 py-1 text-destructive">Nicht besetzt</span>
-          )}
-        </div>
-        <details className="group rounded-lg border border-border/60 bg-muted/40">
-          <summary className="flex cursor-pointer items-center justify-between gap-3 px-3 py-2 text-xs font-semibold text-foreground">
-            <span className="flex items-center gap-2">
-              <span>Besetzung</span>
-              <span className="inline-flex items-center gap-1 rounded-full bg-muted/60 px-2 py-0.5 text-[11px] font-semibold text-muted-foreground">
-                <UserRoundCheck className="h-3 w-3" aria-hidden />
-                {sortedCastings.length}
-              </span>
-            </span>
-            <ChevronDown className="h-4 w-4 text-muted-foreground transition duration-200 group-open:rotate-180" aria-hidden />
-          </summary>
-          <div className="space-y-2 border-t border-border/60 px-3 py-3">
-            <CastingAssignments castings={sortedCastings} />
-          </div>
-        </details>
-      </CardContent>
-    </Card>
-  );
-}
-
-function AssignCastingDialog({ characterId, users }: { characterId: string; users: DisplayUser[] }) {
-  return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button type="button" variant="ghost" size="icon" className="h-9 w-9" aria-label="Besetzung hinzufügen">
-          <Plus className="h-4 w-4" />
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Mitglied zuordnen</DialogTitle>
-          <DialogDescription>
-            Weise dieser Rolle ein Mitglied zu und lege Besetzungsart sowie optionale Notizen fest.
-          </DialogDescription>
-        </DialogHeader>
-        <form className="grid gap-3" action={assignCharacterCastingAction} method="post">
-          <input type="hidden" name="characterId" value={characterId} />
-          <input type="hidden" name="redirectPath" value={currentPath} />
-          <div className="space-y-1">
-            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Mitglied</label>
-            <select name="userId" className={selectSmallClassName} required>
-              <option value="">Mitglied auswählen</option>
-              {users.map((user) => (
-                <option key={user.id} value={user.id}>
-                  {formatUserName(user)}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="space-y-1">
-            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Besetzungsart</label>
-            <CastingTypeSelect defaultValue={CharacterCastingType.primary} />
-          </div>
-          <div className="space-y-1">
-            <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
-            <Input name="notes" maxLength={200} placeholder="optional" />
-          </div>
-          <DialogFooter className="sm:justify-end">
-            <DialogClose asChild>
-              <Button type="button" variant="ghost">
-                Abbrechen
-              </Button>
-            </DialogClose>
-            <DialogClose asChild>
-              <Button type="submit">Mitglied besetzen</Button>
-            </DialogClose>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function UpdateCharacterDialog({ character }: { character: Character }) {
-  return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button type="button" variant="ghost" size="icon" className="h-9 w-9" aria-label="Rolle bearbeiten">
-          <Pencil className="h-4 w-4" />
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-3xl">
-        <DialogHeader>
-          <DialogTitle>Rolle bearbeiten</DialogTitle>
-          <DialogDescription>Aktualisiere die Stammdaten der Rolle und speichere deine Änderungen.</DialogDescription>
-        </DialogHeader>
-        <form action={updateCharacterAction} method="post" className="grid gap-3">
-          <input type="hidden" name="characterId" value={character.id} />
-          <input type="hidden" name="redirectPath" value={currentPath} />
-          <div className="grid gap-3 md:grid-cols-2">
-            <div className="space-y-1">
-              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</label>
-              <Input name="name" defaultValue={character.name} minLength={2} maxLength={120} required />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Rollengröße</label>
-              <select
-                name="rolePreferenceCode"
-                className={selectSmallClassName}
-                defaultValue={character.rolePreferenceCode ?? ""}
-              >
-                <option value="">Keine Rollengröße</option>
-                {ROLE_PREFERENCE_OPTIONS.map((option) => (
-                  <option key={option.code} value={option.code}>
-                    {option.title}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="space-y-1 md:col-span-2">
-              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Beschreibung</label>
-              <Textarea name="description" rows={2} maxLength={500} defaultValue={character.description ?? ""} />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Farbe</label>
-              <input
-                type="color"
-                name="color"
-                defaultValue={character.color ?? "#7c3aed"}
-                className="h-10 w-full cursor-pointer rounded-md border border-input bg-background"
-              />
-            </div>
-            <div className="space-y-1 md:col-span-2">
-              <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Notiz</label>
-              <Textarea name="notes" rows={2} maxLength={500} defaultValue={character.notes ?? ""} />
-            </div>
-          </div>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button type="submit" variant="outline">
-                Rolle aktualisieren
-              </Button>
-            </DialogClose>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-export default async function ProduktionsBesetzungPage({ searchParams }: PageProps) {
+export default async function ProduktionsBesetzungPage() {
   const session = await requireAuth();
   const allowed = await hasPermission(session.user, "mitglieder.produktionen");
 
@@ -675,35 +287,6 @@ export default async function ProduktionsBesetzungPage({ searchParams }: PagePro
     ),
   ).size;
 
-  const resolvedSearchParams = (await searchParams) ?? {};
-
-  const searchTermRaw = resolvedSearchParams.q;
-  const castingTypeRaw = resolvedSearchParams.castingType;
-
-  const searchTerm = Array.isArray(searchTermRaw) ? searchTermRaw[0] ?? "" : searchTermRaw ?? "";
-  const castingType = Array.isArray(castingTypeRaw) ? castingTypeRaw[0] ?? "all" : castingTypeRaw ?? "all";
-
-  const normalizedSearch = searchTerm.trim().toLowerCase();
-  const activeCastingType = castingType in CASTING_LABELS ? (castingType as CharacterCastingType) : null;
-
-  const filteredCharacters = show.characters.filter((character) => {
-    const matchesSearch = normalizedSearch
-      ? [
-          character.name,
-          character.shortName,
-          character.rolePreferenceCode ? getRolePreferenceTitle(character.rolePreferenceCode) : null,
-          character.description,
-          character.notes,
-          ...character.castings.map((casting) => formatUserName(casting.user)),
-        ].some((value) => value?.toLowerCase().includes(normalizedSearch))
-      : true;
-
-    const matchesType = activeCastingType ? character.castings.some((casting) => casting.type === activeCastingType) : true;
-
-    return matchesSearch && matchesType;
-  });
-
-  const unassignedCharacters = filteredCharacters.filter((character) => character.castings.length === 0);
   const showTitle = show.title ?? `Produktion ${show.year}`;
   const exportCharacters: ExportCharacter[] = show.characters.map((character) => ({
     id: character.id,
@@ -736,60 +319,7 @@ export default async function ProduktionsBesetzungPage({ searchParams }: PagePro
 
       <HeaderStats stats={headerStats} showId={show.id} users={users} characters={exportCharacters} showTitle={showTitle} />
 
-      <CastingFilters searchTerm={searchTerm} castingType={castingType} />
-
-      {unassignedCharacters.length > 0 ? (
-        <div
-          className="rounded-2xl border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive shadow-sm"
-          role="status"
-        >
-          <p className="font-semibold">
-            {unassignedCharacters.length === 1 ? "Diese Rolle ist noch nicht besetzt." : "Mehrere Rollen sind noch nicht besetzt."}
-          </p>
-          <p className="text-xs text-destructive/80">
-            Klicke auf eine Rolle, um direkt zur Karte zu springen und ein Mitglied zuzuordnen.
-          </p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {unassignedCharacters.map((character) => (
-              <Button
-                key={character.id}
-                asChild
-                variant="outline"
-                size="sm"
-                className="border-destructive/60 text-destructive hover:bg-destructive/10 hover:text-destructive"
-              >
-                <a href={`#role-${character.id}`}>{character.name}</a>
-              </Button>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      <section className="space-y-3">
-        {show.characters.length === 0 ? (
-          <Card>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Noch keine Rollen angelegt. Nutze den Button „Rolle anlegen“, um die erste Figur zu erstellen.
-              </p>
-            </CardContent>
-          </Card>
-        ) : filteredCharacters.length === 0 ? (
-          <Card>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">
-                Keine Rollen erfüllen aktuell die ausgewählten Filter oder Suchbegriffe.
-              </p>
-            </CardContent>
-          </Card>
-        ) : (
-          <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]">
-            {filteredCharacters.map((character) => (
-              <CharacterCard key={character.id} character={character} users={users} />
-            ))}
-          </div>
-        )}
-      </section>
+      <CastingListClient characters={show.characters} users={users} currentPath={currentPath} />
     </div>
   );
 }

--- a/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/page.tsx
@@ -9,6 +9,7 @@ import { ProductionWorkspaceHeader } from "@/components/production/workspace-hea
 import { ProductionWorkspaceEmptyState } from "@/components/production/workspace-empty-state";
 
 import { SceneListClient } from "./scene-list-client";
+import { SceneCreateDialog } from "./scene-create-dialog";
 
 type SceneIdentifier = string | null;
 
@@ -205,10 +206,12 @@ export default async function ProduktionsSzenenPage() {
             </div>
           ))}
         </div>
+        <div className="mt-4 flex justify-end">
+          <SceneCreateDialog showId={show.id} currentPath={currentPath} />
+        </div>
       </div>
 
       <SceneListClient
-        showId={show.id}
         scenes={scenes}
         characters={show.characters}
         departments={departments}

--- a/src/app/(members)/mitglieder/produktionen/szenen/scene-create-dialog.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/scene-create-dialog.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+import { createSceneAction } from "../actions";
+
+type Props = {
+  showId: string;
+  currentPath: string;
+};
+
+export function SceneCreateDialog({ showId, currentPath }: Props) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="primary" size="sm">
+          Szene erstellen
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Neue Szene anlegen</DialogTitle>
+          <DialogDescription>
+            Erfasse Orte, Zusammenfassungen und Notizen, um den Szenenplan aktuell zu halten.
+          </DialogDescription>
+        </DialogHeader>
+        <form action={createSceneAction} method="post" className="grid gap-6">
+          <input type="hidden" name="showId" value={showId} />
+          <input type="hidden" name="redirectPath" value={currentPath} />
+          <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 md:grid-cols-3">
+            <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Basisdaten
+            </legend>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Nummer</label>
+              <Input name="identifier" maxLength={40} placeholder="z.B. 1" required />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label className="text-sm font-medium">Titel</label>
+              <Input name="title" maxLength={160} placeholder="z.B. Ankunft im Park" />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Ort</label>
+              <Input name="location" maxLength={120} />
+            </div>
+          </fieldset>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Zusammenfassung</label>
+            <Textarea name="summary" rows={2} maxLength={600} />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Notizen</label>
+            <Textarea name="notes" rows={2} maxLength={400} />
+          </div>
+          <DialogFooter className="pt-2 sm:justify-end">
+            <DialogClose asChild>
+              <Button type="submit">Szene speichern</Button>
+            </DialogClose>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(members)/mitglieder/produktionen/szenen/scene-list-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/scene-list-client.tsx
@@ -12,7 +12,6 @@ import {
   DialogClose,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -24,7 +23,6 @@ import { Textarea } from "@/components/ui/textarea";
 import {
   addSceneCharacterAction,
   createBreakdownItemAction,
-  createSceneAction,
   deleteSceneAction,
   removeBreakdownItemAction,
   removeSceneCharacterAction,
@@ -79,7 +77,6 @@ type Department = { id: string; name: string; slug: string; color: string | null
 type Character = { id: string; name: string; shortName: string | null; color: string | null };
 
 type Props = {
-  showId: string;
   scenes: SceneData[];
   characters: Character[];
   departments: Department[];
@@ -119,8 +116,32 @@ function formatIsoDate(value: string | null) {
   return value.slice(0, 10);
 }
 
+type SceneFilter = "all" | "with-roles" | "without-roles" | "with-breakdowns" | "without-breakdowns";
+type SceneSort = "asc" | "desc";
+
+function parseSceneIdentifier(value: string | null): number[] {
+  if (!value) return [Number.POSITIVE_INFINITY];
+  return value
+    .split(".")
+    .map((segment) => Number.parseInt(segment, 10))
+    .filter((segment) => !Number.isNaN(segment));
+}
+
+function compareSceneIdentifiers(a: string | null, b: string | null): number {
+  const aParts = parseSceneIdentifier(a);
+  const bParts = parseSceneIdentifier(b);
+  const maxLength = Math.max(aParts.length, bParts.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const aPart = aParts[index] ?? 0;
+    const bPart = bParts[index] ?? 0;
+    if (aPart !== bPart) {
+      return aPart - bPart;
+    }
+  }
+  return 0;
+}
+
 export function SceneListClient({
-  showId,
   scenes,
   characters,
   departments,
@@ -129,86 +150,121 @@ export function SceneListClient({
   statusOptions,
 }: Props) {
   const [viewMode, setViewMode] = useState<"list" | "tiles">("list");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sceneFilter, setSceneFilter] = useState<SceneFilter>("all");
+  const [sceneSort, setSceneSort] = useState<SceneSort>("asc");
   const sortedCharacters = useMemo(
     () => [...characters].sort((a, b) => a.name.localeCompare(b.name, "de")),
     [characters],
   );
+  const filteredScenes = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    const matchesSearch = (scene: SceneData) => {
+      if (!normalizedSearch) return true;
+      return [
+        scene.identifier,
+        scene.title,
+        scene.summary,
+        scene.location,
+        scene.notes,
+        ...scene.characters.map((entry) => entry.character.name),
+      ].some((value) => value?.toLowerCase().includes(normalizedSearch));
+    };
+
+    const matchesFilter = (scene: SceneData) => {
+      switch (sceneFilter) {
+        case "with-roles":
+          return scene.characters.length > 0;
+        case "without-roles":
+          return scene.characters.length === 0;
+        case "with-breakdowns":
+          return scene.breakdownItems.length > 0;
+        case "without-breakdowns":
+          return scene.breakdownItems.length === 0;
+        default:
+          return true;
+      }
+    };
+
+    const results = scenes.filter((scene) => matchesSearch(scene) && matchesFilter(scene));
+    results.sort((a, b) => compareSceneIdentifiers(a.identifier, b.identifier));
+    if (sceneSort === "desc") {
+      results.reverse();
+    }
+    return results;
+  }, [sceneFilter, sceneSort, scenes, searchTerm]);
 
   const listClassName = viewMode === "tiles" ? "grid gap-6 lg:grid-cols-2" : "space-y-6";
   const detailLayoutClassName = viewMode === "tiles" ? "grid gap-4" : "grid gap-4 lg:grid-cols-2";
 
   return (
     <>
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button variant="ghost" size="sm" className="text-primary hover:text-primary/90">
-              Szenen erstellen
+      <div className="rounded-2xl border border-border/70 bg-card/60 p-3 shadow-sm">
+        <div className="grid gap-3 lg:grid-cols-[2fr_1fr_1fr_auto] lg:items-end">
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="scene-search">
+              Suche
+            </label>
+            <Input
+              id="scene-search"
+              placeholder="Szenen oder Orte suchen"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              className="h-9 text-sm"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="scene-filter">
+              Filter
+            </label>
+            <select
+              id="scene-filter"
+              className={selectSmallClassName}
+              value={sceneFilter}
+              onChange={(event) => setSceneFilter(event.target.value as SceneFilter)}
+            >
+              <option value="all">Alle Szenen</option>
+              <option value="with-roles">Mit Figuren</option>
+              <option value="without-roles">Ohne Figuren</option>
+              <option value="with-breakdowns">Mit Breakdowns</option>
+              <option value="without-breakdowns">Ohne Breakdowns</option>
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-muted-foreground" htmlFor="scene-sort">
+              Sortierung
+            </label>
+            <select
+              id="scene-sort"
+              className={selectSmallClassName}
+              value={sceneSort}
+              onChange={(event) => setSceneSort(event.target.value as SceneSort)}
+            >
+              <option value="asc">Nummer A-Z</option>
+              <option value="desc">Nummer Z-A</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2 justify-self-end">
+            <Button
+              type="button"
+              variant={viewMode === "list" ? "secondary" : "outline"}
+              size="icon"
+              aria-label="Listenansicht"
+              onClick={() => setViewMode("list")}
+            >
+              <List className="h-4 w-4" aria-hidden="true" />
             </Button>
-          </DialogTrigger>
-          <DialogContent className="max-w-2xl">
-            <DialogHeader>
-              <DialogTitle>Neue Szene anlegen</DialogTitle>
-              <DialogDescription>
-                Erfasse Orte, Zusammenfassungen und Notizen, um den Szenenplan aktuell zu halten.
-              </DialogDescription>
-            </DialogHeader>
-            <form action={createSceneAction} method="post" className="grid gap-6">
-              <input type="hidden" name="showId" value={showId} />
-              <input type="hidden" name="redirectPath" value={currentPath} />
-              <fieldset className="grid gap-3 rounded-lg border border-border/60 bg-background/70 p-4 md:grid-cols-3">
-                <legend className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Basisdaten
-                </legend>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">Nummer</label>
-                  <Input name="identifier" maxLength={40} placeholder="z.B. 1" required />
-                </div>
-                <div className="space-y-1 md:col-span-2">
-                  <label className="text-sm font-medium">Titel</label>
-                  <Input name="title" maxLength={160} placeholder="z.B. Ankunft im Park" />
-                </div>
-                <div className="space-y-1">
-                  <label className="text-sm font-medium">Ort</label>
-                  <Input name="location" maxLength={120} />
-                </div>
-              </fieldset>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Zusammenfassung</label>
-                <Textarea name="summary" rows={2} maxLength={600} />
-              </div>
-              <div className="space-y-1">
-                <label className="text-sm font-medium">Notizen</label>
-                <Textarea name="notes" rows={2} maxLength={400} />
-              </div>
-              <DialogFooter className="pt-2 sm:justify-end">
-                <DialogClose asChild>
-                  <Button type="submit">Szene speichern</Button>
-                </DialogClose>
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant={viewMode === "list" ? "secondary" : "outline"}
-            size="icon"
-            aria-label="Listenansicht"
-            onClick={() => setViewMode("list")}
-          >
-            <List className="h-4 w-4" aria-hidden="true" />
-          </Button>
-          <Button
-            type="button"
-            variant={viewMode === "tiles" ? "secondary" : "outline"}
-            size="icon"
-            aria-label="Kachelansicht"
-            onClick={() => setViewMode("tiles")}
-          >
-            <LayoutGrid className="h-4 w-4" aria-hidden="true" />
-          </Button>
+            <Button
+              type="button"
+              variant={viewMode === "tiles" ? "secondary" : "outline"}
+              size="icon"
+              aria-label="Kachelansicht"
+              onClick={() => setViewMode("tiles")}
+            >
+              <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -221,8 +277,16 @@ export function SceneListClient({
               </p>
             </CardContent>
           </Card>
+        ) : filteredScenes.length === 0 ? (
+          <Card className="lg:col-span-2">
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Keine Szenen erfüllen aktuell die ausgewählten Filter oder Suchbegriffe.
+              </p>
+            </CardContent>
+          </Card>
         ) : (
-          scenes.map((scene) => {
+          filteredScenes.map((scene) => {
             const assignedCharacterIds = new Set(scene.characters.map((entry) => entry.character.id));
             const availableCharacters = sortedCharacters.filter(
               (character) => !assignedCharacterIds.has(character.id),


### PR DESCRIPTION
### Motivation
- Nutzer sollen Rollen nach Rollengröße filtern und A–Z/Z–A sortieren ohne vollständiges Reload der Seite.
- Die Such-/Filter-/Sortier-Interaktion auf den Seiten „Besetzung“ und „Szenen“ soll in einer kompakten Toolbar zusammengefasst werden und die Schaltfläche zum Erstellen von Szenen sichtbar in der Summary-Box liegen.
- Texte und Layout für Rollengröße/Beschreibung sollen klarer und konsistenter dargestellt werden.

### Description
- Besetzung: Filter/Sort/ Suche auf die Client-Seite verlagert und in `src/app/(members)/mitglieder/produktionen/besetzung/casting-list-client.tsx` implementiert, inklusive Rollengröße-Filter, A–Z/Z–A Toggle und Entfernen des separaten Such-Submit-Buttons. (Neue Datei: `casting-list-client.tsx`)
- Gemeinsame Hilfsfunktionen und Typen extrahiert nach `casting-utils.ts` und in beiden Komponenten wiederverwendet (`formatUserName`, Labels, Klassen, Truncate-Helpers).
- Besetzung-Page an die neue Client-Liste angebunden (`page.tsx` aktualisiert) und serverseitige Query-Form-Reloads entfernt.
- Szenen: Button „Szene erstellen“ als `SceneCreateDialog` in die Summary-Card verschoben und eine Toolbar mit Suche/Filter/Sort/View-Toggles in `scene-list-client.tsx` ergänzt; außerdem wurde ein eigenständiges Dialog-Component `scene-create-dialog.tsx` hinzugefügt.
- UI/Textüberarbeitungen: Rollenkarte zeigt jetzt klarere Felder für „Rollengröße“, „Beschreibung“ und „Notiz“ (z. B. `Keine Rollengröße`, `Ohne Beschreibung`) und nutzt ein dl-basiertes Layout für bessere Lesbarkeit.

### Testing
- `pnpm lint` wurde ausgeführt und beendet mit 0 Fehlern und 2 Warnungen (neue Dateien verwendbare Imports / unused-vars bereinigt soweit möglich); Lauf beendet ohne Fehler.
- `pnpm test` (Vitest) wurde ausgeführt und alle Tests liefen grün (`123 passed`).
- `pnpm build` wurde ausgeführt und schlug fehl in dieser Umgebung aufgrund fehlender dev-dependencies (`@radix-ui/react-dropdown-menu` und `@radix-ui/react-popover`), daher kein erfolgreicher Produktions-Build hier; die Änderungen sind lokal und funktionieren in `pnpm dev` (Dev-Server startet), aber fehlende Pakete verhindern vollständigen Produktions-Build in CI/dev-VM.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697603f7800c832d96d88a56a26d63c8)