### PR TITLE
Use NEXT_PUBLIC_BASE_URL for sitemap generation

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const base = (process.env.NEXTAUTH_URL || "http://localhost:3000").replace(/\/$/, "");
+  const base = (process.env.NEXT_PUBLIC_BASE_URL ?? "https://sommertheater-altrossthal.de").replace(/\/$/, "");
   const now = new Date();
   return [
     { url: `${base}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
@@ -12,4 +12,3 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${base}/login`, lastModified: now, changeFrequency: "monthly", priority: 0.3 },
   ];
 }
-


### PR DESCRIPTION
### Motivation
- Make the sitemap base URL configurable by using `process.env.NEXT_PUBLIC_BASE_URL` with a sensible default so deployments can control the canonical site URL.

### Description
- Updated `src/app/sitemap.ts` to set `base` to `process.env.NEXT_PUBLIC_BASE_URL ?? 'https://sommertheater-altrossthal.de'` and preserved all existing sitemap entries and behavior.

### Testing
- No automated tests were run for this single-line configuration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ec01a2f88327863924e022a2d02f)