### PR TITLE
Add horizontal department filter, selection state and empty-state for Gewerke listing

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
@@ -291,6 +291,7 @@ export default async function ProduktionsGewerkePage({
       ),
     },
   ];
+  const hasSelection = selectedSlug !== null;
 
   return (
     <Dialog>
@@ -370,8 +371,50 @@ export default async function ProduktionsGewerkePage({
           </form>
         </DialogContent>
 
-        <div className="grid gap-6 xl:grid-cols-2">
-          {viewDepartments.map((department) => {
+        <nav aria-label="Gewerkefilter" className="overflow-x-auto pb-px">
+          <div className="inline-flex min-w-full flex-nowrap items-center gap-1 rounded-full border border-border/60 bg-background/80 p-1 text-muted-foreground shadow-inner ring-1 ring-primary/10">
+            <Link
+              href="/mitglieder/produktionen/gewerke"
+              aria-current={hasSelection ? undefined : "page"}
+              className={[
+                "inline-flex min-w-36 flex-1 basis-0 items-center justify-center whitespace-nowrap rounded-full px-3 py-2 text-[0.75rem] font-semibold uppercase tracking-wide transition",
+                hasSelection
+                  ? "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                  : "bg-background text-foreground shadow-sm ring-1 ring-border/60",
+              ].join(" ")}
+            >
+              Allgemeines
+            </Link>
+            {departments.map((department) => {
+              const isSelected = department.slug === selectedSlug;
+              return (
+                <Link
+                  key={department.id}
+                  href={`/mitglieder/produktionen/gewerke?department=${department.slug}`}
+                  aria-current={isSelected ? "page" : undefined}
+                  className={[
+                    "inline-flex min-w-36 flex-1 basis-0 items-center justify-center whitespace-nowrap rounded-full px-3 py-2 text-[0.75rem] font-semibold uppercase tracking-wide transition",
+                    isSelected
+                      ? "bg-background text-foreground shadow-sm ring-1 ring-border/60"
+                      : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                  ].join(" ")}
+                >
+                  {department.name}
+                </Link>
+              );
+            })}
+          </div>
+        </nav>
+
+        {viewDepartments.length === 0 ? (
+          <Card className="border-border/60 bg-background/80">
+            <CardContent className="p-6 text-sm text-muted-foreground">
+              Das ausgewählte Gewerk wurde nicht gefunden.
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-6 xl:grid-cols-2">
+            {viewDepartments.map((department) => {
             const departmentMemberIds = department.memberships.map(
               (membership) => membership.user.id,
             );
@@ -929,8 +972,9 @@ export default async function ProduktionsGewerkePage({
                 </div>
               </Card>
             );
-          })}
-        </div>
+            })}
+          </div>
+        )}
       </div>
     </Dialog>
   );


### PR DESCRIPTION
### Motivation
- Provide a compact, keyboard- and touch-friendly way to filter/select Gewerke and to surface an explicit empty state when a requested Gewerk is not available.

### Description
- Introduce a horizontal, pill-style department filter `nav` with an "Allgemeines" entry and per-department `Link`s that set `aria-current` and selection styling. 
- Add `hasSelection` derived state to determine whether the general tab or a specific department is active and apply corresponding classes. 
- Render an explicit empty-state `Card` when `viewDepartments.length === 0`, and otherwise keep the existing department card rendering inside the conditional branch. 
- Improve accessibility and layout by adding `nav aria-label`, overflow handling, and consistent focus/active visuals for the new filter UI.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` which completed successfully. 
- Ran the project's test suite with `pnpm test` and the existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaa29afa24832db9dec0301ea8826f)