### PR TITLE
Set robots sitemap to production domain

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,14 +1,13 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const base = process.env.NEXTAUTH_URL || "http://localhost:3000";
   return {
     rules: {
       userAgent: "*",
       allow: "/",
       disallow: ["/mitglieder"],
     },
-    sitemap: `${base.replace(/\/$/, "")}/sitemap.xml`,
+    sitemap: "https://sommertheater-altrossthal.de/sitemap.xml",
   };
 }
 


### PR DESCRIPTION
### Motivation
- Die robots-Konfiguration soll eine feste Produktions-`sitemap` verwenden und gleichzeitig den Mitgliederbereich weiterhin für Suchmaschinen sperren (`disallow: ['/mitglieder']`).

### Description
- Einzeilige Änderung in `src/app/robots.ts`: die dynamische `base`-Ermittlung wurde entfernt und `sitemap` auf `"https://sommertheater-altrossthal.de/sitemap.xml"` gesetzt, wobei die bestehende `disallow: ['/mitglieder']`-Regel unverändert blieb.

### Testing
- Automatisierte Checks ausgeführt: `pnpm lint`, `pnpm test` und `pnpm build`; alle drei schlugen fehl aufgrund von Umgebungsproblemen außerhalb der Änderung: `pnpm lint` meldet einen zirkulären ESLint-Konfigurationsfehler, `pnpm test` scheitert wegen des fehlenden generierten Prisma-Clients (`.prisma/client/default`) und `pnpm build` bricht wegen einer Prisma-Schema/-Konfigurationsinkompatibilität ab.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06ef50bf608327ab3d441e310275b0)