### PR TITLE
Fix homepage header contrast in light mode

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -187,7 +187,7 @@ export function SiteHeader({ siteTitle, navigationItems = primaryNavigation }: {
         className={`fixed top-0 z-50 w-full transition-all duration-300 ${
           scrolled || !isHomePage
             ? "border-b border-border/50 bg-background/95 backdrop-blur-md shadow-lg"
-            : "bg-gradient-to-b from-black/40 via-black/25 via-black/12 to-transparent backdrop-blur-[1px]"
+            : "bg-gradient-to-b from-background/80 via-background/50 via-background/20 to-transparent backdrop-blur-[1px]"
         }`}
       >
         <div


### PR DESCRIPTION
### Motivation
- Ensure the homepage navbar and logo remain readable in Light Mode by removing the hard-coded black gradient and using semantic design tokens for the transparent (non-scrolled) header state.

### Description
- Replaced the transparent-state gradient in `src/components/site-header.tsx` from `from-black/...` to `from-background/80 via-background/50 via-background/20` so the header uses semantic tokens and works in both Light and Dark themes.

### Testing
- Ran `pnpm lint`, `pnpm test` and `pnpm build`; lint completed with existing unused-import warnings and both tests and build succeeded. 
- Attempted an automated Playwright screenshot in Light mode, but browser installation failed due to Playwright CDN downloads returning `403 Forbidden`, so a visual screenshot could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0788ebb6b8832c9178d8381df1b917)