### PR TITLE
Premieren-Countdown: dynamische Vorstellungen, Overflow-Fix und action-icons-Ersatz

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
@@ -3,8 +3,8 @@
 import Link from "next/link";
 import { useMemo, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { Pencil, Trash2 } from "lucide-react";
 import { ActionDropdownMenu } from "@/components/ui/action-dropdown-menu";
-import { EditIcon, TrashIcon } from "@/components/ui/action-icons";
 import { toast } from "sonner";
 import { deleteRehearsalAction } from "./actions";
 import type { RehearsalLite } from "./rehearsal-list";
@@ -53,14 +53,14 @@ export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: 
   const menuItems = [
     {
       label: "Bearbeiten",
-      icon: <EditIcon className="w-4 h-4" />,
+      icon: <Pencil className="w-4 h-4" />,
       onClick: handleEdit,
       variant: "default" as const,
       disabled: false,
     },
     {
       label: isDeletingTransition ? "Wird gelöscht..." : "Löschen",
-      icon: <TrashIcon className="w-4 h-4" />,
+      icon: <Trash2 className="w-4 h-4" />,
       onClick: handleDelete,
       variant: "destructive" as const,
       disabled: isDeletingTransition,

--- a/src/app/(site)/_components/premiere-countdown-section.tsx
+++ b/src/app/(site)/_components/premiere-countdown-section.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
+import { Plus, Trash2 } from "lucide-react";
 
 import { Countdown } from "@/components/countdown";
 import { useFrontendEditing } from "@/components/frontend-editing/frontend-editing-provider";
@@ -14,6 +15,8 @@ import { Switch } from "@/components/ui/switch";
 import { Heading, Text } from "@/components/ui/typography";
 
 type TerminInput = { datum: string; uhrzeit: string; label: string };
+const MIN_TERMINE = 1;
+const MAX_TERMINE = 8;
 
 type PremiereCountdownSectionProps = {
   initialCountdownTarget: string | null;
@@ -110,12 +113,51 @@ export function PremiereCountdownSection(props: PremiereCountdownSectionProps) {
           <div className="space-y-3">
             {settings.termine.map((termin, index) => {
               const isNext = nextTermin ? nextTermin.label === termin.label : false;
-              return <div key={termin.label} className={`grid grid-cols-1 gap-2 rounded-xl border p-3 md:grid-cols-2 md:[grid-template-columns:minmax(0,1fr)_minmax(0,1fr)] ${isNext ? "border-primary" : "border-border"}`}>
-                <Label className="md:col-span-2">Vorstellung {index + 1}</Label>
-                <Input className="min-w-0" type="date" value={termin.datum} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, datum: event.target.value } : t) }))} />
-                <Input className="min-w-0" type="time" value={termin.uhrzeit} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, uhrzeit: event.target.value } : t) }))} />
+              return <div key={`${termin.label}-${index}`} className={`grid grid-cols-1 gap-2 rounded-xl border p-3 md:grid-cols-2 md:[grid-template-columns:minmax(0,1fr)_minmax(0,1fr)] ${isNext ? "border-primary" : "border-border"}`}>
+                <div className="min-w-0 md:col-span-2 flex items-center justify-between gap-2">
+                  <Label>Vorstellung {index + 1}</Label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    disabled={settings.termine.length <= MIN_TERMINE}
+                    aria-label={`Vorstellung ${index + 1} entfernen`}
+                    onClick={() =>
+                      setSettings((prev) => ({
+                        ...prev,
+                        termine: prev.termine.length <= MIN_TERMINE ? prev.termine : prev.termine.filter((_, i) => i !== index),
+                      }))
+                    }
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+                <div className="min-w-0">
+                  <Input className="min-w-0" type="date" value={termin.datum} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, datum: event.target.value } : t) }))} />
+                </div>
+                <div className="min-w-0">
+                  <Input className="min-w-0" type="time" value={termin.uhrzeit} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, uhrzeit: event.target.value } : t) }))} />
+                </div>
               </div>;
             })}
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              disabled={settings.termine.length >= MAX_TERMINE}
+              onClick={() =>
+                setSettings((prev) => ({
+                  ...prev,
+                  termine:
+                    prev.termine.length >= MAX_TERMINE
+                      ? prev.termine
+                      : [...prev.termine, { datum: "", uhrzeit: "", label: `Vorstellung ${prev.termine.length + 1}` }],
+                }))
+              }
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Vorstellung hinzufügen
+            </Button>
           </div>
 
           <div className="space-y-2">

