### PR TITLE
Show logo on mobile navbar and update default site title to "Sommertheater Altrossthal"

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import {
   type CSSProperties,
   useEffect,
@@ -212,7 +213,16 @@ export function SiteHeader({ siteTitle, navigationItems = primaryNavigation }: {
             title={siteTitle}
           >
             <span className="hidden md:inline">{siteTitle}</span>
-            <span className="md:hidden">Sommertheater</span>
+            <span className="md:hidden">
+              <Image
+                src="/Logo-Sommertheater.png"
+                alt={siteTitle}
+                width={140}
+                height={40}
+                className="h-10 w-auto"
+                priority
+              />
+            </span>
           </Link>
 
           <div className="hidden items-center gap-[var(--space-md)] md:flex">

--- a/src/lib/website-settings.ts
+++ b/src/lib/website-settings.ts
@@ -6,7 +6,7 @@ import type { Prisma, WebsiteSettings, WebsiteTheme } from "@prisma/client";
 
 export const DEFAULT_THEME_ID = "default-website-theme" as const;
 export const DEFAULT_WEBSITE_SETTINGS_ID = "public" as const;
-export const DEFAULT_SITE_TITLE = "Sommertheater im Schlosspark" as const;
+export const DEFAULT_SITE_TITLE = "Sommertheater Altrossthal" as const;
 export const DEFAULT_COLOR_MODE = "dark" as const;
 export const DEFAULT_MAINTENANCE_MODE = false as const;
 


### PR DESCRIPTION
### Motivation
- Auf Mobilgeräten soll in der Navbar anstelle des Texts das Logo angezeigt werden und der globale Default-Titel für Browser-Tab/OG/Twitter auf „Sommertheater Altrossthal“ angepasst werden.

### Description
- In `src/components/site-header.tsx` `next/image` eingebunden und die mobile Marke (`md:hidden`) durch das Bild `src="/Logo-Sommertheater.png"` ersetzt, während der Desktop-Text (`hidden md:inline`) unverändert bleibt.
- In `src/lib/website-settings.ts` die Konstante `DEFAULT_SITE_TITLE` von `"Sommertheater im Schlosspark"` auf `"Sommertheater Altrossthal"` geändert, sodass Metadata/OG/Twitter-Defaults den neuen Namen verwenden.

### Testing
- `pnpm lint` wurde ausgeführt und schlägt in dieser Umgebung fehl wegen eines bestehenden ESLint-Konfigurationsfehlers (Zirkuläre Struktur), der nicht durch diese Änderungen verursacht wurde.
- `pnpm test` wurde ausgeführt und schlägt fehl, da der Prisma-Client (`.prisma/client/default`) in der Testumgebung fehlt, wodurch mehrere Test-Suites fehlschlagen.
- `pnpm build` wurde ausgeführt und schlägt fehl wegen eines Prisma-7-Datasource-Konfigurationsproblems im Projektsetup, das außerhalb der Scope dieser Änderungen liegt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0783eec7dc8327a376f1ed8c0f85ce)