### PR TITLE
fix(members): pass isAuthenticated to SiteFooter

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -155,6 +155,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
               globalFooter={
                 <SiteFooter
                   buildInfo={buildInfo}
+                  isAuthenticated={true}
                   isDevBuild={isDevBuild}
                   siteTitle={siteTitle}
                 />


### PR DESCRIPTION
### Motivation
- Behebt einen TypeScript-/Build-Fehler, weil `SiteFooter` in der Members-Layout-Instanz das erforderliche Prop `isAuthenticated` fehlte, wobei Nutzer im Members-Bereich stets eingeloggt sind.

### Description
- Fügt `isAuthenticated={true}` in `src/app/(members)/layout.tsx` am `SiteFooter`-JSX-Aufruf hinzu, sodass die Typanforderung erfüllt ist.

### Testing
- `pnpm lint` wurde ausgeführt und ist erfolgreich (`✅`).
- `pnpm test` wurde ausgeführt und ist erfolgreich (`✅`).
- `pnpm build` wurde gestartet und erreichte die Next.js-Phase `Creating an optimized production build ...`, der vollständige Build wurde jedoch innerhalb des CI-Output-Fensters nicht abgeschlossen (`⚠️`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02d766e8dc8323b7a81b000456d4eb)