### PR TITLE
Fix realtime status callback typing

### DIFF
--- a/src/components/realtime-status.tsx
+++ b/src/components/realtime-status.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState } from 'react';
-import { useAttendanceRealtime, usePresence, useRealtime } from '@/hooks/useRealtime';
+import { type AttendanceUpdateMessage, useAttendanceRealtime, usePresence, useRealtime } from '@/hooks/useRealtime';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { 
@@ -14,6 +14,7 @@ import {
   XCircle 
 } from 'lucide-react';
 import { toast } from 'sonner';
+import type { UserPresenceEvent } from '@/lib/realtime/types';
 
 const STATUS_TEXT: Record<string, string> = {
   yes: 'Zusage',
@@ -40,7 +41,7 @@ interface RealtimeStatusProps {
 export function RealtimeStatus({ rehearsalId, showPresence = true }: RealtimeStatusProps) {
   const { connectionStatus, isConnected, reconnect } = useRealtime();
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
-  const handleAttendanceEvent = useCallback((event) => {
+  const handleAttendanceEvent = useCallback((event: AttendanceUpdateMessage) => {
     const occurredAt = event.timestamp ? new Date(event.timestamp) : new Date();
     setLastUpdate(occurredAt);
 
@@ -59,8 +60,8 @@ export function RealtimeStatus({ rehearsalId, showPresence = true }: RealtimeSta
         duration: 3000,
       }
     );
-  }, [rehearsalId]);
-  const handlePresenceEvent = useCallback((event) => {
+  }, []);
+  const handlePresenceEvent = useCallback((event: UserPresenceEvent) => {
     const action = event.action === 'join' ? 'ist online gekommen' : 'ist offline gegangen';
     toast.info(`${event.user.name} ${action}`);
   }, []);

--- a/src/hooks/useRealtime.tsx
+++ b/src/hooks/useRealtime.tsx
@@ -46,7 +46,7 @@ function normalizeSocketPath(path: string | undefined | null): string {
 }
 
 type SocketInstance = Socket<ServerToClientEvents, ClientToServerEvents>;
-type AttendanceUpdateMessage = Parameters<ServerToClientEvents['attendance_updated']>[0];
+export type AttendanceUpdateMessage = Parameters<ServerToClientEvents['attendance_updated']>[0];
 type NotificationMessage = Parameters<ServerToClientEvents['notification_created']>[0];
 type RehearsalCreatedMessage = Parameters<ServerToClientEvents['rehearsal_created']>[0];
 type RehearsalUpdatedMessage = Parameters<ServerToClientEvents['rehearsal_updated']>[0];


### PR DESCRIPTION
### Motivation
- Behebt TypeScript-Buildfehler in `src/components/realtime-status.tsx`, die durch fehlende/ungueltige Typ-Exporte und implizite `any`-Parameter verursacht wurden. 
- Ziel war ausschließlich, Typ-Annotationen hinzuzufügen und den Importpfad anzupassen, ohne die bestehende Runtime-Logik zu ändern.

### Description
- Importiert `AttendanceUpdateMessage` als Type in `src/components/realtime-status.tsx` und typisiert das Attendance-Callback als `useCallback((event: AttendanceUpdateMessage) => { ... })`.
- Entfernt `rehearsalId` aus dem Dependency-Array des Attendance-`useCallback` und lässt das Array bewusst leer, um das ESLint-Warning zu adressieren.
- Fügt eine explizite Typannotation `UserPresenceEvent` für das Presence-Callback hinzu und importiert diesen Typ aus `@/lib/realtime/types`.
- Exportiert die lokale Typ-Alias-Definition `AttendanceUpdateMessage` in `src/hooks/useRealtime.tsx` als `export type` damit der Import in der Komponente aufgelöst wird.

### Testing
- Führte den kompletten Build-Workflow mit `pnpm build` aus und der Build verlief erfolgreich ohne den vorherigen Type-Error in `realtime-status.tsx`.
- Der Build zeigte weiterhin unveränderte ESLint-Warnungen in anderen Dateien, die nicht Teil dieser Änderung sind, aber keine Fehler verursachten.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a072b12951883279c757b975dde4248)