### PR TITLE
Startseite: FAQ-Formulierungen zu Vorstellungen pluralisieren

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -39,7 +39,7 @@ export default async function PublicHomePage() {
     {
       question: "Was ist das Sommertheater im Schlosspark?",
       answer:
-        "Unser Sommertheater vereint Musik, Schauspiel und eine Prise Geheimnis vor der einzigartigen Kulisse des Schlossparks. Wir gestalten jedes Jahr ein neues Stück, das Publikum aller Altersgruppen begeistert und zum Staunen einlädt.",
+        "Unser Sommertheater vereint Musik, Schauspiel und eine Prise Geheimnis vor der einzigartigen Kulisse des Schlossparks. Wir gestalten jedes Jahr ein neues Stück, das unser Publikum aller Altersgruppen begeistert und zum Staunen einlädt.",
     },
     {
       question: "Wann startet der Ticketverkauf?",
@@ -47,14 +47,14 @@ export default async function PublicHomePage() {
         "Der Ticketverkauf wird über den Instagram-Kanal der Schule bekanntgegeben. Folge uns dort, um nichts zu verpassen.",
     },
     {
-      question: "Wo findet die Aufführung statt?",
+      question: "Wo finden die Aufführungen statt?",
       answer:
-        "Die Vorstellung findet im Schlosspark Altroßthal statt. Adresse: BSZ für Agrarwirtschaft und Ernährung Dresden, Altroßthal 1, 01169 Dresden.",
+        "Die Vorstellungen finden im Schlosspark Altroßthal statt. Adresse: BSZ für Agrarwirtschaft und Ernährung Dresden, Altroßthal 1, 01169 Dresden.",
     },
     {
-      question: "Wie lange dauert die Vorstellung?",
+      question: "Wie lange dauern die Vorstellungen?",
       answer:
-        "Die Vorstellung dauert durchschnittlich 1,5 Stunden und beinhaltet eine Pause.",
+        "Die Vorstellungen dauern durchschnittlich 1,5 Stunden und beinhalten eine Pause.",
     },
     {
       question: "Gibt es eine Altersempfehlung?",


### PR DESCRIPTION
### Motivation
- Korrigiere die Formulierungen auf der Startseiten-FAQ, sodass „Aufführung/Vorstellung" in die Mehrzahl gesetzt wird und im ersten Satz ein „unser" ergänzt wird, um die Ansprache des Publikums klarer zu machen.

### Description
- Änderungen in `src/app/(site)/page.tsx`: ergänzt „unser" im ersten FAQ-Antwortsatz und ersetzt Vorkommen von „Aufführung"/„Vorstellung" durch die Mehrzahl „Aufführungen"/„Vorstellungen" in Frage- und Antworttexten.

### Testing
- Ausgeführte Checks: `pnpm lint`, `pnpm test`, `pnpm prisma:generate`, `pnpm build` und `git diff --check`; `git diff --check` war erfolgreich, `pnpm lint` schlägt fehl wegen einer zirkulären ESLint-Konfigurationsstruktur, `pnpm test` schlägt fehl weil der Prisma-Client nicht generiert ist (Fehler beim Auflösen von `.prisma/client/default`) und mehrere Tests fehlschlagen, `pnpm prisma:generate` schlägt fehl aufgrund der Prisma-CLI-7.8-Validierung gegen die `datasource url` in `prisma/schema.prisma`, und `pnpm build` schlägt infolgedessen im `prebuild`-Schritt fehl.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a081a20d064832c80864a7db5cee4f3)