### PR TITLE
Add CI trigger marker to NextAuth route file

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -68,3 +68,5 @@ export async function POST(request: NextRequest, context: NextAuthContext) {
   return safeHandle(request, context);
 }
 
+
+// CI trigger marker: update path under src/** for docker-publish workflow.


### PR DESCRIPTION
### Motivation
- Add a marker comment in `src/app/api/auth/[...nextauth]/route.ts` to ensure the `docker-publish` workflow picks up changes under `src/**` for CI triggering.

### Description
- Insert a single-line comment `// CI trigger marker: update path under src/** for docker-publish workflow.` at the end of `src/app/api/auth/[...nextauth]/route.ts` to force the CI path matcher to detect changes.

### Testing
- Ran the repository's test suite with `npm test` and the automated tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87c1b4ee4832393b4cf73bcf75c08)