### PR TITLE
Fix page visibility save typing in Seitensteuerung manager

### DIFF
--- a/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
+++ b/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
@@ -82,7 +82,13 @@ export function SeitensteuerungManager() {
     toast.success("Wartungsmodus gespeichert");
   };
 
-  const saveVisibility = async (partial: { public?: Record<string, boolean>; members?: Record<string, boolean> }, key: string) => {
+  const saveVisibility = async (
+    partial: {
+      public?: ClientWebsiteSettings["pageVisibility"]["public"];
+      members?: ClientWebsiteSettings["pageVisibility"]["members"];
+    },
+    key: string,
+  ) => {
     setSavingPage(key);
     const nextVisibility = { ...pageVisibility, ...partial };
     const res = await fetch("/api/website/settings", {


### PR DESCRIPTION
### Motivation
- Fix a TypeScript assignability error when calling `setPageVisibility(nextVisibility)` in `src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx` by tightening the `saveVisibility` parameter types.

### Description
- Update `saveVisibility` to accept `partial` with `public?: ClientWebsiteSettings["pageVisibility"]["public"]` and `members?: ClientWebsiteSettings["pageVisibility"]["members"]` so `nextVisibility` stays compatible with `ClientWebsiteSettings["pageVisibility"]`.
- Change is localized to `src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx` and only affects the `saveVisibility` signature and its callers.

### Testing
- Ran `pnpm lint` which failed due to an unrelated ESLint configuration error (`TypeError: Converting circular structure to JSON`).
- Ran `pnpm test` which failed due to a missing Prisma client module (`.prisma/client/default`).
- Ran `pnpm build` which failed due to Prisma CLI/schema validation incompatibility (Prisma v7 datasource config); the original TypeScript assignability error targeted by this change is addressed by the typing update, while remaining failures are unrelated to this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05f785e464832d8782a7d3f280b9a1)