### PR TITLE
Use local logo for PWA icons and metadata images

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -16,21 +16,21 @@
   "prefer_related_applications": false,
   "icons": [
     {
-      "src": "/favicon.ico",
-      "sizes": "48x48",
-      "type": "image/x-icon",
-      "purpose": "any"
-    },
-    {
-      "src": "/globe.svg",
-      "sizes": "192x192",
-      "type": "image/svg+xml",
-      "purpose": "any"
-    },
-    {
-      "src": "/window.svg",
+      "src": "/Logo-Sommertheater.png",
       "sizes": "512x512",
-      "type": "image/svg+xml",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/Logo-Sommertheater.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/Logo-Sommertheater.png",
+      "sizes": "512x512",
+      "type": "image/png",
       "purpose": "any maskable"
     }
   ]

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,11 @@ export const metadata: Metadata = {
   },
   description: "Mystische Bühne unter freiem Himmel",
   manifest: "/manifest.json",
+  icons: {
+    icon: "/Logo-Sommertheater.png",
+    shortcut: "/Logo-Sommertheater.png",
+    apple: "/Logo-Sommertheater.png",
+  },
   alternates: {
     canonical: "/",
   },
@@ -36,7 +41,7 @@ export const metadata: Metadata = {
     description: "Mystische Bühne unter freiem Himmel",
     images: [
       {
-        url: "https://picsum.photos/id/1069/1200/630",
+        url: "/Logo-Sommertheater.png",
         width: 1200,
         height: 630,
         alt: "Mystischer Schlosspark",
@@ -49,7 +54,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: DEFAULT_SITE_TITLE,
     description: "Mystische Bühne unter freiem Himmel",
-    images: ["https://picsum.photos/id/1069/1200/630"],
+    images: ["/Logo-Sommertheater.png"],
   },
 };
 


### PR DESCRIPTION
### Motivation
- Unify and stabilize the app's branding by using the local logo instead of external images for PWA icons and social metadata.
- Ensure manifest icon entries use a PNG asset compatible with maskable and common platform expectations.

### Description
- Updated `public/manifest.json` to replace multiple icon sources with `/Logo-Sommertheater.png` and adjusted `sizes`, `type`, and `purpose` accordingly.
- Added `icons` entries to the app metadata in `src/app/layout.tsx` pointing `icon`, `shortcut`, and `apple` to `/Logo-Sommertheater.png`.
- Replaced the external Open Graph and Twitter preview image URLs with the local `/Logo-Sommertheater.png` in `src/app/layout.tsx`.

### Testing
- Ran `pnpm lint` to verify formatting and style, which completed successfully.
- Performed a type check and Next.js build via `pnpm build`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076518c0fc8327ac8e648486a01590)