### PR TITLE
Add page visibility settings groundwork for members area

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -674,6 +674,7 @@ model WebsiteSettings {
   siteTitle String   @default("Sommertheater im Schlosspark")
   colorMode String   @default("dark")
   maintenanceMode Boolean  @default(false)
+  pageVisibility Json?
   themeId   String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/lib/page-visibility.ts
+++ b/src/lib/page-visibility.ts
@@ -1,0 +1,15 @@
+import type { PageVisibilitySettings } from "@/lib/website-settings";
+
+export function isMembersPathEnabled(pathname: string, visibility: PageVisibilitySettings): boolean {
+  const ds = visibility.categories.dateisystem;
+  if (!ds.enabled) {
+    return !pathname.startsWith("/mitglieder/archiv") && !pathname.startsWith("/mitglieder/bilder") && !pathname.startsWith("/mitglieder/chronik") && !pathname.startsWith("/mitglieder/daten");
+  }
+
+  if (pathname.startsWith("/mitglieder/archiv")) return ds.archive;
+  if (pathname.startsWith("/mitglieder/bilder")) return ds.images;
+  if (pathname.startsWith("/mitglieder/chronik")) return ds.timeline;
+  if (pathname.startsWith("/mitglieder/daten")) return ds.data;
+
+  return true;
+}

--- a/src/lib/website-settings.ts
+++ b/src/lib/website-settings.ts
@@ -10,6 +10,54 @@ export const DEFAULT_SITE_TITLE = "Sommertheater im Schlosspark" as const;
 export const DEFAULT_COLOR_MODE = "dark" as const;
 export const DEFAULT_MAINTENANCE_MODE = false as const;
 
+
+export type PageVisibilitySettings = {
+  pages: {
+    general: boolean;
+    maintenance: boolean;
+    ui: boolean;
+    websiteTheme: boolean;
+  };
+  categories: {
+    dateisystem: {
+      enabled: boolean;
+      archive: boolean;
+      images: boolean;
+      timeline: boolean;
+      data: boolean;
+    };
+  };
+};
+
+export const DEFAULT_PAGE_VISIBILITY: PageVisibilitySettings = {
+  pages: { general: true, maintenance: true, ui: true, websiteTheme: true },
+  categories: { dateisystem: { enabled: true, archive: true, images: true, timeline: true, data: true } },
+};
+
+function sanitisePageVisibility(input: unknown): PageVisibilitySettings {
+  const source = input && typeof input === "object" ? (input as Record<string, unknown>) : {};
+  const pages = source.pages && typeof source.pages === "object" ? source.pages as Record<string, unknown> : {};
+  const categories = source.categories && typeof source.categories === "object" ? source.categories as Record<string, unknown> : {};
+  const dateisystem = categories.dateisystem && typeof categories.dateisystem === "object" ? categories.dateisystem as Record<string, unknown> : {};
+  const pick=(v:unknown,d:boolean)=> typeof v === 'boolean' ? v : d;
+  return {
+    pages: {
+      general: pick(pages.general, true),
+      maintenance: pick(pages.maintenance, true),
+      ui: pick(pages.ui, true),
+      websiteTheme: pick(pages.websiteTheme, true),
+    },
+    categories: {
+      dateisystem: {
+        enabled: pick(dateisystem.enabled, true),
+        archive: pick(dateisystem.archive, true),
+        images: pick(dateisystem.images, true),
+        timeline: pick(dateisystem.timeline, true),
+        data: pick(dateisystem.data, true),
+      },
+    },
+  };
+}
 export const THEME_COLOR_MODES = ["light", "dark", "system"] as const;
 export type ThemeColorMode = (typeof THEME_COLOR_MODES)[number];
 
@@ -1063,6 +1111,7 @@ export type ResolvedWebsiteSettings = {
   siteTitle: string;
   colorMode: ThemeColorMode;
   maintenanceMode: boolean;
+  pageVisibility: PageVisibilitySettings;
   updatedAt: Date | null;
   theme: ResolvedWebsiteTheme;
 };
@@ -1100,6 +1149,7 @@ export function resolveWebsiteSettings(record: WebsiteSettingsRecord): ResolvedW
     siteTitle: record ? sanitiseSiteTitle(record.siteTitle) : DEFAULT_SITE_TITLE,
     colorMode: record ? sanitiseColorMode(record.colorMode) : DEFAULT_COLOR_MODE,
     maintenanceMode: record ? sanitiseMaintenanceMode(record.maintenanceMode) : DEFAULT_MAINTENANCE_MODE,
+    pageVisibility: record ? sanitisePageVisibility(record.pageVisibility) : DEFAULT_PAGE_VISIBILITY,
     updatedAt: record?.updatedAt ?? null,
     theme,
   };
