### PR TITLE
Fix nullable Link href in department selector

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/department-select.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/department-select.tsx
@@ -25,13 +25,15 @@ export function DepartmentSelect({ options, selectedDepartmentId }: DepartmentSe
       className="flex flex-wrap items-center gap-2 overflow-x-auto rounded-full border border-border/60 bg-background/80 p-1 text-muted-foreground shadow-inner ring-1 ring-primary/10"
     >
       {navOptions.map((option) => {
-        const href = option.value ? `${pathname}?department=${encodeURIComponent(option.value)}` : pathname;
+        const href = option.value
+          ? `${pathname ?? ""}?department=${encodeURIComponent(option.value)}`
+          : (pathname ?? "/");
         const isActive = option.value ? selectedDepartmentId === option.value : !selectedDepartmentId;
 
         return (
           <Link
             key={option.value || "none"}
-            href={href}
+            href={href ?? "/"}
             aria-current={isActive ? "page" : undefined}
             className={cn(
               "inline-flex min-w-0 items-center justify-center rounded-full px-3.5 py-2 text-xs font-semibold uppercase tracking-wide transition",


### PR DESCRIPTION
### Motivation
- Ensure Next.js `Link` always receives a non-null `href` to fix a TypeScript `Url` typing error in the department selector component.

### Description
- In `src/app/(members)/mitglieder/meine-gewerke/department-select.tsx` compute `href` with `pathname` fallbacks (`pathname ?? ""` / `pathname ?? "/"`) and pass a non-null fallback to `Link` via `href={href ?? "/"}` so `href` is never `null`.

### Testing
- Ran `pnpm build`; the previous nullable-`href` TypeScript error is resolved, but the full build failed due to unrelated missing modules (`@radix-ui/react-dropdown-menu` and `@radix-ui/react-popover`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b9751cb8832da6f16d0415169fa9)