### PR TITLE
Send production magic link emails via nodemailer

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -260,7 +260,20 @@ export const authOptions = {
       async sendVerificationRequest({ identifier, url }) {
         if (!process.env.EMAIL_SERVER || process.env.NODE_ENV !== "production") {
           console.log("[DEV Magic Link]", identifier, url);
+          return;
         }
+        console.log("[MAGIC LINK REQUEST]", identifier);
+        // send mail via nodemailer using process.env.EMAIL_SERVER
+        const { createTransport } = await import("nodemailer");
+        const transport = createTransport(process.env.EMAIL_SERVER);
+        await transport.sendMail({
+          to: identifier,
+          from: process.env.EMAIL_FROM,
+          subject: "Dein Magic Link",
+          text: `Hier ist dein Login-Link:\n\n${url}\n\nDer Link ist 24 Stunden gültig.`,
+          html: `<p>Hier ist dein Login-Link:</p><p><a href="${url}">${url}</a></p><p>Der Link ist 24 Stunden gültig.</p>`,
+        });
+        console.log("[MAGIC LINK SENT]", identifier);
       },
     }),
     credentialsProvider,


### PR DESCRIPTION
### Motivation
- Ensure that magic link emails are actually delivered in production instead of only logging them during development.
- Use a reliable mail transport when `EMAIL_SERVER` is configured and the app is in production.

### Description
- Updated `EmailProvider.sendVerificationRequest` to return early in dev when `EMAIL_SERVER` is not set or `NODE_ENV` is not `production` to keep the existing dev logging behavior.
- Added production path that logs the request, dynamically imports `nodemailer`, creates a transport with `process.env.EMAIL_SERVER`, and sends an email to the user with German subject/body including the magic link.
- Added logs for both the magic link request and successful send to aid observability.

### Testing
- Ran `npm run build` to verify TypeScript compilation succeeded. (passed)
- Ran the test suite with `npm test` to ensure existing tests are unaffected. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c02297ec832dbe3e19fa4239eebf)