### PR TITLE
Add Datenschutzerklärung page, link in footer, and adjust Impressum layout/fax link

### DIFF
--- a/src/app/(site)/datenschutz/page.tsx
+++ b/src/app/(site)/datenschutz/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Heading, Text } from "@/components/ui/typography";
+
+export const metadata: Metadata = {
+  title: "Datenschutzerklärung",
+  description: "Datenschutzhinweise des Sommertheaters Altrossthal.",
+  alternates: {
+    canonical: "/datenschutz",
+  },
+};
+
+export default function DatenschutzPage() {
+  return (
+    <div className="layout-container space-y-6 py-12">
+      <Heading level="h1">Datenschutzerklärung</Heading>
+
+      <div className="space-y-3">
+        <Heading level="h2" className="text-xl" weight="bold">
+          1. Verantwortlicher
+        </Heading>
+        <Text>Freunde und Förderer des BSZ für Agrarwirtschaft und Ernährung e.V.</Text>
+        <Text>Altroßthal 1, 01169 Dresden</Text>
+      </div>
+
+      <div className="space-y-3">
+        <Heading level="h2" className="text-xl" weight="bold">
+          2. Allgemeine Hinweise zur Datenverarbeitung
+        </Heading>
+        <Text>
+          Wir verarbeiten personenbezogene Daten nur, soweit dies zur Bereitstellung unserer Website
+          sowie zur Bearbeitung von Anfragen erforderlich ist.
+        </Text>
+        <Text>
+          Eine Nutzung zu Werbezwecken findet nicht statt. Auf dieser Website werden keine
+          personalisierten Werbeeinblendungen eingesetzt.
+        </Text>
+      </div>
+
+      <div className="space-y-3">
+        <Heading level="h2" className="text-xl" weight="bold">
+          3. Kontaktaufnahme per E-Mail oder Kontaktformular
+        </Heading>
+        <Text>
+          Wenn Sie uns per E-Mail oder über ein Kontaktformular kontaktieren, verarbeiten wir die von
+          Ihnen übermittelten Angaben (z. B. Name, E-Mail-Adresse, Nachricht), um Ihre Anfrage zu
+          bearbeiten.
+        </Text>
+        <Text>
+          Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO (vorvertragliche bzw. vertragliche
+          Kommunikation) oder Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an der Bearbeitung
+          von Anfragen).
+        </Text>
+      </div>
+
+      <div className="space-y-3">
+        <Heading level="h2" className="text-xl" weight="bold">
+          4. Keine Tracking- und Analyse-Tools
+        </Heading>
+        <Text>
+          Wir setzen keine Tracking- oder Analyse-Tools ein, die Ihr Nutzungsverhalten
+          personenbezogen auswerten.
+        </Text>
+      </div>
+
+      <div className="space-y-3">
+        <Heading level="h2" className="text-xl" weight="bold">
+          5. Speicherdauer
+        </Heading>
+        <Text>
+          Wir speichern personenbezogene Daten nur so lange, wie dies zur Bearbeitung Ihrer Anfrage
+          oder zur Erfüllung gesetzlicher Aufbewahrungspflichten erforderlich ist.
+        </Text>
+      </div>
+
+      <div className="space-y-3">
+        <Heading level="h2" className="text-xl" weight="bold">
+          6. Ihre Rechte
+        </Heading>
+        <Text>
+          Sie haben nach der DSGVO das Recht auf Auskunft, Berichtigung, Löschung, Einschränkung der
+          Verarbeitung, Datenübertragbarkeit sowie Widerspruch gegen die Verarbeitung Ihrer Daten,
+          soweit die gesetzlichen Voraussetzungen vorliegen.
+        </Text>
+        <Text>
+          Außerdem haben Sie das Recht, sich bei einer Datenschutzaufsichtsbehörde zu beschweren.
+        </Text>
+      </div>
+
+      <div className="space-y-3">
+        <Heading level="h2" className="text-xl" weight="bold">
+          7. Kontakt
+        </Heading>
+        <Text>
+          Bei Fragen zum Datenschutz erreichen Sie uns unter{" "}
+          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="mailto:info@bsz-ae-dd.de">
+            info@bsz-ae-dd.de
+          </Link>
+          .
+        </Text>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/impressum/page.tsx
+++ b/src/app/(site)/impressum/page.tsx
@@ -35,7 +35,7 @@ export default function ImpressumPage() {
     <div className="layout-container space-y-6 py-12">
       <Heading level="h1">Impressum</Heading>
 
-      <div className="space-y-2">
+      <div className="mb-8 space-y-2 border-t border-border pt-6">
         <Heading level="h2" className="text-xl" weight="bold">
           Angaben gemäß §5 TMG
         </Heading>
@@ -64,7 +64,7 @@ export default function ImpressumPage() {
         <Text>Registernummer: VR 2281</Text>
       </div>
 
-      <div className="space-y-2">
+      <div className="mb-8 space-y-2 border-t border-border pt-6">
         <Heading level="h3" className="text-xl" weight="bold">
           Vorstand (Vertretungsberechtigte)
         </Heading>
@@ -72,7 +72,7 @@ export default function ImpressumPage() {
         <Text>Anke Habich (2. Vorsitzende)</Text>
       </div>
 
-      <div className="space-y-2">
+      <div className="space-y-2 border-t border-border pt-6">
         <Heading level="h3" className="text-xl" weight="bold">
           Kontakt
         </Heading>
@@ -92,7 +92,7 @@ export default function ImpressumPage() {
         </Text>
         <Text>
           Fax:{" "}
-          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="fax:+4935143509420">
+          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="tel:+4935143509420">
             0351 / 435094 20
           </Link>
         </Text>

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -121,6 +121,9 @@ export function SiteFooter({
             <Link className="transition-colors hover:text-primary" href="/impressum">
               Impressum
             </Link>
+            <Link className="transition-colors hover:text-primary" href="/datenschutz">
+              Datenschutzerklärung
+            </Link>
           </div>
           {isAuthenticated ? (
             <p className="text-xs text-muted-foreground/80 sm:text-sm">


### PR DESCRIPTION
### Motivation
- Provide a dedicated Datenschutzerklärung (privacy policy) page and make it accessible from the site footer while improving the Impressum page layout and fixing contact link correctness.

### Description
- Add `src/app/(site)/datenschutz/page.tsx` which defines page `metadata` and renders the privacy policy using `Heading`, `Text`, and `Link` components.
- Add a footer link to `/datenschutz` in `src/components/site-footer.tsx` so the privacy page is discoverable from every page.
- Update `src/app/(site)/impressum/page.tsx` to add section separators and spacing (`border-t`, `pt-6`, `mb-8`) for better visual grouping.
- Fix the fax contact link in the Impressum by changing the `href` from `fax:` to `tel:` for proper dialing behavior.

### Testing
- Performed a local production build with `next build`, which completed without errors.
- No automated unit or integration tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06f4bc69a0832789b980be3e1fbb6b)