### PR TITLE
Fix nullable breadcrumb href type causing Next.js build failure

### DIFF
--- a/src/lib/members-breadcrumbs.ts
+++ b/src/lib/members-breadcrumbs.ts
@@ -5,7 +5,7 @@ import { findMembersNavigationItem } from "@/lib/members-navigation";
 export interface MembersBreadcrumbItem {
   id?: string;
   label: ReactNode;
-  href?: string | null;
+  href?: string;
   icon?: ReactNode;
   isCurrent?: boolean;
   ariaLabel?: string;
@@ -21,7 +21,10 @@ export function isMembersBreadcrumbItem(
 export function createMembersBreadcrumbItems(
   items: readonly (MembersBreadcrumbItem | null | undefined | false)[],
 ): MembersBreadcrumbItem[] {
-  return items.filter(isMembersBreadcrumbItem);
+  return items.filter(isMembersBreadcrumbItem).map((item) => ({
+    ...item,
+    href: item.href ?? undefined,
+  }));
 }
 
 export function membersNavigationBreadcrumb(


### PR DESCRIPTION
### Motivation
- The production build failed with a TypeScript error (`Type 'string | null' is not assignable to type 'Url'`) because nullable breadcrumb `href` values could be passed into `next/link`.

### Description
- Change `MembersBreadcrumbItem.href` from `string | null` to `string` to avoid passing nullable types into `Link`.
- Harden `createMembersBreadcrumbItems` to normalize missing `href` values to `undefined` so components receive an acceptable `href` type instead of `null`.

### Testing
- Ran `pnpm lint` which passed successfully.
- Ran `pnpm test` (Vitest) which passed all tests.
- Ran `pnpm build` (Next.js production build) which now completes successfully without the previous TypeScript error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aae5f80f7c832da7109d11764c6dd5)