### PR TITLE
Fix: Konvertiere Flyer-Bild in Buffer für NextResponse

### DIFF
--- a/src/app/api/homepage/flyer/image/route.ts
+++ b/src/app/api/homepage/flyer/image/route.ts
@@ -8,7 +8,7 @@ const MAX_SIZE = 5 * 1024 * 1024;
 export async function GET() {
   const flyer = await readHomepageFlyer();
   if (!flyer?.bildData || !flyer.bildMimeType) return new NextResponse(null, { status: 404 });
-  return new NextResponse(flyer.bildData, { headers: { "Content-Type": flyer.bildMimeType } });
+  return new NextResponse(Buffer.from(flyer.bildData), { headers: { "Content-Type": flyer.bildMimeType } });
 }
 
 export async function POST(request: Request) {


### PR DESCRIPTION
### Motivation
- Behebt einen TypeScript-Fehler, weil `Uint8Array` nicht direkt als `NextResponse`-Body akzeptiert wird, indem die Bilddaten in einen `Buffer` konvertiert werden.

### Description
- Ersetzt die Rückgabezeile in `src/app/api/homepage/flyer/image/route.ts` durch `return new NextResponse(Buffer.from(flyer.bildData), { headers: { "Content-Type": flyer.bildMimeType } });` ohne weitere Änderungen an der Datei.

### Testing
- `pnpm test` wurde ausgeführt und bestanden (35 Dateien, 123 Tests), `pnpm lint` schlägt fehl aufgrund eines bestehenden ESLint-Konfigurationsproblems (circular structure → JSON error) und `pnpm build` schlägt fehl wegen vorhandener, nicht durch diese Änderung verursachter fehlender `@radix-ui`-Module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02f2be05388323b25926e656541a2b)