### PR TITLE
Public site: remove FAQ item, responsive countdown & hero, auth-gated UI, update footer/header

### DIFF
--- a/src/app/(site)/_components/homepage-countdown.tsx
+++ b/src/app/(site)/_components/homepage-countdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
 
 import { Countdown } from "@/components/countdown";
 import { useFrontendEditing } from "@/components/frontend-editing/frontend-editing-provider";
@@ -92,7 +93,8 @@ export function HomepageCountdown({
   initialNow,
 }: HomepageCountdownProps) {
   const { hasFeature, openFeature, closeFeature, activeFeature } = useFrontendEditing();
-  const canEdit = hasFeature("site.countdown");
+  const { status } = useSession();
+  const canEdit = status === "authenticated" && hasFeature("site.countdown");
   const editorOpen = canEdit && activeFeature === "site.countdown";
 
   const [settings, setSettings] = useState<CountdownSettingsState>(() => ({

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -113,7 +113,12 @@ export default async function SiteLayout({ children }: { children: React.ReactNo
         )}
       </main>
       {!showMaintenanceNotice ? (
-        <SiteFooter buildInfo={buildInfo} isDevBuild={isDevBuild} siteTitle={siteTitle} />
+        <SiteFooter
+          buildInfo={buildInfo}
+          isDevBuild={isDevBuild}
+          siteTitle={siteTitle}
+          isAuthenticated={Boolean(session?.user)}
+        />
       ) : null}
     </div>
   );

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -42,11 +42,6 @@ export default async function Home() {
         "Der Ticketverkauf wird über den Instagram-Kanal der Schule bekanntgegeben. Folge uns dort, um nichts zu verpassen.",
     },
     {
-      question: "Benötige ich Vorkenntnisse, um das Stück zu genießen?",
-      answer:
-        "Nein – unsere Inszenierungen sind so konzipiert, dass alle Gäste ohne Vorkenntnisse direkt eintauchen können. Dank moderner Regie und einer leicht zugänglichen Handlung finden alle schnell in die Geschichte hinein.",
-    },
-    {
       question: "Wo findet die Aufführung statt?",
       answer:
         "Die Vorstellung findet im Schlosspark Altroßthal statt. Adresse: BSZ für Agrarwirtschaft und Ernährung Dresden, Altroßthal 1, 01169 Dresden.",
@@ -116,20 +111,18 @@ export default async function Home() {
                       <Text asChild variant="bodyLg" weight="semibold">
                         <span>{faq.question}</span>
                       </Text>
-                      <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/50 bg-background/70 text-primary transition duration-300 group-open:rotate-180">
-                        <svg
-                          className="h-4 w-4"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          aria-hidden="true"
-                        >
-                          <path d="m6 9 6 6 6-6" />
-                        </svg>
-                      </span>
+                      <svg
+                        className="h-4 w-4 text-orange-500 transition duration-300 group-open:rotate-180"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="m6 9 6 6 6-6" />
+                      </svg>
                     </summary>
                     <Text tone="muted" className="mt-4 leading-relaxed">
                       {faq.answer}

--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -105,13 +105,13 @@ export function Countdown({ targetDate, initialNow, className, variant = "defaul
     { label: "Sekunden", value: state.seconds },
   ];
 
-  const containerClassName = cn("grid w-full grid-cols-2 gap-3 sm:grid-cols-4", className);
+  const containerClassName = cn("grid w-full grid-cols-2 gap-[clamp(0.4rem,1.5vw,1rem)] sm:grid-cols-4", className);
   const cellClassName =
     variant === "highlight"
-      ? "rounded-lg border border-primary/50 bg-primary/10 px-4 py-3 text-center shadow-sm text-primary"
-      : "rounded-lg border border-border bg-card px-4 py-3 text-center shadow-sm";
+      ? "rounded-lg border border-primary/50 bg-primary/10 px-[clamp(0.5rem,2vw,1.5rem)] py-[clamp(0.5rem,2vw,1.5rem)] text-center text-primary shadow-sm"
+      : "rounded-lg border border-border bg-card px-[clamp(0.5rem,2vw,1.5rem)] py-[clamp(0.5rem,2vw,1.5rem)] text-center shadow-sm";
   const numberClassName = cn(
-    "text-3xl font-semibold tabular-nums sm:text-4xl",
+    "text-[clamp(1.5rem,6vw,3.5rem)] font-semibold tabular-nums",
     variant === "highlight" ? "text-primary" : undefined,
   );
   const labelTone = variant === "highlight" ? "primary" : "muted";
@@ -124,7 +124,10 @@ export function Countdown({ targetDate, initialNow, className, variant = "defaul
           <Text
             variant="small"
             tone={labelTone}
-            className={cn("mt-1 uppercase tracking-[0.2em]", variant === "highlight" ? "text-primary/80" : undefined)}
+            className={cn(
+              "mt-1 text-[clamp(0.6rem,1.5vw,0.85rem)] uppercase tracking-[0.2em]",
+              variant === "highlight" ? "text-primary/80" : undefined,
+            )}
           >
             {part.label}
           </Text>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -81,12 +81,12 @@ export function Hero({ images }: { images: string[] }) {
                       aria-hidden="true"
                       className="pointer-events-none absolute -inset-[4rem] -z-10 bg-[conic-gradient(from_110deg_at_50%_50%,rgba(59,130,246,0.22),rgba(236,72,153,0.18),rgba(16,185,129,0.2),rgba(59,130,246,0.22))] opacity-60 blur-[110px]"
                     />
-                    <span className="relative text-[clamp(2.3rem,5.6vw,4.6rem)] uppercase tracking-[0.12em] leading-[0.94]">
+                    <span className="relative text-[clamp(1.8rem,8vw,5rem)] uppercase tracking-[0.12em] leading-[0.94]">
                       <span className="bg-gradient-to-br from-white via-white/95 to-white/70 bg-clip-text text-transparent drop-shadow-[0_22px_48px_rgba(5,8,22,0.65)]">
                         Das Geheimnis
                       </span>
                     </span>
-                    <span className="relative text-[clamp(2rem,4.8vw,3.8rem)] uppercase tracking-[0.26em] leading-[0.92] text-white/85">
+                    <span className="relative text-[clamp(1.5rem,7vw,4.5rem)] uppercase tracking-[0.26em] leading-[0.92] text-white/85">
                       <span className="bg-gradient-to-r from-white/80 via-white to-white/65 bg-clip-text text-transparent drop-shadow-[0_18px_42px_rgba(5,8,22,0.58)]">
                         im Schlosspark
                       </span>
@@ -107,7 +107,11 @@ export function Hero({ images }: { images: string[] }) {
                 Ein Sommer. Ein Wochenende. Ein einziges Stück – verborgen zwischen Licht und Laub.
               </Text>
               <div className="flex flex-col items-center justify-center gap-4 md:flex-row md:gap-5">
-                <Button asChild size="xl" className="px-8 py-5 text-base font-semibold tracking-wide md:px-10 md:text-lg">
+                <Button
+                  asChild
+                  size="xl"
+                  className="w-[clamp(200px,60vw,340px)] rounded-[clamp(0.75rem,2vw,1rem)] px-[clamp(1rem,3vw,2rem)] py-[clamp(0.6rem,2vw,1rem)] text-[clamp(0.85rem,2vw,1rem)] font-semibold tracking-wide"
+                >
                   <Link href="/mystery" title="Geheimnis entdecken">
                     <Sparkles aria-hidden className="h-5 w-5" />
                     <span>Das Geheimnis entdecken</span>
@@ -117,7 +121,7 @@ export function Hero({ images }: { images: string[] }) {
                   variant="outline"
                   asChild
                   size="xl"
-                  className="border-white/50 bg-white/10 px-8 py-5 text-base font-semibold text-white shadow-lg backdrop-blur md:px-10 md:text-lg"
+                  className="w-[clamp(200px,60vw,340px)] rounded-[clamp(0.75rem,2vw,1rem)] border-white/50 bg-white/10 px-[clamp(1rem,3vw,2rem)] py-[clamp(0.6rem,2vw,1rem)] text-[clamp(0.85rem,2vw,1rem)] font-semibold text-white shadow-lg backdrop-blur"
                 >
                   <Link href="/chronik" title="Chronik öffnen">
                     <BookOpen aria-hidden className="h-5 w-5" />

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -18,11 +18,10 @@ type SiteFooterProps = {
   buildInfo: BuildInfo;
   isDevBuild: boolean;
   siteTitle: string;
+  isAuthenticated: boolean;
 };
 
-export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps) {
-  const currentYear = new Date().getFullYear();
-
+export function SiteFooter({ buildInfo, isDevBuild, siteTitle, isAuthenticated }: SiteFooterProps) {
   return (
     <footer className="relative z-20 border-t border-border/60 bg-background/80 backdrop-blur">
       <div className="layout-container py-12 sm:py-16">
@@ -109,7 +108,7 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
 
         <div className="mt-12 flex flex-col gap-4 border-t border-border/50 pt-6 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
           <p>
-            © {currentYear} Schultheater „{siteTitle}“
+            © 2026 Sommertheater-Altrossthal
           </p>
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
             <Link className="transition-colors hover:text-primary" href="/impressum">
@@ -119,8 +118,9 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
               Kontakt
             </a>
           </div>
-          <p className="text-xs text-muted-foreground/80 sm:text-sm">
-            {isDevBuild ? (
+          {isAuthenticated ? (
+            <p className="text-xs text-muted-foreground/80 sm:text-sm">
+              {isDevBuild ? (
               <>
                 Build {" "}
                 {buildInfo.commit ? (
@@ -146,8 +146,9 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle }: SiteFooterProps
                 formattedTimestamp={buildInfo.timestamp}
                 isoTimestamp={buildInfo.isoTimestamp}
               />
-            )}
-          </p>
+              )}
+            </p>
+          ) : null}
         </div>
       </div>
     </footer>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
 
 import { NotificationBell } from "@/components/notification-bell";
 import { UserNav } from "@/components/user-nav";
@@ -99,6 +100,8 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
   const [open, setOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const pathname = usePathname();
+  const { status } = useSession();
+  const isAuthenticated = status === "authenticated";
   const isHomePage = pathname === "/";
 
   const navigationItems = useMemo(() => primaryNavigation, []);
@@ -208,7 +211,8 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
             href="/"
             title={siteTitle}
           >
-            {siteTitle}
+            <span className="hidden md:inline">{siteTitle}</span>
+            <span className="md:hidden">Sommertheater</span>
           </Link>
 
           <div className="hidden items-center gap-[var(--space-md)] md:flex">
@@ -315,6 +319,16 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
               </Link>
             );
           })}
+          {!isAuthenticated ? (
+            <Link
+              onClick={() => setOpen(false)}
+              style={drawerLinkPaddingStyles}
+              className="mt-2 block border-t border-border/60 pt-3 font-medium text-foreground/90 transition-colors duration-200 hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              href="/login"
+            >
+              Login
+            </Link>
+          ) : null}
         </div>
 
         <div className="mt-auto text-xs text-muted-foreground">
@@ -326,4 +340,3 @@ export function SiteHeader({ siteTitle }: { siteTitle: string }) {
     </Sheet>
   );
 }
-


### PR DESCRIPTION
### Motivation
- Implement UX updates for the public site: remove an FAQ entry and simplify the FAQ chevron markup for a cleaner layout and brand color.
- Make countdown tiles and hero typography/buttons responsive so content scales across viewports using `clamp()`/responsive classes.
- Hide edit and build/timestamp UI from unauthenticated visitors and provide a mobile login entry point for non-authenticated users.

### Description
- Removed the FAQ item "Benötige ich Vorkenntnisse, um das Stück zu genießen?" and simplified the FAQ chevron markup to remove its container while keeping the chevron SVG and setting its color to `text-orange-500` (`src/app/(site)/page.tsx`).
- Converted countdown tiles to responsive sizes using `clamp()` for gap, tile padding, number font-size and label font-size (`src/components/countdown.tsx`).
- Auth-gated the "Countdown bearbeiten" button by requiring an authenticated session before rendering via `useSession` and updated logic in `src/app/(site)/_components/homepage-countdown.tsx`.
- Adjusted hero title sizes to the requested `clamp()` targets and unified both hero CTA buttons to identical responsive width, padding, border-radius and font-size (`src/components/hero.tsx`).
- Updated footer copyright to `© 2026 Sommertheater-Altrossthal` and made build/timestamp info render only for authenticated users by passing an `isAuthenticated` prop from the site layout (`src/components/site-footer.tsx`, `src/app/(site)/layout.tsx`).
- Made header title responsive (full `siteTitle` shown at `md+`, short "Sommertheater" on small viewports) and added a mobile drawer `Login` link rendered only for unauthenticated users with a top border separator (`src/components/site-header.tsx`).
- Minor imports/props added: `useSession` usage in modified components and wiring `isAuthenticated` from layout to footer.

### Testing
- Ran `pnpm test`; Vitest completed successfully: `35 test files` and `123 tests` all passed.
- Ran `pnpm lint`; ESLint failed due to an existing configuration issue: `TypeError: Converting circular structure to JSON` (pre-existing, unrelated to these changes).
- Ran `pnpm build`; build failed due to missing dependencies (`@radix-ui/react-dropdown-menu`, `@radix-ui/react-popover`) and a Turbopack/Tailwind module-format warning, which are unrelated dependency/config issues rather than the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01ec249b588323bc43190ee397632a)