### PR TITLE
Seitensteuerung: Self‑Lockout verhindern und graue Kacheln entfernen

### DIFF
--- a/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
+++ b/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
@@ -30,10 +30,12 @@ export function SeitensteuerungManager() {
       membersNavigation.map((group) => ({
         id: group.id,
         label: group.label,
-        pages: group.items.map((item) => ({ key: item.href, label: item.label })),
+        pages: group.items
+          .filter((item) => item.href !== "/mitglieder/pages/seitensteuerung")
+          .map((item) => ({ key: item.href, label: item.label })),
       })),
     [],
-  );
+  ).filter((group) => group.pages.length > 0);
   const memberPages = useMemo(() => memberPageGroups.flatMap((group) => group.pages), [memberPageGroups]);
   const [maintenanceMode, setMaintenanceMode] = useState(false);
   const [savingMaintenance, setSavingMaintenance] = useState(false);
@@ -222,7 +224,7 @@ export function SeitensteuerungManager() {
                 {expanded && (
                   <div className="space-y-2 pl-2">
                     {group.pages.map((page) => (
-                      <div key={page.key} className="flex items-center justify-between rounded-md border border-border bg-muted px-3 py-2">
+                      <div key={page.key} className="flex items-center justify-between px-3 py-2">
                         <span>{page.label}</span>
                         <Dialog>
                           <DialogTrigger asChild><Button variant="ghost" size="icon"><Settings className="h-4 w-4" /></Button></DialogTrigger>


### PR DESCRIPTION
### Motivation
- Verhindern, dass Admins sich selbst aussperren, indem die Verwaltungsseite ` /mitglieder/pages/seitensteuerung` abschaltbar ist. 
- Die Darstellung aufgeklappter Kategorien soll ohne störende graue Kacheln dargestellt werden. 
- Leere Kategorien nach dem Entfernen der Verwaltungsseite sollen nicht mehr angezeigt werden.

### Description
- Beim Erstellen von `memberPageGroups` wird der Eintrag with `href === "/mitglieder/pages/seitensteuerung"` herausgefiltert, so dass die Seitensteuerung nicht mehr ausschaltbar ist (`src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx`).
- Nach dem Filtern werden leere Gruppen entfernt (`.filter((group) => group.pages.length > 0)`), damit keine leeren Kategorien angezeigt werden.
- Die CSS-Klassen `rounded-md border border-border bg-muted` wurden von den Zeilen in ausgeklappten Kategorien entfernt, so dass die einzelnen Seitenzeilen nun als einfache Zeilen ohne graue Box gerendert werden.

### Testing
- `pnpm lint` wurde ausgeführt und schlägt fehl aufgrund eines ESLint-Konfigurationsfehlers (`Converting circular structure to JSON`) in der Umgebung, daher nicht grün.
- `pnpm test` wurde ausgeführt und schlägt fehl wegen fehlender Prisma-Client-Module (`.prisma/client/default`), daher nicht grün.
- `pnpm build` wurde ausgeführt und schlägt fehl bei `prisma generate` wegen Prisma-7-`datasource`-Konfigurationsvalidierung (`url` nicht mehr im Schema), daher nicht grün.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06089150cc832d94048d00a5695f70)