### PR TITLE
Fix Seitensteuerung: stabilisiere category state (useMemo)

### DIFF
--- a/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
+++ b/src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx
@@ -27,15 +27,17 @@ const publicPages: PublicPageConfig[] = [
 export function SeitensteuerungManager() {
   const memberPageGroups = useMemo(
     () =>
-      membersNavigation.map((group) => ({
-        id: group.id,
-        label: group.label,
-        pages: group.items
-          .filter((item) => item.href !== "/mitglieder/pages/seitensteuerung")
-          .map((item) => ({ key: item.href, label: item.label })),
-      })),
+      membersNavigation
+        .map((group) => ({
+          id: group.id,
+          label: group.label,
+          pages: group.items
+            .filter((item) => item.href !== "/mitglieder/pages/seitensteuerung")
+            .map((item) => ({ key: item.href, label: item.label })),
+        }))
+        .filter((group) => group.pages.length > 0),
     [],
-  ).filter((group) => group.pages.length > 0);
+  );
   const memberPages = useMemo(() => memberPageGroups.flatMap((group) => group.pages), [memberPageGroups]);
   const [maintenanceMode, setMaintenanceMode] = useState(false);
   const [savingMaintenance, setSavingMaintenance] = useState(false);


### PR DESCRIPTION
### Motivation
- `memberPageGroups` hatte keine stabile Referenz über Renders, wodurch Effekte neu getriggert wurden und Kategorien/Schalter in der Seitensteuerung sofort zurückgesetzt wurden.

### Description
- Memoisiere `memberPageGroups` vollständig in einem einzelnen `useMemo` (inkl. `filter`) in `src/app/(members)/mitglieder/pages/seitensteuerung/seitensteuerung-manager.tsx`, wodurch die Array-Referenz zwischen Renders stabil bleibt und die Ein-/Ausklapp- sowie Toggle-Zustände nicht mehr verloren gehen.

### Testing
- `pnpm lint` wurde ausgeführt und schlägt in dieser Umgebung fehl wegen eines ESLint-Fehlers beim Serialisieren der Konfiguration, `pnpm test` schlägt fehl, weil der Prisma-Client (`.prisma/client/default`) in dieser Umgebung fehlt, und `pnpm build` schlägt fehl während `prisma generate` aufgrund einer Prisma-7-Datasource-Config-Inkompatibilität; alle drei Fehler sind umgebungsbedingt und nicht durch die UI-Änderung verursacht.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062f81de0083279ab01f7d13a8dfd2)