### PR TITLE
Fix Mystery page UX/state consistency and unify permissions

### DIFF
--- a/src/app/(members)/mitglieder/mystery/tipps/page.tsx
+++ b/src/app/(members)/mitglieder/mystery/tipps/page.tsx
@@ -10,7 +10,7 @@ export default async function MysteryTipsAdminPage({
   searchParams?: Promise<{ clue?: string }>;
 }) {
   const session = await requireAuth();
-  const allowed = await hasPermission(session.user, "mitglieder.mystery.tips");
+  const allowed = await hasPermission(session.user, "mystery.tips.manage");
   if (!allowed) {
     return <div className="text-sm text-red-600">Kein Zugriff auf die Mystery-Tipps</div>;
   }

--- a/src/app/(site)/mystery/_components/mystery-guess-board.tsx
+++ b/src/app/(site)/mystery/_components/mystery-guess-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { type FocusEvent, type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { RefreshCw } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -60,10 +60,17 @@ export function MysteryGuessBoard({ initialTips = [], clueOptions, defaultClueId
   const [listError, setListError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoading, setIsLoading] = useState(initialTips.length === 0);
+  const [didSubmit, setDidSubmit] = useState(false);
+  const [touchedFields, setTouchedFields] = useState<{ playerName: boolean; clueId: boolean }>({
+    playerName: false,
+    clueId: false,
+  });
 
   const hasMinimumLength = useMemo(() => tipText.trim().length >= 3, [tipText]);
   const hasValidName = useMemo(() => playerName.trim().length >= 2, [playerName]);
   const hasSelectedClue = Boolean(selectedClueId);
+  const showPlayerNameError = (didSubmit || touchedFields.playerName) && !hasValidName;
+  const showClueError = (didSubmit || touchedFields.clueId) && !hasSelectedClue;
 
   const refreshTips = useCallback(async () => {
     setIsLoading(true);
@@ -107,6 +114,7 @@ export function MysteryGuessBoard({ initialTips = [], clueOptions, defaultClueId
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      setDidSubmit(true);
       const trimmed = tipText.trim();
       if (trimmed.length < 3) {
         setSubmissionError("Dein Tipp sollte mindestens 3 Zeichen lang sein.");
@@ -144,6 +152,8 @@ export function MysteryGuessBoard({ initialTips = [], clueOptions, defaultClueId
         });
         setTipText("");
         setPlayerName("");
+        setDidSubmit(false);
+        setTouchedFields({ playerName: false, clueId: false });
       } catch (err) {
         console.error("Failed to submit mystery tip", err);
         setSubmissionError(err instanceof Error ? err.message : "Unbekannter Fehler beim Speichern.");
@@ -176,17 +186,37 @@ export function MysteryGuessBoard({ initialTips = [], clueOptions, defaultClueId
                   maxLength={50}
                   placeholder="Wie dürfen wir dich im Scoreboard nennen?"
                   disabled={isSubmitting}
-                  aria-invalid={hasValidName ? undefined : true}
+                  aria-invalid={showPlayerNameError ? true : undefined}
+                  onBlur={(event: FocusEvent<HTMLInputElement>) => {
+                    if (!touchedFields.playerName) {
+                      setTouchedFields((current) => ({ ...current, playerName: true }));
+                    }
+                    setPlayerName(event.target.value);
+                  }}
                 />
-                <Text variant="small" tone={hasValidName ? "muted" : "destructive"}>
+                <Text variant="small" tone={showPlayerNameError ? "destructive" : "muted"}>
                   Mindestens 2 Zeichen. Dieser Name erscheint im öffentlichen Scoreboard.
                 </Text>
               </div>
 
               <div className="space-y-2">
                 <Label htmlFor="mystery-clue">Rätsel auswählen</Label>
-                <Select value={selectedClueId} onValueChange={setSelectedClueId} disabled={clueOptions.length === 0 || isSubmitting}>
-                  <SelectTrigger id="mystery-clue" className="w-full">
+                <Select value={selectedClueId} onValueChange={(value) => {
+                  setSelectedClueId(value);
+                  if (!touchedFields.clueId) {
+                    setTouchedFields((current) => ({ ...current, clueId: true }));
+                  }
+                }} disabled={clueOptions.length === 0 || isSubmitting}>
+                  <SelectTrigger
+                    id="mystery-clue"
+                    className="w-full"
+                    aria-invalid={showClueError ? true : undefined}
+                    onBlur={() => {
+                      if (!touchedFields.clueId) {
+                        setTouchedFields((current) => ({ ...current, clueId: true }));
+                      }
+                    }}
+                  >
                     <SelectValue placeholder="Rätsel wählen" />
                   </SelectTrigger>
                   <SelectContent>
@@ -197,7 +227,7 @@ export function MysteryGuessBoard({ initialTips = [], clueOptions, defaultClueId
                     ))}
                   </SelectContent>
                 </Select>
-                <Text variant="small" tone={hasSelectedClue ? "muted" : "destructive"}>
+                <Text variant="small" tone={showClueError ? "destructive" : "muted"}>
                   Ordne deinen Tipp einem konkreten Rätsel zu, um Punkte zu sammeln.
                 </Text>
               </div>

--- a/src/app/(site)/mystery/_components/mystery-scoreboard.tsx
+++ b/src/app/(site)/mystery/_components/mystery-scoreboard.tsx
@@ -1,10 +1,8 @@
+import { Trophy } from "lucide-react";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Text } from "@/components/ui/typography";
-
-const DATE_FORMATTER = new Intl.DateTimeFormat("de-DE", {
-  dateStyle: "medium",
-  timeStyle: "short",
-});
+import { cn } from "@/lib/utils";
 
 const NUMBER_FORMATTER = new Intl.NumberFormat("de-DE");
 
@@ -14,6 +12,12 @@ type ScoreboardEntry = {
   correctCount: number;
   lastUpdated: string | null;
 };
+
+function initialsFor(name: string) {
+  const cleaned = name.trim();
+  if (!cleaned) return "--";
+  return cleaned.slice(0, 2).toUpperCase();
+}
 
 export function MysteryScoreboard({ entries }: { entries: ScoreboardEntry[] }) {
   return (
@@ -32,33 +36,37 @@ export function MysteryScoreboard({ entries }: { entries: ScoreboardEntry[] }) {
             <table className="min-w-full divide-y divide-border text-left text-sm">
               <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
                 <tr>
-                  <th scope="col" className="px-3 py-2 font-semibold">
-                    Spielername
-                  </th>
-                  <th scope="col" className="px-3 py-2 font-semibold">
-                    Punkte
-                  </th>
-                  <th scope="col" className="px-3 py-2 font-semibold">
-                    Richtige Tipps
-                  </th>
-                  <th scope="col" className="px-3 py-2 font-semibold">
-                    Zuletzt aktualisiert
-                  </th>
+                  <th className="px-3 py-2 font-semibold">Rang</th>
+                  <th className="px-3 py-2 font-semibold">Spieler</th>
+                  <th className="px-3 py-2 font-semibold">Punkte</th>
+                  <th className="px-3 py-2 font-semibold">Rätsel-Treffer</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border/70">
-                {entries.map((entry) => (
-                  <tr key={entry.playerName} className="bg-background/60">
-                    <td className="px-3 py-2 font-medium text-foreground">{entry.playerName}</td>
-                    <td className="px-3 py-2 font-semibold text-foreground">
-                      {NUMBER_FORMATTER.format(entry.totalScore)}
-                    </td>
-                    <td className="px-3 py-2 text-muted-foreground">{entry.correctCount}</td>
-                    <td className="px-3 py-2 text-muted-foreground">
-                      {entry.lastUpdated ? DATE_FORMATTER.format(new Date(entry.lastUpdated)) : "–"}
-                    </td>
-                  </tr>
-                ))}
+                {entries.map((entry, index) => {
+                  const rank = index + 1;
+                  const isTopThree = rank <= 3;
+                  return (
+                    <tr key={entry.playerName} className={cn("bg-background/60", isTopThree && "bg-primary/10")}>
+                      <td className="px-3 py-2 font-semibold text-foreground">
+                        <span className="inline-flex items-center gap-1">
+                          {rank <= 3 ? <Trophy className="h-4 w-4 text-primary" aria-hidden /> : null}
+                          {rank}.
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 font-medium text-foreground">
+                        <div className="flex items-center gap-2">
+                          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground">
+                            {initialsFor(entry.playerName)}
+                          </span>
+                          {entry.playerName}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 font-semibold text-foreground">{NUMBER_FORMATTER.format(entry.totalScore)}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{entry.correctCount}</td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>

--- a/src/app/(site)/mystery/page.tsx
+++ b/src/app/(site)/mystery/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
+import { Eye, Lock } from "lucide-react";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Heading, Text } from "@/components/ui/typography";
@@ -92,10 +93,7 @@ export default async function MysteryPage() {
 
   if (process.env.DATABASE_URL) {
     const [cluesResult, tipsResult, settingsResult, scoreboardResult, clueSummaryResult] = await Promise.allSettled([
-      prisma.clue.findMany({
-        where: { published: true, releaseAt: { lte: now } },
-        orderBy: [{ index: "asc" }],
-      }),
+      prisma.clue.findMany({ orderBy: [{ index: "asc" }] }),
       prisma.mysteryTip.findMany({
         orderBy: [
           { count: "desc" },
@@ -123,8 +121,9 @@ export default async function MysteryPage() {
   const effectiveExpirationMessage = resolvedSettings.effectiveExpirationMessage ?? DEFAULT_MYSTERY_EXPIRATION_MESSAGE;
   const updatedAtIso = resolvedSettings.updatedAt ? resolvedSettings.updatedAt.toISOString() : null;
 
+  const visibleClues = clues.filter((clue) => clue.published && clue.releaseAt <= now);
   const firstRiddle = clues.find((clue) => clue.index === 1) ?? null;
-  const remainingClues = firstRiddle ? clues.filter((clue) => clue.id !== firstRiddle.id) : clues;
+  const remainingClues = clues.filter((clue) => clue.id !== firstRiddle?.id);
   const firstRiddleContent = firstRiddle ? parseClueContent(firstRiddle.content) : null;
 
   const initialTips = tips.map((tip) => ({
@@ -150,9 +149,8 @@ export default async function MysteryPage() {
     lastUpdated: entry.lastUpdated ? entry.lastUpdated.toISOString() : null,
   }));
 
-  const countdownReached = resolvedSettings.effectiveCountdownTarget <= now;
-  const isFirstRiddleReleased = countdownReached || Boolean(firstRiddle);
-  const showSilentMessage = !isFirstRiddleReleased && clues.length === 0;
+  const isFirstRiddleReleased = Boolean(firstRiddle && firstRiddle.published && firstRiddle.releaseAt <= now);
+  const showSilentMessage = !isFirstRiddleReleased && visibleClues.length === 0;
   const hasAdditionalClues = remainingClues.length > 0;
 
   return (
@@ -196,7 +194,15 @@ export default async function MysteryPage() {
                   <Text tone="muted">Das Rätsel wird gerade vorbereitet. Schau bald wieder vorbei.</Text>
                 )
               ) : (
-                <Text className="text-2xl font-semibold text-muted-foreground">Das 1. Rätsel</Text>
+                <div className="space-y-2">
+                  <Lock className="mx-auto h-8 w-8 text-muted-foreground" aria-hidden />
+                  <Text tone="muted">Das 1. Rätsel kommt bald.</Text>
+                  {firstRiddle?.releaseAt ? (
+                    <Text variant="small" tone="muted">
+                      Geplant für {new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" }).format(firstRiddle.releaseAt)}
+                    </Text>
+                  ) : null}
+                </div>
               )}
             </CardContent>
           </Card>
@@ -214,6 +220,7 @@ export default async function MysteryPage() {
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {remainingClues.map((clue) => {
               const content = parseClueContent(clue.content);
+              const isReleased = clue.published && clue.releaseAt <= now;
               return (
                 <Card key={clue.id}>
                   <CardHeader>
@@ -222,7 +229,13 @@ export default async function MysteryPage() {
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-3">
-                    {renderClueBody(clue, content)}
+                    <div className="flex items-center gap-2 text-muted-foreground">
+                      {isReleased ? <Eye className="h-4 w-4" aria-hidden /> : <Lock className="h-4 w-4" aria-hidden />}
+                      <Text variant="small" tone="muted">
+                        {isReleased ? "Enthüllt" : "Geplant"} am {new Intl.DateTimeFormat("de-DE", { dateStyle: "medium", timeStyle: "short" }).format(clue.releaseAt)}
+                      </Text>
+                    </div>
+                    {isReleased ? renderClueBody(clue, content) : <Text tone="muted">Dieser Hinweis ist noch verschlossen.</Text>}
                   </CardContent>
                 </Card>
               );

--- a/src/app/api/mystery/settings/route.ts
+++ b/src/app/api/mystery/settings/route.ts
@@ -43,7 +43,7 @@ function serializeSettings(record: Awaited<ReturnType<typeof readMysterySettings
 
 export async function GET(request: NextRequest) {
   const session = await requireAuth();
-  if (!(await hasPermission(session.user, "mitglieder.mystery.launch-countdown"))) {
+  if (!(await hasPermission(session.user, "mystery.timer.edit"))) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
@@ -63,7 +63,7 @@ export async function GET(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   const session = await requireAuth();
-  if (!(await hasPermission(session.user, "mitglieder.mystery.launch-countdown"))) {
+  if (!(await hasPermission(session.user, "mystery.timer.edit"))) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/src/app/api/mystery/submissions/[id]/route.ts
+++ b/src/app/api/mystery/submissions/[id]/route.ts
@@ -13,7 +13,7 @@ const updateSchema = z.object({
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const session = await requireAuth();
-  const allowed = await hasPermission(session.user, "mitglieder.mystery.tips");
+  const allowed = await hasPermission(session.user, "mystery.tips.manage");
   if (!allowed) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/src/lib/frontend-editing.ts
+++ b/src/lib/frontend-editing.ts
@@ -17,7 +17,7 @@ const FEATURE_DEFINITIONS: FeatureDefinition[] = [
     key: "mystery.launch-countdown",
     label: "Mystery-Timer",
     description: "Countdown und Hinweistext für die Mystery-Startseite verwalten.",
-    permissionKey: "mitglieder.mystery.launch-countdown",
+    permissionKey: "mystery.timer.edit",
   },
   {
     key: "website.premiere-countdown",

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -240,15 +240,33 @@ export const DEFAULT_PERMISSION_DEFINITIONS: PermissionDefinition[] = [
     category: "membership",
   },
   {
-    key: "mitglieder.mystery.launch-countdown",
-    label: "Mystery-Timer verwalten",
+    key: "mystery.timer.edit",
+    label: "Mystery-Timer bearbeiten",
     description: "Countdown und Hinweistext für das öffentliche Geheimnis pflegen.",
     category: "mystery",
   },
   {
-    key: "mitglieder.mystery.tips",
+    key: "mystery.puzzle.manage",
+    label: "Mystery-Rätsel verwalten",
+    description: "Rätsel erstellen, bearbeiten und veröffentlichen.",
+    category: "mystery",
+  },
+  {
+    key: "mystery.tips.manage",
     label: "Mystery-Tipps verwalten",
-    description: "Community-Tipps nach Rätsel auswerten und Punkte für richtige Ideen vergeben.",
+    description: "Community-Tipps moderieren und löschen.",
+    category: "mystery",
+  },
+  {
+    key: "mystery.scoreboard.manage",
+    label: "Mystery-Scoreboard verwalten",
+    description: "Punkte vergeben und Scoreboard-Einträge bearbeiten.",
+    category: "mystery",
+  },
+  {
+    key: "mystery.hints.manage",
+    label: "Mystery-Hinweise verwalten",
+    description: "Hinweise freischalten und hinzufügen.",
     category: "mystery",
   },
   {


### PR DESCRIPTION
### Motivation
- Prevent form fields on the public Mystery page from showing validation errors before user interaction so the form is neutral at first view.  
- Ensure Timer and Puzzle cards use a single source of truth for release visibility so both show consistent states.  
- Replace the placeholder hints area with real cards that show revealed vs. planned hints.  
- Improve scoreboard readability and consolidate all mystery-related permissions under a single `mystery.*` namespace.

### Description
- Adjusted tip form validation in `src/app/(site)/mystery/_components/mystery-guess-board.tsx` by introducing `didSubmit` and `touchedFields` state and showing `aria-invalid` / error tone only after a submit attempt or on `blur`.  
- Synchronized puzzle visibility by loading all `prisma.clue.findMany()` rows and deriving the released state with `clue.published && clue.releaseAt <= now`, then rendering Lock/Eye states and planned dates in `src/app/(site)/mystery/page.tsx`.  
- Redesigned the "Bisher enthüllte Hinweise" section to card-based hint items that use `Eye`/`Lock` icons and show either content or a locked message (no local style overrides) in `src/app/(site)/mystery/page.tsx`.  
- Reworked the scoreboard into a ranked table with trophy icons, avatar initials and top-3 highlighting in `src/app/(site)/mystery/_components/mystery-scoreboard.tsx`.  
- Consolidated and added permissions in `src/lib/permissions.ts` (`mystery.timer.edit`, `mystery.puzzle.manage`, `mystery.tips.manage`, `mystery.scoreboard.manage`, `mystery.hints.manage`) and updated permission checks/usages in `src/lib/frontend-editing.ts`, `src/app/api/mystery/settings/route.ts`, `src/app/api/mystery/submissions/[id]/route.ts`, and the members admin page.

### Testing
- Ran `pnpm lint` which completed successfully while reporting existing unrelated warnings in other files.  
- Ran `pnpm test` and all Vitest suites passed.  
- Ran `pnpm build` and Next.js produced a successful production build with the usual unrelated Next lint hints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0588ff69ec8333bc05cf272abf87dc)