### PR TITLE
Add missing `countdownTarget` to HomepageCountdown state initialization

### DIFF
--- a/src/app/(site)/_components/homepage-countdown.tsx
+++ b/src/app/(site)/_components/homepage-countdown.tsx
@@ -69,13 +69,19 @@ export function HomepageCountdown(props: HomepageCountdownProps) {
   const { status } = useSession();
   const canEdit = status === "authenticated" && hasFeature("site.countdown");
   const editorOpen = canEdit && activeFeature === "site.countdown";
-  const [settings, setSettings] = useState<CountdownSettingsState>(() => ({ ...props }));
+  const [settings, setSettings] = useState<CountdownSettingsState>(() => ({
+    ...props,
+    countdownTarget: props.effectiveCountdownTarget,
+  }));
   const [formDisabled, setFormDisabled] = useState(() => props.disabled);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
-  useEffect(() => { setSettings({ ...props }); setFormDisabled(props.disabled); }, [props]);
+  useEffect(() => {
+    setSettings({ ...props, countdownTarget: props.effectiveCountdownTarget });
+    setFormDisabled(props.disabled);
+  }, [props]);
   const nextTermin = useMemo(() => getNextTermin(settings.termine), [settings.termine]);
   const countdownActive = !settings.disabled;
   const allDone = countdownActive && !nextTermin;


### PR DESCRIPTION
### Motivation
- The `CountdownSettingsState` type requires a `countdownTarget` field but the `useState` initializer in `HomepageCountdown` omitted it, causing a TypeScript type error during build.
- The prop-sync path in the `useEffect` also re-set state without `countdownTarget`, risking the same type mismatch when props change.

### Description
- Updated the `useState<CountdownSettingsState>` initializer to include `countdownTarget: props.effectiveCountdownTarget` so the initial state matches the required type.
- Updated the `useEffect` sync to call `setSettings({ ...props, countdownTarget: props.effectiveCountdownTarget })` so re-synced state also includes the required field.
- No other functional changes were made to behavior or API payloads.

### Testing
- Ran `pnpm build` to validate the change and confirmed the TypeScript error related to the countdown state initialization is resolved.
- The build stops on unrelated missing modules (`@radix-ui/react-dropdown-menu` and `@radix-ui/react-popover`) which caused the overall build to fail and are not related to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038972ca688323bfb9e13432ce5be3)