### PR TITLE
chore: trigger production build

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,6 +16,7 @@ import { ensureDevTestUser } from "@/lib/dev-auth";
 import { recordSessionEnd, recordSessionStart } from "@/lib/auth/session";
 import { getAuthSecret } from "@/lib/auth-secret";
 // trigger build
+// trigger build
 
 type MutableToken = JWT & {
   id?: string;


### PR DESCRIPTION
### Motivation
- Create a no-op change to trigger the GitHub Actions build pipeline for the `production` workflow by introducing a simple comment in the auth module.

### Description
- Added a `// trigger build` comment in `src/lib/auth.ts` (comment-only change) to produce a commit that will kick off CI; the requested `production` branch did not exist locally so the change was committed on the current `work` branch.

### Testing
- Ran repository checks to verify the change: `git status --short`, `git diff -- src/lib/auth.ts`, and `git add src/lib/auth.ts && git commit -m "chore: trigger production build"`; no runtime or build tests were executed because this is a comment-only change (allowed by the repository's documentation-only exception).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9a89e6210832387120f24c83db9c0)