--- a/src/app/api/website/premiere-countdown/route.ts
+++ b/src/app/api/website/premiere-countdown/route.ts
@@ -12,10 +12,12 @@ import { hasPermission } from "@/lib/permissions";
 import { requireAuth } from "@/lib/rbac";
 
 const terminSchema = z.object({ datum: z.string(), uhrzeit: z.string().regex(/^\d{2}:\d{2}$/), label: z.string().optional() });
+const MIN_TERMINE = 1;
+const MAX_TERMINE = 8;
 const updateSchema = z.object({
   countdownTarget: z.union([z.string().datetime({ offset: true }), z.null()]).transform((value) => (value ? new Date(value) : null)),
   disabled: z.boolean().optional().default(false),
-  termine: z.array(terminSchema).optional().default([]),
+  termine: z.array(terminSchema).min(MIN_TERMINE).max(MAX_TERMINE),
   nachSommerText: z.string().optional().default("Bis zum nächsten Sommer!"),
 });
 
@@ -45,14 +47,14 @@ function serializeSettings(record: Awaited<ReturnType<typeof readPremiereCountdo
 }
 export async function GET() { /* unchanged auth */
   const session = await requireAuth();
-  if (!(await hasPermission(session.user, "mitglieder.website.premiere-countdown"))) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!(await hasPermission(session.user, "mitglieder.website.countdown"))) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   try { const record = await readPremiereCountdownSettings(); return NextResponse.json({ settings: serializeSettings(record) }); }
   catch { return NextResponse.json({ error: "Einstellungen konnten nicht geladen werden." }, { status: 500 }); }
 }
 
 export async function PUT(request: NextRequest) {
   const session = await requireAuth();
-  if (!(await hasPermission(session.user, "mitglieder.website.premiere-countdown"))) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!(await hasPermission(session.user, "mitglieder.website.countdown"))) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   const parsed = updateSchema.safeParse(await request.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ error: parsed.error.issues[0]?.message ?? "Ungültige Eingabe." }, { status: 400 });
   if (!isChronological(parsed.data.termine)) return NextResponse.json({ error: "Termine müssen chronologisch sortiert sein." }, { status: 400 });


### PR DESCRIPTION
### Motivation
- Verhindern, dass Datum-/Uhrzeit-Felder aus den Vorstellungs-Boxen horizontal herausragen und die Editor-Usability verbessern.
- Vorstellungen von statisch auf dynamisch umstellen, damit Redakteure 1–8 Termine verwalten können.
- API-Validierung und Berechtigungsprüfung an das neue Verhalten anpassen und letzte Verwendung von `action-icons` entfernen.

### Description
- UI: `PremiereCountdownSection` wurde auf eine dynamische Liste umgestellt und erlaubt jetzt zwischen `1` und `8` Vorstellungen mit einem „Hinzufügen“-Button (`Plus`) und pro-Row „Entfernen“-Button (`Trash2`) (neue leere Einträge werden am Ende erzeugt). (`src/app/(site)/_components/premiere-countdown-section.tsx`)
- Layout/Fix: Grid-Kinder rund um die Datum-/Uhrzeit-Felder erhalten `min-w-0` und Wrapper-Elemente, um horizontales Overflow sicher zu verhindern und responsive Verhalten zu stabilisieren. (`src/app/(site)/_components/premiere-countdown-section.tsx`)
- API: Server-Validation mit `zod` erzwingt nun `termine` als Array mit `.min(1).max(8)` und die GET/PUT-Handler prüfen die Berechtigung `mitglieder.website.countdown` statt des vorherigen Scopes. (`src/app/api/website/premiere-countdown/route.ts`)
- Konsistenz: Letzte `action-icons`-Referenz wurde entfernt und in `RehearsalCardWithActions` durch direkte Lucide-Icons (`Pencil`, `Trash2`) ersetzt. (`src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx`)
- Kleinigkeiten: List-Key wurde auf ``${termin.label}-${index}` (unique per index) geändert, und die Remove-Button-Logik deaktiviert, wenn nur noch ein Eintrag vorhanden ist.

### Testing
- Projektweite Suche mit `git grep -n "action-icons" src` wurde ausgeführt und es existieren danach keine Treffer mehr for diesen Identifier (Ersetzung erfolgreich).
- Projektweite Suche mit `git grep -n "<button\b" src/app src/components` wurde ausgeführt und zeigt weiterhin bestehende native `<button>`-Vorkommen außerhalb dieses scoped-Changes, was bestätigt, dass die vollständige Projekt-Migration noch ein nachfolgender Batch ist.
- `pnpm lint` wurde ausgeführt und schlägt fehl in dieser Umgebung aufgrund eines bestehenden ESLint-Konfigurationsproblems (`TypeError: Converting circular structure to JSON`), welches nicht durch diese Code-Änderungen verursacht wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043c7585ec8333baabe327e536388b)