### PR TITLE
Fix Next.js type error for Meine-Gewerke todo links

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
@@ -271,7 +271,10 @@ export default async function DepartmentTodosPage() {
       } as const;
     }
 
-    return { href: undefined, label: "Team ansehen" } as const;
+    return {
+      href: TEAM_OVERVIEW_LINK,
+      label: "Zur Gewerke-Übersicht",
+    } as const;
   };
 
   const aggregatedAssignments = (
@@ -332,11 +335,9 @@ export default async function DepartmentTodosPage() {
                       </p>
                     ) : null}
                   </div>
-                  {link.href ? (
-                    <Button asChild size="sm" variant="ghost" className="h-8 self-start rounded-full px-3 text-xs font-semibold">
-                      <Link href={link.href}>{link.label}</Link>
-                    </Button>
-                  ) : null}
+                  <Button asChild size="sm" variant="ghost" className="h-8 self-start rounded-full px-3 text-xs font-semibold">
+                    <Link href={link.href}>{link.label}</Link>
+                  </Button>
                 </div>
               </li>
             );
@@ -364,14 +365,12 @@ export default async function DepartmentTodosPage() {
                       <p className="font-medium text-foreground">{entry.task.title}</p>
                       <p className="text-xs text-muted-foreground">{entry.department.name}</p>
                     </div>
-                    {link.href ? (
-                      <Link
-                        href={link.href}
-                        className="text-xs font-semibold text-primary transition hover:text-primary/80"
-                      >
-                        {link.label}
-                      </Link>
-                    ) : null}
+                    <Link
+                      href={link.href}
+                      className="text-xs font-semibold text-primary transition hover:text-primary/80"
+                    >
+                      {link.label}
+                    </Link>
                   </div>
                 </li>
               );
@@ -436,11 +435,9 @@ export default async function DepartmentTodosPage() {
                     </div>
                   </div>
                 </div>
-                {link.href ? (
-                  <Button asChild size="sm" variant="outline" className="rounded-full border-border/60 bg-background/80 px-4">
-                    <Link href={link.href}>{link.label}</Link>
-                  </Button>
-                ) : null}
+                <Button asChild size="sm" variant="outline" className="rounded-full border-border/60 bg-background/80 px-4">
+                  <Link href={link.href}>{link.label}</Link>
+                </Button>
               </header>
 
               <div className="grid gap-6 lg:grid-cols-2">


### PR DESCRIPTION
### Motivation
- The Next.js build failed with a TypeScript error because some `Link` `href` values could be `null`/`undefined`, triggering "Type 'string | null' is not assignable to type 'Url'" during production build.

### Description
- Ensure `departmentLinkFor` always returns a valid string `href` by using `TEAM_OVERVIEW_LINK` as the fallback and updating the fallback label.
- Remove now-unnecessary `link.href ? ... : null` guards and render the `Link`/`Button` elements directly since `href` is guaranteed.
- Change is limited to `src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx` to address the typed `Link` usage.

### Testing
- Ran `pnpm lint` and it completed successfully.
- Ran `pnpm test` (Vitest) and all tests passed (124 tests passed).
- Ran `pnpm build` and the Next.js production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf28fe4cc832d9b14570a1b291465)