### PR TITLE
Unify action icon usage

### DIFF
--- a/src/app/(members)/mitglieder/scan/scan-page-client.tsx
+++ b/src/app/(members)/mitglieder/scan/scan-page-client.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ComponentProps } from "react";
 import { liveQuery } from "dexie";
 import { toast } from "sonner";
+import { Download, RefreshCw } from "lucide-react";
 
 import { BarcodeScanner } from "@/components/scan/scanner";
 import { Badge } from "@/components/ui/badge";
@@ -548,6 +549,7 @@ export default function ScanPageClient({ breadcrumb }: ScanPageClientProps) {
               onClick={handleBootstrap}
               disabled={manualActionPending || isSyncing}
             >
+              <Download className="h-4 w-4" aria-hidden />
               Offline-Daten laden
             </Button>
             <Button
@@ -556,7 +558,8 @@ export default function ScanPageClient({ breadcrumb }: ScanPageClientProps) {
               onClick={handleForceRefresh}
               disabled={manualActionPending || isSyncing}
             >
-              Force-Refresh
+              <RefreshCw className="h-4 w-4" aria-hidden />
+              Neu laden
             </Button>
             <Button
               size="sm"
@@ -571,7 +574,7 @@ export default function ScanPageClient({ breadcrumb }: ScanPageClientProps) {
 
       {!offlineReady ? (
         <div className="rounded-lg border border-dashed border-warning/40 bg-warning/10 p-4 text-sm text-warning">
-          Offline-Speicher wird initialisiert. Starte einen Force-Refresh oder lade die Offline-Daten, sobald die
+          Offline-Speicher wird initialisiert. Starte „Neu laden“ oder lade die Offline-Daten, sobald die
           Verbindung steht.
         </div>
       ) : null}

--- a/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/block-overview.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/dialog';
 import { formatWeekdayList, getWeekdayLabel, sortWeekdays, type WeekdayValue } from '@/lib/weekdays';
 import { toast } from 'sonner';
+import { FileDown } from 'lucide-react';
 
 import type { HolidayRange } from '@/types/holidays';
 
@@ -364,6 +365,7 @@ export function BlockOverview({
                 aria-busy={isExportingPdf}
                 className="sm:w-auto"
               >
+                <FileDown className="h-4 w-4" aria-hidden />
                 PDF exportieren
               </Button>
             </div>

--- a/src/app/(members)/mitglieder/sperrliste/overview/overview-content.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/overview/overview-content.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import "./sperrliste-styles.css";
 import { Button } from "@/components/ui/button";
+import { FileDown } from "lucide-react";
 
 import { DesktopCalendar } from "./DesktopCalendar";
 import { DesktopTable } from "./desktop-table";
@@ -391,10 +392,11 @@ export default function OverviewContent({
 
         <Button
           type="button"
-          className="self-end"
+          className="self-end gap-2"
           onClick={onExportPdf}
           aria-label="Sperrlistenübersicht als PDF exportieren"
         >
+          <FileDown className="h-4 w-4" aria-hidden />
           PDF exportieren
         </Button>
     </div>

--- a/src/app/(site)/mystery/_components/mystery-tips-board.tsx
+++ b/src/app/(site)/mystery/_components/mystery-tips-board.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { RefreshCw } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Heading, Text } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
 
 const MAX_TIP_LENGTH = 280;
 
@@ -226,7 +228,8 @@ export function MysteryTipsBoard({ initialTips = [], clueOptions, defaultClueId 
                 <Button type="submit" disabled={!canSubmit}>
                   {isSubmitting ? "Wird gesendet…" : "Tipp abschicken"}
                 </Button>
-                <Button type="button" variant="ghost" onClick={refreshTips} disabled={isLoading}>
+                <Button type="button" variant="ghost" onClick={refreshTips} disabled={isLoading} className="gap-2">
+                  <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} aria-hidden />
                   Aktualisieren
                 </Button>
               </div>

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/header-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { Download, Loader2, Share2 } from "lucide-react";
+import { FileDown, Loader2, RefreshCw, Share2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { OnboardingSummary } from "@/lib/onboarding/dashboard-schemas";
+import { cn } from "@/lib/utils";
 
 const statusVariant: Record<OnboardingSummary["status"], "success" | "warning" | "muted"> = {
   active: "success",
@@ -128,7 +129,7 @@ export function HeaderBar({
               {isExportingPdf ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
-                <Download className="h-4 w-4" />
+                <FileDown className="h-4 w-4" />
               )}
               {isExportingPdf ? "Bereite PDF vor…" : "Statistik exportieren"}
             </Button>
@@ -153,7 +154,8 @@ export function HeaderBar({
           onClick={onRefresh}
           disabled={isRefreshing}
         >
-          {isRefreshing ? "Aktualisiere…" : "Refresh"}
+          <RefreshCw className={cn("h-4 w-4", isRefreshing && "animate-spin")} aria-hidden />
+          {isRefreshing ? "Aktualisiere…" : "Neu laden"}
         </Button>
       ) : null}
     </Card>

--- a/src/components/members/file-library/file-library-manager.tsx
+++ b/src/components/members/file-library/file-library-manager.tsx
@@ -353,7 +353,9 @@ export function FileLibraryManager({ folderId, canUpload, canDownload, canManage
                           <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Upload läuft…
                         </>
                       ) : (
-                        "Upload starten"
+                        <>
+                          <UploadCloud className="mr-2 h-4 w-4" aria-hidden /> Upload starten
+                        </>
                       )}
                     </Button>
                   </div>

--- a/src/components/members/finance/finance-entry-table.tsx
+++ b/src/components/members/finance/finance-entry-table.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { RefreshCw } from "lucide-react";
 
 function formatCurrency(amount: number, currency: string) {
   try {
@@ -190,7 +191,8 @@ export function FinanceEntryTable({
           <div className="text-xs text-muted-foreground">
             {filteredEntries.length} von {entries.length} Buchungen · Ausgaben {formatCurrency(totalExpenses, dominantCurrency)} · Einnahmen {formatCurrency(totalIncome, dominantCurrency)}
           </div>
-          <Button type="button" variant="secondary" size="sm" onClick={onRefresh} disabled={refreshing}>
+          <Button type="button" variant="secondary" size="sm" onClick={onRefresh} disabled={refreshing} className="gap-2">
+            <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin")} aria-hidden />
             {refreshing ? "Aktualisiere…" : "Aktualisieren"}
           </Button>
         </div>

--- a/src/components/members/finance/finance-export-section.tsx
+++ b/src/components/members/finance/finance-export-section.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "sonner";
+import { FileDown, Loader2 } from "lucide-react";
 
 type FinanceExportSectionProps = {
   showId: string;
@@ -110,7 +111,12 @@ export function FinanceExportSection({ showId }: FinanceExportSectionProps) {
         <Input type="date" value={to} onChange={(event) => setTo(event.target.value)} placeholder="Bis" />
       </div>
       <div>
-        <Button type="button" onClick={handleDownload} disabled={downloading}>
+        <Button type="button" onClick={handleDownload} disabled={downloading} className="gap-2">
+          {downloading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          ) : (
+            <FileDown className="h-4 w-4" aria-hidden />
+          )}
           {downloading ? "Export wird erstellt…" : "CSV-Export herunterladen"}
         </Button>
       </div>

--- a/src/components/members/gallery/member-gallery-manager.tsx
+++ b/src/components/members/gallery/member-gallery-manager.tsx
@@ -481,7 +481,9 @@ export function MemberGalleryManager({ year, canUpload, canModerate, initialItem
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Upload läuft
                       </>
                     ) : (
-                      "Upload starten"
+                      <>
+                        <UploadCloud className="mr-2 h-4 w-4" aria-hidden /> Upload starten
+                      </>
                     )}
                   </Button>
                 </div>

--- a/src/components/members/issues/issue-detail.tsx
+++ b/src/components/members/issues/issue-detail.tsx
@@ -33,6 +33,7 @@ import {
   isIssueVisibility,
 } from "@/lib/issues";
 import { cn } from "@/lib/utils";
+import { RefreshCw } from "lucide-react";
 import type { IssueDetail as IssueDetailType, IssueSummary } from "./types";
 
 function formatDateTime(value: string | null | undefined) {
@@ -294,6 +295,7 @@ export function IssueDetail({ issueId, canManage, currentUserId, onIssueUpdated,
               size="sm"
               onClick={() => loadIssue(true, { showLoading: false })}
             >
+              <RefreshCw className="h-4 w-4" aria-hidden />
               Aktualisieren
             </Button>
           </CardHeader>

--- a/src/components/members/measurements/member-measurements-control-center.tsx
+++ b/src/components/members/measurements/member-measurements-control-center.tsx
@@ -8,7 +8,7 @@ import {
   ArrowUpAZ,
   BarChart3,
   Clock3,
-  Download,
+  FileDown,
   Ruler,
   Settings,
   Users,
@@ -601,7 +601,7 @@ export function MemberMeasurementsControlCenter({
                     className="w-full justify-between border-warning/60 text-warning hover:border-warning/80 hover:text-warning sm:w-auto"
                   >
                     Export
-                    <Download className="h-4 w-4 text-warning" />
+                    <FileDown className="h-4 w-4 text-warning" />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState, useTransition } from "react"
 import type { FormEvent } from "react";
 import { toast } from "sonner";
 import type { Role } from "@prisma/client";
-import { ChevronDown, ChevronUp, Copy, Download, ExternalLink, MessageCircle, Pencil, Power, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Copy, ExternalLink, FileDown, MessageCircle, Pencil, Power, Trash2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -997,7 +997,7 @@ export function MemberInviteManager() {
                     "PDF wird erstellt …"
                   ) : (
                     <>
-                      <Download className="h-4 w-4" />
+                      <FileDown className="h-4 w-4" />
                       PDF generieren
                     </>
                   )}
@@ -1088,7 +1088,7 @@ export function MemberInviteManager() {
                         },
                         {
                           label: isDownloading ? "PDF wird erstellt …" : "PDF generieren",
-                          icon: <Download className="h-4 w-4" />,
+                          icon: <FileDown className="h-4 w-4" />,
                           onClick: () => {
                             if (isDownloading) return;
                             void requestInvitePdf({
@@ -1301,7 +1301,7 @@ export function MemberInviteManager() {
                                       "PDF wird erstellt …"
                                     ) : (
                                       <>
-                                        <Download className="h-4 w-4" />
+                                        <FileDown className="h-4 w-4" />
                                         PDF generieren
                                       </>
                                     )}

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ChangeEvent, FormEvent } from "react";
 import { toast } from "sonner";
-import { Camera, ChevronDown } from "lucide-react";
+import { Camera, ChevronDown, RefreshCw, Upload } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -729,6 +729,7 @@ export function PhotoConsentCard({
                         onClick={handleSelectUploadMode}
                         disabled={submitting}
                       >
+                        <Upload className="h-4 w-4" aria-hidden />
                         Datei hochladen
                       </Button>
                       <Button
@@ -818,6 +819,7 @@ export function PhotoConsentCard({
                     {submitting ? "Speichere …" : "Jetzt zustimmen"}
                   </Button>
                   <Button type="button" variant="outline" size="sm" onClick={() => void load()} disabled={submitting}>
+                    <RefreshCw className="h-4 w-4" aria-hidden />
                     Status aktualisieren
                   </Button>
                   {status === "approved" && (

--- a/src/components/production/casting-export-dialog.tsx
+++ b/src/components/production/casting-export-dialog.tsx
@@ -256,6 +256,7 @@ export function CastingExportDialog({ showTitle, characters }: CastingExportDial
             </Button>
           </DialogClose>
           <Button type="button" onClick={handleExport} disabled={isPending}>
+            <FileDown className="h-4 w-4" aria-hidden />
             {isPending ? "Exportiert…" : "PDF exportieren"}
           </Button>
         </DialogFooter>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -46,7 +46,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">Schließen</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>


### PR DESCRIPTION
### Motivation
- Standardize the icon language for common actions (share, sort, export/download, refresh, upload, close) across the codebase to remove inconsistencies and improve UX parity. 
- Make action affordances visually consistent in lists, dialogs and admin tooling so that exports/refreshes/uploads use the same iconography everywhere.

### Description
- Replaced various `Download`/ad-hoc icons with `FileDown` for export/download actions in components such as `finance` export, measurements export, casting export, sperrliste exports and invite PDF generation.  
- Introduced `RefreshCw` for refresh/reload actions and updated labels to `Neu laden` where appropriate (e.g. scan page and onboarding header).  
- Added `Upload` / `UploadCloud` icons to upload-related affordances (photo consent upload, file library, gallery) and kept `Share2` for sharing flows.  
- Small accessibility & polish: localized dialog close `sr-only` string to `Schließen` and performed minor formatting/whitespace cleanups across affected files.

### Testing
- Ran `pnpm lint` and it completed without lint errors.  
- Ran the test suite with `pnpm test` and all tests passed (`123 tests` in total).  
- Built the production bundle with `pnpm build` and the Next.js build completed successfully.  
- Attempted an automated dev screenshot via the `/api/dev/screenshot-session` helper but Playwright browser binaries are not installed in the environment, so the screenshot step failed (Playwright install missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a039684f8ac832ea0bd0825886d20ac)