### PR TITLE
Remove RealtimeProvider and FrontendEditingProvider from app providers

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,9 +4,7 @@ import { Toaster } from "sonner";
 import * as React from "react";
 import { SessionProvider } from "next-auth/react";
 import type { Session } from "next-auth";
-import { FrontendEditingProvider } from "@/components/frontend-editing/frontend-editing-provider";
 import { useWebVitals } from "@/hooks/useWebVitals";
-import { RealtimeProvider } from "@/hooks/useRealtime";
 import { OfflineSyncStatusProvider } from "@/lib/offline/hooks";
 import { OfflineSyncProvider as OfflineStorageProvider } from "@/lib/offline/storage";
 import { PwaProvider } from "@/lib/pwa/register-sw";
@@ -33,18 +31,14 @@ export function Providers({
         <OfflineStorageProvider>
           <OfflineSyncStatusProvider authToken={syncToken}>
             <PwaProvider>
-              <RealtimeProvider>
-                <FrontendEditingProvider>
-                  {children}
-                  <Toaster
-                    richColors
-                    position="top-right"
-                    expand={true}
-                    visibleToasts={5}
-                    gap={8}
-                  />
-                </FrontendEditingProvider>
-              </RealtimeProvider>
+              {children}
+              <Toaster
+                richColors
+                position="top-right"
+                expand={true}
+                visibleToasts={5}
+                gap={8}
+              />
             </PwaProvider>
           </OfflineSyncStatusProvider>
         </OfflineStorageProvider>


### PR DESCRIPTION
### Motivation
- Simplify the global provider composition by removing the `RealtimeProvider` and `FrontendEditingProvider` wrappers so the app bootstrap does not include these client-side feature providers at the top level.

### Description
- Removed the `RealtimeProvider` and `FrontendEditingProvider` imports and their wrapper usage, and placed the `Toaster` directly under `PwaProvider` in `src/app/providers.tsx`.

### Testing
- Ran `npm run build` (TypeScript compile), `npm test` (unit tests), and `npm run lint`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071ba2f98083279786e4c6262b140d)