### PR TITLE
Add expandable member page groups with category-level toggles and partial state

### DIFF
--- a/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
+++ b/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Settings } from "lucide-react";
+import { ChevronDown, Settings } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
@@ -25,10 +25,16 @@ const publicPages: PublicPageConfig[] = [
 ];
 
 export function SeitensteuerungManager() {
-  const memberPages = useMemo(
-    () => membersNavigation.flatMap((group) => group.items.map((item) => ({ key: item.href, label: item.label }))),
+  const memberPageGroups = useMemo(
+    () =>
+      membersNavigation.map((group) => ({
+        id: group.id,
+        label: group.label,
+        pages: group.items.map((item) => ({ key: item.href, label: item.label })),
+      })),
     [],
   );
+  const memberPages = useMemo(() => memberPageGroups.flatMap((group) => group.pages), [memberPageGroups]);
   const [maintenanceMode, setMaintenanceMode] = useState(false);
   const [savingMaintenance, setSavingMaintenance] = useState(false);
   const [pageVisibility, setPageVisibility] = useState<ClientWebsiteSettings["pageVisibility"]>({
@@ -40,11 +46,15 @@ export function SeitensteuerungManager() {
   const [pendingPublic, setPendingPublic] = useState(pageVisibility.public);
   const [pendingMembers, setPendingMembers] = useState<Record<string, boolean>>({});
   const [savingPage, setSavingPage] = useState<string | null>(null);
+  const [expandedCategories, setExpandedCategories] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     const initialMembers = Object.fromEntries(memberPages.map((page) => [page.key, true]));
     setPendingMembers(initialMembers);
   }, [memberPages]);
+  useEffect(() => {
+    setExpandedCategories(Object.fromEntries(memberPageGroups.map((group) => [group.id, false])));
+  }, [memberPageGroups]);
 
   useEffect(() => {
     let mounted = true;
@@ -110,6 +120,30 @@ export function SeitensteuerungManager() {
     toast.success("Seitenstatus gespeichert");
   };
 
+  const setCategoryExpanded = (categoryId: string) => {
+    setExpandedCategories((prev) => ({ ...prev, [categoryId]: !prev[categoryId] }));
+  };
+
+  const getCategoryStatus = (categoryPageKeys: string[]) => {
+    const enabledCount = categoryPageKeys.filter((pageKey) => (pendingMembers[pageKey] ?? true) === true).length;
+    if (enabledCount === 0) return "disabled";
+    if (enabledCount === categoryPageKeys.length) return "enabled";
+    return "partial";
+  };
+
+  const toggleCategory = async (categoryPageKeys: string[], next: boolean, categoryId: string) => {
+    const nextMembers = {
+      ...pageVisibility.members,
+      ...Object.fromEntries(categoryPageKeys.map((pageKey) => [pageKey, next])),
+    };
+
+    setPendingMembers((prev) => ({
+      ...prev,
+      ...Object.fromEntries(categoryPageKeys.map((pageKey) => [pageKey, next])),
+    }));
+    await saveVisibility({ members: nextMembers }, categoryId);
+  };
+
   return (
     <div className="space-y-6">
       <h1 className="text-3xl font-semibold tracking-tight">Seitensteuerung</h1>
@@ -155,24 +189,61 @@ export function SeitensteuerungManager() {
       <Card>
         <CardHeader><CardTitle>Mitglieder-Seiten ({memberPages.length})</CardTitle></CardHeader>
         <CardContent className="space-y-3">
-          {memberPages.map((page) => (
-            <div key={page.key} className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2">
-              <span>{page.label}</span>
-              <Dialog>
-                <DialogTrigger asChild><Button variant="ghost" size="icon"><Settings className="h-4 w-4" /></Button></DialogTrigger>
-                <DialogContent>
-                  <DialogHeader><DialogTitle>{page.label} konfigurieren</DialogTitle></DialogHeader>
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <Label htmlFor={`member-${page.key}`}>Seite aktivieren</Label>
-                      <Switch id={`member-${page.key}`} checked={pendingMembers[page.key] ?? true} onCheckedChange={(checked) => setPendingMembers((prev) => ({ ...prev, [page.key]: checked }))} />
-                    </div>
-                    <Button disabled={savingPage === page.key} onClick={() => void saveVisibility({ members: { ...pageVisibility.members, [page.key]: pendingMembers[page.key] ?? true } }, page.key)}>Speichern</Button>
+          {memberPageGroups.map((group) => {
+            const categoryPageKeys = group.pages.map((page) => page.key);
+            const categoryStatus = getCategoryStatus(categoryPageKeys);
+            const expanded = expandedCategories[group.id] ?? false;
+
+            return (
+              <div key={group.id} className="space-y-2">
+                <div className="flex items-center gap-3 px-1 py-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-auto flex-1 justify-start p-0 text-left"
+                    onClick={() => setCategoryExpanded(group.id)}
+                  >
+                    <ChevronDown
+                      className={`mr-2 h-4 w-4 shrink-0 transition-transform ${expanded ? "rotate-0" : "-rotate-90"}`}
+                    />
+                    <span className="text-lg font-semibold">{group.label}</span>
+                  </Button>
+                  <div className="relative">
+                    <Switch
+                      checked={categoryStatus === "enabled"}
+                      onCheckedChange={(checked) => void toggleCategory(categoryPageKeys, checked, group.id)}
+                      aria-label={`${group.label} aktivieren`}
+                    />
+                    {categoryStatus === "partial" ? (
+                      <span className="pointer-events-none absolute left-1/2 top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-background shadow-sm" />
+                    ) : null}
                   </div>
-                </DialogContent>
-              </Dialog>
-            </div>
-          ))}
+                </div>
+                {expanded && (
+                  <div className="space-y-2 pl-2">
+                    {group.pages.map((page) => (
+                      <div key={page.key} className="flex items-center justify-between rounded-md border border-border bg-muted px-3 py-2">
+                        <span>{page.label}</span>
+                        <Dialog>
+                          <DialogTrigger asChild><Button variant="ghost" size="icon"><Settings className="h-4 w-4" /></Button></DialogTrigger>
+                          <DialogContent>
+                            <DialogHeader><DialogTitle>{page.label} konfigurieren</DialogTitle></DialogHeader>
+                            <div className="space-y-4">
+                              <div className="flex items-center justify-between">
+                                <Label htmlFor={`member-${page.key}`}>Seite aktivieren</Label>
+                                <Switch id={`member-${page.key}`} checked={pendingMembers[page.key] ?? true} onCheckedChange={(checked) => setPendingMembers((prev) => ({ ...prev, [page.key]: checked }))} />
+                              </div>
+                              <Button disabled={savingPage === page.key} onClick={() => void saveVisibility({ members: { ...pageVisibility.members, [page.key]: pendingMembers[page.key] ?? true } }, page.key)}>Speichern</Button>
+                            </div>
+                          </DialogContent>
+                        </Dialog>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
### Motivation
- Improve manageability of member pages by grouping navigation items into collapsible categories and allow toggling whole categories at once.

### Description
- Replace flat `memberPages` with `memberPageGroups` and compute `memberPages` from groups to support grouping and collapse state.
- Add `expandedCategories` state with `setCategoryExpanded` and initialize it from `memberPageGroups` to control per-category expansion.
- Implement `getCategoryStatus` to compute `enabled`/`disabled`/`partial` states for category switches and `toggleCategory` to set visibility for all pages in a category and persist via `saveVisibility`.
- Update UI: import `ChevronDown`, render category header with collapsible button, a category-level `Switch` showing a partial indicator, and move individual page dialogs into an expandable section with adjusted styling.

### Testing
- Ran TypeScript check with `tsc --noEmit`, which completed without errors.
- Executed the project test suite with `pnpm test`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0600c3258c832da606164a8da6d8d4)