@@ -1129,6 +1179,7 @@ export type ClientWebsiteSettings = {
   siteTitle: string;
   colorMode: ThemeColorMode;
   maintenanceMode: boolean;
+  pageVisibility: PageVisibilitySettings;
   updatedAt: string | null;
   theme: ClientWebsiteTheme;
 };
@@ -1164,6 +1215,7 @@ export function toClientWebsiteSettings(resolved: ResolvedWebsiteSettings): Clie
     siteTitle: resolved.siteTitle,
     colorMode: resolved.colorMode,
     maintenanceMode: resolved.maintenanceMode,
+    pageVisibility: resolved.pageVisibility,
     updatedAt: resolved.updatedAt ? resolved.updatedAt.toISOString() : null,
     theme: toClientWebsiteTheme(resolved.theme),
   };
@@ -1227,6 +1279,7 @@ export async function ensureWebsiteSettingsRecord() {
       siteTitle: DEFAULT_SITE_TITLE,
       colorMode: DEFAULT_COLOR_MODE,
       maintenanceMode: DEFAULT_MAINTENANCE_MODE,
+      pageVisibility: DEFAULT_PAGE_VISIBILITY as Prisma.InputJsonValue,
       theme: { connect: { id: theme.id } },
     },
     include: { theme: true },
@@ -1237,6 +1290,7 @@ export type WebsiteSettingsInput = {
   siteTitle?: string | null;
   colorMode?: ThemeColorMode | null;
   maintenanceMode?: boolean | null;
+  pageVisibility?: PageVisibilitySettings | null;
   themeId?: string | null;
 };
 
@@ -1247,6 +1301,7 @@ export async function saveWebsiteSettings(input: WebsiteSettingsInput) {
     siteTitle: DEFAULT_SITE_TITLE,
     colorMode: DEFAULT_COLOR_MODE,
     maintenanceMode: DEFAULT_MAINTENANCE_MODE,
+    pageVisibility: DEFAULT_PAGE_VISIBILITY as Prisma.InputJsonValue,
   };
 
   if (input.siteTitle !== undefined) {
@@ -1265,6 +1320,12 @@ export async function saveWebsiteSettings(input: WebsiteSettingsInput) {
     const maintenanceMode = sanitiseMaintenanceMode(input.maintenanceMode);
     update.maintenanceMode = maintenanceMode;
     create.maintenanceMode = maintenanceMode;
+  }
+
+  if (input.pageVisibility !== undefined) {
+    const pageVisibility = sanitisePageVisibility(input.pageVisibility);
+    update.pageVisibility = pageVisibility as Prisma.InputJsonValue;
+    create.pageVisibility = pageVisibility as Prisma.InputJsonValue;
   }
 
   if (input.themeId !== undefined) {


### PR DESCRIPTION
### Motivation
- Provide a central, typed configuration for enabling/disabling members-area pages and whole categories so pages like `Archiv` can be hidden site-wide when turned off.
- Lay the backend/config foundation so navigation and route-level enforcement can later read a single source of truth to hide/mask pages and categories (e.g. `Dateisystem` with `Archiv`, `Bilder`, `Chronik`, `Daten`).

### Description
- Add a `pageVisibility Json?` field to the `WebsiteSettings` model in `prisma/schema.prisma` to persist visibility settings.
- Introduce `PageVisibilitySettings`, `DEFAULT_PAGE_VISIBILITY` and a `sanitisePageVisibility` function in `src/lib/website-settings.ts` and wire `pageVisibility` into `resolveWebsiteSettings`, `toClientWebsiteSettings`, `ensureWebsiteSettingsRecord`, `WebsiteSettingsInput` and `saveWebsiteSettings`.
- Add `src/lib/page-visibility.ts` with `isMembersPathEnabled(pathname, visibility)` to centralise per-path/category checks for the members area (currently implements the Dateisystem category and its subpages).
- Keep all changes non-breaking by providing defaults and sanitisation so existing installations get a sane default visibility.

### Testing
- Ran `pnpm lint`, which completed successfully; the run reports two unrelated pre-existing warnings but no new errors.
- No further automated tests were added in this change; integration of the visibility checks into navigation/routes and unit tests will be implemented in follow-up changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b4a1e280832dbab274a547afae4f)