### PR TITLE
UI: Vereinheitliche Formular‑Tokens, Button‑Shadows und zentrale Checkbox‑Komponente

### DIFF
--- a/src/app/(site)/_components/premiere-countdown-section.tsx
+++ b/src/app/(site)/_components/premiere-countdown-section.tsx
@@ -110,10 +110,10 @@ export function PremiereCountdownSection(props: PremiereCountdownSectionProps) {
           <div className="space-y-3">
             {settings.termine.map((termin, index) => {
               const isNext = nextTermin ? nextTermin.label === termin.label : false;
-              return <div key={termin.label} className={`grid grid-cols-1 gap-2 rounded-xl border p-3 md:grid-cols-2 ${isNext ? "border-primary" : "border-border"}`}>
+              return <div key={termin.label} className={`grid grid-cols-1 gap-2 rounded-xl border p-3 md:grid-cols-2 md:[grid-template-columns:minmax(0,1fr)_minmax(0,1fr)] ${isNext ? "border-primary" : "border-border"}`}>
                 <Label className="md:col-span-2">Vorstellung {index + 1}</Label>
-                <Input type="date" value={termin.datum} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, datum: event.target.value } : t) }))} />
-                <Input type="time" value={termin.uhrzeit} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, uhrzeit: event.target.value } : t) }))} />
+                <Input className="min-w-0" type="date" value={termin.datum} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, datum: event.target.value } : t) }))} />
+                <Input className="min-w-0" type="time" value={termin.uhrzeit} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, uhrzeit: event.target.value } : t) }))} />
               </div>;
             })}
           </div>

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -1255,7 +1255,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                     }))
                   }
                 >
-                  <SelectTrigger className="bg-background">
+                  <SelectTrigger>
                     <SelectValue placeholder="Wähle eine Option" />
                   </SelectTrigger>
                   <SelectContent>
@@ -1837,7 +1837,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                       }))
                     }
                   >
-                    <SelectTrigger className="bg-background/80">
+                    <SelectTrigger >
                       <SelectValue placeholder="Wähle deinen Stil" />
                     </SelectTrigger>
                     <SelectContent>
@@ -1878,7 +1878,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                           setForm((prev) => ({ ...prev, nutritionStrictness: value as DietaryStrictnessOption }))
                         }
                       >
-                        <SelectTrigger className="bg-background/80">
+                        <SelectTrigger >
                           <SelectValue placeholder="Wähle eine Option" />
                         </SelectTrigger>
                         <SelectContent>
@@ -1971,7 +1971,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
                     value={dietaryDraft.level}
                     onValueChange={(value: AllergyLevel) => setDietaryDraft((prev) => ({ ...prev, level: value }))}
                   >
-                    <SelectTrigger className="bg-background/80">
+                    <SelectTrigger >
                       <SelectValue placeholder="Wähle den Schweregrad" />
                     </SelectTrigger>
                     <SelectContent>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,19 +18,19 @@ const buttonVariants = cva(
         accent:
           "bg-accent text-accent-foreground shadow-[var(--shadow-md)] hover:bg-accent/90",
         outline:
-          "border border-border bg-transparent text-foreground hover:border-primary/50 hover:text-primary",
+          "border border-border bg-transparent text-foreground shadow-[var(--shadow-sm)] hover:border-primary/50 hover:text-primary",
         ghost:
-          "bg-transparent text-foreground hover:bg-muted/40 hover:text-foreground",
+          "bg-transparent text-foreground shadow-[var(--shadow-sm)] hover:bg-muted/40 hover:text-foreground",
         subtle:
-          "bg-muted text-foreground/90 hover:bg-muted/70",
+          "bg-muted text-foreground/90 shadow-[var(--shadow-sm)] hover:bg-muted/70",
         link:
           "text-primary underline underline-offset-4 decoration-primary/60 hover:text-primary/90 hover:decoration-primary",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/40",
+          "bg-destructive text-destructive-foreground shadow-[var(--shadow-md)] hover:bg-destructive/90 focus-visible:ring-destructive/40",
         success:
-          "bg-success text-success-foreground hover:bg-success/90 focus-visible:ring-success/40",
+          "bg-success text-success-foreground shadow-[var(--shadow-md)] hover:bg-success/90 focus-visible:ring-success/40",
         info:
-          "bg-info text-info-foreground hover:bg-info/90 focus-visible:ring-info/40",
+          "bg-info text-info-foreground shadow-[var(--shadow-md)] hover:bg-info/90 focus-visible:ring-info/40",
       },
       size: {
         xs: "h-8 rounded-md px-3 text-xs",

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type CheckboxProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type">;
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    type="checkbox"
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-input bg-background text-primary shadow-sm transition-colors",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      "checked:border-primary checked:bg-primary checked:text-primary-foreground",
+      "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
+      className
+    )}
+    {...props}
+  />
+));
+
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,9 +8,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...pr
     <input
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-card px-3 py-2 text-base shadow-sm transition md:text-sm",
-        "placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base shadow-sm transition md:text-sm",
+        "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
         "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
