### PR TITLE
Replace privacy page with full Datenschutzerklärung (Stand: 15. Mai 2026)

### DIFF
--- a/src/app/(site)/datenschutz/page.tsx
+++ b/src/app/(site)/datenschutz/page.tsx
@@ -15,82 +15,221 @@ export default function DatenschutzPage() {
   return (
     <div className="layout-container space-y-6 py-12">
       <Heading level="h1">Datenschutzerklärung</Heading>
+      <Text>Stand: 15. Mai 2026</Text>
 
-      <div className="mb-8 space-y-2 border-t border-border pt-6">
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
         <Heading level="h2" className="text-xl" weight="bold">
           1. Verantwortlicher
         </Heading>
+        <Text>Verantwortlich für die Datenverarbeitung auf dieser Website im Sinne der DSGVO ist:</Text>
         <Text>Freunde und Förderer des Beruflichen Schulzentrums für Agrarwirtschaft und Ernährung e.V.</Text>
         <Text>Altroßthal 1, 01169 Dresden</Text>
-        <Text>
-          E-Mail:{" "}
-          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="mailto:info@bsz-ae-dd.de">
-            info@bsz-ae-dd.de
-          </Link>
-        </Text>
         <Text>Vertreten durch: Dr. Falk Hohmann (1. Vorsitzender), Anke Habich (2. Vorsitzende)</Text>
-      </div>
-
-      <div className="mb-8 space-y-2 border-t border-border pt-6">
-        <Heading level="h2" className="text-xl" weight="bold">
-          2. Hosting
-        </Heading>
-        <Text>Eigener Server in Deutschland.</Text>
-        <Text>Beim Aufruf der Website werden Server-Logs gespeichert (IP-Adresse, Zeitstempel, aufgerufene Seiten).</Text>
-        <Text>Speicherdauer: 7 Tage.</Text>
-        <Text>Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an Sicherheit und Stabilität).</Text>
-      </div>
-
-      <div className="mb-8 space-y-2 border-t border-border pt-6">
-        <Heading level="h2" className="text-xl" weight="bold">
-          3. Nutzerkonto und Login (Magic Link)
-        </Heading>
-        <Text>Zur Nutzung des Mitgliederbereichs wird eine E-Mail-Adresse benötigt.</Text>
-        <Text>Der Login erfolgt per Magic Link (einmaliger Link per E-Mail, kein Passwort).</Text>
-        <Text>Die E-Mail-Adresse wird gespeichert zur Authentifizierung und Verwaltung der Mitgliedschaft.</Text>
-        <Text>Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO.</Text>
-      </div>
-
-      <div className="mb-8 space-y-2 border-t border-border pt-6">
-        <Heading level="h2" className="text-xl" weight="bold">
-          4. Cookies und Session
-        </Heading>
-        <Text>Nach dem Login wird ein Session-Cookie gesetzt, der die Anmeldung aufrechterhält.</Text>
-        <Text>Es werden keine Tracking-Cookies, keine Analyse-Tools und keine Werbecookies verwendet.</Text>
-      </div>
-
-      <div className="mb-8 space-y-2 border-t border-border pt-6">
-        <Heading level="h2" className="text-xl" weight="bold">
-          5. Keine Weitergabe an Dritte
-        </Heading>
-        <Text>Personenbezogene Daten werden nicht an Dritte weitergegeben.</Text>
-        <Text>Kein Einsatz von Google Analytics, Facebook, oder ähnlichen Diensten.</Text>
-      </div>
-
-      <div className="mb-8 space-y-2 border-t border-border pt-6">
-        <Heading level="h2" className="text-xl" weight="bold">
-          6. Betroffenenrechte (Art. 15–21 DSGVO)
-        </Heading>
-        <Text>Auskunft, Berichtigung, Löschung, Einschränkung, Datenübertragbarkeit, Widerspruch.</Text>
         <Text>
-          Kontakt:{" "}
-          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="mailto:info@bsz-ae-dd.de">
-            info@bsz-ae-dd.de
-          </Link>
+          E-Mail: <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="mailto:info@bsz-ae-dd.de">info@bsz-ae-dd.de</Link>
         </Text>
-      </div>
+      </section>
 
-      <div className="space-y-2 border-t border-border pt-6">
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
         <Heading level="h2" className="text-xl" weight="bold">
-          7. Beschwerderecht
+          2. Allgemeines zur Datenverarbeitung
         </Heading>
-        <Text>Bei der Sächsischen Datenschutz- und Transparenzbeauftragten:</Text>
         <Text>
-          <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="https://www.saechsdsb.de" target="_blank" rel="noreferrer">
-            https://www.saechsdsb.de
-          </Link>
+          Wir nehmen den Schutz Ihrer persönlichen Daten sehr ernst. Diese Datenschutzerklärung informiert Sie darüber, welche
+          personenbezogenen Daten wir auf unserer Website sommertheater-altrossthal.de erheben, wie wir diese nutzen und welche Rechte
+          Ihnen zustehen.
         </Text>
-      </div>
+        <Text>
+          Rechtsgrundlagen für die Verarbeitung personenbezogener Daten sind insbesondere Art. 6 DSGVO. Soweit wir für
+          Verarbeitungsvorgänge eine Einwilligung einholen, dient Art. 6 Abs. 1 lit. a DSGVO als Rechtsgrundlage. Sofern die Verarbeitung
+          zur Wahrung berechtigter Interessen erforderlich ist und die Interessen der betroffenen Person nicht überwiegen, ist Art. 6
+          Abs. 1 lit. f DSGVO Rechtsgrundlage.
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          3. Hosting und Server-Logfiles
+        </Heading>
+        <Text>Diese Website wird auf einem selbst betriebenen Virtual Private Server (VPS) gehostet.</Text>
+        <Text>Beim Aufruf unserer Website übermittelt Ihr Browser automatisch Informationen an unseren Server. Diese sogenannten Server-Logfiles enthalten:</Text>
+        <ul className="list-disc space-y-1 pl-6 text-foreground">
+          <li>IP-Adresse des anfragenden Rechners</li>
+          <li>Datum und Uhrzeit des Zugriffs</li>
+          <li>Name und URL der abgerufenen Datei</li>
+          <li>Meldung über erfolgreichen Abruf (HTTP-Statuscode)</li>
+          <li>Übertragene Datenmenge</li>
+          <li>Browsertyp und Browserversion</li>
+          <li>Betriebssystem</li>
+        </ul>
+        <Text>
+          Die Verarbeitung erfolgt auf Basis von Art. 6 Abs. 1 lit. f DSGVO. Unser berechtigtes Interesse liegt in der technischen
+          Bereitstellung und Sicherstellung des Betriebs der Website. Die Logfiles werden nach spätestens 30 Tagen gelöscht, sofern keine
+          sicherheitsrelevante Auswertung erforderlich ist.
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          4. Cloudflare (CDN und DDoS-Schutz)
+        </Heading>
+        <Text>
+          Diese Website nutzt Dienste von Cloudflare Inc., 101 Townsend St., San Francisco, CA 94107, USA, als vorgelagerten Reverse
+          Proxy und zum Schutz vor Angriffen (DDoS-Schutz). Alle Anfragen an unsere Website werden zunächst über die Server von
+          Cloudflare geleitet.
+        </Text>
+        <Text>
+          Dabei können technische Daten wie IP-Adresse, HTTP-Header und Anfragedaten verarbeitet werden. Cloudflare verarbeitet diese
+          Daten gemäß seiner Datenschutzrichtlinie. Eine Übermittlung in die USA erfolgt auf Basis von Standardvertragsklauseln gemäß
+          Art. 46 Abs. 2 lit. c DSGVO.
+        </Text>
+        <Text>
+          Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an Sicherheit und Verfügbarkeit der Website).
+        </Text>
+        <Text>
+          Weitere Informationen: <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noreferrer">https://www.cloudflare.com/privacypolicy/</Link>
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          5. Kontaktaufnahme per E-Mail
+        </Heading>
+        <Text>
+          Wenn Sie uns per E-Mail kontaktieren, werden die von Ihnen übermittelten Daten (E-Mail-Adresse, Name, Inhalt) zum Zweck der
+          Bearbeitung Ihrer Anfrage gespeichert. Diese Daten geben wir nicht ohne Ihre Einwilligung weiter.
+        </Text>
+        <Text>
+          Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an der Bearbeitung von Anfragen) bzw. Art. 6 Abs. 1 lit. b
+          DSGVO, soweit Ihre Anfrage auf den Abschluss eines Vertrags gerichtet ist.
+        </Text>
+        <Text>
+          Die Daten werden gelöscht, sobald Ihre Anfrage abschließend bearbeitet wurde und keine gesetzlichen Aufbewahrungspflichten
+          entgegenstehen.
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          6. Mitgliederbereich und Anmeldung (Magic Link)
+        </Heading>
+        <Text>
+          Unsere Website verfügt über einen passwortgeschützten Mitgliederbereich, der ausschließlich registrierten Mitgliedern zugänglich
+          ist. Für die Anmeldung verwenden wir ein sogenanntes Magic-Link-Verfahren: Sie geben Ihre E-Mail-Adresse ein und erhalten einen
+          Einmal-Link zur Anmeldung.
+        </Text>
+        <Text>Im Zuge der Nutzung des Mitgliederbereichs verarbeiten wir folgende Daten:</Text>
+        <ul className="list-disc space-y-1 pl-6 text-foreground">
+          <li>E-Mail-Adresse (zur Authentifizierung und Kommunikation)</li>
+          <li>Name (soweit angegeben)</li>
+          <li>Vereinsrolle (z. B. Vorstand, Ensemble, Mitglied)</li>
+          <li>Zeitstempel von Anmeldungen (Session-Daten)</li>
+          <li>Hochgeladene oder erstellte Inhalte innerhalb der Plattform</li>
+        </ul>
+        <Text>Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung im Rahmen der Vereinsmitgliedschaft) sowie Art. 6 Abs. 1 lit. f DSGVO.</Text>
+        <Text>
+          Die Daten werden gelöscht oder gesperrt, sobald die Mitgliedschaft endet oder der Zweck der Speicherung entfällt, sofern keine
+          gesetzlichen Aufbewahrungspflichten bestehen.
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          7. Nextcloud (Dateiablage)
+        </Heading>
+        <Text>
+          Für die vereinsinterne Dateiablage und Zusammenarbeit betreiben wir eine eigene Nextcloud-Instanz unter
+          cloud.sommertheater-altrossthal.de. Dabei werden Nutzerdaten (E-Mail-Adresse, hochgeladene Dateien, Aktivitätsprotokolle)
+          ausschließlich auf unserem eigenen Server gespeichert und nicht an Dritte übermittelt.
+        </Text>
+        <Text>Rechtsgrundlage: Art. 6 Abs. 1 lit. b DSGVO (Vereinsmitgliedschaft).</Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          8. Cookies und Session-Daten
+        </Heading>
+        <Text>
+          Unsere Website verwendet technisch notwendige Cookies, um den Betrieb des Mitgliederbereichs zu ermöglichen (Session-Cookie für
+          den Login). Diese Cookies enthalten keine personenbezogenen Daten im eigentlichen Sinne, sondern lediglich eine zufällig
+          generierte Session-ID.
+        </Text>
+        <Text>Wir verwenden keine Tracking-Cookies, keine Werbe-Cookies und kein Cookie-basiertes Analyse-Tracking.</Text>
+        <Text>
+          Rechtsgrundlage: Art. 6 Abs. 1 lit. f DSGVO. Technisch notwendige Cookies erfordern keine Einwilligung gemäß § 25 Abs. 2 TTDSG.
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          9. Keine Drittanbieter-Tracking-Dienste
+        </Heading>
+        <Text>
+          Wir setzen auf dieser Website keine Analyse- oder Tracking-Werkzeuge von Drittanbietern ein (z. B. Google Analytics, Facebook
+          Pixel o. Ä.). Es findet keine Weitergabe Ihrer Daten zu Werbe- oder Analysezwecken an Dritte statt.
+        </Text>
+        <Text>
+          Hinweis: Sollten zu einem späteren Zeitpunkt externe Dienste eingebunden werden (z. B. eingebettete Videos, Kartendienste,
+          externe Schriftarten), wird diese Datenschutzerklärung entsprechend aktualisiert.
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          10. Ihre Rechte als betroffene Person
+        </Heading>
+        <Text>Sie haben gegenüber uns folgende Rechte hinsichtlich Ihrer personenbezogenen Daten:</Text>
+        <ul className="list-disc space-y-1 pl-6 text-foreground">
+          <li>Recht auf Auskunft (Art. 15 DSGVO)</li>
+          <li>Recht auf Berichtigung unrichtiger Daten (Art. 16 DSGVO)</li>
+          <li>Recht auf Löschung (Art. 17 DSGVO)</li>
+          <li>Recht auf Einschränkung der Verarbeitung (Art. 18 DSGVO)</li>
+          <li>Recht auf Datenübertragbarkeit (Art. 20 DSGVO)</li>
+          <li>Widerspruchsrecht gegen die Verarbeitung (Art. 21 DSGVO)</li>
+          <li>Recht auf Widerruf erteilter Einwilligungen (Art. 7 Abs. 3 DSGVO)</li>
+        </ul>
+        <Text>Zur Ausübung Ihrer Rechte wenden Sie sich bitte an die oben genannte Kontaktadresse.</Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          11. Beschwerderecht bei der Aufsichtsbehörde
+        </Heading>
+        <Text>
+          Sie haben das Recht, sich bei einer Datenschutz-Aufsichtsbehörde über die Verarbeitung Ihrer personenbezogenen Daten durch uns
+          zu beschweren. Die zuständige Aufsichtsbehörde richtet sich nach dem Bundesland des Vereinssitzes.
+        </Text>
+        <Text>
+          Hinweis: Sächsischer Datenschutzbeauftragter (SächsDSB)
+          <br />
+          Website: <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="https://www.saechsdsb.de" target="_blank" rel="noreferrer">https://www.saechsdsb.de</Link>
+        </Text>
+        <Text>
+          Eine Übersicht aller deutschen Datenschutz-Aufsichtsbehörden finden Sie unter: <Link className="underline underline-offset-4 transition-colors hover:text-primary" href="https://www.bfdi.bund.de/DE/Infothek/Anschriften_Links/anschriften_links-node.html" target="_blank" rel="noreferrer">https://www.bfdi.bund.de/DE/Infothek/Anschriften_Links/anschriften_links-node.html</Link>
+        </Text>
+      </section>
+
+      <section className="mb-8 space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          12. Datensicherheit
+        </Heading>
+        <Text>
+          Wir treffen technische und organisatorische Maßnahmen, um Ihre Daten gegen Verlust, Zerstörung, Manipulation und unberechtigten
+          Zugriff zu schützen. Alle Verbindungen zu unserer Website werden per TLS/HTTPS verschlüsselt übertragen. Unsere Server sind
+          durch Zugangskontrollen und aktuelle Sicherheitsupdates geschützt.
+        </Text>
+      </section>
+
+      <section className="space-y-2 border-t border-border pt-6">
+        <Heading level="h2" className="text-xl" weight="bold">
+          13. Aktualität und Änderungen dieser Datenschutzerklärung
+        </Heading>
+        <Text>
+          Diese Datenschutzerklärung ist aktuell gültig. Durch die Weiterentwicklung unserer Website oder aufgrund geänderter gesetzlicher
+          Vorgaben kann es notwendig werden, diese Datenschutzerklärung anzupassen. Die jeweils aktuelle Fassung ist jederzeit auf unserer
+          Website unter sommertheater-altrossthal.de/datenschutz abrufbar.
+        </Text>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the previous short privacy placeholder with the full, legally complete Datenschutzerklärung text (effective date `15. Mai 2026`) to provide comprehensive information on processing, rights and third-party services.
- Include precise legal bases and infrastructure details (Cloudflare, Nextcloud, VPS, Magic-Link members area) so the site’s visitors and members have transparent GDPR information.

### Description
- Updated the privacy page at `src/app/(site)/datenschutz/page.tsx` to include the full 13-section Datenschutzerklärung and the line `Stand: 15. Mai 2026` using semantic `<section>` blocks and lists for clarity. 
- Added detailed paragraphs covering general processing, hosting/server-logfiles, Cloudflare, contact-by-email, members area (Magic Link) data, Nextcloud, cookies/session, no third‑party tracking, data subject rights, supervisory authority, data security and update clause. 
- Kept markup consistent with existing UI components by using `Heading` and `Text` from `@/components/ui/typography` and internal link styling for external/internal URLs. 
- No binary assets were added and change is limited to the privacy page component.

### Testing
- Ran `pnpm lint`, which failed due to an existing ESLint configuration error (`TypeError: Converting circular structure to JSON`).
- Ran `pnpm test` (Vitest), which executed but overall failed because the Prisma client is missing (`Cannot find module '.prisma/client/default'`) causing multiple test failures and a mocked-module error during setup.
- Ran `pnpm build`, which failed in the prebuild Prisma step with schema validation error `P1012` complaining that `url` in the datasource is no longer supported with the current Prisma CLI; this prevented successful build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071190024883278a3a0f04f1fb5d7c)