### PR TITLE
Wrap app with Realtime and FrontendEditing providers; tighten socket reconnection policy

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,6 +4,8 @@ import { Toaster } from "sonner";
 import * as React from "react";
 import { SessionProvider } from "next-auth/react";
 import type { Session } from "next-auth";
+import { FrontendEditingProvider } from "@/components/frontend-editing/frontend-editing-provider";
+import { RealtimeProvider } from "@/hooks/useRealtime";
 import { useWebVitals } from "@/hooks/useWebVitals";
 import { OfflineSyncStatusProvider } from "@/lib/offline/hooks";
 import { OfflineSyncProvider as OfflineStorageProvider } from "@/lib/offline/storage";
@@ -31,14 +33,18 @@ export function Providers({
         <OfflineStorageProvider>
           <OfflineSyncStatusProvider authToken={syncToken}>
             <PwaProvider>
-              {children}
-              <Toaster
-                richColors
-                position="top-right"
-                expand={true}
-                visibleToasts={5}
-                gap={8}
-              />
+              <RealtimeProvider>
+                <FrontendEditingProvider>
+                  {children}
+                  <Toaster
+                    richColors
+                    position="top-right"
+                    expand={true}
+                    visibleToasts={5}
+                    gap={8}
+                  />
+                </FrontendEditingProvider>
+              </RealtimeProvider>
             </PwaProvider>
           </OfflineSyncStatusProvider>
         </OfflineStorageProvider>

--- a/src/hooks/useRealtime.tsx
+++ b/src/hooks/useRealtime.tsx
@@ -21,8 +21,7 @@ import type {
 } from '@/lib/realtime/types';
 import { useOfflineSyncClient } from '@/lib/offline/hooks';
 
-// Allow essentially unlimited reconnects; avoid noisy hard-fail in production
-const MAX_RECONNECT_ATTEMPTS: number = Number.POSITIVE_INFINITY;
+const MAX_RECONNECT_ATTEMPTS = 10;
 const PING_INTERVAL_MS = 30_000;
 const REALTIME_URL = process.env.NEXT_PUBLIC_REALTIME_URL;
 const REALTIME_PATH = process.env.NEXT_PUBLIC_REALTIME_PATH || '/socket.io';
@@ -252,8 +251,8 @@ export function RealtimeProvider({ children }: { children: ReactNode }) {
           transports: ['websocket', 'polling'],
           forceNew: true,
           reconnection: true,
-          reconnectionDelay: 1000,
-          reconnectionDelayMax: 5000,
+          reconnectionDelay: 2000,
+          reconnectionDelayMax: 30000,
           reconnectionAttempts: MAX_RECONNECT_ATTEMPTS,
           auth: handshake,
         };


### PR DESCRIPTION
### Motivation
- Enable realtime features and frontend editing across the application by exposing providers at the top-level providers tree. 
- Prevent endless noisy socket reconnects in production by imposing a sensible limit on reconnect attempts. 
- Increase reconnection backoff ceiling to reduce rapid retry storms while still allowing recovery.

### Description
- Added `RealtimeProvider` and `FrontendEditingProvider` imports and wrapped the app children (and existing `Toaster`) with those providers inside `src/app/providers.tsx`.
- Changed the socket reconnection policy in `src/hooks/useRealtime.tsx` by setting `MAX_RECONNECT_ATTEMPTS` to `10` and updating `reconnectionDelay` from `1000` to `2000` and `reconnectionDelayMax` from `5000` to `30000`.
- Preserved existing session, offline sync, PWA, and query client provider ordering while introducing realtime and frontend editing contexts.

### Testing
- Ran a TypeScript type check with `tsc --noEmit` which completed successfully. 
- Ran the test suite with `pnpm test` which passed. 
- Performed a production build with `next build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0721fd26588327a6b4ff0adc9e1985)