### PR TITLE
Force dynamic rendering for robots route

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next";
 
 import { readWebsiteSettings, resolveWebsiteSettings } from "@/lib/website-settings";
 
+export const dynamic = "force-dynamic";
+
 const SITEMAP_URL = "https://sommertheater-altrossthal.de/sitemap.xml";
 
 const publicRouteMap = {


### PR DESCRIPTION
### Motivation
- Ensure the robots endpoint is evaluated at request time so `robots.txt` reflects the current website settings and visibility.

### Description
- Add `export const dynamic = "force-dynamic";` to `src/app/robots.ts` to force dynamic rendering of the robots route.

### Testing
- No automated tests were run for this trivial change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a1e491ba4832687cbe8a42cbea561)