### PR TITLE
Remove Dieter memorial section from unsere-schulkatze page

### DIFF
--- a/src/app/(site)/unsere-schulkatze/page.tsx
+++ b/src/app/(site)/unsere-schulkatze/page.tsx
@@ -302,21 +302,6 @@ export default async function SchoolCatPage() {
 
       <SchoolCatEncountersSection />
 
-      <section className="layout-container pb-24">
-        <div className="mx-auto max-w-3xl space-y-4 text-center">
-          <Heading level="h2" align="center">
-            In Erinnerung an Dieter
-          </Heading>
-          <Text variant="bodyLg" tone="muted" align="center">
-            Dieter hat Generationen von Schülern begleitet und unserer Schule ein unverwechselbares Gefühl von Heimat gegeben.
-            Seine Geschichte erinnert uns daran, wie wertvoll Fürsorge und Gemeinschaft sind.
-          </Text>
-          <Text tone="muted" align="center">
-            Wer Erinnerungen teilen oder die Arbeit der Pflege-AG weiterführen möchte, erreicht uns unter{' '}
-            <TextLink href="mailto:schulkatze@sommertheater-altrossthal.de">schulkatze@sommertheater-altrossthal.de</TextLink>.
-          </Text>
-        </div>
-      </section>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Auf Anforderung wurde der abschließende Erinnerungsabschnitt auf der Seite „Unsere Schulkatze“ entfernt, inklusive des Textes und der Kontakt-Mailadresse.

### Description
- Die komplette `section` mit der Überschrift „In Erinnerung an Dieter“ (Heading, die beiden `Text`-Blöcke und der `TextLink`-mailto) wurde aus `src/app/(site)/unsere-schulkatze/page.tsx` gelöscht, sodass die Seite nun nach `SchoolCatEncountersSection` endet.

### Testing
- Es wurde `pnpm lint` ausgeführt und der Lauf schlug fehl aufgrund eines vorhandenen ESLint-Konfigurationsproblems (`Converting circular structure to JSON`), das nicht durch diese Codeänderung verursacht wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0633b148ec8327befe9998b74f8969)