### PR TITLE
Add AsyncButton and ConfirmDialog components and UI type standards

### DIFF
--- a/src/components/ui/async-button.tsx
+++ b/src/components/ui/async-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { LoadingIcon } from "@/components/ui/action-icons";
+import type { AsyncButtonProps } from "@/lib/ui-standards";
+
+export function AsyncButton({
+  isLoading,
+  loadingText,
+  children,
+  disabled,
+  ...props
+}: AsyncButtonProps) {
+  return (
+    <Button disabled={disabled || isLoading} data-state={isLoading ? "loading" : undefined} {...props}>
+      {isLoading ? (
+        <>
+          <LoadingIcon className="h-4 w-4 animate-spin" aria-hidden />
+          <span>{loadingText ?? children}</span>
+        </>
+      ) : (
+        children
+      )}
+    </Button>
+  );
+}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { ConfirmDialogProps } from "@/lib/ui-standards";
+
+export function ConfirmDialog({
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  variant,
+  onConfirm,
+  onCancel,
+  open,
+  onOpenChange,
+}: ConfirmDialogProps) {
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      onCancel();
+    }
+    onOpenChange(nextOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+          <Button type="button" variant={variant === "destructive" ? "destructive" : "default"} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/ui-standards.ts
+++ b/src/lib/ui-standards.ts
@@ -1,0 +1,34 @@
+import type * as React from "react";
+import type { ButtonProps } from "@/components/ui/button";
+
+export interface ConfirmDialogProps {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  variant: "destructive" | "default";
+  onConfirm: () => void;
+  onCancel: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export interface AsyncButtonProps extends ButtonProps {
+  isLoading: boolean;
+  loadingText?: string;
+}
+
+export interface ModalFormDialogProps {
+  title: string;
+  description?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+export const UI_PATTERNS = {
+  confirmDialog: "confirm-dialog",
+  asyncButton: "async-button",
+  modalFormDialog: "modal-form-dialog",
+} as const;


### PR DESCRIPTION
### Motivation

- Introduce reusable UI primitives to standardize async action buttons and confirmation dialogs across the app.
- Centralize prop typings and common UI pattern identifiers to improve consistency and type safety.

### Description

- Add `AsyncButton` component (`src/components/ui/async-button.tsx`) as a client component that disables the button while loading and optionally shows a `LoadingIcon` with `loadingText`.
- Add `ConfirmDialog` component (`src/components/ui/confirm-dialog.tsx`) as a client dialog wrapper that renders title, description, cancel and confirm buttons and calls `onCancel` when the dialog is closed.
- Add `src/lib/ui-standards.ts` exporting `ConfirmDialogProps`, `AsyncButtonProps`, `ModalFormDialogProps`, and a `UI_PATTERNS` const to centralize prop interfaces and pattern names.

### Testing

- Ran TypeScript type-check with `tsc --noEmit`, which succeeded.
- Ran the existing automated test suite with `npm test`, which completed successfully.
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12cc5984048332a877c7f1067bde0d)