### PR TITLE
Provide fallback for undefined `termine` in homepage-countdown

### DIFF
--- a/src/lib/homepage-countdown.ts
+++ b/src/lib/homepage-countdown.ts
@@ -41,7 +41,7 @@ export function resolveHomepageCountdown(record: HomepageCountdownRecord) {
     updatedAt: record?.updatedAt ?? null,
     hasCustomCountdown: storedCountdown !== null,
     disabled,
-    termine: buildFourTermine(record?.termine, storedCountdown),
+    termine: buildFourTermine(record?.termine ?? [], storedCountdown),
     nachSommerText: record?.nachSommerText ?? "Bis zum nächsten Sommer!",
   } as const;
 }


### PR DESCRIPTION
### Motivation
- Fix a TypeScript call-site error where `buildFourTermine` could receive `undefined` from `record?.termine` instead of an expected JSON value.

### Description
- In `src/lib/homepage-countdown.ts` replace `termine: buildFourTermine(record?.termine, storedCountdown)` with `termine: buildFourTermine(record?.termine ?? [], storedCountdown)` to provide an empty-array fallback.

### Testing
- Ran `pnpm build`; the targeted TypeScript issue is resolved, but the overall build still fails due to unrelated missing modules (`@radix-ui/react-dropdown-menu` and `@radix-ui/react-popover`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038b53cbd08323a3c59d4184025f89)