### PR TITLE
fix: force dynamic sitemap generation

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next";
 
 import { readWebsiteSettings, resolveWebsiteSettings } from "@/lib/website-settings";
 
+export const dynamic = "force-dynamic";
+
 const BASE_URL = (process.env.NEXT_PUBLIC_BASE_URL ?? "https://sommertheater-altrossthal.de").replace(/\/$/, "");
 
 const publicRouteMap = {


### PR DESCRIPTION
### Motivation
- Ensure the sitemap is evaluated at runtime so it can read current website settings (`readWebsiteSettings()`), avoiding stale static sitemap output.

### Description
- Inserted `export const dynamic = "force-dynamic";` immediately after the imports in `src/app/sitemap.ts` and made no other changes.

### Testing
- No automated tests were executed for this single-line configuration change; `pnpm lint`, `pnpm test` and `pnpm build` were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a20c323d883269c40b6e58191e6da)