+        "[&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-70 [&::-webkit-calendar-picker-indicator]:transition-opacity [&::-webkit-calendar-picker-indicator]:hover:opacity-100 [&::-webkit-date-and-time-value]:text-foreground [&::-webkit-datetime-edit]:text-foreground [&::-webkit-datetime-edit-fields-wrapper]:text-foreground",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base focus:outline-none focus:ring-2 focus:ring-ring md:text-sm",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-60 md:text-sm",
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     <textarea
       ref={ref}
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background shadow-sm px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 md:text-sm",
         className
       )}
       {...props}


### PR DESCRIPTION
### Motivation
- Einheitliches Erscheinungsbild für alle Form‑Controls erreichen, damit Input, Textarea, Select und native Date/Time‑Picker visuell konsistent im dynamischen Theme reagieren.
- Overflow‑Problem in der Premieren‑Countdown‑Form verhindern, damit die vier Vorstellungs‑Boxen immer gleich groß bleiben.
- Ein zentrales, tokenbasiertes Checkbox‑Element bereitstellen, damit Checkboxen dieselben Fokus/Disabled/Invalid‑Konventionen wie andere Controls nutzen.
- Konsistentes Shadow‑Verhalten für alle Button‑Varianten durchsetzen, damit visueller Tiefeneindruck projektweit einheitlich ist.

### Description
- Input, Textarea und `SelectTrigger` auf denselben Hintergrund‑Token `bg-background` umgestellt, Placeholder‑Behandlung vereinheitlicht und Shadow‑Tiefe bei Feldern konsistent auf `shadow-sm` gebracht.
- Native `input[type=date|time]` Pseudo‑Elemente im `Input` gestylt (`::-webkit-calendar-picker-indicator`, `::-webkit-datetime-edit*`), sodass Browser‑Picker dem Feld‑Styling folgen.
- Neue `src/components/ui/checkbox.tsx` hinzugefügt, die dieselben Token-, Fokus‑ und Disabled/Invalid‑Konventionen wie andere UI‑Kontrollen verwendet.
- Button‑Variants angepasst und leichte tokenbasierte Shadows (`--shadow-sm`/`--shadow-md`) für zuvor flache Varianten (`outline`, `ghost`, `subtle`, `destructive`, `success`, `info`) ergänzt, um die Tiefe konsistent zu machen.
- Overflow‑Fix für die Premieren‑Grid‑Boxen implementiert durch `md:[grid-template-columns:minmax(0,1fr)_minmax(0,1fr)]` und `className="min-w-0"` auf den Date/Time‑Inputs, damit Felder nicht aus dem Rahmen ragen.
- Lokale `SelectTrigger`‑Background‑Overrides in der Onboarding‑Wizard‑Komponente entfernt, damit die Stellen dem zentralen `SelectTrigger`‑Token folgen.

### Testing
- `pnpm lint` wurde ausgeführt und schlug fehl aufgrund eines bestehenden ESLint‑Konfigurationsproblems (circular structure to JSON) in der Umgebung, welches nicht durch diese Änderungen verursacht wurde.
- `pnpm test` (Vitest) wurde ausgeführt und schlug fehl wegen fehlender Prisma‑Client‑Artefakte (`Cannot find module '.prisma/client/default'`) in der aktuellen CI/Dev‑Umgebung.
- `pnpm build` wurde ausgeführt und schlug fehl beim `prisma generate` Schritt aufgrund einer Prisma‑7 datasource‑Konfiguration (`url` in `schema.prisma`) in der aktuellen Umgebung, die außerhalb der UI‑Änderungen liegt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0433edfc9c8333819e3430976f0983)