### PR TITLE
Use shared `Button` component and lucide icons; standardize action icons

### DIFF
--- a/src/app/(site)/chronik/chronik-year-navigation.tsx
+++ b/src/app/(site)/chronik/chronik-year-navigation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 type ChronikItem = {
@@ -92,9 +93,10 @@ export function ChronikYearNavigation({ items }: { items: ChronikItem[] }) {
               const isPast = activeIndex !== -1 && originalIndex > activeIndex;
 
               return (
-                <button
+                <Button
                   key={item.id}
                   onClick={() => scrollToSection(item.id)}
+                  variant="ghost"
                   className={cn(
                     "group relative m-1 flex min-w-fit flex-col items-center gap-2 rounded-lg p-3 transition-all duration-300 hover:scale-105 focus:outline-none",
                     isActive ? "ring-2 ring-primary/70" : "ring-1 ring-border/50",
@@ -129,7 +131,7 @@ export function ChronikYearNavigation({ items }: { items: ChronikItem[] }) {
                   >
                     {item.year}
                   </span>
-                </button>
+                </Button>
               );
             })}
           </div>

--- a/src/app/(site)/unsere-schulkatze/schulkatze-gallery.tsx
+++ b/src/app/(site)/unsere-schulkatze/schulkatze-gallery.tsx
@@ -117,9 +117,10 @@ export function SchulkatzeGallery({
         )}
       >
         <DialogTrigger asChild>
-          <button
+          <Button
             type="button"
-            className="group relative block w-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
+            variant="ghost"
+            className="group relative block h-auto w-full p-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
             aria-label="Galerie mit Erinnerungsfotos unserer Schulkatze öffnen"
           >
             <SchulkatzeImageRotator
@@ -133,7 +134,7 @@ export function SchulkatzeGallery({
               <Images className="h-4 w-4" aria-hidden="true" />
               Galerie ansehen
             </span>
-          </button>
+          </Button>
         </DialogTrigger>
         <figcaption className="border-t border-border bg-background px-4 py-3 text-sm text-muted-foreground">
           {caption}

--- a/src/components/members/finance/finance-budget-table.tsx
+++ b/src/components/members/finance/finance-budget-table.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { Pencil, Trash2 } from "lucide-react";
 import type { FinanceBudgetDTO } from "@/app/api/finance/utils";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -105,6 +106,7 @@ export function FinanceBudgetTable({ budgets, onRequestEdit, onBudgetDeleted, ca
                   <td className="px-3 py-2 align-top text-right">
                     <div className="flex justify-end gap-2">
                       <Button type="button" variant="ghost" size="sm" onClick={() => onRequestEdit(budget)}>
+                        <Pencil className="h-4 w-4" aria-hidden />
                         Bearbeiten
                       </Button>
                       <Button
@@ -114,6 +116,7 @@ export function FinanceBudgetTable({ budgets, onRequestEdit, onBudgetDeleted, ca
                         onClick={() => handleDelete(budget)}
                         disabled={deletingId === budget.id}
                       >
+                        <Trash2 className="h-4 w-4" aria-hidden />
                         Löschen
                       </Button>
                     </div>

--- a/src/components/members/finance/finance-entry-table.tsx
+++ b/src/components/members/finance/finance-entry-table.tsx
@@ -15,7 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, Trash2 } from "lucide-react";
 
 function formatCurrency(amount: number, currency: string) {
   try {
@@ -315,6 +315,7 @@ export function FinanceEntryTable({
                         onClick={() => handleDelete(entry)}
                         disabled={deletingId === entry.id}
                       >
+                        <Trash2 className="h-4 w-4" aria-hidden />
                         Löschen
                       </Button>
                     </td>

--- a/src/components/ui/action-icons.tsx
+++ b/src/components/ui/action-icons.tsx
@@ -1,60 +1,19 @@
 "use client";
-import * as React from "react";
 
-export const EditIcon = ({ className, ...props }: React.SVGProps<SVGSVGElement>) => {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      {...props}
-    >
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-      <path d="m18.5 2.5 3 3L12 15l-4 1 1-4Z" />
-    </svg>
-  );
-}
+import { MoreVertical, Pencil, Trash2 } from "lucide-react";
+import type * as React from "react";
+
+export const EditIcon = ({ className = "w-4 h-4", ...props }: React.SVGProps<SVGSVGElement>) => {
+  return <Pencil className={className} aria-hidden {...props} />;
+};
 
 export function TrashIcon({ className = "w-4 h-4", ...props }: { className?: string } & React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      {...props}
-    >
-      <path d="M3 6h18" />
-      <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
-      <path d="M8 6V4c0-1 1-2 2-2h4c0 1 1 2 1 2v2" />
-      <line x1="10" x2="10" y1="11" y2="17" />
-      <line x1="14" x2="14" y1="11" y2="17" />
-    </svg>
-  );
+  return <Trash2 className={className} aria-hidden {...props} />;
 }
 
-export function MoreVerticalIcon({ className = "w-4 h-4", ...props }: { className?: string } & React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      {...props}
-    >
-      <circle cx="12" cy="12" r="1" />
-      <circle cx="12" cy="5" r="1" />
-      <circle cx="12" cy="19" r="1" />
-    </svg>
-  );
+export function MoreVerticalIcon({
+  className = "w-4 h-4",
+  ...props
+}: { className?: string } & React.SVGProps<SVGSVGElement>) {
+  return <MoreVertical className={className} aria-hidden {...props} />;
 }


### PR DESCRIPTION
### Motivation
- Standardize interactive elements across the app by replacing raw `<button>` elements with the shared `Button` component and make action icons consistent by switching to `lucide-react` icons.
- Improve visual consistency and accessibility of gallery, chronicle navigation, and finance tables by applying `Button` variants and adding icon affordances.

### Description
- Replaced native `<button>` elements with the shared `Button` component in `chronik-year-navigation.tsx` and `schulkatze-gallery.tsx`, applying `variant="ghost"` and adjusting classes for layout.
- Added icon buttons to finance tables by importing `Pencil` and `Trash2` from `lucide-react` and embedding them inside existing `Button` instances in `finance-budget-table.tsx` and `finance-entry-table.tsx`.
- Replaced custom SVG implementations with `lucide-react` components in `components/ui/action-icons.tsx`, mapping `EditIcon`, `TrashIcon`, and `MoreVerticalIcon` to `Pencil`, `Trash2`, and `MoreVertical` respectively.
- Imported `Button` where needed and updated classNames to preserve spacing and focus styles.

### Testing
- Ran TypeScript checks with `tsc --noEmit` and the project build, and there were no type errors reported.
- Executed the test suite via `pnpm test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0437bd46e08333bf2232676b4ccb43)