### PR TITLE
Remove unsupported experimental.browsersListForSwc from next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,9 +22,6 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "www.gravatar.com" },
     ],
   },
-  experimental: {
-    browsersListForSwc: true,
-  },
   // Next.js 15+: serverComponentsExternalPackages moved to serverExternalPackages
   serverExternalPackages: [
     "bcryptjs",


### PR DESCRIPTION
### Motivation
- The Next.js production build was failing with a TypeScript error because `experimental.browsersListForSwc` is not a known property of `NextConfig`, causing `next build` to abort in CI/Docker.

### Description
- Removed the `experimental.browsersListForSwc` entry from `next.config.ts` so the config conforms to the `NextConfig` type. 
- All other configuration (images, `serverExternalPackages`, redirects and webpack aliases) was left unchanged.

### Testing
- `pnpm build` was run locally: the Next.js config type error that previously caused `next build` to fail is resolved, but a full build could not be completed locally due to unrelated dependency/prisma install issues. 
- `pnpm lint` was run and failed with an existing ESLint configuration serialization error unrelated to this change. 
- `pnpm test` was run and failed due to missing/inconsistent local Prisma client generation and dependency installation, which are environmental issues not caused by this config fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0824edff28832c9ecf8ec34172d6c7)