### PR TITLE
Sync members navigation with page visibility and add collapsible sidebar groups

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -5,6 +5,7 @@ import { execSync } from "node:child_process";
 import { MysticBackground } from "@/components/mystic-background";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import { primaryNavigation } from "@/config/navigation";
 import type { AssignmentFocus } from "@/components/members-nav";
 import { MembersPermissionsProvider } from "@/components/members/permissions-context";
 import { MembersAppShell } from "@/components/members/members-app-shell";
@@ -101,6 +102,13 @@ export default async function MembersLayout({ children }: { children: React.Reac
   }
 
   const siteTitle = resolvedSettings.siteTitle;
+  const visibleNavigationItems = primaryNavigation.filter((item) => {
+    if (item.href === "/ueber-uns") return resolvedSettings.pageVisibility.public.about;
+    if (item.href === "/mystery") return resolvedSettings.pageVisibility.public.mystery;
+    if (item.href === "/unsere-schulkatze") return resolvedSettings.pageVisibility.public.schoolCat;
+    if (item.href === "/chronik") return resolvedSettings.pageVisibility.public.timeline;
+    return true;
+  });
 
   let assignmentFocus: AssignmentFocus = "none";
   const userId = session.user?.id;
@@ -136,7 +144,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
   return (
     <div className="app-shell bg-background">
       <MysticBackground />
-      <SiteHeader siteTitle={siteTitle} />
+      <SiteHeader siteTitle={siteTitle} navigationItems={visibleNavigationItems} />
       <main className="relative z-10 flex min-h-0 flex-col pt-[var(--header-height)]">
         <SidebarProvider
           defaultOpen={defaultSidebarOpen}

--- a/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
+++ b/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
@@ -25,7 +25,10 @@ const publicPages: PublicPageConfig[] = [
 ];
 
 export function SeitensteuerungManager() {
-  const memberPages = useMemo(() => membersNavigation.flatMap((group) => group.items.map((item) => item.label)), []);
+  const memberPages = useMemo(
+    () => membersNavigation.flatMap((group) => group.items.map((item) => ({ key: item.href, label: item.label }))),
+    [],
+  );
   const [maintenanceMode, setMaintenanceMode] = useState(false);
   const [savingMaintenance, setSavingMaintenance] = useState(false);
   const [pageVisibility, setPageVisibility] = useState<ClientWebsiteSettings["pageVisibility"]>({
@@ -39,7 +42,7 @@ export function SeitensteuerungManager() {
   const [savingPage, setSavingPage] = useState<string | null>(null);
 
   useEffect(() => {
-    const initialMembers = Object.fromEntries(memberPages.map((name) => [name, true]));
+    const initialMembers = Object.fromEntries(memberPages.map((page) => [page.key, true]));
     setPendingMembers(initialMembers);
   }, [memberPages]);
 
@@ -57,7 +60,9 @@ export function SeitensteuerungManager() {
       setPageVisibility(payload.settings.pageVisibility);
       setPendingPublic(payload.settings.pageVisibility.public);
       const membersFromSettings = payload.settings.pageVisibility.members ?? {};
-      setPendingMembers(Object.fromEntries(memberPages.map((name) => [name, membersFromSettings[name] ?? true])));
+      setPendingMembers(
+        Object.fromEntries(memberPages.map((page) => [page.key, membersFromSettings[page.key] ?? true])),
+      );
     };
     void loadSettings();
     return () => {
@@ -150,19 +155,19 @@ export function SeitensteuerungManager() {
       <Card>
         <CardHeader><CardTitle>Mitglieder-Seiten ({memberPages.length})</CardTitle></CardHeader>
         <CardContent className="space-y-3">
-          {memberPages.map((name) => (
-            <div key={name} className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2">
-              <span>{name}</span>
+          {memberPages.map((page) => (
+            <div key={page.key} className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2">
+              <span>{page.label}</span>
               <Dialog>
                 <DialogTrigger asChild><Button variant="ghost" size="icon"><Settings className="h-4 w-4" /></Button></DialogTrigger>
                 <DialogContent>
-                  <DialogHeader><DialogTitle>{name} konfigurieren</DialogTitle></DialogHeader>
+                  <DialogHeader><DialogTitle>{page.label} konfigurieren</DialogTitle></DialogHeader>
                   <div className="space-y-4">
                     <div className="flex items-center justify-between">
-                      <Label htmlFor={`member-${name}`}>Seite aktivieren</Label>
-                      <Switch id={`member-${name}`} checked={pendingMembers[name] ?? true} onCheckedChange={(checked) => setPendingMembers((prev) => ({ ...prev, [name]: checked }))} />
+                      <Label htmlFor={`member-${page.key}`}>Seite aktivieren</Label>
+                      <Switch id={`member-${page.key}`} checked={pendingMembers[page.key] ?? true} onCheckedChange={(checked) => setPendingMembers((prev) => ({ ...prev, [page.key]: checked }))} />
                     </div>
-                    <Button disabled={savingPage === name} onClick={() => void saveVisibility({ members: { ...pageVisibility.members, [name]: pendingMembers[name] ?? true } }, name)}>Speichern</Button>
+                    <Button disabled={savingPage === page.key} onClick={() => void saveVisibility({ members: { ...pageVisibility.members, [page.key]: pendingMembers[page.key] ?? true } }, page.key)}>Speichern</Button>
                   </div>
                 </DialogContent>
               </Dialog>

--- a/src/components/members-nav.tsx
+++ b/src/components/members-nav.tsx
@@ -270,6 +270,7 @@ export function MembersNav({
   const pathname = usePathname() ?? "";
   const router = useRouter();
   const [query, setQuery] = useState("");
+  const [visibilityMap, setVisibilityMap] = useState<Record<string, boolean>>({});
   const normalizedQuery = query.trim().toLowerCase();
   const isFiltering = normalizedQuery.length > 0;
   const searchInputId = useId();
@@ -317,6 +318,43 @@ export function MembersNav({
 
     return filterMembersNavigationByQuery(permittedGroups, normalizedQuery);
   }, [permittedFlat, permittedGroups, isFiltering, normalizedQuery]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadVisibility = async () => {
+      const response = await fetch("/api/website/settings", { cache: "no-store" });
+      if (!response.ok) {
+        return;
+      }
+
+      const payload = (await response.json()) as {
+        settings?: { pageVisibility?: { members?: Record<string, boolean> } };
+      };
+      if (!mounted) return;
+      setVisibilityMap(payload.settings?.pageVisibility?.members ?? {});
+    };
+
+    void loadVisibility();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const visibleGroups = useMemo(
+    () =>
+      groups
+        .map((group) => ({
+          ...group,
+          items: group.items.filter((item) => visibilityMap[item.href] ?? true),
+          subgroups: group.subgroups?.map((subgroup) => ({
+            ...subgroup,
+            items: subgroup.items.filter((item) => visibilityMap[item.href] ?? true),
+          })).filter((subgroup) => subgroup.items.length > 0),
+        }))
+        .filter((group) => group.items.length > 0 || (group.subgroups?.length ?? 0) > 0),
+    [groups, visibilityMap],
+  );
 
   const emptyStateMessage = isFiltering
     ? "Keine Bereiche gefunden. Passe die Suche an."
@@ -377,29 +415,33 @@ export function MembersNav({
           currentPath={pathname}
         />
 
-        {groups.length === 0 ? (
+        {visibleGroups.length === 0 ? (
           <div className="mx-[var(--space-xs)] rounded-lg border border-dashed border-sidebar-border/60 bg-sidebar/40 p-[var(--space-xs)] text-sidebar-foreground/70">
             <Text variant="small" className="text-sidebar-foreground/70">
               {emptyStateMessage}
             </Text>
           </div>
         ) : (
-          groups.map((group) => (
+          visibleGroups.map((group) => (
             <SidebarGroup key={group.id}>
-              <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {group.items.map((item) => renderItem(pathname, isCollapsed, item))}
-                  {group.subgroups?.map((subgroup) => (
-                    <details key={subgroup.id} open className="space-y-1">
-                      <summary className="cursor-pointer list-none rounded-md px-2 py-1 text-xs font-medium text-sidebar-foreground/75">
-                        {subgroup.label}
-                      </summary>
-                      {subgroup.items.map((item) => renderItem(pathname, isCollapsed, item))}
-                    </details>
-                  ))}
-                </SidebarMenu>
-              </SidebarGroupContent>
+              <details open>
+                <summary className="list-none">
+                  <SidebarGroupLabel className="cursor-pointer">{group.label}</SidebarGroupLabel>
+                </summary>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {group.items.map((item) => renderItem(pathname, isCollapsed, item))}
+                    {group.subgroups?.map((subgroup) => (
+                      <details key={subgroup.id} open className="space-y-1">
+                        <summary className="cursor-pointer list-none rounded-md px-2 py-1 text-xs font-medium text-sidebar-foreground/75">
+                          {subgroup.label}
+                        </summary>
+                        {subgroup.items.map((item) => renderItem(pathname, isCollapsed, item))}
+                      </details>
+                    ))}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </details>
             </SidebarGroup>
           ))
         )}


### PR DESCRIPTION
### Motivation
- Ensure that disabling public pages also removes them from the members-area top navigation and that disabling member pages truly hides their links in the members sidebar, and make sidebar categories collapsible for better overview.

### Description
- Filter the members-area header navigation by the existing `pageVisibility.public` settings and pass filtered `navigationItems` to `SiteHeader` so disabled public pages are hidden in the members area (`src/app/(members)/layout.tsx`).
- Change the page-control keys in the Seitensteuerung manager to use route `href` keys instead of labels and persist/load member visibility by `href`, making visibility toggles stable (`src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx`).
- Load `pageVisibility.members` in `MembersNav` and filter out disabled entries from groups and subgroups so disabled member pages no longer appear as links (`src/components/members-nav.tsx`).
- Wrap top-level member groups with native `<details>/<summary>` to allow collapsing/expanding main categories for a more compact sidebar (`src/components/members-nav.tsx`).

### Testing
- Ran `pnpm lint` which completed successfully but reports two pre-existing warnings about unused `Input` imports (no new lint errors are introduced). 
- Ran `pnpm test` and all tests passed (`123 tests` across `35 files` reported by Vitest). 
- Ran `pnpm build` and the Next.js production build completed successfully with the usual compile warnings already present in CI output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fc69e8e4832d859dab0834f5d1e1)