### PR TITLE
Add first-visit cookie consent banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { getSession } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
 import { createSyncToken } from "@/lib/sync/tokens";
+import { CookieBanner } from "@/components/CookieBanner";
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXTAUTH_URL || "http://localhost:3000"),
@@ -134,6 +135,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             Zum Inhalt springen
           </a>
           {children}
+          <CookieBanner />
         </Providers>
       </body>
     </html>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const COOKIE_NAME = "cookie_consent";
+const COOKIE_VALUE = "true";
+const COOKIE_MAX_AGE_DAYS = 132;
+
+function hasConsentCookie() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.cookie
+    .split(";")
+    .map((entry) => entry.trim())
+    .some((entry) => entry === `${COOKIE_NAME}=${COOKIE_VALUE}`);
+}
+
+function setConsentCookie() {
+  const maxAgeSeconds = COOKIE_MAX_AGE_DAYS * 24 * 60 * 60;
+  document.cookie = `${COOKIE_NAME}=${COOKIE_VALUE}; max-age=${maxAgeSeconds}; path=/; samesite=lax`;
+}
+
+export function CookieBanner() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    setIsVisible(!hasConsentCookie());
+  }, []);
+
+  const handleAccept = () => {
+    setConsentCookie();
+    setIsVisible(false);
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-card/95 p-4 backdrop-blur supports-[backdrop-filter]:bg-card/85">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-foreground">
+          Diese Website verwendet technisch notwendige Cookies für den Login-Bereich. Kein Tracking, keine
+          Werbung.
+        </p>
+        <button
+          type="button"
+          onClick={handleAccept}
+          className="inline-flex items-center justify-center rounded-md border border-border bg-muted px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          aria-label="Cookie-Hinweis bestätigen"
+        >
+          Verstanden
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal cookie-consent UI shown on first visit to inform users about necessary cookies for the login area and to avoid repeated prompts after acknowledgment. 
- Ensure the banner visually fits the site's dark theme and uses the existing semantic design-token classes.

### Description
- Added a client component `src/components/CookieBanner.tsx` that renders a fixed bottom banner with the required text and a "Verstanden" button. 
- Implemented consent persistence by setting the cookie `cookie_consent=true` with a `max-age` of 132 days and hiding the banner after the button is clicked. 
- Integrated the component by importing and mounting `<CookieBanner />` in `src/app/layout.tsx` so it is available site-wide and styled with the repository's token classes.

### Testing
- Ran `pnpm lint`, which failed due to an existing ESLint configuration error (circular structure -> JSON conversion). 
- Ran `pnpm test`, which failed in this environment because the Prisma client artifact `.prisma/client/default` is missing. 
- Ran `pnpm build`, which failed due to a repository Prisma v7 schema/configuration incompatibility (`datasource.url` migration issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a070d4a0fac8327aaa901c215983e91)