### PR TITLE
ci(workflow): publish Docker image for `dev` branch and include `pages/**` in paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - production
+      - dev
     paths:
       - '.github/workflows/docker-publish.yml'
       - 'Dockerfile.dev'
@@ -21,6 +22,7 @@ on:
       - 'vitest.config.ts'
       - 'components.json'
       - 'src/**'
+      - 'pages/**'
       - 'public/**'
       - 'prisma/**'
       - 'realtime-server/**'
@@ -41,6 +43,14 @@ jobs:
     strategy:
       matrix:
         include:
+          - branch: dev
+            environment: dev
+            dockerfile: Dockerfile.dev
+            build_args: |
+              NODE_ENV=development
+              GIT_COMMIT_SHA=${{ github.sha }}
+            metadata_tags: |
+              type=raw,value=dev
           - branch: main
             environment: dev
             dockerfile: Dockerfile.dev


### PR DESCRIPTION
### Motivation

- Enable publishing Docker images from the `dev` branch so non-production builds can be built and pushed similarly to `main` and `production`.
- Ensure changes to site page files under `pages/**` trigger the Docker publish workflow.
- Provide a dedicated matrix entry that builds a development image using `Dockerfile.dev` and tags metadata for dev inspection.

### Description

- Added `dev` to the `on.push.branches` list in `.github/workflows/docker-publish.yml` so pushes to `dev` trigger the workflow.
- Added `pages/**` to the workflow `paths` so changes under `pages` cause the job to run.
- Introduced a matrix entry for `branch: dev` with `environment: dev`, `dockerfile: Dockerfile.dev`, `build_args` including `NODE_ENV=development` and `GIT_COMMIT_SHA`, and `metadata_tags` set to `type=raw,value=dev`.
- Left existing matrix entries for `main` and `production` intact to preserve current build behavior for dev, prod, and latest images.

### Testing

- No automated tests were run as part of this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a5dfb54c83238781dd09458123a8)