### PR TITLE
Remove production scoping from Gewerke overview Prisma queries

### DIFF
--- a/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/page.tsx
@@ -37,13 +37,12 @@ export default async function ProduktionsGewerkePage() {
   const breadcrumbs = [membersNavigationBreadcrumb(currentPath)];
 
   const departmentCount = activeProduction
-    ? await prisma.department.count({ where: { productionId: activeProduction.id } })
+    ? await prisma.department.count()
     : 0;
 
   const openTaskCount = activeProduction
     ? await prisma.departmentTask.count({
         where: {
-          department: { productionId: activeProduction.id },
           status: { in: ["todo", "doing"] },
         },
       })
@@ -51,15 +50,12 @@ export default async function ProduktionsGewerkePage() {
 
   const memberCount = activeProduction
     ? await prisma.departmentMembership.count({
-        where: {
-          department: { productionId: activeProduction.id },
-        },
+        where: {},
       })
     : 0;
 
   const departments = activeProduction
     ? await prisma.department.findMany({
-        where: { productionId: activeProduction.id },
         select: {
           id: true,
           name: true,
@@ -73,7 +69,6 @@ export default async function ProduktionsGewerkePage() {
   const doneTaskCount = activeProduction
     ? await prisma.departmentTask.count({
         where: {
-          department: { productionId: activeProduction.id },
           status: "done",
         },
       })


### PR DESCRIPTION
### Motivation
- Change Prisma queries so overview counts and the department list are not filtered by the active production and instead return global results.
- This appears intended to present site-wide statistics and departments rather than limiting to `activeProduction`.

### Description
- Removed `where: { productionId: activeProduction.id }` filters from `prisma.department.count`, `prisma.department.findMany`, and task/member counts so they no longer scope to a specific production.
- Removed nested `department: { productionId: ... }` conditions from `prisma.departmentTask.count` and `prisma.departmentMembership.count` so task and membership counts become global while retaining existing `status` filters where present.
- Updated queries to use empty `where` or no `where` so lists and counts return across all departments.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8bb43f548832d82c92066c6d0c219)