### PR TITLE
Dokumentation: Surface- & Card-Hierarchie in AGENTS.md ergänzt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,15 @@ Diese Datei definiert die Projektstandards für die Website des Sommertheaters A
 - Farben immer über semantische CSS-Variablen aus `src/design-system/tokens.json` verwenden, z. B. `text-primary`, `text-destructive`, `bg-muted`.
 - Hardcodierte Farbwerte sind nicht erlaubt.
 
+## Surface & Card Hierarchie
+
+- `bg-background` ist die Seitenbasis. Innerhalb einer Card darf es nie verwendet werden.
+- `bg-card` gilt für alle primären Cards und Section-Container.
+- `bg-muted` gilt für verschachtelte/sekundäre Flächen innerhalb einer Card (Sub-Cards, innere Sektionen).
+- `bg-popover` ist ausschließlich für Overlays, Dropdowns und Tooltips reserviert.
+- Card-Rahmen verwenden `border-border`. `border-primary` (orange) ist auf strukturellen Containern verboten — orange Rahmen sind ausschließlich für interaktive/ausgewählte Zustände reserviert.
+- Niemals hardcodierte Farben für Flächen verwenden. Immer semantische Tokens nutzen.
+
 ## Seiten-Patterns
 
 - Seiten-Header verwenden das `PageHeader`-Pattern aus `src/design-system/patterns/page-header.tsx`.


### PR DESCRIPTION
### Motivation

- Klarstellung und Vereinheitlichung von Flächen- und Karten-Hierarchie zur Vermeidung inkonsistenter Hintergrund- und Rahmenfarben in der UI.

### Description

- Neue Sektion „Surface & Card Hierarchie“ in `AGENTS.md` hinzugefügt, die semantische Hintergrundtokens und ihre Verwendung definiert.
- Festgelegt, dass `bg-background` die Seitenbasis ist und innerhalb von Cards nicht verwendet werden darf.
- Festgelegt, dass `bg-card` für primäre Cards, `bg-muted` für verschachtelte Flächen und `bg-popover` ausschließlich für Overlays/Tooltips genutzt werden sollen.
- Card-Rahmen sollen `border-border` verwenden und `border-primary` (orange) ist auf strukturellen Containern verboten; harte Farbwerte sind generell untersagt.

### Testing

- Linter/Format-Checks mit `npm run lint` wurden ausgeführt und sind erfolgreich gewesen.
- Build/Type-Checks mit `npm run build` bzw. `npm run typecheck` wurden ausgeführt und sind erfolgreich gewesen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d91080048332bce9c3f6478a59ce)