### PR TITLE
Fix footer links for disabled public pages

### DIFF
--- a/src/app/(members)/layout.tsx
+++ b/src/app/(members)/layout.tsx
@@ -166,6 +166,7 @@ export default async function MembersLayout({ children }: { children: React.Reac
                   isAuthenticated={true}
                   isDevBuild={isDevBuild}
                   siteTitle={siteTitle}
+                  primaryNavigationItems={visibleNavigationItems}
                 />
               }
             >

--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -126,6 +126,7 @@ export default async function SiteLayout({ children }: { children: React.ReactNo
           isDevBuild={isDevBuild}
           siteTitle={siteTitle}
           isAuthenticated={Boolean(session?.user)}
+          primaryNavigationItems={visibleNavigationItems}
         />
       ) : null}
     </div>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import { BuildInfoTimestamp } from "@/components/build-info-timestamp";
-import { primaryNavigation, secondaryNavigation } from "@/config/navigation";
+import { primaryNavigation, secondaryNavigation, type NavigationItem } from "@/config/navigation";
 
 type CommitInfo = {
   short: string;
@@ -19,9 +19,16 @@ type SiteFooterProps = {
   isDevBuild: boolean;
   siteTitle: string;
   isAuthenticated: boolean;
+  primaryNavigationItems?: NavigationItem[];
 };
 
-export function SiteFooter({ buildInfo, isDevBuild, siteTitle, isAuthenticated }: SiteFooterProps) {
+export function SiteFooter({
+  buildInfo,
+  isDevBuild,
+  siteTitle,
+  isAuthenticated,
+  primaryNavigationItems = primaryNavigation,
+}: SiteFooterProps) {
   return (
     <footer className="relative z-20 border-t border-border/60 bg-background/80 backdrop-blur">
       <div className="layout-container py-12 sm:py-16">
@@ -79,7 +86,7 @@ export function SiteFooter({ buildInfo, isDevBuild, siteTitle, isAuthenticated }
                 Programm
               </h2>
               <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
-                {primaryNavigation.map((item) => (
+                {primaryNavigationItems.map((item) => (
                   <li key={item.href}>
                     <Link className="transition-colors hover:text-primary" href={item.href}>
                       {item.label}


### PR DESCRIPTION
### Motivation
- The footer always rendered the full primary navigation which could expose links to public pages even when those pages are disabled in the site settings, causing an inconsistent UX compared to the header.

### Description
- Added an optional `primaryNavigationItems?: NavigationItem[]` prop to `SiteFooter` and defaulted it to `primaryNavigation` to preserve backwards compatibility (`src/components/site-footer.tsx`).
- Updated `SiteFooter` to render `primaryNavigationItems` instead of the static `primaryNavigation` list (`src/components/site-footer.tsx`).
- Wired the already-filtered `visibleNavigationItems` into the footer from both site and members layouts so header and footer share the same visibility rules (`src/app/(site)/layout.tsx`, `src/app/(members)/layout.tsx`).

### Testing
- Ran `pnpm lint` which completed successfully with existing pre-existing warnings about unused imports. 
- Ran `pnpm test` and all tests passed. 
- Ran `pnpm build` which completed successfully (warnings identical to lint stage).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a063bd6fd308327b6463ecd9bfbcec6)