### PR TITLE
Fix duplicate PublicPageConfig type declaration

### DIFF
--- a/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
+++ b/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
@@ -12,7 +12,6 @@ import { membersNavigation } from "@/config/members-navigation";
 import { toast } from "sonner";
 import type { ClientWebsiteSettings } from "@/lib/website-settings";
 
-type PublicPageConfig = { key: keyof ClientWebsiteSettings["pageVisibility"]["public"]; label: string };
 type PublicPageConfig = {
   key: keyof ClientWebsiteSettings["pageVisibility"]["public"];
   label: string;


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript build error caused by a duplicated `PublicPageConfig` type declaration that blocked `pnpm build` during CI/production builds.

### Description
- Removed the accidental duplicate `PublicPageConfig` type alias from `src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx`, leaving a single, correct definition.

### Testing
- Ran `pnpm lint`, `pnpm test`, and `pnpm build`; `lint` failed due to an existing ESLint config/runtime error (`TypeError: Converting circular structure to JSON`), `test` failed due to a Prisma client/module mismatch (`Cannot find module '.prisma/client/default'`), and `build` failed due to an unrelated Prisma 7 schema validation issue (`datasource.url` is no longer supported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f5e65d2c832da08329dc8fcd7f08)