### PR TITLE
Fix Countdown hook order and remove unused ref

### DIFF
--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { cn } from "@/lib/utils";
 import { Text } from "@/components/ui/typography";
@@ -94,13 +94,16 @@ export function Countdown({ targetDate, initialNow, className, variant = "defaul
     return () => window.clearInterval(interval);
   }, [targetTimestamp]);
 
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setLoaded(true);
+  }, []);
+
   if (Number.isNaN(targetTimestamp)) {
     return <Text tone="destructive">Ungültiges Datum</Text>;
   }
 
-  const [loaded, setLoaded] = useState(false);
-  const prevRef = useRef({ days: -1, hours: -1, minutes: -1, seconds: -1 });
-  useEffect(() => { setLoaded(true); }, []);
   const timeParts = [
     { label: "Tage", value: state.days },
     { label: "Stunden", value: state.hours },


### PR DESCRIPTION
### Motivation
- Resolve a React Hooks rules-of-hooks violation in `src/components/countdown.tsx` by ensuring all hooks (`useMemo`, `useState`, `useEffect`) are declared unconditionally and remove an unused variable that caused dead code.

### Description
- Move the `loaded` state (`const [loaded, setLoaded] = useState(false)`) and its `useEffect` so they run before the early `if (Number.isNaN(targetTimestamp))` return, stabilizing hook call order across renders.
- Remove the unused `prevRef` variable and the `useRef` import to eliminate dead code while keeping the existing countdown/interval behavior intact.

### Testing
- Ran `pnpm lint`, which failed due to an unrelated ESLint circular-config error in the repository and not caused by this change.
- Ran `pnpm build`, which failed due to unrelated missing dependencies (`@radix-ui/react-dropdown-menu` and `@radix-ui/react-popover`) and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02edec4f0c832384b076b4b90e74d3)