### PR TITLE
Add optional emailVerified timestamp to User and DB migration

### DIFF
--- a/prisma/migrations/20260504090000_add_email_verified_to_user/migration.sql
+++ b/prisma/migrations/20260504090000_add_email_verified_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "emailVerified" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -265,6 +265,7 @@ model User {
   lastName  String?
   name      String?
   email     String?  @unique
+  emailVerified DateTime?
   role      Role     @default(member)
   passwordHash String?
   createdAt DateTime @default(now())


### PR DESCRIPTION
### Motivation
- Persist when a user's email was verified to support authentication and account-management flows.

### Description
- Add `emailVerified DateTime?` to the `User` model in `prisma/schema.prisma` and add a migration file `prisma/migrations/20260504090000_add_email_verified_to_user/migration.sql` that executes `ALTER TABLE "User" ADD COLUMN "emailVerified" TIMESTAMP(3);`.

### Testing
- Ran `prisma migrate dev` and `prisma generate` locally to create and apply the migration, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d1518830832da488f71de4934832)