### PR TITLE
fix(realtime): stabilize RealtimeStatus event handlers with useCallback

### DIFF
--- a/src/components/realtime-status.tsx
+++ b/src/components/realtime-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useAttendanceRealtime, usePresence, useRealtime } from '@/hooks/useRealtime';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -40,39 +40,41 @@ interface RealtimeStatusProps {
 export function RealtimeStatus({ rehearsalId, showPresence = true }: RealtimeStatusProps) {
   const { connectionStatus, isConnected, reconnect } = useRealtime();
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
+  const handleAttendanceEvent = useCallback((event) => {
+    const occurredAt = event.timestamp ? new Date(event.timestamp) : new Date();
+    setLastUpdate(occurredAt);
+
+    const statusLabel = getStatusText(event.status);
+    const actorLabel = formatUserId(event.actorUserId);
+    const targetLabel = event.targetUserId ? ` für ${formatUserId(event.targetUserId)}` : '';
+    const descriptionParts = [
+      event.rehearsalId ? `Probe: ${event.rehearsalId}` : null,
+      event.comment ? `Kommentar: ${event.comment}` : null,
+    ].filter(Boolean) as string[];
+
+    toast.info(
+      `${actorLabel} hat die Anwesenheit${targetLabel} auf „${statusLabel}“ gesetzt`,
+      {
+        description: descriptionParts.length ? descriptionParts.join(' · ') : undefined,
+        duration: 3000,
+      }
+    );
+  }, [rehearsalId]);
+  const handlePresenceEvent = useCallback((event) => {
+    const action = event.action === 'join' ? 'ist online gekommen' : 'ist offline gegangen';
+    toast.info(`${event.user.name} ${action}`);
+  }, []);
   
   // Handle attendance updates if rehearsalId is provided
   useAttendanceRealtime(
     rehearsalId || null,
-    (event) => {
-      const occurredAt = event.timestamp ? new Date(event.timestamp) : new Date();
-      setLastUpdate(occurredAt);
-
-      const statusLabel = getStatusText(event.status);
-      const actorLabel = formatUserId(event.actorUserId);
-      const targetLabel = event.targetUserId ? ` für ${formatUserId(event.targetUserId)}` : '';
-      const descriptionParts = [
-        event.rehearsalId ? `Probe: ${event.rehearsalId}` : null,
-        event.comment ? `Kommentar: ${event.comment}` : null,
-      ].filter(Boolean) as string[];
-
-      toast.info(
-        `${actorLabel} hat die Anwesenheit${targetLabel} auf „${statusLabel}“ gesetzt`,
-        {
-          description: descriptionParts.length ? descriptionParts.join(' · ') : undefined,
-          duration: 3000,
-        }
-      );
-    }
+    handleAttendanceEvent
   );
 
   // Handle user presence if enabled and rehearsalId provided
   const presentUsers = usePresence(
     showPresence && rehearsalId ? rehearsalId : null,
-    (event) => {
-      const action = event.action === 'join' ? 'ist online gekommen' : 'ist offline gegangen';
-      toast.info(`${event.user.name} ${action}`);
-    }
+    handlePresenceEvent
   );
 
   const getConnectionIcon = () => {


### PR DESCRIPTION
### Motivation
- Prevent listener accumulation and potential memory leaks by making the attendance and presence handlers stable references across re-renders.

### Description
- Imported `useCallback` and introduced `handleAttendanceEvent` wrapped in `useCallback(..., [rehearsalId])` in `src/components/realtime-status.tsx` to replace the inline attendance callback.
- Introduced `handlePresenceEvent` wrapped in `useCallback(..., [])` to replace the inline presence callback passed to `usePresence`.
- Passed the stable callbacks to `useAttendanceRealtime` and `usePresence` without changing any runtime logic or behavior.

### Testing
- Ran `pnpm lint`, which failed in this environment due to an ESLint circular-config serialization error.
- Ran `pnpm test`, which failed here because the test environment could not find the generated Prisma client module (`.prisma/client/default`).
- Ran `pnpm build`, which failed during `prisma generate` due to a Prisma 7 schema/config validation error about `datasource.url` in `prisma/schema.prisma`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07292e7e608327af4f37681093f6d5)