### PR TITLE
Rename home feature keys to `FEATURE.HOME.*` and remove chronik entry

### DIFF
--- a/src/lib/frontend-editing.ts
+++ b/src/lib/frontend-editing.ts
@@ -1,6 +1,6 @@
 import { hasPermission } from "@/lib/permissions";
 
-export type FrontendEditingFeatureKey = "mystery.launch-countdown" | "FEATURE.HOME.COUNTDOWN" | "FEATURE.HOME.FLYER" | "chronik.performance-dates";
+export type FrontendEditingFeatureKey = "FEATURE.HOME.COUNTDOWN" | "FEATURE.HOME.FLYER";
 
 export type FrontendEditingFeature = {
   key: FrontendEditingFeatureKey;
@@ -14,12 +14,6 @@ type FeatureDefinition = FrontendEditingFeature & {
 
 const FEATURE_DEFINITIONS: FeatureDefinition[] = [
   {
-    key: "mystery.launch-countdown",
-    label: "Mystery-Timer",
-    description: "Countdown und Hinweistext für die Mystery-Startseite verwalten.",
-    permissionKey: "PRIVATE.MYSTERY.TIMER.EDIT",
-  },
-  {
     key: "FEATURE.HOME.COUNTDOWN",
     label: "Premieren-Countdown",
     description: "Countdown für die öffentliche Startseite anpassen.",
@@ -30,12 +24,6 @@ const FEATURE_DEFINITIONS: FeatureDefinition[] = [
     label: "Homepage-Flyer",
     description: "Flyer-Sektion für die öffentliche Startseite anpassen.",
     permissionKey: "PUBLIC.HOME.FLYER.EDIT",
-  },
-  {
-    key: "chronik.performance-dates",
-    label: "Chronik-Termine",
-    description: "Aufführungstermine in der öffentlichen Chronik bearbeiten.",
-    permissionKey: "PRIVATE.WEBSITE.CHRONIK.EDIT",
   },
 ];
 


### PR DESCRIPTION
### Motivation
- Konsolidieren der Frontend-Feature-Keys nach dem Schema `FEATURE.PAGE.CONTEXT` und sicherstellen, dass Chronik-Features nicht mehr in der Home-Definitionsdatei liegen.

### Description
- Aktualisiert `src/lib/frontend-editing.ts` und reduziert `FrontendEditingFeatureKey` auf nur `"FEATURE.HOME.COUNTDOWN"` und `"FEATURE.HOME.FLYER"`.
- `FEATURE_DEFINITIONS` enthält jetzt ausschließlich die beiden Einträge `FEATURE.HOME.COUNTDOWN` und `FEATURE.HOME.FLYER` mit den zugehörigen `permissionKey`-Werten.
- Der bisherige Chronik-Eintrag (`chronik.performance-dates`) wurde aus `FEATURE_DEFINITIONS` entfernt and ebenso wurde der zuvor vorhandene Mystery-Eintrag entfernt; keine weiteren Dateien wurden geändert.

### Testing
- `pnpm test` wurde ausgeführt und alle Tests liefen erfolgreich (`Vitest`): **passed**.
- `pnpm lint` wurde ausgeführt und schlägt fehl aufgrund eines bestehenden ESLint-Konfigurationsfehlers (Zirkuläre Struktur beim Parsen der Konfiguration): **failed**.
- `pnpm build` wurde ausgeführt und schlägt fehl aufgrund einer bestehenden Prisma-Validierungsfehlermeldung (datasource `url` in `prisma/schema.prisma` nicht kompatibel mit der verwendeten Prisma-CLI): **failed**.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e48261348332964c50b05f8f4767)