### PR TITLE
Send production magic-link emails via nodemailer in EmailProvider

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -260,6 +260,16 @@ export const authOptions = {
       async sendVerificationRequest({ identifier, url }) {
         if (!process.env.EMAIL_SERVER || process.env.NODE_ENV !== "production") {
           console.log("[DEV Magic Link]", identifier, url);
+        } else {
+          const { createTransport } = await import("nodemailer");
+          const transport = createTransport(process.env.EMAIL_SERVER);
+          await transport.sendMail({
+            to: identifier,
+            from: process.env.EMAIL_FROM,
+            subject: "Dein Login-Link für das Sommertheater",
+            text: `Klicke auf diesen Link um dich einzuloggen:\n\n${url}\n\nDer Link ist nur kurze Zeit gültig.`,
+            html: `<p>Klicke auf diesen Link um dich einzuloggen:</p><p><a href="${url}">${url}</a></p><p>Der Link ist nur kurze Zeit gültig.</p>`,
+          });
         }
       },
     }),


### PR DESCRIPTION
### Motivation
Replace the dev-only `console.log` magic-link output with real email delivery in production so users receive verification links instead of relying on logs.

### Description
In `authOptions`'s `EmailProvider.sendVerificationRequest` branch for production, dynamically import `nodemailer`, create a transport using `process.env.EMAIL_SERVER`, and send the verification mail from `process.env.EMAIL_FROM` with a German subject and both text and HTML bodies while preserving console logging for non-production environments.

### Testing
Ran the project's automated test suite and TypeScript build (`npm test` / `tsc`), and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2290108c832d81f11eb01ff16fe1)