### PR TITLE
Fix website theme delete payload activeThemeId mapping

### DIFF
--- a/src/lib/website-settings.ts
+++ b/src/lib/website-settings.ts
@@ -1518,7 +1518,7 @@ export async function deleteWebsiteTheme(id: string) {
   const active = await ensureWebsiteSettingsRecord();
   return {
     themes: await listWebsiteThemes(),
-    activeThemeId: active.activeThemeId,
+    activeThemeId: active.themeId ?? DEFAULT_THEME_ID,
   };
 }
 


### PR DESCRIPTION
### Motivation
- Fix a TypeScript/build error observed during Next.js production build where `deleteWebsiteTheme` returned a non-existent property `active.activeThemeId` causing compilation to fail.

### Description
- Replace the invalid `active.activeThemeId` with `active.themeId ?? DEFAULT_THEME_ID` in `src/lib/website-settings.ts` so the delete response returns the actual theme id with a stable fallback.

### Testing
- Ran `pnpm lint` which currently fails in this environment due to an ESLint circular-config error (not related to this change).
- Ran `pnpm test` which currently fails due to a Prisma client/module mismatch (`Cannot find module '.prisma/client/default'`) in the test environment.
- Ran `pnpm build` which still fails earlier in the pipeline due to Prisma 7 schema validation changes (`datasource.url` no longer supported), but the one-line fix addresses the TypeScript error reported by the Next build logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e9114434832db0ec9b14b133c50c)