### PR TITLE
Trigger CI rebuild by adding no-op comment in auth module

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,7 @@ import { combineNameParts } from "@/lib/names";
 import { ensureDevTestUser } from "@/lib/dev-auth";
 import { recordSessionEnd, recordSessionStart } from "@/lib/auth/session";
 import { getAuthSecret } from "@/lib/auth-secret";
+// trigger build
 
 type MutableToken = JWT & {
   id?: string;


### PR DESCRIPTION
### Motivation
- Force the CI/build system to re-run by making a small, non-functional change to `src/lib/auth.ts`.

### Description
- Inserted a single-line comment `// trigger build` near the imports in `src/lib/auth.ts` to produce a harmless diff and prompt a rebuild.

### Testing
- Ran the project build with `npm run build` and the unit test suite with `npm test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c7f1066c832db8ba97e1d943e503)