### PR TITLE
Secure password reset magic links

### DIFF
--- a/src/app/api/auth/request-magic-link/route.ts
+++ b/src/app/api/auth/request-magic-link/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  createAndSendMagicLink,
+  getResetRequestIp,
+  MAGIC_LINK_RATE_LIMIT_MESSAGE,
+  MAGIC_LINK_SUCCESS_MESSAGE,
+  normalizeMagicLinkEmail,
+  recordMagicLinkAttempt,
+} from "@/lib/auth/magic-link";
+import { prisma } from "@/lib/prisma";
+
+const magicLinkRequestSchema = z.object({
+  email: z.string().email(),
+});
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const parsed = magicLinkRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ message: MAGIC_LINK_SUCCESS_MESSAGE });
+  }
+
+  const email = normalizeMagicLinkEmail(parsed.data.email);
+  const rateLimit = recordMagicLinkAttempt(email, getResetRequestIp(request));
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { message: MAGIC_LINK_RATE_LIMIT_MESSAGE },
+      {
+        status: 429,
+        headers: rateLimit.retryAfterSeconds
+          ? { "Retry-After": String(rateLimit.retryAfterSeconds) }
+          : undefined,
+      },
+    );
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    return NextResponse.json({ message: MAGIC_LINK_SUCCESS_MESSAGE });
+  }
+
+  try {
+    await createAndSendMagicLink(request.url, email);
+  } catch (error) {
+    console.error("[MAGIC LINK ERROR]", error);
+  }
+
+  return NextResponse.json({ message: MAGIC_LINK_SUCCESS_MESSAGE });
+}

