### PR TITLE
Über-uns: Statistik‑Karten zentriert, Info‑Icon orange, Atmosphäre‑Box kompakter

### DIFF
--- a/src/app/(site)/ueber-uns/carousel-hint.tsx
+++ b/src/app/(site)/ueber-uns/carousel-hint.tsx
@@ -13,11 +13,11 @@ export function CarouselHint() {
         <TooltipTrigger asChild>
           <button
             type="button"
-            className="rounded-full p-1 text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            className="rounded-full p-1 text-primary transition hover:text-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
             aria-label="Karussell-Bedienhinweis"
             title={HINT_TEXT}
           >
-            <Info className="h-4 w-4" aria-hidden />
+            <Info className="h-5 w-5" aria-hidden />
           </button>
         </TooltipTrigger>
         <TooltipContent side="left" className="max-w-xs text-xs">

--- a/src/app/(site)/ueber-uns/page.tsx
+++ b/src/app/(site)/ueber-uns/page.tsx
@@ -298,13 +298,13 @@ export default async function PublicAboutPage() {
 
           <div className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {statisticItems.map((item) => (
-              <Card key={item.label} className="border-border/60 bg-card/70 p-4 shadow-sm">
-                <CardHeader className="p-0 pb-1.5">
-                  <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">{item.label}</p>
+              <Card key={item.label} className="flex flex-col items-center border border-primary/60 bg-card/70 p-4 text-center shadow-sm">
+                <CardHeader className="p-0 pb-2">
+                  <p className="text-center text-xs font-semibold uppercase tracking-widest text-primary">{item.label}</p>
                 </CardHeader>
-                <CardContent className="p-0 pt-0">
-                  <p className="text-lg font-bold text-foreground">{item.value}</p>
-                  <p className="mt-1 text-xs text-muted-foreground">{item.detail}</p>
+                <CardContent className="p-0">
+                  <p className="text-center text-[clamp(1.8rem,3vw,2.4rem)] font-bold text-primary">{item.value}</p>
+                  <p className="mt-1 text-center text-sm text-muted-foreground">{item.detail}</p>
                 </CardContent>
               </Card>
             ))}
@@ -407,13 +407,13 @@ export default async function PublicAboutPage() {
               </div>
             </div>
 
-            <div className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/10 via-background to-background p-8 shadow-lg">
+            <div className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-primary/10 via-background to-background p-[clamp(1rem,2vw,1.5rem)] shadow-lg">
               <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(248,223,150,0.18),_transparent_60%)]" aria-hidden />
               <div className="relative space-y-4">
                 <Text variant="eyebrow" uppercase tone="primary">
                   Atmosphäre
                 </Text>
-                <Heading level="h3" className="text-2xl">
+                <Heading level="h3" className="text-[clamp(1rem,2vw,1.3rem)] font-bold">
                   Wenn die Sonne hinter den Baumwipfeln verschwindet, beginnt unser Bühnenraum zu leben: leuchtende Pfade, flüsternde Bäume und ein Ensemble, das
                   das Publikum mitnimmt in eine andere Welt.
                 </Heading>


### PR DESCRIPTION
### Motivation
- Die Statistik‑Karten, das Karussell‑Info‑Icon und die Atmosphäre‑Box sollten visuell dem orangen Akzentsystem folgen und in Layout sowie Typografie besser aufeinander abgestimmt werden.
- Die Veränderungen reduzieren visuelle Dominanz der Atmosphäre‑Box und verbessern die Lesbarkeit der Statistikwerte in der Intro‑Sektion.

### Description
- Statistik‑Karten: In `src/app/(site)/ueber-uns/page.tsx` wurden die Karten auf `flex flex-col items-center text-center` umgestellt, Label und Zahl auf `text-primary` gesetzt, Zahl auf `text-[clamp(1.8rem,3vw,2.4rem)]` skaliert, Beschreibung auf `text-sm text-muted-foreground` angepasst und Rahmen auf `border border-primary/60` gesetzt.
- Info‑Icon: In `src/app/(site)/ueber-uns/carousel-hint.tsx` wurde der Button‑Icon‑Stil auf `text-primary` geändert und das Icon auf `h-5 w-5` vergrößert (Hover/Focus‑Ring beibehalten).
- Atmosphäre‑Box: In `src/app/(site)/ueber-uns/page.tsx` wurde das Padding auf `p-[clamp(1rem,2vw,1.5rem)]` reduziert und das Zitat/Heading auf `text-[clamp(1rem,2vw,1.3rem)] font-bold` gesetzt, sonstige Inhalte und Position unverändert.

### Testing
- `pnpm lint` wurde ausgeführt und schlug fehl aufgrund eines bestehenden ESLint‑Konfigurationsfehlers (`Converting circular structure to JSON`).
- `pnpm test` (Vitest) wurde ausgeführt und mehrere vorhandene Tests schlugen fehl, u. a. wegen fehlendem Prisma‑Client (`.prisma/client/default`).
- `pnpm build` wurde ausgeführt und schlug fehl wegen Prisma‑7‑Schemavalidierung (`datasource.url` im `prisma/schema.prisma` ist nicht mehr unterstützt).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c6df8f4c8333bf125a504690b05b)