### PR TITLE
docs: ergänze UI-Komponenten-Regeln in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,10 @@ Diese Datei definiert die Projektstandards für die Website des Sommertheaters A
 - Löschaktionen verwenden immer `variant="destructive"` und das `TrashIcon`.
 - Bearbeitungsaktionen verwenden immer das `EditIcon`.
 - Dialoge für destruktive Aktionen müssen vor der Ausführung eine Bestätigung abfragen.
+- Für alle Buttons mit Ladezustand AsyncButton aus `src/components/ui/async-button.tsx` verwenden. Nie Button manuell mit Loader2 kombinieren.
+- Für alle destruktiven Bestätigungen ConfirmDialog aus `src/components/ui/confirm-dialog.tsx` verwenden. `window.confirm` ist verboten.
+- Für alle Create/Edit-Dialoge ModalFormDialog aus `src/components/ui/modal-form-dialog.tsx` verwenden.
+- `src/lib/ui-standards.ts` ist die Single Source of Truth für Props-Interfaces aller geteilten UI-Patterns.
 
 ## Design-Tokens
 


### PR DESCRIPTION
### Motivation
- Die UI-Richtlinien sollen um verbindliche Pattern für Ladezustände, Bestätigungen und Form-Dialoge erweitert werden, sowie eine zentrale Quelle für Props-Interfaces definieren, um Konsistenz und Wiederverwendbarkeit im Design-System zu verbessern.

### Description
- In `AGENTS.md` im Abschnitt `## UI-Komponenten` wurden am Ende vier Bullet-Points ergänzt, die die Verwendung von `AsyncButton` (`src/components/ui/async-button.tsx`), `ConfirmDialog` (`src/components/ui/confirm-dialog.tsx`), `ModalFormDialog` (`src/components/ui/modal-form-dialog.tsx`) und `src/lib/ui-standards.ts` als Single Source of Truth für Props-Interfaces vorschreiben, und keine weiteren Abschnitte wurden verändert.

### Testing
- Keine automatisierten Tests wurden ausgeführt, da es sich um eine reine Dokumentationsänderung handelt und dies gemäß der Projektregeln für Dokumentationsänderungen zulässig ist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d57691e48332b54568eae8e2978f)