--- a/src/app/login/login-client.tsx
+++ b/src/app/login/login-client.tsx
@@ -96,7 +96,9 @@ export function LoginPageClient() {
     const reason = sp?.get("reason");
     if (err) {
       if (err === "AccessDenied" && reason === "deactivated") {
-        toast.error("Dieses Konto wurde deaktiviert. Bitte kontaktiere die Administration.");
+        toast.error(
+          "Dieses Konto wurde deaktiviert. Bitte kontaktiere die Administration.",
+        );
         setShowMagicSuggestion(false);
         return;
       }
@@ -104,6 +106,7 @@ export function LoginPageClient() {
         OAuthAccountNotLinked: "Account nicht verknüpft",
         CredentialsSignin: "Ungültige Zugangsdaten",
         AccessDenied: "Zugriff verweigert",
+        Verification: "Dieser Link ist ungültig oder abgelaufen",
         default: "Login fehlgeschlagen",
       };
       toast.error(map[err] ?? map.default);
@@ -114,15 +117,25 @@ export function LoginPageClient() {
   async function onMagicSubmit(values: z.infer<typeof magicSchema>) {
     setLoading(true);
     try {
-      const res: SignInResponse | undefined = await signIn("email", {
-        email: values.email,
-        redirect: false,
-        callbackUrl: "/reset-password",
+      const res = await fetch("/api/auth/request-magic-link", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: values.email }),
       });
-      if (res?.error) {
-        toast.error(res.error || "E-Mail Versand fehlgeschlagen");
+      const data = (await res.json().catch(() => null)) as {
+        message?: string;
+      } | null;
+      if (res.status === 429) {
+        toast.error(
+          data?.message ?? "Zu viele Versuche, bitte später erneut versuchen",
+        );
+      } else if (!res.ok) {
+        toast.error("E-Mail Versand fehlgeschlagen");
       } else {
-        toast.success("Link gesendet – bitte E-Mail prüfen.");
+        toast.success(
+          data?.message ??
+            "Falls ein Konto mit dieser E-Mail existiert, erhältst du in Kürze eine E-Mail.",
+        );
         setMagicDialogOpen(false);
       }
     } catch {
@@ -205,14 +218,22 @@ export function LoginPageClient() {
                   <MailCheck className="h-5 w-5" aria-hidden />
                 </div>
                 <div className="space-y-1">
-                  <p className="text-sm font-semibold">Kein Passwort zur Hand?</p>
+                  <p className="text-sm font-semibold">
+                    Kein Passwort zur Hand?
+                  </p>
                   <p className="text-sm text-muted-foreground">
-                    Lass dir einen Link zum Zurücksetzen deines Passworts senden.
+                    Lass dir einen Link zum Zurücksetzen deines Passworts
+                    senden.
                   </p>
                 </div>
               </div>
               <DialogTrigger asChild>
-                <Button type="button" size="sm" variant="secondary" onClick={handleOpenMagic}>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={handleOpenMagic}
+                >
                   Passwort vergessen
                 </Button>
               </DialogTrigger>
@@ -255,7 +276,8 @@ export function LoginPageClient() {
           <DialogHeader>
             <DialogTitle>Passwort zurücksetzen</DialogTitle>
             <DialogDescription>
-              Gib deine E-Mail-Adresse ein. Wir schicken dir einen Link zum Zurücksetzen deines Passworts.
+              Gib deine E-Mail-Adresse ein. Wir schicken dir einen Link zum
+              Zurücksetzen deines Passworts.
             </DialogDescription>
           </DialogHeader>
           <form
@@ -271,7 +293,11 @@ export function LoginPageClient() {
               aria-required
             />
             <DialogFooter className="gap-2">
-              <Button type="button" variant="outline" onClick={() => setMagicDialogOpen(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setMagicDialogOpen(false)}
+              >
                 Abbrechen
               </Button>
               <Button type="submit" disabled={loading}>
@@ -285,7 +311,8 @@ export function LoginPageClient() {
           <div className="rounded-xl border border-primary/40 bg-primary/5 p-4 text-sm text-primary">
             <p className="font-semibold">Passwort vergessen?</p>
             <p className="mt-1">
-              Versuch es mit einem einmaligen Login-Link. Wir schicken dir eine E-Mail an {magicForm.getValues("email") || "deine Adresse"}.
+              Versuch es mit einem einmaligen Login-Link. Wir schicken dir eine
+              E-Mail an {magicForm.getValues("email") || "deine Adresse"}.
             </p>
           </div>
         )}
@@ -304,7 +331,9 @@ export function LoginPageClient() {
                   onClick={() => testLogin(option.email)}
                   disabled={loading}
                 >
-                  {option.label ? `${option.label} (${option.email})` : option.email}
+                  {option.label
+                    ? `${option.label} (${option.email})`
+                    : option.email}
                 </Button>
               ))}
             </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,18 +3,26 @@ import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { prisma } from "@/lib/prisma";
 import type { NextAuthOptions } from "next-auth";
 import type { AvatarSource, Role } from "@prisma/client";
-import type { AdapterUser } from "next-auth/adapters";
+import type { Adapter, AdapterUser } from "next-auth/adapters";
 import type { JWT } from "next-auth/jwt";
 import EmailProvider from "next-auth/providers/email";
 import Credentials from "next-auth/providers/credentials";
 import type { CredentialInput } from "next-auth/providers/credentials";
 import { sortRoles, ROLES } from "@/lib/roles";
-import { DEV_TEST_USER_EMAILS, DEV_TEST_USER_ROLE_MAP } from "@/lib/auth-dev-test-users";
+import {
+  DEV_TEST_USER_EMAILS,
+  DEV_TEST_USER_ROLE_MAP,
+} from "@/lib/auth-dev-test-users";
 import { verifyPassword } from "@/lib/password";
 import { combineNameParts } from "@/lib/names";
 import { ensureDevTestUser } from "@/lib/dev-auth";
 import { recordSessionEnd, recordSessionStart } from "@/lib/auth/session";
 import { getAuthSecret } from "@/lib/auth-secret";
+import {
+  normalizeMagicLinkEmail,
+  recordMagicLinkAttempt,
+  sendMagicLinkEmail,
+} from "@/lib/auth/magic-link";
 // trigger build
 // trigger build
 
@@ -45,7 +53,8 @@ const isRole = (value: unknown): value is Role =>
 const AVATAR_SOURCE_VALUES = ["GRAVATAR", "UPLOAD", "INITIALS"] as const;
 
 const isAvatarSource = (value: unknown): value is AvatarSource =>
-  typeof value === "string" && (AVATAR_SOURCE_VALUES as readonly string[]).includes(value);
+  typeof value === "string" &&
+  (AVATAR_SOURCE_VALUES as readonly string[]).includes(value);
 
 function extractAvatarSource(value: unknown): AvatarSource | undefined {
   if (typeof value !== "string") return undefined;
@@ -68,7 +77,10 @@ function extractIsoDate(value: unknown): string | undefined {
   return undefined;
 }
 
-function applyAvatarFields(target: MutableToken, source: Record<string, unknown>) {
+function applyAvatarFields(
+  target: MutableToken,
+  source: Record<string, unknown>,
+) {
   if ("avatarSource" in source) {
     const raw = (source as { avatarSource?: unknown }).avatarSource;
     const parsed = extractAvatarSource(raw);
@@ -77,11 +89,12 @@ function applyAvatarFields(target: MutableToken, source: Record<string, unknown>
     }
   }
 
-  const updatedRaw = "avatarUpdatedAt" in source
-    ? (source as { avatarUpdatedAt?: unknown }).avatarUpdatedAt
-    : "avatarImageUpdatedAt" in source
-    ? (source as { avatarImageUpdatedAt?: unknown }).avatarImageUpdatedAt
-    : undefined;
+  const updatedRaw =
+    "avatarUpdatedAt" in source
+      ? (source as { avatarUpdatedAt?: unknown }).avatarUpdatedAt
+      : "avatarImageUpdatedAt" in source
+        ? (source as { avatarImageUpdatedAt?: unknown }).avatarImageUpdatedAt
+        : undefined;
 
   if (updatedRaw === null) {
     target.avatarUpdatedAt = null;
@@ -93,7 +106,10 @@ function applyAvatarFields(target: MutableToken, source: Record<string, unknown>
   }
 }
 
-function applyNameFields(target: MutableToken, source: Record<string, unknown>) {
+function applyNameFields(
+  target: MutableToken,
+  source: Record<string, unknown>,
+) {
   let fallbackName: string | null | undefined;
 
   if ("firstName" in source) {
@@ -167,7 +183,9 @@ function extractRoles(value: unknown): Role[] | undefined {
   return undefined;
 }
 
-function extractRolesFromSource(source: RoleSource | undefined): Role[] | undefined {
+function extractRolesFromSource(
+  source: RoleSource | undefined,
+): Role[] | undefined {
   if (!source) return undefined;
   return extractRoles(source.roles) ?? extractRoles(source.role);
 }
@@ -184,6 +202,50 @@ const credentialInputs: Record<string, CredentialInput> = {
 if (process.env.NODE_ENV !== "production") {
   credentialInputs.dev = { label: "Dev", type: "text" };
 }
+
+const baseAdapter = PrismaAdapter(prisma);
+
+const authAdapter: Adapter = {
+  ...baseAdapter,
+  async createVerificationToken(verificationToken) {
+    const email = normalizeMagicLinkEmail(verificationToken.identifier);
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+    if (!user) {
+      return null;
+    }
+
+    return baseAdapter.createVerificationToken?.({
+      ...verificationToken,
+      identifier: email,
+    });
+  },
+  async useVerificationToken(params) {
+    const verificationToken = await baseAdapter.useVerificationToken?.(params);
+    if (
+      !verificationToken ||
+      verificationToken.expires.valueOf() < Date.now()
+    ) {
+      return null;
+    }
+
+    const email = normalizeMagicLinkEmail(verificationToken.identifier);
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+    if (!user) {
+      return null;
+    }
+
+    return {
+      ...verificationToken,
+      identifier: email,
+    };
+  },
+};
 
 const credentialsProvider = Credentials({
   name: "Passwort Login",
@@ -235,7 +297,8 @@ const credentialsProvider = Credentials({
       email: user.email!,
       firstName: user.firstName ?? null,
       lastName: user.lastName ?? null,
-      name: combineNameParts(user.firstName, user.lastName) ?? (user.name ?? null),
+      name:
+        combineNameParts(user.firstName, user.lastName) ?? user.name ?? null,
       role: combinedRoles[combinedRoles.length - 1],
       roles: combinedRoles,
       avatarSource: user.avatarSource,
@@ -245,7 +308,7 @@ const credentialsProvider = Credentials({
 });
 
 export const authOptions = {
-  adapter: PrismaAdapter(prisma),
+  adapter: authAdapter,
   useSecureCookies,
   // Use JWT sessions for reliability in dev (works with Credentials + Email).
   session: {
@@ -259,40 +322,52 @@ export const authOptions = {
     EmailProvider({
       server: process.env.EMAIL_SERVER,
       from: process.env.EMAIL_FROM,
-      async sendVerificationRequest({ identifier, url }) {
-        if (!process.env.EMAIL_SERVER || process.env.NODE_ENV !== "production") {
-          console.log("[DEV Magic Link]", identifier, url);
+      async sendVerificationRequest({ identifier, url, provider }) {
+        const email = normalizeMagicLinkEmail(identifier);
+        const user = await prisma.user.findUnique({
+          where: { email },
+          select: { id: true },
+        });
+        if (!user) {
           return;
         }
-        console.log("[MAGIC LINK REQUEST]", identifier);
-        // send mail via nodemailer using process.env.EMAIL_SERVER
-        const { createTransport } = await import("nodemailer");
-        const transport = createTransport(process.env.EMAIL_SERVER);
-        await transport.sendMail({
-          to: identifier,
-          from: process.env.EMAIL_FROM,
-          subject: "Passwort zurücksetzen – Sommertheater Altroßthal",
-          text: `Sommertheater Altroßthal\n\nPasswort zurücksetzen\n\nKlicke auf den Link, um ein neues Passwort festzulegen. Der Link ist 24 Stunden gültig.\n\n${url}\n\nFalls du diese E-Mail nicht angefordert hast, kannst du sie ignorieren.`,
-          html: `
-            <div style="background:#0d1117;padding:32px 16px;font-family:Inter,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#ffffff;">
-              <div style="max-width:560px;margin:0 auto;background:#111827;border:1px solid #1f2937;border-radius:16px;padding:32px;">
-                <p style="margin:0 0 20px 0;font-size:24px;line-height:1.3;font-weight:700;color:#f97316;">Sommertheater Altroßthal</p>
-                <h1 style="margin:0 0 16px 0;font-size:28px;line-height:1.2;font-weight:700;color:#ffffff;">Passwort zurücksetzen</h1>
-                <p style="margin:0 0 28px 0;font-size:16px;line-height:1.6;color:#ffffff;">Klicke auf den Button unten, um ein neues Passwort festzulegen. Der Link ist 24 Stunden gültig.</p>
-                <a href="${url}" style="display:inline-block;background:#f97316;color:#ffffff;text-decoration:none;font-size:16px;font-weight:600;padding:14px 24px;border-radius:10px;">Neues Passwort festlegen</a>
-                <p style="margin:28px 0 0 0;font-size:13px;line-height:1.5;color:#d1d5db;">Falls du diese E-Mail nicht angefordert hast, kannst du sie ignorieren.</p>
-              </div>
-            </div>
-          `,
-        });
-        console.log("[MAGIC LINK SENT]", identifier);
+
+        try {
+          await sendMagicLinkEmail({ identifier: email, url, provider });
+        } catch (error) {
+          console.error("[MAGIC LINK ERROR]", error);
+        }
       },
     }),
     credentialsProvider,
   ],
-  pages: { signIn: "/login" },
+  pages: { signIn: "/login", error: "/login" },
   callbacks: {
-    async signIn({ user }) {
+    async signIn({ user, account, email }) {
+      if (account?.provider === "email") {
+        const rawEmail = typeof user?.email === "string" ? user.email : null;
+        if (!rawEmail) return "/login?error=Verification";
+
+        const normalizedEmail = normalizeMagicLinkEmail(rawEmail);
+
+        if (email?.verificationRequest) {
+          const rateLimit = recordMagicLinkAttempt(
+            normalizedEmail,
+            "nextauth-direct",
+          );
+          if (!rateLimit.allowed) return false;
+        }
+
+        const dbUser = await prisma.user.findUnique({
+          where: { email: normalizedEmail },
+          select: { id: true, deactivatedAt: true },
+        });
+        if (!dbUser) return "/login?error=Verification";
+        if (dbUser.deactivatedAt)
+          return "/login?error=AccessDenied&reason=deactivated";
+        return true;
+      }
+
       const userId = typeof user?.id === "string" ? user.id : null;
       if (!userId) return false;
       const dbUser = await prisma.user.findUnique({
@@ -322,21 +397,27 @@ export const authOptions = {
         mutableToken.deactivatedAt = null;
         mutableToken.isDeactivated = false;
         applyNameFields(mutableToken, user);
-        const userRoles = extractRolesFromSource(user as AdapterUser & RoleSource);
+        const userRoles = extractRolesFromSource(
+          user as AdapterUser & RoleSource,
+        );
         if (userRoles) applyRoles(userRoles);
         applyAvatarFields(mutableToken, user);
       }
 
       if (trigger === "update") {
         const updateSource = isRecord(session)
-          ? (isRecord(session.user) ? session.user : session)
+          ? isRecord(session.user)
+            ? session.user
+            : session
           : undefined;
 
         if (isRecord(updateSource)) {
           applyNameFields(mutableToken, updateSource);
           const nextEmail = extractString(updateSource.email);
           if (nextEmail) mutableToken.email = nextEmail;
-          const updatedRoles = extractRolesFromSource(updateSource as RoleSource);
+          const updatedRoles = extractRolesFromSource(
+            updateSource as RoleSource,
+          );
           if (updatedRoles) applyRoles(updatedRoles);
           applyAvatarFields(mutableToken, updateSource);
         }
@@ -367,12 +448,18 @@ export const authOptions = {
             ...dbUser.roles.map((r) => r.role as Role),
           ]);
           applyRoles(combined);
-          applyNameFields(mutableToken, dbUser as unknown as Record<string, unknown>);
+          applyNameFields(
+            mutableToken,
+            dbUser as unknown as Record<string, unknown>,
+          );
           const dbEmail = extractString(dbUser.email);
           if (dbEmail) {
             mutableToken.email = dbEmail;
           }
-          applyAvatarFields(mutableToken, dbUser as unknown as Record<string, unknown>);
+          applyAvatarFields(
+            mutableToken,
+            dbUser as unknown as Record<string, unknown>,
+          );
           if (dbUser.deactivatedAt) {
             mutableToken.deactivatedAt = dbUser.deactivatedAt.toISOString();
             mutableToken.isDeactivated = true;
@@ -393,7 +480,9 @@ export const authOptions = {
         }
         session.user.firstName = mutableToken.firstName ?? null;
         session.user.lastName = mutableToken.lastName ?? null;
-        const sessionFullName = combineNameParts(mutableToken.firstName, mutableToken.lastName) ?? (typeof mutableToken.name === "string" ? mutableToken.name : null);
+        const sessionFullName =
+          combineNameParts(mutableToken.firstName, mutableToken.lastName) ??
+          (typeof mutableToken.name === "string" ? mutableToken.name : null);
         session.user.name = sessionFullName;
         if (mutableToken.role) {
           session.user.role = mutableToken.role;
@@ -420,7 +509,9 @@ export const authOptions = {
     async session({ token }) {
       const mutableToken = token as MutableToken;
       const roles = Array.isArray(mutableToken.roles)
-        ? (mutableToken.roles.filter((role): role is Role => typeof role === "string") as Role[])
+        ? (mutableToken.roles.filter(
+            (role): role is Role => typeof role === "string",
+          ) as Role[])
         : undefined;
 
       await recordSessionStart({

--- a/src/lib/auth/magic-link.ts
+++ b/src/lib/auth/magic-link.ts
@@ -1,0 +1,197 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { EmailConfig } from "next-auth/providers/email";
+import { prisma } from "@/lib/prisma";
+import { getAuthSecret } from "@/lib/auth-secret";
+
+export const MAGIC_LINK_SUCCESS_MESSAGE =
+  "Falls ein Konto mit dieser E-Mail existiert, erhältst du in Kürze eine E-Mail.";
+export const MAGIC_LINK_RATE_LIMIT_MESSAGE =
+  "Zu viele Versuche, bitte später erneut versuchen";
+export const MAGIC_LINK_INVALID_MESSAGE =
+  "Dieser Link ist ungültig oder abgelaufen";
+
+const ONE_HOUR_IN_MS = 60 * 60 * 1000;
+const EMAIL_LIMIT = 3;
+const IP_LIMIT = 10;
+const MAGIC_LINK_MAX_AGE_IN_SECONDS = 24 * 60 * 60;
+
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+type RateLimitResult = {
+  allowed: boolean;
+  retryAfterSeconds?: number;
+};
+
+type MagicLinkEmailProvider = {
+  server?: EmailConfig["server"];
+  from?: string;
+};
+
+type SendMagicLinkEmailParams = {
+  identifier: string;
+  url: string;
+  provider: MagicLinkEmailProvider;
+};
+
+const emailAttempts = new Map<string, RateLimitBucket>();
+const ipAttempts = new Map<string, RateLimitBucket>();
+
+export function normalizeMagicLinkEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+export function getResetRequestIp(request: Request) {
+  const forwardedFor = request.headers
+    .get("x-forwarded-for")
+    ?.split(",")[0]
+    ?.trim();
+  const realIp = request.headers.get("x-real-ip")?.trim();
+  return forwardedFor || realIp || "unknown";
+}
+
+function pruneExpiredAttempts(now: number) {
+  for (const [key, bucket] of emailAttempts.entries()) {
+    if (bucket.resetAt <= now) emailAttempts.delete(key);
+  }
+  for (const [key, bucket] of ipAttempts.entries()) {
+    if (bucket.resetAt <= now) ipAttempts.delete(key);
+  }
+}
+
+function incrementBucket(
+  map: Map<string, RateLimitBucket>,
+  key: string,
+  limit: number,
+  now: number,
+) {
+  const existing = map.get(key);
+  const bucket =
+    existing && existing.resetAt > now
+      ? existing
+      : { count: 0, resetAt: now + ONE_HOUR_IN_MS };
+  bucket.count += 1;
+  map.set(key, bucket);
+
+  return {
+    allowed: bucket.count <= limit,
+    retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+  };
+}
+
+export function recordMagicLinkAttempt(
+  email: string,
+  ip: string,
+  now = Date.now(),
+): RateLimitResult {
+  pruneExpiredAttempts(now);
+
+  const emailResult = incrementBucket(
+    emailAttempts,
+    `email:${normalizeMagicLinkEmail(email)}`,
+    EMAIL_LIMIT,
+    now,
+  );
+  const ipResult = incrementBucket(ipAttempts, `ip:${ip}`, IP_LIMIT, now);
+
+  if (emailResult.allowed && ipResult.allowed) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    retryAfterSeconds: Math.max(
+      emailResult.retryAfterSeconds,
+      ipResult.retryAfterSeconds,
+    ),
+  };
+}
+
+export async function sendMagicLinkEmail({
+  identifier,
+  url,
+  provider,
+}: SendMagicLinkEmailParams) {
+  if (!provider.server || process.env.NODE_ENV !== "production") {
+    console.log("[DEV Magic Link]", identifier, url);
+    return;
+  }
+
+  console.log("[MAGIC LINK REQUEST]", identifier);
+  const { createTransport } = await import("nodemailer");
+  const transport = createTransport(provider.server);
+  await transport.sendMail({
+    to: identifier,
+    from: provider.from,
+    subject: "Passwort zurücksetzen – Sommertheater Altroßthal",
+    text: `Sommertheater Altroßthal\n\nPasswort zurücksetzen\n\nKlicke auf den Link, um ein neues Passwort festzulegen. Der Link ist 24 Stunden gültig.\n\n${url}\n\nFalls du diese E-Mail nicht angefordert hast, kannst du sie ignorieren.`,
+    html: `
+            <div style="background:#0d1117;padding:32px 16px;font-family:Inter,Segoe UI,Roboto,Helvetica,Arial,sans-serif;color:#ffffff;">
+              <div style="max-width:560px;margin:0 auto;background:#111827;border:1px solid #1f2937;border-radius:16px;padding:32px;">
+                <p style="margin:0 0 20px 0;font-size:24px;line-height:1.3;font-weight:700;color:#f97316;">Sommertheater Altroßthal</p>
+                <h1 style="margin:0 0 16px 0;font-size:28px;line-height:1.2;font-weight:700;color:#ffffff;">Passwort zurücksetzen</h1>
+                <p style="margin:0 0 28px 0;font-size:16px;line-height:1.6;color:#ffffff;">Klicke auf den Button unten, um ein neues Passwort festzulegen. Der Link ist 24 Stunden gültig.</p>
+                <a href="${url}" style="display:inline-block;background:#f97316;color:#ffffff;text-decoration:none;font-size:16px;font-weight:600;padding:14px 24px;border-radius:10px;">Neues Passwort festlegen</a>
+                <p style="margin:28px 0 0 0;font-size:13px;line-height:1.5;color:#d1d5db;">Falls du diese E-Mail nicht angefordert hast, kannst du sie ignorieren.</p>
+              </div>
+            </div>
+          `,
+  });
+  console.log("[MAGIC LINK SENT]", identifier);
+}
+
+export function createMagicLinkToken() {
+  const token = randomBytes(32).toString("hex");
+  return {
+    token,
+    tokenHash: hashMagicLinkToken(token),
+  };
+}
+
+export function hashMagicLinkToken(token: string) {
+  return createHash("sha256")
+    .update(`${token}${getAuthSecret()}`)
+    .digest("hex");
+}
+
+export function createMagicLinkUrl(
+  requestUrl: string,
+  identifier: string,
+  token: string,
+) {
+  const baseUrl = new URL(requestUrl).origin;
+  const params = new URLSearchParams({
+    callbackUrl: `${baseUrl}/reset-password`,
+    token,
+    email: identifier,
+  });
+  return `${baseUrl}/api/auth/callback/email?${params}`;
+}
+
+export async function createAndSendMagicLink(
+  requestUrl: string,
+  identifier: string,
+) {
+  const { token, tokenHash } = createMagicLinkToken();
+  const expires = new Date(Date.now() + MAGIC_LINK_MAX_AGE_IN_SECONDS * 1000);
+  const url = createMagicLinkUrl(requestUrl, identifier, token);
+
+  await prisma.verificationToken.create({
+    data: {
+      identifier,
+      token: tokenHash,
+      expires,
+    },
+  });
+
+  await sendMagicLinkEmail({
+    identifier,
+    url,
+    provider: {
+      server: process.env.EMAIL_SERVER,
+      from: process.env.EMAIL_FROM,
+    },
+  });
+}


### PR DESCRIPTION
### Motivation
- Fix a security issue where requesting a magic-link / password-reset for an unknown email still created a token and allowed onboarding via that link, enabling user enumeration and unwanted account creation.
- Implement industry-standard behavior: silent success for unknown emails, explicit token validation when using a link, and rate limiting to prevent abuse.

### Description
- Add a dedicated request route `src/app/api/auth/request-magic-link/route.ts` that validates input, normalizes the email, enforces rate limits (3 per email / hour, 10 per IP / hour), silently returns a generic success message for unknown emails, and only generates/sends tokens for existing users.
- Introduce `src/lib/auth/magic-link.ts` with helpers for email normalization, in-memory rate limiting, token generation/hashing (`hashMagicLinkToken`), magic-link URL creation, and a single place to send the reset email (`sendMagicLinkEmail`).
- Harden NextAuth integration in `src/lib/auth.ts` by installing a custom adapter wrapper that only creates/uses verification tokens for existing users and by changing the email provider flow to re-check user existence before sending a link; the `signIn` callback is updated to rate-limit direct email sign-ins and to return a generic verification error for invalid cases.
- Update the client flow in `src/app/login/login-client.tsx` to call the new endpoint (`/api/auth/request-magic-link`) and surface only the generic success message or the generic rate-limit message, preventing any disclosure about whether an address exists.

### Testing
- Ran `pnpm exec prettier --check src/lib/auth.ts src/lib/auth/magic-link.ts src/app/api/auth/request-magic-link/route.ts src/app/login/login-client.tsx` which passed.
- `pnpm lint` / `pnpm lint --fix` failed due to an existing project ESLint configuration issue (circular JSON serialization in the React plugin) unrelated to these changes; linting did not complete.
- `pnpm test` failed because Prisma Client was not generated in the test environment (`Cannot find module '.prisma/client/default'`), so unit/integration tests could not fully run.
- `pnpm prisma:generate` / `pnpm build` failed in this environment due to the installed Prisma CLI (7.x) rejecting the project `datasource.url` schema setting (existing repo config mismatch), preventing Prisma client generation and blocking further tests and the build.
- Type-check attempts (`tsc`) reported repository-level config/type issues (referenced `tsconfig.sw.json`, missing generated Prisma types) that are environmental and not caused by the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08dc314ad8832c8bcb93a969308324)