### PR TITLE
Impressum: Kontaktangaben klickbar machen und Footer-Kontakt entfernen

### DIFF
--- a/src/app/(site)/impressum/page.tsx
+++ b/src/app/(site)/impressum/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { Heading, Text } from "@/components/ui/typography";
 
@@ -38,8 +39,26 @@ export default function ImpressumPage() {
         <Heading level="h2" className="text-xl" weight="bold">
           BSZ für Agrarwirtschaft und Ernährung Dresden
         </Heading>
-        <Text>Canalettostraße 8</Text>
-        <Text>01307 Dresden</Text>
+        <Text>
+          <a
+            className="underline underline-offset-4 transition-colors hover:text-primary"
+            href="https://maps.google.com/?q=Canalettostra%C3%9Fe+8,+01307+Dresden"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Canalettostraße 8
+          </a>
+        </Text>
+        <Text>
+          <a
+            className="underline underline-offset-4 transition-colors hover:text-primary"
+            href="https://maps.google.com/?q=Canalettostra%C3%9Fe+8,+01307+Dresden"
+            target="_blank"
+            rel="noreferrer"
+          >
+            01307 Dresden
+          </a>
+        </Text>
       </div>
 
       <div className="space-y-2">
@@ -53,9 +72,24 @@ export default function ImpressumPage() {
         <Heading level="h3" className="text-xl" weight="bold">
           Kontakt
         </Heading>
-        <Text>E-Mail: info@bsz-ae-dd.de</Text>
-        <Text>Tel.: 0351 / 435094 0</Text>
-        <Text>Fax: 0351 / 435094 20</Text>
+        <Text>
+          E-Mail:{" "}
+          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="mailto:info@bsz-ae-dd.de">
+            info@bsz-ae-dd.de
+          </Link>
+        </Text>
+        <Text>
+          Tel.:{" "}
+          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="tel:+493514350940">
+            0351 / 435094 0
+          </Link>
+        </Text>
+        <Text>
+          Fax:{" "}
+          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="fax:+4935143509420">
+            0351 / 435094 20
+          </Link>
+        </Text>
       </div>
     </div>
   );

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -121,9 +121,6 @@ export function SiteFooter({
             <Link className="transition-colors hover:text-primary" href="/impressum">
               Impressum
             </Link>
-            <a className="transition-colors hover:text-primary" href="mailto:hallo@sommertheater.de">
-              Kontakt
-            </a>
           </div>
           {isAuthenticated ? (
             <p className="text-xs text-muted-foreground/80 sm:text-sm">


### PR DESCRIPTION
### Motivation
- Bessere Nutzerführung und Barrierefreiheit, indem der doppelte „Kontakt“-Link im Footer entfernt wird und Impressums-Angaben (Adresse, E‑Mail, Telefon, Fax) als interaktive Links verfügbar gemacht werden (`mailto:`, `tel:`, `fax:` und Google Maps für die Adresse). 

### Description
- Entfernt den Footer-`Kontakt`-Anchor in `src/components/site-footer.tsx` und aktualisiert `src/app/(site)/impressum/page.tsx`, sodass die Adresszeilen Google-Maps-Links verwenden und E‑Mail/Telefon/Fax per `mailto:`, `tel:+...` bzw. `fax:+...` klickbar sind, dabei wurden bestehende Utility-Klassen für das Styling beibehalten. 

### Testing
- Automatisierte Checks ausgeführt: `pnpm lint` schlug fehl wegen eines bestehenden ESLint-Config-/Runtime-Fehlers (`Converting circular structure to JSON`), `pnpm test` schlug fehl wegen fehlendem generiertem Prisma-Client (`.prisma/client/default`) und `pnpm build` schlug fehl bei `prisma generate` aufgrund der Prisma‑7‑Schema-Validierung (`datasource.url` nicht mehr unterstützt); diese Fehler sind konfigurations- bzw. Umgebungsspezifisch und stehen nicht im Zusammenhang mit den Link-/UI-Änderungen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ebd32b9c832798223a4a59cd050e)