### PR TITLE
Fix theme deletion fallback and ensure website settings record

### DIFF
--- a/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
+++ b/src/app/(members)/mitglieder/website/theme-settings-manager.tsx
@@ -1262,7 +1262,7 @@ export function WebsiteThemeSettingsManager({ initialSettings, initialThemes }: 
       setAvailableThemes(themes);
       const fallbackId = payload.activeThemeId ?? themes[0]?.id;
       if (fallbackId) {
-        await loadThemeById(fallbackId);
+        await handleThemeSelect(fallbackId);
       }
       setSiteSnapshot((prev) => ({ ...prev, activeThemeId: payload.activeThemeId ?? prev.activeThemeId }));
       toast.success("Theme wurde gelöscht.");

--- a/src/lib/website-settings.ts
+++ b/src/lib/website-settings.ts
@@ -1515,7 +1515,7 @@ export async function deleteWebsiteTheme(id: string) {
   }
 
   await prisma.websiteTheme.delete({ where: { id } });
-  const active = await readWebsiteSettings();
+  const active = await ensureWebsiteSettingsRecord();
   return {
     themes: await listWebsiteThemes(),
     activeThemeId: active.activeThemeId,


### PR DESCRIPTION
### Motivation
- Ensure the UI correctly selects and loads a fallback theme after a theme is deleted and make the server reliably return an active theme id by guaranteeing the website settings record exists.

### Description
- Client change: use `handleThemeSelect(fallbackId)` instead of `loadThemeById(fallbackId)` after deleting a theme to reuse the existing selection logic and side effects (`src/app/(members)/mitglieder/website/theme-settings-manager.tsx`).
- Server change: replace `readWebsiteSettings()` with `ensureWebsiteSettingsRecord()` in `deleteWebsiteTheme` so deletion returns a valid `activeThemeId` and creates default settings if the record is missing (`src/lib/website-settings.ts`).

### Testing
- Ran the automated test suite and project checks with `pnpm test` and build/type checks (`pnpm build` / `pnpm lint`), and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e558b2e8832d9d8d533c343b5777)