### PR TITLE
Fehler im robots()-Fallback loggen (src/app/robots.ts)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -31,7 +31,8 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
       },
       sitemap: SITEMAP_URL,
     };
-  } catch {
+  } catch (error) {
+    console.error("[robots.ts] Fehler beim Laden der WebsiteSettings:", error);
     return {
       rules: {
         userAgent: "*",


### PR DESCRIPTION
### Motivation
- Der `catch`-Block in `robots()` hat Fehler still verschluckt, wodurch der Fallback immer greift, aber die Ursache nicht in den Logs sichtbar war; das Logging soll den echten Fehler in den Docker-Logs sichtbar machen.

### Description
- In `src/app/robots.ts` den `catch`-Block angepasst und `console.error("[robots.ts] Fehler beim Laden der WebsiteSettings:", error)` hinzugefügt, wobei die existierende Fallback-Rückgabe unverändert bleibt.

### Testing
- Es wurden lokal keine automatisierten Tests ausgeführt; die Änderung ist ein rein logging-bezogener Patch und wird durch die vorhandene CI-Checks (`pnpm lint`, `pnpm test`, `pnpm build`) abgedeckt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1beb2d94832691a8fc5e135b3c3d)