### PR TITLE
Add always-on magic-link request log in sendVerificationRequest

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -258,6 +258,7 @@ export const authOptions = {
       server: process.env.EMAIL_SERVER,
       from: process.env.EMAIL_FROM,
       async sendVerificationRequest({ identifier, url }) {
+        console.log("[MAGIC LINK REQUEST]", identifier, "EMAIL_SERVER set:", !!process.env.EMAIL_SERVER, "NODE_ENV:", process.env.NODE_ENV);
         if (!process.env.EMAIL_SERVER || process.env.NODE_ENV !== "production") {
           console.log("[DEV Magic Link]", identifier, url);
         } else {


### PR DESCRIPTION
### Motivation
- Ensure every magic-link request is logged so calls to `/api/auth/signin/email` are visible in Docker logs regardless of `EMAIL_SERVER` or `NODE_ENV`.

### Description
- Inserted an unconditional `console.log` as the first line of `sendVerificationRequest` in `src/lib/auth.ts` with the exact format `console.log("[MAGIC LINK REQUEST]", identifier, "EMAIL_SERVER set:", !!process.env.EMAIL_SERVER, "NODE_ENV:", process.env.NODE_ENV)` and preserved the existing dev/prod branching for actually sending or printing the magic link; no other files were changed.

### Testing
- Ran `pnpm lint`, `pnpm test`, and `pnpm build`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef773fead0832d8481103ca39a9b18)