### PR TITLE
Remove caretakers panel and preset encounters on Schulkatze page

### DIFF
--- a/src/app/(site)/unsere-schulkatze/encounters-section.tsx
+++ b/src/app/(site)/unsere-schulkatze/encounters-section.tsx
@@ -31,38 +31,7 @@ type CatEncounter = {
 
 type StoredCatEncounter = Omit<CatEncounter, "source">;
 
-const curatedCatEncounters: CatEncounter[] = [
-  {
-    id: "curated-1",
-    since: "Sommer 2024",
-    nickname: "Dennis Dieter vom Werkhof",
-    story:
-      "Bei der Generalprobe huschte Dennis Dieter zwischen den Kulissen hindurch, kletterte auf die letzte Reihe und beobachtete uns mit großen Augen. Sein zufriedenes Schnurren nahm allen die Nervosität.",
-    author: "Lara aus der Kostümwerkstatt",
-    createdAt: "Juni 2024",
-    source: "curated",
-  },
-  {
-    id: "curated-2",
-    since: "Frühjahr 2024",
-    nickname: "Bibliotheks-Dennis",
-    story:
-      "Im Selbstlernzentrum legte er sich mitten zwischen Karteikästen und erinnerte uns daran, Pausen zu machen. Seitdem gehört ein kurzer Streichler für Dennis Dieter zu jeder Lernrunde.",
-    author: "Herr Schubert, Mathekollegium",
-    createdAt: "März 2024",
-    source: "curated",
-  },
-  {
-    id: "curated-3",
-    since: "Herbst 2024",
-    nickname: "Captain Dennis",
-    story:
-      "Beim Kulissenbau bewachte er mit wachem Blick die Werkzeugkisten. Niemand vergaß dank ihm den Helm – Dennis Dieter passte einfach auf uns auf.",
-    author: "Werkstatt-AG",
-    createdAt: "Oktober 2024",
-    source: "curated",
-  },
-];
+const curatedCatEncounters: CatEncounter[] = [];
 
 function generateEncounterId() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {

--- a/src/app/(site)/unsere-schulkatze/page.tsx
+++ b/src/app/(site)/unsere-schulkatze/page.tsx
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import type { LucideIcon } from "lucide-react";
-import { Cat, Fish, Heart, MoonStar, PawPrint, ShieldCheck, Sun, Users } from "lucide-react";
+import { Cat, Heart, MoonStar, PawPrint, ShieldCheck, Sun } from "lucide-react";
 
 import { Card } from "@/components/ui/card";
 import { TextLink } from "@/components/ui/text-link";
@@ -66,12 +66,6 @@ type CatMemoryItem = {
   detail: string;
 };
 
-type CatCareSupporter = {
-  icon: LucideIcon;
-  title: string;
-  description: string;
-};
-
 const catProfileHighlights: CatProfileHighlight[] = [
   {
     icon: Cat,
@@ -111,27 +105,6 @@ const catMemoryItems: CatMemoryItem[] = [
     title: "Abende im Park",
     detail:
       "Wenn der Tag endete, blieb er oft noch eine Weile, als wolle er sicherstellen, dass alles seinen Platz hat, bevor er in die Nacht verschwand.",
-  },
-];
-
-const catCareSupporters: CatCareSupporter[] = [
-  {
-    icon: Users,
-    title: "Pflege-AG & Schülerschaft",
-    description:
-      "In festen Diensten sorgten engagierte Schüler für Futter, frisches Wasser und liebevolle Aufmerksamkeit.",
-  },
-  {
-    icon: ShieldCheck,
-    title: "Hausmeisterteam & Tierärztin",
-    description:
-      "Sie behielten Gesundheit und Sicherheit im Blick, koordinierten Checks und boten Dieter auch in seinen älteren Jahren Halt.",
-  },
-  {
-    icon: Fish,
-    title: "Patenschaften & Spenden",
-    description:
-      "Klassen und Kollegium legten zusammen, damit Futter, Medikamente und letzte Wege gemeinschaftlich getragen wurden.",
   },
 ];
 
@@ -244,31 +217,6 @@ export default async function SchoolCatPage() {
             </div>
           </Card>
 
-          <Card className="h-full space-y-4">
-            <div className="flex items-center gap-3">
-              <div className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-primary/15 text-primary">
-                <Heart className="h-5 w-5" aria-hidden />
-              </div>
-              <Text weight="semibold" className="text-base sm:text-lg">
-                Wer sich gekümmert hat
-              </Text>
-            </div>
-            <div className="space-y-3">
-              {catCareSupporters.map((entry) => (
-                <div key={entry.title} className="flex gap-3">
-                  <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-primary/10 text-primary">
-                    <entry.icon className="h-5 w-5" aria-hidden />
-                  </div>
-                  <div className="space-y-1">
-                    <Text weight="medium">{entry.title}</Text>
-                    <Text variant="small" tone="muted" className="leading-relaxed">
-                      {entry.description}
-                    </Text>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </Card>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Die Box „Wer sich gekümmert hat“ und die drei fest hinterlegten Begegnungen sollten entfernt werden, damit nur noch nutzerseitig eingereichte Begegnungen angezeigt werden und keine vordefinierten „Bewegungen“ mehr gerendert werden.

### Description
- Entfernt die Care‑Sektion aus der Seite, indem der `CatCareSupporter`-Typ, das `catCareSupporters`-Array und das zugehörige `Card`-Rendering aus `src/app/(site)/unsere-schulkatze/page.tsx` gelöscht wurden.
- Setzt `curatedCatEncounters` in `src/app/(site)/unsere-schulkatze/encounters-section.tsx` auf ein leeres Array, wodurch die drei vordefinierten Begegnungen nicht mehr erscheinen.
- Entfernt nicht mehr benötigte Icon-Imports (`Users`, `Fish`) aus `src/app/(site)/unsere-schulkatze/page.tsx` und belässt die Nutzer-Encounters sowie die Moderationslogik unverändert.

### Testing
- `pnpm lint` wurde ausgeführt und schlägt fehl wegen einer bestehenden ESLint-Konfigurationsproblematik: "Converting circular structure to JSON".
- `pnpm test` wurde ausgeführt und schlägt in dieser Umgebung fehl, weil das Prisma-Client-Modul `.prisma/client/default` fehlt und dadurch mehrere Tests fehlschlagen.
- `pnpm build` wurde ausgeführt und schlägt fehl wegen einer Prisma‑7‑Datasource‑Validierungsfehlermeldung bezüglich `datasource.url` in `prisma/schema.prisma`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071525d2548327980f047902c26985)