### PR TITLE
Make confirm description optional and add ModalFormDialog component

### DIFF
--- a/src/components/ui/modal-form-dialog.tsx
+++ b/src/components/ui/modal-form-dialog.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { ModalFormDialogProps } from "@/lib/ui-standards";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export function ModalFormDialog({
+  title,
+  description,
+  open,
+  onOpenChange,
+  children,
+  footer,
+}: ModalFormDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+        {children}
+        {footer ? <DialogFooter>{footer}</DialogFooter> : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/ui-standards.ts
+++ b/src/lib/ui-standards.ts
@@ -3,7 +3,7 @@ import type { ButtonProps } from "@/components/ui/button";
 
 export interface ConfirmDialogProps {
   title: string;
-  description: string;
+  description?: string;
   confirmLabel: string;
   cancelLabel: string;
   variant: "destructive" | "default";


### PR DESCRIPTION
### Motivation
- Allow callers to omit the description when using confirmation dialogs by making the `description` field optional in the UI standards type.
- Provide a reusable modal form dialog component so pages/forms can compose modals consistently from the existing dialog primitives.
- Keep presentation logic simple by conditionally rendering optional pieces like description and footer instead of duplicating modal markup across the codebase.

### Description
- Updated `src/lib/ui-standards.ts` to make `ConfirmDialogProps.description` optional (`description?: string`).
- Added `src/components/ui/modal-form-dialog.tsx` exporting `ModalFormDialog` which implements `ModalFormDialogProps` and composes `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, and `DialogFooter` primitives.
- The component renders `children` inside `DialogContent`, shows `DialogDescription` only when `description` is provided, and includes `DialogFooter` only when `footer` is provided.

### Testing
- Ran `pnpm lint` which completed (only pre-existing warnings unrelated to these changes were reported).
- Ran `pnpm test` and all tests passed.
- Ran `pnpm build` which completed successfully and type-checked the project (pre-existing build warnings remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d1eccfd48332843601da8af3bd5d)