### PR TITLE
Fix hydration-safe countdowns, flyer image sizing and deterministic sidebar skeleton

### DIFF
--- a/src/app/(site)/_components/premiere-countdown-section.tsx
+++ b/src/app/(site)/_components/premiere-countdown-section.tsx
@@ -46,8 +46,7 @@ type SavedSettingsResponse = { settings?: CountdownSettingsState; error?: string
 function parseIso(iso: string | null) { return iso ? new Date(iso).getTime() : Number.NaN; }
 function localInputToIso(value: string) { if (!value) return null; const date = new Date(value); return Number.isNaN(date.getTime()) ? null : date.toISOString(); }
 
-function getNextTermin(termine: TerminInput[]) {
-  const now = Date.now();
+function getNextTermin(termine: TerminInput[], now: number) {
   return termine.find((t) => {
     const iso = localInputToIso(`${t.datum}T${t.uhrzeit}`);
     if (!iso) return false;
@@ -68,12 +67,24 @@ export function PremiereCountdownSection(props: PremiereCountdownSectionProps) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [now, setNow] = useState(() => props.initialNow);
 
   useEffect(() => {
     setSettings({ ...props, countdownTarget: props.effectiveCountdownTarget });
     setFormDisabled(props.disabled);
   }, [props]);
-  const nextTermin = useMemo(() => getNextTermin(settings.termine), [settings.termine]);
+
+  useEffect(() => {
+    setNow(Date.now());
+
+    const interval = window.setInterval(() => {
+      setNow(Date.now());
+    }, 30_000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const nextTermin = useMemo(() => getNextTermin(settings.termine, now), [settings.termine, now]);
   const countdownActive = !settings.disabled;
   const allDone = countdownActive && !nextTermin;
 

--- a/src/app/(site)/mystery/_components/mystery-launch-countdown-card.tsx
+++ b/src/app/(site)/mystery/_components/mystery-launch-countdown-card.tsx
@@ -75,6 +75,7 @@ export function MysteryLaunchCountdownCard({
     hasCustomMessage,
     updatedAt,
   }));
+  const [now, setNow] = useState(() => initialNow);
 
   useEffect(() => {
     setState({
@@ -99,6 +100,16 @@ export function MysteryLaunchCountdownCard({
   const canEdit = hasFeature("mystery.launch-countdown");
   const editorOpen = canEdit && activeFeature === "mystery.launch-countdown";
 
+  useEffect(() => {
+    setNow(Date.now());
+
+    const interval = window.setInterval(() => {
+      setNow(Date.now());
+    }, 30_000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
   const countdownLabel = useMemo(
     () => formatLabel(state.effectiveCountdownTarget),
     [state.effectiveCountdownTarget],
@@ -107,8 +118,8 @@ export function MysteryLaunchCountdownCard({
   const countdownReached = useMemo(() => {
     const target = new Date(state.effectiveCountdownTarget);
     if (Number.isNaN(target.getTime())) return false;
-    return target.getTime() <= Date.now();
-  }, [state.effectiveCountdownTarget]);
+    return target.getTime() <= now;
+  }, [state.effectiveCountdownTarget, now]);
 
   const showCountdown = !isFirstRiddleReleased && !countdownReached;
 

--- a/src/components/site/production-flyer-section.tsx
+++ b/src/components/site/production-flyer-section.tsx
@@ -60,6 +60,7 @@ export function ProductionFlyerSection({ aktiv, titel, beschreibung, hasBild }: 
               alt={titel ?? "Flyer"}
               width={800}
               height={450}
+              sizes="(max-width: 768px) 100vw, 800px"
               className="mx-auto block h-auto w-full max-w-[clamp(280px,80vw,800px)] shadow-[0_4px_24px_rgba(0,0,0,0.35)]"
             />
           ) : null}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -909,9 +909,7 @@ const SidebarMenuSkeleton = React.forwardRef<
     showIcon?: boolean;
   }
 >(({ className, showIcon = false, ...props }, ref) => {
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  const width = "70%";
 
   return (
     <div


### PR DESCRIPTION
### Motivation
- Fix a client/server hydration mismatch (React error #418) caused by components reading `Date.now()`/`Math.random()` during initial render so server HTML differs from the first client render. 
- Ensure the site serves a responsive, smaller flyer image on mobile so Next.js can pick an appropriate variant and save bandwidth. 
- Validate `robots.txt` content for Lighthouse/SEO by ensuring no invalid `Content-Signal` directives are present.

### Description
- Use the server-provided `initialNow` for initial countdown rendering and move live clock updates into `useEffect` so `Date.now()` is only read after hydration in `src/app/(site)/_components/premiere-countdown-section.tsx` and `src/app/(site)/mystery/_components/mystery-launch-countdown-card.tsx`.
- Make the countdown next-event selection depend on a stable `now` state updated in an effect to avoid hydration mismatches (`getNextTermin(..., now)`).
- Replace run-time randomness in the sidebar skeleton width by using a deterministic value (`"70%"`) to avoid differing server/client markup in `src/components/ui/sidebar.tsx`.
- Add a responsive `sizes="(max-width: 768px) 100vw, 800px"` attribute to the production flyer `Image` so Next.js can deliver a smaller image on mobile in `src/components/site/production-flyer-section.tsx`.
- Verified `src/app/robots.ts` does not contain the invalid `Content-Signal` directive and only returns valid rules and a sitemap.
- Files changed: `src/app/(site)/_components/premiere-countdown-section.tsx`, `src/app/(site)/mystery/_components/mystery-launch-countdown-card.tsx`, `src/components/site/production-flyer-section.tsx`, `src/components/ui/sidebar.tsx`.

### Testing
- Ran `git diff --check` with no issues reported.
- Searched for the invalid `Content-Signal`/AI directive using `rg` and found no matches, confirming `robots.ts` is valid.
- Attempted `pnpm lint` but it could not complete in this environment due to local dependency/tooling inconsistencies (ESLint config/version resolution failure), so lint could not be confirmed here.
- Ran `pnpm test` (Vitest); test execution started but several suites failed due to missing/generated Prisma client and incomplete local dependency installation, so unit/integration tests could not be fully validated in this environment.

If you want, I can (1) revert the deterministic skeleton width to a deterministic but different value or expose it as a prop, (2) run the full `pnpm install`/`pnpm prisma:generate`/`pnpm test` cycle in CI (or advise how to reproduce locally) to confirm no remaining failures, or (3) adjust the `sizes` value if different breakpoints are preferred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0831deb554832c80f5fdb1e072b953)