### PR TITLE
Fix undefined theme loader call in theme settings manager

### DIFF
--- a/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
+++ b/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
@@ -1262,7 +1262,7 @@ export function WebsiteThemeSettingsManager({ initialSettings, initialThemes }: 
       setAvailableThemes(themes);
       const fallbackId = payload.activeThemeId ?? themes[0]?.id;
       if (fallbackId) {
-        await loadThemeById(fallbackId);
+        await handleThemeSelect(fallbackId);
       }
       setSiteSnapshot((prev) => ({ ...prev, activeThemeId: payload.activeThemeId ?? prev.activeThemeId }));
       toast.success("Theme wurde gelöscht.");


### PR DESCRIPTION
### Motivation
- Behebt einen TypeScript-Buildfehler, bei dem ein Aufruf von `loadThemeById` nicht definiert war und dadurch die Fallback-Theme-Auswahl nach dem Löschen eines Themes ausfiel.

### Description
- Ersetzt den Aufruf `loadThemeById(fallbackId)` durch den bereits vorhandenen Loader `handleThemeSelect(fallbackId)` in `src/app/(members)/mitglieder/website/theme-settings-manager.tsx`, sodass das Fallback-Theme mit dem bestehenden Ladefluss geladen wird.

### Testing
- Ausgeführt: `pnpm lint`, `pnpm test` und `pnpm build`; alle drei Befehle schlugen fehl, wobei die Fehler auf bestehende Umgebungs-/Konfigurationsprobleme zurückzuführen sind (ESLint-Konfigurations-JSON-Zyklus, fehlende Prisma-Client-Datei und Prisma-v7-`datasource.url`-Validierung) und nicht durch diese Änderung verursacht wurden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e558b2e8832d9d8d533c343b5777)