### PR TITLE
Add NextAuth Pages Router auth entrypoint

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,4 @@
+import NextAuth from "next-auth"
+import { authOptions } from "@/lib/auth"
+
+export default NextAuth(authOptions)


### PR DESCRIPTION
### Motivation
- Stelle einen NextAuth v4 Pages-Router-Entrypoint bereit, damit der Magic-Link E‑Mail-Provider (z. B. `sendVerificationRequest`) korrekt aufgerufen werden kann.

### Description
- Füge `pages/api/auth/[...nextauth].ts` hinzu, das `NextAuth(authOptions)` aus `@/lib/auth` exportiert.

### Testing
- `pnpm lint` und `pnpm test` wurden ausgeführt und sind erfolgreich durchgelaufen.
- `pnpm build` schlägt fehl aufgrund eines Next.js-Konflikts zwischen `pages/api/auth/[...nextauth].ts` und der bestehenden App-Router-Route `app/api/auth/[...nextauth]/route.ts`, wodurch ein Build-Adjustment nötig ist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2417318a0832dace570eeb2c7f710)