### PR TITLE
docs(AGENTS): append six UI standards sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,38 @@ Diese Datei definiert die Projektstandards für die Website des Sommertheaters A
 
 - Seiten-Header verwenden das `PageHeader`-Pattern aus `src/design-system/patterns/page-header.tsx`.
 - Metric-Cards verwenden das `KeyMetricCard`-Pattern aus `src/design-system/patterns/key-metric.tsx`.
+
+## Typografie & Abstände
+- Seitentitel (h1): text-3xl font-bold, nur einmal pro Seite.
+- Abschnittstitel (h2): text-xl font-semibold, mit mb-4 darunter.
+- Kartentitel (h3): text-base font-medium.
+- Abstände zwischen Hauptsektionen: space-y-6 oder gap-6.
+- Text-Hierarchie: text-foreground für Haupttext, text-muted-foreground für Sekundärtext und Labels.
+
+## Badge & Status
+- Badges verwenden die Badge-Komponente aus src/components/ui/badge.tsx.
+- Status-Semantik: success-Token für positiv/aktiv, warning-Token für ausstehend/Hinweis, destructive-Token für Fehler/gesperrt, muted für neutral/inaktiv.
+- Nie hardcodierte Farben für Statusbadges. Immer variant oder className mit semantischem Token.
+
+## Empty States
+- Leere Zustände immer mit zentriertem Text und muted-foreground Farbe darstellen.
+- Struktur: umschließende div mit py-12 text-center, Icon optional in text-muted-foreground, darunter p mit text-muted-foreground.
+- Kein window.confirm, kein gestrichelter Box-Eigenbau ohne diese Struktur.
+
+## Skeleton & Ladezeichen
+- Ladezeichen immer mit der Skeleton-Komponente aus src/components/ui/skeleton.tsx.
+- animate-pulse direkt auf Elementen ist verboten. Immer Skeleton verwenden.
+- Suspense-Fallbacks verwenden dedizierte loading.tsx Dateien mit Skeleton-Komponenten.
+
+## Toast & Feedback
+- toast.success für erfolgreich abgeschlossene Aktionen.
+- toast.error für Fehler die eine Nutzeraktion erfordern.
+- toast.info für neutrale Statusänderungen und Echtzeit-Events.
+- Dauer: Erfolg 3000ms, Fehler 5000ms, Info 2000ms.
+- Toasts haben immer einen kurzen Titel und optional eine description für Details.
+
+## Callout & Hinweisboxen
+- Hinweisboxen verwenden bg-muted border border-border rounded-lg p-4.
+- Warnhinweise verwenden bg-warning/10 border border-warning text-warning-foreground rounded-lg p-4.
+- Fehlerhinweise verwenden bg-destructive/10 border border-destructive text-destructive-foreground rounded-lg p-4.
+- Nie eigene Farben oder hardcodierte Hintergründe für Hinweisboxen.


### PR DESCRIPTION
### Motivation
- Add explicit project conventions for typography, badges/status, empty states, skeleton/loading, toast feedback, and callout/hint boxes so contributors follow a consistent design and UX pattern.
- Insert these rules immediately after the existing `Seiten-Patterns` block without modifying any pre-existing content.

### Description
- Appended six new sections to `AGENTS.md`: `Typografie & Abstände`, `Badge & Status`, `Empty States`, `Skeleton & Ladezeichen`, `Toast & Feedback`, and `Callout & Hinweisboxen`.
- Each section references existing project primitives and tokens (for example `src/components/ui/badge.tsx`, `src/components/ui/skeleton.tsx`, and semantic tokens like `text-foreground` and `bg-muted`).
- The additions are documentation-only and do not change application code or configuration.

### Testing
- Verified the file tail and line-numbered output with `tail -n 80 AGENTS.md` and `nl -ba AGENTS.md | tail -n 80` to confirm the six sections were appended in order.
- Inspected the appended content to ensure it follows the repository’s markdown and path conventions and references existing component paths.
- No automated unit or integration tests were required because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12db678c38832d98c1d46e86426787)