### PR TITLE
Rename countdown form, make premiere modal body scrollable, and hide flyer file input

### DIFF
--- a/src/app/(site)/_components/premiere-countdown-section.tsx
+++ b/src/app/(site)/_components/premiere-countdown-section.tsx
@@ -98,9 +98,10 @@ export function PremiereCountdownSection(props: PremiereCountdownSectionProps) {
     </div>
 
     <Dialog open={editorOpen} onOpenChange={(open) => (open ? openFeature("website.premiere-countdown") : closeFeature())}>
-      <DialogContent>
+      <DialogContent className="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden sm:max-h-[85dvh]">
         <DialogHeader><DialogTitle>Premieren-Countdown einstellen</DialogTitle></DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+          <div className="space-y-6 overflow-y-auto pr-1">
           <div className="flex items-center justify-between rounded-2xl border border-border/60 bg-background/60 p-4">
             <Label htmlFor="premiere-countdown-section-visible" className="text-sm font-semibold">Countdown auf der Startseite anzeigen</Label>
             <Switch id="premiere-countdown-section-visible" checked={!formDisabled} onCheckedChange={(v) => setFormDisabled(!v)} />
@@ -124,7 +125,8 @@ export function PremiereCountdownSection(props: PremiereCountdownSectionProps) {
 
           {error ? <Text tone="destructive">{error}</Text> : null}
           {success ? <Text tone="success">{success}</Text> : null}
-          <DialogFooter className="gap-2"><Button type="submit" disabled={saving}>{saving ? "Speichern…" : "Einstellungen speichern"}</Button></DialogFooter>
+          </div>
+          <DialogFooter className="mt-6 gap-2 border-t border-border/60 pt-4"><Button type="submit" disabled={saving}>{saving ? "Speichern…" : "Einstellungen speichern"}</Button></DialogFooter>
         </form>
       </DialogContent>
     </Dialog>

--- a/src/app/(site)/mystery/_components/mystery-launch-countdown-card.tsx
+++ b/src/app/(site)/mystery/_components/mystery-launch-countdown-card.tsx
@@ -9,9 +9,9 @@ import { Text } from "@/components/ui/typography";
 import { Countdown } from "@/components/countdown";
 import { useFrontendEditing } from "@/components/frontend-editing/frontend-editing-provider";
 import {
-  type MysteryCountdownSettingsFormSavedSettings,
-  MysteryCountdownSettingsForm,
-} from "@/components/mystery/mystery-countdown-settings-form";
+  type PremiereCountdownSettingsFormSavedSettings,
+  PremiereCountdownSettingsForm,
+} from "@/components/mystery/premiere-countdown-settings-form";
 
 const COUNTDOWN_LABEL_FORMATTER = new Intl.DateTimeFormat("de-DE", {
   dateStyle: "full",
@@ -112,7 +112,7 @@ export function MysteryLaunchCountdownCard({
 
   const showCountdown = !isFirstRiddleReleased && !countdownReached;
 
-  function handleSaved(next: MysteryCountdownSettingsFormSavedSettings) {
+  function handleSaved(next: PremiereCountdownSettingsFormSavedSettings) {
     setState({
       countdownTarget: next.countdownTarget,
       expirationMessage: next.expirationMessage,
@@ -177,7 +177,7 @@ export function MysteryLaunchCountdownCard({
           <Text variant="small" tone="muted">
             Änderungen werden direkt auf der öffentlichen Mystery-Seite sichtbar.
           </Text>
-          <MysteryCountdownSettingsForm
+          <PremiereCountdownSettingsForm
             scope="public"
             initialCountdownTarget={state.countdownTarget}
             initialExpirationMessage={state.expirationMessage}

--- a/src/components/mystery/premiere-countdown-settings-form.tsx
+++ b/src/components/mystery/premiere-countdown-settings-form.tsx
@@ -45,7 +45,7 @@ function formatIsoForDisplay(iso: string | null, formatter: Intl.DateTimeFormat)
   return formatter.format(date);
 }
 
-export type MysteryCountdownSettingsFormSavedSettings = {
+export type PremiereCountdownSettingsFormSavedSettings = {
   countdownTarget: string | null;
   expirationMessage: string | null;
   effectiveCountdownTarget: string;
@@ -55,7 +55,7 @@ export type MysteryCountdownSettingsFormSavedSettings = {
   hasCustomMessage: boolean;
 };
 
-export type MysteryCountdownSettingsFormProps = {
+export type PremiereCountdownSettingsFormProps = {
   scope: "public" | "members";
   initialCountdownTarget: string | null;
   initialExpirationMessage: string | null;
@@ -66,10 +66,10 @@ export type MysteryCountdownSettingsFormProps = {
   updatedAt: string | null;
   hasCustomCountdown: boolean;
   hasCustomMessage: boolean;
-  onSaved?: (settings: MysteryCountdownSettingsFormSavedSettings) => void;
+  onSaved?: (settings: PremiereCountdownSettingsFormSavedSettings) => void;
 };
 
-export function MysteryCountdownSettingsForm({
+export function PremiereCountdownSettingsForm({
   scope,
   initialCountdownTarget,
   initialExpirationMessage,
@@ -81,7 +81,7 @@ export function MysteryCountdownSettingsForm({
   hasCustomCountdown,
   hasCustomMessage,
   onSaved,
-}: MysteryCountdownSettingsFormProps) {
+}: PremiereCountdownSettingsFormProps) {
   const [countdownValue, setCountdownValue] = useState(() => isoToLocalInputValue(initialCountdownTarget));
   const [messageValue, setMessageValue] = useState(() => initialExpirationMessage ?? "");
   const [saving, setSaving] = useState(false);
@@ -128,7 +128,7 @@ export function MysteryCountdownSettingsForm({
         body: JSON.stringify(payload),
       });
       const data = (await response.json().catch(() => ({}))) as {
-        settings?: MysteryCountdownSettingsFormSavedSettings;
+        settings?: PremiereCountdownSettingsFormSavedSettings;
         error?: string;
       };
 

--- a/src/components/site/production-flyer-section.tsx
+++ b/src/components/site/production-flyer-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import { toast } from "sonner";
 
@@ -22,6 +22,7 @@ export function ProductionFlyerSection({ aktiv, titel, beschreibung, hasBild }: 
 
   const [form, setForm] = useState({ aktiv, titel: titel ?? "", beschreibung: beschreibung ?? "" });
   const [file, setFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function removeImage() {
     const res = await fetch("/api/website/production-flyer/image", { method: "DELETE" });
@@ -86,9 +87,15 @@ export function ProductionFlyerSection({ aktiv, titel, beschreibung, hasBild }: 
             </div>
             <Input placeholder="Stücktitel 2026" value={form.titel} onChange={(e) => setForm((s) => ({ ...s, titel: e.target.value }))} />
             <Textarea placeholder="Beschreibung" value={form.beschreibung} onChange={(e) => setForm((s) => ({ ...s, beschreibung: e.target.value }))} />
-            <Input type="file" accept="image/*" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+            <Input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            />
             <div className="flex gap-2">
-              <Button type="button" variant="outline" onClick={() => document.querySelector<HTMLInputElement>('input[type="file"]')?.click()}>
+              <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()}>
                 Datei ändern
               </Button>
               <Button type="button" variant="outline" onClick={removeImage}>


### PR DESCRIPTION
### Motivation
- Finish a partial refactor by renaming the countdown settings component to the canonical `PremiereCountdownSettingsForm` to avoid inconsistent identifiers and imports.
- Fix UX on small viewports so the modal's save button is always reachable by making the modal body scrollable while keeping header and footer fixed.
- Improve the Flyer editor UX by hiding the native file input (while keeping it in the DOM) so only the central action buttons are visible.

### Description
- Renamed `src/components/mystery/mystery-countdown-settings-form.tsx` to `src/components/mystery/premiere-countdown-settings-form.tsx` and updated exported types/components from `MysteryCountdownSettingsForm*` to `PremiereCountdownSettingsForm*`.
- Updated imports/usages to the new path and names (notably `src/app/(site)/mystery/_components/mystery-launch-countdown-card.tsx` now imports `PremiereCountdownSettingsForm` and the corresponding saved settings type).
- Adjusted the premiere countdown modal in `src/app/(site)/_components/premiere-countdown-section.tsx` by adding constrained `max-h` on `DialogContent`, wrapping the form in a flex column, and making the middle form area `overflow-y-auto` so the header and `DialogFooter` remain visible while the central content scrolls.
- Hid the native file input in `src/components/site/production-flyer-section.tsx` by adding a `useRef` and `className="hidden"`, and switched the "Datei ändern" button to trigger the hidden input via the ref while leaving the input in the DOM for functionality.

### Testing
- Verified there are no remaining occurrences of the old identifier with a repository search (`rg` / `git grep`) which returned no `MysteryCountdownSettingsForm` hits.
- Ran `pnpm lint` which failed due to an existing ESLint configuration issue (`Converting circular structure to JSON`) unrelated to these changes.
- Ran `pnpm test` which exercised the test suite but several tests failed due to a missing generated Prisma client artefact (`.prisma/client/default`) in the environment and thus are not indicative of regressions from these edits.
- Ran `pnpm build` which failed due to the repository's Prisma 7 datasource schema validation (the project-wide schema requires migration to the new Prisma 7 config format) and is unrelated to the front-end changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a042de28e048333a2a85111b869c40b)