### PR TITLE
Add password reset flow: UI copy, reset page, email template, and API

### DIFF
--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { z } from "zod";
+import { authOptions } from "@/lib/auth";
+import { hashPassword } from "@/lib/password";
+import { prisma } from "@/lib/prisma";
+
+const resetSchema = z.object({
+  password: z.string().min(8, "Passwort muss mindestens 8 Zeichen lang sein."),
+});
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = resetSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0]?.message ?? "Ungültige Eingabe." }, { status: 400 });
+  }
+
+  const passwordHash = await hashPassword(parsed.data.password, 12);
+  await prisma.user.update({
+    where: { id: session.user.id },
+    data: { passwordHash },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/login/login-client.tsx
+++ b/src/app/login/login-client.tsx
@@ -117,12 +117,12 @@ export function LoginPageClient() {
       const res: SignInResponse | undefined = await signIn("email", {
         email: values.email,
         redirect: false,
-        callbackUrl: "/mitglieder",
+        callbackUrl: "/reset-password",
       });
       if (res?.error) {
         toast.error(res.error || "E-Mail Versand fehlgeschlagen");
       } else {
-        toast.success("Magic Link gesendet – bitte E-Mail prüfen.");
+        toast.success("Link gesendet – bitte E-Mail prüfen.");
         setMagicDialogOpen(false);
       }
     } catch {
@@ -207,13 +207,13 @@ export function LoginPageClient() {
                 <div className="space-y-1">
                   <p className="text-sm font-semibold">Kein Passwort zur Hand?</p>
                   <p className="text-sm text-muted-foreground">
-                    Lass dir einen einmaligen Login-Link an deine E-Mail senden.
+                    Lass dir einen Link zum Zurücksetzen deines Passworts senden.
                   </p>
                 </div>
               </div>
               <DialogTrigger asChild>
                 <Button type="button" size="sm" variant="secondary" onClick={handleOpenMagic}>
-                  Magic Link
+                  Passwort vergessen
                 </Button>
               </DialogTrigger>
             </div>
@@ -253,9 +253,9 @@ export function LoginPageClient() {
 
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Login-Link anfordern</DialogTitle>
+            <DialogTitle>Passwort zurücksetzen</DialogTitle>
             <DialogDescription>
-              Wir senden dir einen einmaligen Login-Link an deine E-Mail-Adresse. Der Link ist nur kurze Zeit gültig.
+              Gib deine E-Mail-Adresse ein. Wir schicken dir einen Link zum Zurücksetzen deines Passworts.
             </DialogDescription>
           </DialogHeader>
           <form
@@ -275,7 +275,7 @@ export function LoginPageClient() {
                 Abbrechen
               </Button>
               <Button type="submit" disabled={loading}>
-                {loading ? "Senden…" : "Login-Link schicken"}
+                {loading ? "Senden…" : "Link senden"}
               </Button>
             </DialogFooter>
           </form>

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,20 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth";
+import { ResetPasswordForm } from "./reset-password-form";
+
+export default async function ResetPasswordPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-6 rounded-2xl border border-border bg-card p-6 shadow-sm">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Neues Passwort festlegen</h1>
+      </div>
+      <ResetPasswordForm />
+    </div>
+  );
+}

--- a/src/app/reset-password/reset-password-form.tsx
+++ b/src/app/reset-password/reset-password-form.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { PasswordInput } from "@/components/ui/password-input";
+import { toast } from "sonner";
+
+export function ResetPasswordForm() {
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const validate = () => {
+    if (password.length < 8 || confirmPassword.length < 8) {
+      return "Beide Passwörter müssen mindestens 8 Zeichen lang sein.";
+    }
+    if (password !== confirmPassword) {
+      return "Die Passwörter stimmen nicht überein.";
+    }
+    return null;
+  };
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const validationError = validate();
+    setError(validationError);
+    if (validationError) return;
+
+    setLoading(true);
+    try {
+      const response = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+
+      if (response.redirected) {
+        router.push(response.url);
+        return;
+      }
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(data?.error ?? "Passwort konnte nicht gespeichert werden.");
+      }
+
+      toast.success("Passwort erfolgreich gespeichert.");
+      router.push("/mitglieder");
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Passwort konnte nicht gespeichert werden.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={onSubmit}>
+      <label className="block space-y-2 text-sm text-foreground">
+        <span>Neues Passwort</span>
+        <PasswordInput value={password} onChange={(event) => setPassword(event.target.value)} autoComplete="new-password" />
+      </label>
+      <label className="block space-y-2 text-sm text-foreground">
+        <span>Passwort bestätigen</span>
+        <PasswordInput value={confirmPassword} onChange={(event) => setConfirmPassword(event.target.value)} autoComplete="new-password" />
+      </label>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <Button type="submit" className="w-full" disabled={loading}>
+        {loading ? "Speichern…" : "Passwort speichern"}
+      </Button>
+    </form>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -270,9 +270,19 @@ export const authOptions = {
         await transport.sendMail({
           to: identifier,
           from: process.env.EMAIL_FROM,
-          subject: "Dein Magic Link",
-          text: `Hier ist dein Login-Link:\n\n${url}\n\nDer Link ist 24 Stunden gültig.`,
-          html: `<p>Hier ist dein Login-Link:</p><p><a href="${url}">${url}</a></p><p>Der Link ist 24 Stunden gültig.</p>`,
+          subject: "Passwort zurücksetzen – Sommertheater Altroßthal",
+          text: `Sommertheater Altroßthal\n\nPasswort zurücksetzen\n\nKlicke auf den Link, um ein neues Passwort festzulegen. Der Link ist 24 Stunden gültig.\n\n${url}\n\nFalls du diese E-Mail nicht angefordert hast, kannst du sie ignorieren.`,
+          html: `
+            <div style="background:#0d1117;padding:32px 16px;font-family:Inter,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#ffffff;">
+              <div style="max-width:560px;margin:0 auto;background:#111827;border:1px solid #1f2937;border-radius:16px;padding:32px;">
+                <p style="margin:0 0 20px 0;font-size:24px;line-height:1.3;font-weight:700;color:#f97316;">Sommertheater Altroßthal</p>
+                <h1 style="margin:0 0 16px 0;font-size:28px;line-height:1.2;font-weight:700;color:#ffffff;">Passwort zurücksetzen</h1>
+                <p style="margin:0 0 28px 0;font-size:16px;line-height:1.6;color:#ffffff;">Klicke auf den Button unten, um ein neues Passwort festzulegen. Der Link ist 24 Stunden gültig.</p>
+                <a href="${url}" style="display:inline-block;background:#f97316;color:#ffffff;text-decoration:none;font-size:16px;font-weight:600;padding:14px 24px;border-radius:10px;">Neues Passwort festlegen</a>
+                <p style="margin:28px 0 0 0;font-size:13px;line-height:1.5;color:#d1d5db;">Falls du diese E-Mail nicht angefordert hast, kannst du sie ignorieren.</p>
+              </div>
+            </div>
+          `,
         });
         console.log("[MAGIC LINK SENT]", identifier);
       },

--- a/src/lib/password.ts
+++ b/src/lib/password.ts
@@ -31,9 +31,9 @@ async function loadBcrypt(): Promise<BcryptModule> {
   return cachedBcrypt;
 }
 
-export async function hashPassword(password: string) {
+export async function hashPassword(password: string, saltRounds = 10) {
   const bcrypt = await loadBcrypt();
-  return bcrypt.hash(password, 10);
+  return bcrypt.hash(password, saltRounds);
 }
 
 export async function verifyPassword(password: string, hash: string) {


### PR DESCRIPTION
### Motivation
- Provide a localized, branded password-reset flow that reuses the existing magic-link infrastructure and redirects users to a dedicated reset page after email verification. 
- Deliver an HTML email matching the site design (dark background, white text, orange accent) and clear German copy for the reset process. 
- Securely update user passwords server-side only for authenticated sessions and with a stronger bcrypt salt rounds setting.

### Description
- Updated the login UI in `src/app/login/login-client.tsx` to rename the magic-link trigger to `Passwort vergessen`, change the dialog title to `Passwort zurücksetzen`, update the dialog description and set the submit button label to `Link senden`, and changed the `signIn("email")` `callbackUrl` to `"/reset-password"`.
- Reworked `sendVerificationRequest` in `src/lib/auth.ts` to use the subject `Passwort zurücksetzen – Sommertheater Altroßthal`, replaced the `html` body with a fully styled dark template (background `#0d1117`, white text, orange accent `#f97316`) and updated the plain `text` fallback to the new German reset messaging.
- Added a new reset page and client form at `src/app/reset-password/page.tsx` and `src/app/reset-password/reset-password-form.tsx` that use the project UI tokens/components, show `Neues Passwort festlegen`, include two password fields, validate minimum length (8) and equality client-side, and submit to the API.
- Implemented an authenticated API route `POST /api/auth/reset-password` in `src/app/api/auth/reset-password/route.ts` that verifies the session with `getServerSession`, validates input with `zod`, hashes the new password using `hashPassword(..., 12)`, and updates `user.passwordHash` via Prisma; adjusted `src/lib/password.ts` to accept an optional `saltRounds` parameter (default 10).

### Testing
- Ran `pnpm test` and all tests passed (35 test files, 123 tests total). ✅
- Ran `pnpm lint` which failed due to an unrelated repository-level ESLint configuration error (`TypeError: Converting circular structure to JSON`), not introduced by these changes. ⚠️
- Ran `pnpm build` which failed in this environment due to pre-existing missing Radix UI packages (`@radix-ui/react-dropdown-menu`, `@radix-ui/react-popover`) and other unrelated build warnings; the new API route import was adjusted to use the named `prisma` export. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d8e43860832da60bd999a079c0c2)