### PR TITLE
workflow_dispatch: allow selecting branch for Docker matrix (main|production)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,15 @@ on:
       - 'scripts/**'
       - 'deploy-service/**'
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch for matrix selection
+        required: true
+        type: choice
+        default: main
+        options:
+          - main
+          - production
 
 env:
   REGISTRY: docker.io
@@ -70,7 +79,7 @@ jobs:
       - name: Check branch compatibility
         id: branch-filter
         env:
-          CURRENT_BRANCH: ${{ github.ref_name }}
+          CURRENT_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_branch || github.ref_name }}
           MATRIX_BRANCH: ${{ matrix.branch }}
         run: |
           if [ "$CURRENT_BRANCH" != "$MATRIX_BRANCH" ]; then
@@ -88,6 +97,8 @@ jobs:
       - name: Checkout repository
         if: steps.branch-filter.outputs.should_run == 'true'
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_branch || github.ref_name }}
 
       - name: Set up Docker Buildx
         if: steps.branch-filter.outputs.should_run == 'true'


### PR DESCRIPTION
### Motivation
- Manual workflow runs needed a way to trigger the `production` matrix entry from the GitHub UI so the matrix item with `branch: production` actually runs on demand. 
- The existing `workflow_dispatch` had no input to select a branch, so manual runs defaulted to the event ref and could not select `production` in the Run workflow dropdown. 
- This change keeps push behavior unchanged while enabling explicit branch selection for manual dispatches.

### Description
- Added a `workflow_dispatch` input `target_branch` with choices `main` and `production` so the manual Run workflow UI can select the branch. 
- Branch-filter logic was updated to use `github.event.inputs.target_branch` when `github.event_name == 'workflow_dispatch'` and fall back to `github.ref_name` for push runs so the matrix picks the intended branch. 
- `actions/checkout` now uses the selected dispatch branch via `ref` for manual runs so the checked-out code matches the dispatch target.

### Testing
- Ran `pnpm test` (Vitest) which succeeded: 35 test files, 124 tests passed. 
- Ran `pnpm build` (Next.js production build) which completed successfully. 
- Ran `pnpm lint` which failed with an unrelated existing ESLint configuration error (`TypeError: Converting circular structure to JSON`) not caused by this workflow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86eeb8bb883239c8159560fd8ddb8)