### PR TITLE
Add centralized DateInput/TimeInput components and fix date/time overflow

### DIFF
--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/add-item-dialog.tsx
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/add-item-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -294,10 +295,9 @@ export function AddTechnikItemDialog({
               <Label htmlFor={`technik-purchase-${category}`}>
                 Kaufdatum
               </Label>
-              <Input
+              <DateInput
                 id={`technik-purchase-${category}`}
                 name="purchaseDate"
-                type="date"
                 required
               />
             </div>
@@ -307,20 +307,18 @@ export function AddTechnikItemDialog({
               <Label htmlFor={`technik-lastUsedAt-${category}`}>
                 Zuletzt benutzt
               </Label>
-              <Input
+              <DateInput
                 id={`technik-lastUsedAt-${category}`}
                 name="lastUsedAt"
-                type="date"
               />
             </div>
             <div className="grid gap-1.5">
               <Label htmlFor={`technik-lastInventoryAt-${category}`}>
                 Letzte Inventur
               </Label>
-              <Input
+              <DateInput
                 id={`technik-lastInventoryAt-${category}`}
                 name="lastInventoryAt"
-                type="date"
               />
             </div>
           </div>

--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/edit-item-dialog.tsx
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/edit-item-dialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -328,10 +329,9 @@ export function EditTechnikItemDialog({
               <Label htmlFor={`technik-purchase-edit-${item.id}`}>
                 Kaufdatum
               </Label>
-              <Input
+              <DateInput
                 id={`technik-purchase-edit-${item.id}`}
                 name="purchaseDate"
-                type="date"
                 defaultValue={formatDateInput(item.purchaseDate)}
                 required
               />
@@ -342,10 +342,9 @@ export function EditTechnikItemDialog({
               <Label htmlFor={`technik-lastUsed-edit-${item.id}`}>
                 Zuletzt benutzt
               </Label>
-              <Input
+              <DateInput
                 id={`technik-lastUsed-edit-${item.id}`}
                 name="lastUsedAt"
-                type="date"
                 defaultValue={formatDateInput(item.lastUsedAt)}
               />
             </div>
@@ -353,10 +352,9 @@ export function EditTechnikItemDialog({
               <Label htmlFor={`technik-lastInventory-edit-${item.id}`}>
                 Letzte Inventur
               </Label>
-              <Input
+              <DateInput
                 id={`technik-lastInventory-edit-${item.id}`}
                 name="lastInventoryAt"
-                type="date"
                 defaultValue={formatDateInput(item.lastInventoryAt)}
               />
             </div>

--- a/src/app/(members)/mitglieder/meine-gewerke/department-event-create-button.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/department-event-create-button.tsx
@@ -17,7 +17,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
+import { TimeInput } from "@/components/ui/time-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 
@@ -146,20 +148,18 @@ export function CreateDepartmentEventButton({
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="department-event-date">Datum</Label>
-              <Input
+              <DateInput
                 id="department-event-date"
                 name="date"
-                type="date"
                 required
                 defaultValue={resolvedDefaults.date}
               />
             </div>
             <div className="space-y-2">
               <Label htmlFor="department-event-start">Start</Label>
-              <Input
+              <TimeInput
                 id="department-event-start"
                 name="startTime"
-                type="time"
                 required
                 defaultValue={resolvedDefaults.startTime}
               />
@@ -168,10 +168,9 @@ export function CreateDepartmentEventButton({
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="department-event-end">Ende (optional)</Label>
-              <Input
+              <TimeInput
                 id="department-event-end"
                 name="endTime"
-                type="time"
                 defaultValue={resolvedDefaults.endTime}
               />
             </div>

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-editor.tsx
@@ -7,7 +7,9 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
+import { TimeInput } from "@/components/ui/time-input";
 import { RichTextEditor } from "@/components/ui/rich-text-editor";
 import { ROLE_LABELS, ROLES } from "@/lib/roles";
 import { cn } from "@/lib/utils";
@@ -302,9 +304,8 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
                 <label className="text-sm font-medium" htmlFor="rehearsal-date">
                   Datum
                 </label>
-                <Input
+                <DateInput
                   id="rehearsal-date"
-                  type="date"
                   value={date}
                   onChange={(event) => setDate(event.target.value)}
                   required
@@ -314,9 +315,8 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
                 <label className="text-sm font-medium" htmlFor="rehearsal-time">
                   Uhrzeit
                 </label>
-                <Input
+                <TimeInput
                   id="rehearsal-time"
-                  type="time"
                   value={time}
                   onChange={(event) => setTime(event.target.value)}
                   required
@@ -326,9 +326,8 @@ export function RehearsalEditor({ rehearsal, members, initialBlockedUserIds }: R
                 <label className="text-sm font-medium" htmlFor="rehearsal-end">
                   Ende
                 </label>
-                <Input
+                <TimeInput
                   id="rehearsal-end"
-                  type="time"
                   value={endTime}
                   onChange={(event) => setEndTime(event.target.value)}
                 />

--- a/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/[showId]/page.tsx
@@ -7,6 +7,7 @@ import { hasPermission } from "@/lib/permissions";
 import { getActiveProductionId } from "@/lib/active-production";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 
 import { X } from "lucide-react";
@@ -169,9 +170,8 @@ export default async function ProduktionDetailPage({
                 <label className="text-sm font-medium" htmlFor="finalRehearsalWeekStart">
                   Beginn der Endprobenwoche
                 </label>
-                <Input
+                <DateInput
                   id="finalRehearsalWeekStart"
-                  type="date"
                   name="finalRehearsalWeekStart"
                   defaultValue={finalRehearsalWeekStartValue}
                 />
@@ -185,9 +185,8 @@ export default async function ProduktionDetailPage({
                 <label className="text-sm font-medium" htmlFor="finalRehearsalWeekEnd">
                   Ende der Endprobenwoche
                 </label>
-                <Input
+                <DateInput
                   id="finalRehearsalWeekEnd"
-                  type="date"
                   name="finalRehearsalWeekEnd"
                   defaultValue={finalRehearsalWeekEndValue}
                 />

--- a/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
+++ b/src/app/(members)/mitglieder/produktionen/gewerke/[departmentId]/page.tsx
@@ -13,6 +13,7 @@ import { hasPermission } from "@/lib/permissions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -387,7 +388,7 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
                           </div>
                           <div className="space-y-1">
                             <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Fällig bis</label>
-                            <Input type="date" name="dueAt" defaultValue={dueDateValue} />
+                            <DateInput name="dueAt" defaultValue={dueDateValue} />
                           </div>
                           <div className="space-y-1">
                             <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
@@ -492,7 +493,7 @@ export default async function DepartmentMissionControlPage({ params }: PageProps
                 </div>
                 <div className="space-y-1">
                   <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Fällig bis</label>
-                  <Input type="date" name="dueAt" />
+                  <DateInput name="dueAt" />
                 </div>
                 <div className="space-y-1 md:col-span-2">
                   <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">

--- a/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/production-forms-client.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -165,23 +166,23 @@ export function CreateProductionForm({
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
           <div className="space-y-1">
             <label className="text-sm font-medium">Startdatum</label>
-            <Input type="date" name="startDate" />
+            <DateInput name="startDate" />
           </div>
           <div className="space-y-1">
             <label className="text-sm font-medium">Enddatum</label>
-            <Input type="date" name="endDate" />
+            <DateInput name="endDate" />
           </div>
           <div className="space-y-1">
             <label className="text-sm font-medium">Beginn der Endprobenwoche</label>
-            <Input type="date" name="finalRehearsalWeekStart" />
+            <DateInput name="finalRehearsalWeekStart" />
           </div>
           <div className="space-y-1">
             <label className="text-sm font-medium">Ende der Endprobenwoche</label>
-            <Input type="date" name="finalRehearsalWeekEnd" />
+            <DateInput name="finalRehearsalWeekEnd" />
           </div>
           <div className="space-y-1 sm:col-span-2">
             <label className="text-sm font-medium">Premierenankündigung</label>
-            <Input type="date" name="revealDate" />
+            <DateInput name="revealDate" />
           </div>
         </div>
       </details>
@@ -441,19 +442,19 @@ export function UpdateProductionForm({ show, redirectPath, onSuccess }: UpdatePr
             <label className="text-sm font-medium" htmlFor={`startDate-${show.id}`}>
               Startdatum
             </label>
-            <Input id={`startDate-${show.id}`} type="date" name="startDate" defaultValue={startDate} />
+            <DateInput id={`startDate-${show.id}`} name="startDate" defaultValue={startDate} />
           </div>
           <div className="space-y-1">
             <label className="text-sm font-medium" htmlFor={`endDate-${show.id}`}>
               Enddatum
             </label>
-            <Input id={`endDate-${show.id}`} type="date" name="endDate" defaultValue={endDate} />
+            <DateInput id={`endDate-${show.id}`} name="endDate" defaultValue={endDate} />
           </div>
           <div className="space-y-1 sm:col-span-2">
             <label className="text-sm font-medium" htmlFor={`revealDate-${show.id}`}>
               Premierenankündigung
             </label>
-            <Input id={`revealDate-${show.id}`} type="date" name="revealDate" defaultValue={revealDate} />
+            <DateInput id={`revealDate-${show.id}`} name="revealDate" defaultValue={revealDate} />
           </div>
         </div>
       </details>

--- a/src/app/(members)/mitglieder/produktionen/szenen/scene-list-client.tsx
+++ b/src/app/(members)/mitglieder/produktionen/szenen/scene-list-client.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
@@ -424,7 +425,7 @@ export function SceneListClient({
                                 </div>
                                 <div className="space-y-1">
                                   <label className="text-xs font-medium text-muted-foreground">Benötigt bis</label>
-                                  <Input type="date" name="neededBy" />
+                                  <DateInput name="neededBy" />
                                 </div>
                                 <div className="space-y-1 md:col-span-4">
                                   <label className="text-xs font-medium text-muted-foreground">Titel</label>
@@ -674,7 +675,7 @@ export function SceneListClient({
                                     </div>
                                     <div className="space-y-1">
                                       <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Benötigt bis</label>
-                                      <Input type="date" name="neededBy" defaultValue={formatIsoDate(item.neededBy)} />
+                                      <DateInput name="neededBy" defaultValue={formatIsoDate(item.neededBy)} />
                                     </div>
                                     <div className="space-y-1 md:col-span-4">
                                       <label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Beschreibung</label>

--- a/src/app/(members)/mitglieder/profil/profile-client.tsx
+++ b/src/app/(members)/mitglieder/profil/profile-client.tsx
@@ -30,6 +30,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Label } from "@/components/ui/label";
@@ -1573,7 +1574,7 @@ function BasicsSection({ user, onUserUpdated }: BasicsSectionProps) {
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="dateOfBirth">Geburtsdatum</Label>
-                <Input id="dateOfBirth" name="dateOfBirth" type="date" value={formState.dateOfBirth} onChange={handleInputChange} />
+                <DateInput id="dateOfBirth" name="dateOfBirth" value={formState.dateOfBirth} onChange={handleInputChange} />
                 {fieldErrors.dateOfBirth ? <p className="text-sm text-destructive">{fieldErrors.dateOfBirth}</p> : null}
                 <p className="text-xs text-muted-foreground">Benötigt für Fotoeinverständnis und Altersfreigaben.</p>
               </div>

--- a/src/app/(site)/_components/premiere-countdown-section.tsx
+++ b/src/app/(site)/_components/premiere-countdown-section.tsx
@@ -8,7 +8,9 @@ import { Countdown } from "@/components/countdown";
 import { useFrontendEditing } from "@/components/frontend-editing/frontend-editing-provider";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
+import { TimeInput } from "@/components/ui/time-input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
@@ -113,7 +115,7 @@ export function PremiereCountdownSection(props: PremiereCountdownSectionProps) {
           <div className="space-y-3">
             {settings.termine.map((termin, index) => {
               const isNext = nextTermin ? nextTermin.label === termin.label : false;
-              return <div key={`${termin.label}-${index}`} className={`grid grid-cols-1 gap-2 rounded-xl border p-3 md:grid-cols-2 md:[grid-template-columns:minmax(0,1fr)_minmax(0,1fr)] ${isNext ? "border-primary" : "border-border"}`}>
+              return <div key={`${termin.label}-${index}`} className={`grid grid-cols-1 gap-2 overflow-hidden rounded-xl border p-3 md:grid-cols-2 md:[grid-template-columns:minmax(0,1fr)_minmax(0,1fr)] ${isNext ? "border-primary" : "border-border"}`}>
                 <div className="min-w-0 md:col-span-2 flex items-center justify-between gap-2">
                   <Label>Vorstellung {index + 1}</Label>
                   <Button
@@ -133,10 +135,10 @@ export function PremiereCountdownSection(props: PremiereCountdownSectionProps) {
                   </Button>
                 </div>
                 <div className="min-w-0">
-                  <Input className="min-w-0" type="date" value={termin.datum} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, datum: event.target.value } : t) }))} />
+                  <DateInput className="min-w-0" value={termin.datum} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, datum: event.target.value } : t) }))} />
                 </div>
                 <div className="min-w-0">
-                  <Input className="min-w-0" type="time" value={termin.uhrzeit} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, uhrzeit: event.target.value } : t) }))} />
+                  <TimeInput className="min-w-0" value={termin.uhrzeit} onChange={(event) => setSettings((prev) => ({ ...prev, termine: prev.termine.map((t, i) => i === index ? { ...t, uhrzeit: event.target.value } : t) }))} />
                 </div>
               </div>;
             })}

--- a/src/components/members/finance/finance-entry-form.tsx
+++ b/src/components/members/finance/finance-entry-form.tsx
@@ -25,6 +25,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -402,7 +403,7 @@ export function FinanceEntryForm({
               <FormItem>
                 <FormLabel>Buchungsdatum</FormLabel>
                 <FormControl>
-                  <Input type="date" {...field} />
+                  <DateInput {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -418,7 +419,7 @@ export function FinanceEntryForm({
               <FormItem>
                 <FormLabel>Fällig bis</FormLabel>
                 <FormControl>
-                  <Input type="date" value={field.value ?? ""} onChange={field.onChange} />
+                  <DateInput value={field.value ?? ""} onChange={field.onChange} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/components/members/finance/finance-export-section.tsx
+++ b/src/components/members/finance/finance-export-section.tsx
@@ -10,6 +10,7 @@ import {
   FINANCE_TYPE_LABELS,
 } from "@/lib/finance";
 import { Button } from "@/components/ui/button";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "sonner";
@@ -107,8 +108,8 @@ export function FinanceExportSection({ showId }: FinanceExportSectionProps) {
             ))}
           </SelectContent>
         </Select>
-        <Input type="date" value={from} onChange={(event) => setFrom(event.target.value)} placeholder="Von" />
-        <Input type="date" value={to} onChange={(event) => setTo(event.target.value)} placeholder="Bis" />
+        <DateInput value={from} onChange={(event) => setFrom(event.target.value)} placeholder="Von" />
+        <DateInput value={to} onChange={(event) => setTo(event.target.value)} placeholder="Bis" />
       </div>
       <div>
         <Button type="button" onClick={handleDownload} disabled={downloading} className="gap-2">

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -9,6 +9,7 @@ import { ChevronDown, ChevronUp, Copy, ExternalLink, FileDown, MessageCircle, Pe
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -1490,8 +1491,7 @@ export function MemberInviteManager() {
             <div className="grid gap-4 md:grid-cols-2">
               <label className="space-y-1 text-sm">
                 <span className="font-medium">Gültig bis</span>
-                <Input
-                  type="date"
+                <DateInput
                   value={editForm.expiresAt}
                   onChange={(event) => setEditForm((prev) => ({ ...prev, expiresAt: event.target.value }))}
                   disabled={isUpdatingCurrentInvite}
@@ -1633,8 +1633,7 @@ export function MemberInviteManager() {
             <div className="grid gap-4 md:grid-cols-2">
               <label className="space-y-1 text-sm">
                 <span className="font-medium">Gültig bis</span>
-                <Input
-                  type="date"
+                <DateInput
                   value={form.expiresAt}
                   onChange={(event) => setForm((prev) => ({ ...prev, expiresAt: event.target.value }))}
                 />

--- a/src/components/onboarding/onboarding-wizard.tsx
+++ b/src/components/onboarding/onboarding-wizard.tsx
@@ -12,6 +12,7 @@ import { SignaturePad, type SignatureResult } from "@/components/onboarding/sign
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Textarea } from "@/components/ui/textarea";
@@ -1236,8 +1237,7 @@ export function OnboardingWizard({ sessionToken, invite, variant = "default" }: 
             <div className="grid gap-4 lg:grid-cols-2">
               <label className="space-y-1 text-sm">
                 <span className="font-medium">Geburtsdatum</span>
-                <Input
-                  type="date"
+                <DateInput
                   value={form.dateOfBirth}
                   onChange={(event) => setForm((prev) => ({ ...prev, dateOfBirth: event.target.value }))}
                 />

--- a/src/components/ui/date-input.tsx
+++ b/src/components/ui/date-input.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type DateInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type">;
+
+const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(({ className, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      type="date"
+      className={cn(
+        "flex h-10 w-full min-w-0 appearance-none rounded-md border border-input bg-background px-3 py-2 text-base text-foreground shadow-sm transition md:text-sm",
+        "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
+        "[&::-webkit-date-and-time-value]:text-foreground [&::-webkit-date-and-time-value]:text-left [&::-webkit-datetime-edit]:min-w-0 [&::-webkit-datetime-edit]:p-0 [&::-webkit-datetime-edit]:text-foreground",
+        "[&::-webkit-datetime-edit-fields-wrapper]:m-0 [&::-webkit-datetime-edit-fields-wrapper]:p-0 [&::-webkit-datetime-edit-fields-wrapper]:text-foreground",
+        "[&::-webkit-datetime-edit-day-field]:p-0 [&::-webkit-datetime-edit-month-field]:p-0 [&::-webkit-datetime-edit-year-field]:p-0",
+        "[&::-webkit-calendar-picker-indicator]:ml-1 [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-70 [&::-webkit-calendar-picker-indicator]:transition-opacity hover:[&::-webkit-calendar-picker-indicator]:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+DateInput.displayName = "DateInput";
+
+export { DateInput };

--- a/src/components/ui/time-input.tsx
+++ b/src/components/ui/time-input.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type TimeInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type">;
+
+const TimeInput = React.forwardRef<HTMLInputElement, TimeInputProps>(({ className, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      type="time"
+      className={cn(
+        "flex h-10 w-full min-w-0 appearance-none rounded-md border border-input bg-background px-3 py-2 text-base text-foreground shadow-sm transition md:text-sm",
+        "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
+        "[&::-webkit-date-and-time-value]:text-foreground [&::-webkit-date-and-time-value]:text-left [&::-webkit-datetime-edit]:min-w-0 [&::-webkit-datetime-edit]:p-0 [&::-webkit-datetime-edit]:text-foreground",
+        "[&::-webkit-datetime-edit-fields-wrapper]:m-0 [&::-webkit-datetime-edit-fields-wrapper]:p-0 [&::-webkit-datetime-edit-fields-wrapper]:text-foreground",
+        "[&::-webkit-datetime-edit-hour-field]:p-0 [&::-webkit-datetime-edit-minute-field]:p-0 [&::-webkit-datetime-edit-ampm-field]:p-0",
+        "[&::-webkit-calendar-picker-indicator]:ml-1 [&::-webkit-calendar-picker-indicator]:cursor-pointer [&::-webkit-calendar-picker-indicator]:opacity-70 [&::-webkit-calendar-picker-indicator]:transition-opacity hover:[&::-webkit-calendar-picker-indicator]:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+TimeInput.displayName = "TimeInput";
+
+export { TimeInput };


### PR DESCRIPTION
### Motivation
- Native `input[type="date"]` and `input[type="time"]` impose browser-intrinsic minimum widths that cause layout overflow; central components are needed to fully encapsulate and override UA styles.
- Provide a single, token-driven implementation so date/time fields visually match the existing `Input` component and react to the dynamic theme. 
- Replace ad-hoc usages across the project to ensure consistent behavior and prevent future regressions.

### Description
- Added `src/components/ui/date-input.tsx` and `src/components/ui/time-input.tsx` that render `input[type="date"]`/`input[type="time"]` with enforced `w-full min-w-0 appearance-none` and explicit WebKit datetime pseudo-element rules to prevent browser defaults from overflowing.  
- Styling follows the same design tokens and focus/disabled states as the central `Input` component so both light and dark themes behave consistently.  
- Replaced direct `type="date"` / `type="time"` usages in the affected components with `DateInput`/`TimeInput` and added the necessary imports.  
- Updated `src/app/(site)/_components/premiere-countdown-section.tsx` to use the new components and added `overflow-hidden` to the Vorstellung box wrapper as an additional safety net against overflow.

### Testing
- Ran `pnpm lint`, which failed due to an existing ESLint configuration issue (circular structure serialization) unrelated to the changes.  
- Ran `pnpm test` (Vitest), which showed `62` passing and `1` failing test overall, but several suites errored because the Prisma-generated client (`.prisma/client/default`) is missing in the environment.  
- Ran `pnpm build`, which failed at `prisma generate` due to a Prisma v7 datasource `url` schema validation error in this environment.  
- All changes are UI-focused and no binary assets were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0454b941e48333be129aaa10e9f2a9)