### PR TITLE
ci: trigger docker publish workflow on pages changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,7 @@ on:
       - 'vitest.config.ts'
       - 'components.json'
       - 'src/**'
+      - 'pages/**'
       - 'public/**'
       - 'prisma/**'
       - 'realtime-server/**'


### PR DESCRIPTION
### Motivation
- Änderungen im Pages-Router sollen ebenfalls einen Docker-Build/Publish auslösen, damit Deploys auf Seiten-Änderungen berücksichtigt werden.

### Description
- In `.github/workflows/docker-publish.yml` wurde direkt nach `- 'src/**'` der Eintrag `- 'pages/**'` zur `on.push.paths`-Liste hinzugefügt.

### Testing
- Die Änderung wurde durch Überprüfung des YAML-Diffs mit `git diff -- .github/workflows/docker-publish.yml` verifiziert und in einem Commit festgehalten; keine automatisierten Tests wurden für diese Workflow-Pfadänderung ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a5dfb54c83238781dd09458123a8)