### PR TITLE
Replace lucide action icons and native confirms with centralized icons, ConfirmDialog and AsyncButton

### DIFF
--- a/src/app/(members)/mitglieder/lagerverwaltung/technik/edit-item-dialog.tsx
+++ b/src/app/(members)/mitglieder/lagerverwaltung/technik/edit-item-dialog.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useActionState, useEffect, useMemo, useState } from "react";
-import { Pencil } from "lucide-react";
 import { toast } from "sonner";
 
+import { EditIcon } from "@/components/ui/action-icons";
+import { AsyncButton } from "@/components/ui/async-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -200,7 +201,7 @@ export function EditTechnikItemDialog({
           size="icon"
           aria-label={`Inventarposten ${item.sku} bearbeiten`}
         >
-          <Pencil className="h-4 w-4" />
+          <EditIcon className="h-4 w-4" />
         </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
@@ -373,12 +374,12 @@ export function EditTechnikItemDialog({
             </p>
           </div>
           {errorMessage ? (
-            <p className="text-sm text-red-600">{errorMessage}</p>
+            <p className="text-sm text-destructive">{errorMessage}</p>
           ) : null}
           <DialogFooter>
-            <Button type="submit" disabled={isPending}>
-              {isPending ? "Speichere …" : "Änderungen speichern"}
-            </Button>
+            <AsyncButton type="submit" isLoading={isPending} loadingText="Speichere …">
+              Änderungen speichern
+            </AsyncButton>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/src/app/(members)/mitglieder/pages/ui/page.tsx
+++ b/src/app/(members)/mitglieder/pages/ui/page.tsx
@@ -1,10 +1,9 @@
 import { hasRole, requireAuth } from "@/lib/rbac";
 import { redirect } from "next/navigation";
-import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Pencil, Trash2, Settings, Plus, Eye } from "lucide-react";
+import { EditIcon, SettingsIcon, TrashIcon } from "@/components/ui/action-icons";
 
 const uiElements = [
   { type: "Button", variant: "primary", purpose: "Primäre Aktion", usages: ["Szenen > add", "Produktionen > speichern", "Mitglieder > erstellen"] },
@@ -14,9 +13,9 @@ const uiElements = [
 ] as const;
 
 const iconUsages = [
-  { Icon: Pencil, name: "Pencil", purpose: "Bearbeiten", usages: ["Szenen", "Mitgliederverwaltung", "Dokumente"] },
-  { Icon: Trash2, name: "Trash2", purpose: "Löschen", usages: ["Szenen", "Dateimanager", "Theme-Verwaltung"] },
-  { Icon: Settings, name: "Settings", purpose: "Einstellungen", usages: ["Seitensteuerung", "Server-Einstellungen", "Website & Theme"] },
+  { Icon: EditIcon, name: "EditIcon", purpose: "Bearbeiten", usages: ["Szenen", "Mitgliederverwaltung", "Dokumente"] },
+  { Icon: TrashIcon, name: "TrashIcon", purpose: "Löschen", usages: ["Szenen", "Dateimanager", "Theme-Verwaltung"] },
+  { Icon: SettingsIcon, name: "SettingsIcon", purpose: "Einstellungen", usages: ["Seitensteuerung", "Server-Einstellungen", "Website & Theme"] },
 ] as const;
 
 export default async function PagesUiOverviewPage() {
@@ -27,7 +26,7 @@ export default async function PagesUiOverviewPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-semibold tracking-tight">UI</h1>
+      <h1 className="text-h1">UI</h1>
       <Tabs defaultValue="elements" className="space-y-4">
         <TabsList>
           <TabsTrigger value="elements">Elemente</TabsTrigger>
@@ -73,7 +72,6 @@ export default async function PagesUiOverviewPage() {
                 <TableHead>Name</TableHead>
                 <TableHead>Funktion</TableHead>
                 <TableHead>Nutzungen</TableHead>
-                <TableHead>Aktion</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -85,12 +83,6 @@ export default async function PagesUiOverviewPage() {
                   <TableCell>
                     <div className="flex flex-wrap gap-2">
                       {usages.map((usage) => <Badge key={usage} variant="secondary">{usage}</Badge>)}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex gap-2">
-                      <Button size="sm" variant="outline"><Eye className="mr-1 h-4 w-4" />Verwendungen</Button>
-                      <Button size="sm"><Plus className="mr-1 h-4 w-4" />Icon ersetzen</Button>
                     </div>
                   </TableCell>
                 </TableRow>

--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-card-with-actions.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Pencil, Trash2 } from "lucide-react";
 import { ActionDropdownMenu } from "@/components/ui/action-dropdown-menu";
+import { EditIcon, TrashIcon } from "@/components/ui/action-icons";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { toast } from "sonner";
 import { deleteRehearsalAction } from "./actions";
 import type { RehearsalLite } from "./rehearsal-list";
@@ -22,6 +23,7 @@ const timeFormatter = new Intl.DateTimeFormat("de-DE", {
 export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: RehearsalLite; forceOpen?: boolean }) {
   const router = useRouter();
   const [isDeletingTransition, startDeletingTransition] = useTransition();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   const startDate = useMemo(() => new Date(rehearsal.start), [rehearsal.start]);
 
@@ -30,10 +32,6 @@ export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: 
   };
 
   const handleDelete = () => {
-    if (!confirm(`Probe "${rehearsal.title}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) {
-      return;
-    }
-
     startDeletingTransition(() => {
       deleteRehearsalAction({ id: rehearsal.id })
         .then((result) => {
@@ -53,48 +51,61 @@ export function RehearsalCardWithActions({ rehearsal, forceOpen }: { rehearsal: 
   const menuItems = [
     {
       label: "Bearbeiten",
-      icon: <Pencil className="w-4 h-4" />,
+      icon: <EditIcon className="w-4 h-4" />,
       onClick: handleEdit,
       variant: "default" as const,
       disabled: false,
     },
     {
       label: isDeletingTransition ? "Wird gelöscht..." : "Löschen",
-      icon: <Trash2 className="w-4 h-4" />,
-      onClick: handleDelete,
+      icon: <TrashIcon className="w-4 h-4" />,
+      onClick: () => setIsDeleteDialogOpen(true),
       variant: "destructive" as const,
       disabled: isDeletingTransition,
     },
   ];
 
   return (
-    <details
-      className="overflow-hidden rounded-xl border border-border/60 bg-card/60 shadow-sm transition hover:shadow"
-      open={forceOpen ? true : undefined}
-    >
-      <summary className="list-none cursor-pointer px-5 py-4">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex-1">
-            <Link
-              href={`/mitglieder/proben/${rehearsal.id}`}
-              className="text-lg font-semibold text-primary hover:underline"
-            >
-              {rehearsal.title}
-            </Link>
-            <p className="text-sm text-muted-foreground">
-              {dateFormatter.format(startDate)}
-              {" · "}
-              {timeFormatter.format(startDate)}
-            </p>
-            <p className="text-xs text-muted-foreground/80">Ort: {rehearsal.location}</p>
-          </div>
+    <>
+      <details
+        className="overflow-hidden rounded-xl border border-border/60 bg-card/60 shadow-sm transition hover:shadow"
+        open={forceOpen ? true : undefined}
+      >
+        <summary className="list-none cursor-pointer px-5 py-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex-1">
+              <Link
+                href={`/mitglieder/proben/${rehearsal.id}`}
+                className="text-lg font-semibold text-primary hover:underline"
+              >
+                {rehearsal.title}
+              </Link>
+              <p className="text-sm text-muted-foreground">
+                {dateFormatter.format(startDate)}
+                {" · "}
+                {timeFormatter.format(startDate)}
+              </p>
+              <p className="text-xs text-muted-foreground/80">Ort: {rehearsal.location}</p>
+            </div>
             <div className="flex items-start gap-3">
               <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                 <ActionDropdownMenu items={menuItems} align="end" />
               </div>
             </div>
-        </div>
-      </summary>
-    </details>
+          </div>
+        </summary>
+      </details>
+      <ConfirmDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title="Probe löschen"
+        description={`Probe "${rehearsal.title}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.`}
+        confirmLabel="Löschen"
+        cancelLabel="Abbrechen"
+        variant="destructive"
+        onConfirm={handleDelete}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+      />
+    </>
   );
 }

--- a/src/components/members/finance/finance-budget-table.tsx
+++ b/src/components/members/finance/finance-budget-table.tsx
@@ -2,9 +2,11 @@
 
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { Pencil, Trash2 } from "lucide-react";
 import type { FinanceBudgetDTO } from "@/app/api/finance/utils";
+import { EditIcon, TrashIcon } from "@/components/ui/action-icons";
+import { AsyncButton } from "@/components/ui/async-button";
 import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { cn } from "@/lib/utils";
 
 function formatCurrency(amount: number, currency: string) {
@@ -24,6 +26,7 @@ type FinanceBudgetTableProps = {
 
 export function FinanceBudgetTable({ budgets, onRequestEdit, onBudgetDeleted, canManage }: FinanceBudgetTableProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [budgetPendingDelete, setBudgetPendingDelete] = useState<FinanceBudgetDTO | null>(null);
 
   const totals = useMemo(() => {
     return budgets.reduce(
@@ -38,7 +41,6 @@ export function FinanceBudgetTable({ budgets, onRequestEdit, onBudgetDeleted, ca
 
   async function handleDelete(budget: FinanceBudgetDTO) {
     if (!canManage) return;
-    if (!window.confirm(`Budget "${budget.category}" löschen?`)) return;
     try {
       setDeletingId(budget.id);
       const response = await fetch(`/api/finance/budgets/${budget.id}`, { method: "DELETE" });
@@ -106,19 +108,20 @@ export function FinanceBudgetTable({ budgets, onRequestEdit, onBudgetDeleted, ca
                   <td className="px-3 py-2 align-top text-right">
                     <div className="flex justify-end gap-2">
                       <Button type="button" variant="ghost" size="sm" onClick={() => onRequestEdit(budget)}>
-                        <Pencil className="h-4 w-4" aria-hidden />
+                        <EditIcon className="h-4 w-4" aria-hidden />
                         Bearbeiten
                       </Button>
-                      <Button
+                      <AsyncButton
                         type="button"
                         variant="ghost"
                         size="sm"
-                        onClick={() => handleDelete(budget)}
-                        disabled={deletingId === budget.id}
+                        onClick={() => setBudgetPendingDelete(budget)}
+                        isLoading={deletingId === budget.id}
+                        loadingText="Löschen…"
                       >
-                        <Trash2 className="h-4 w-4" aria-hidden />
+                        <TrashIcon className="h-4 w-4" aria-hidden />
                         Löschen
-                      </Button>
+                      </AsyncButton>
                     </div>
                   </td>
                 ) : null}
@@ -142,6 +145,26 @@ export function FinanceBudgetTable({ budgets, onRequestEdit, onBudgetDeleted, ca
           </tr>
         </tfoot>
       </table>
+      <ConfirmDialog
+        open={budgetPendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setBudgetPendingDelete(null);
+          }
+        }}
+        title="Budget löschen"
+        description={budgetPendingDelete ? `Budget "${budgetPendingDelete.category}" löschen?` : ""}
+        confirmLabel="Löschen"
+        cancelLabel="Abbrechen"
+        variant="destructive"
+        onConfirm={async () => {
+          if (budgetPendingDelete) {
+            await handleDelete(budgetPendingDelete);
+            setBudgetPendingDelete(null);
+          }
+        }}
+        onCancel={() => setBudgetPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/src/components/members/finance/finance-entry-table.tsx
+++ b/src/components/members/finance/finance-entry-table.tsx
@@ -10,12 +10,13 @@ import {
   FINANCE_ENTRY_STATUS_VALUES,
   FINANCE_TYPE_LABELS,
 } from "@/lib/finance";
-import { Button } from "@/components/ui/button";
+import { TrashIcon, RefreshIcon } from "@/components/ui/action-icons";
+import { AsyncButton } from "@/components/ui/async-button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import { RefreshCw, Trash2 } from "lucide-react";
 
 function formatCurrency(amount: number, currency: string) {
   try {
@@ -61,6 +62,7 @@ export function FinanceEntryTable({
   const [search, setSearch] = useState("");
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [entryPendingDelete, setEntryPendingDelete] = useState<FinanceEntryDTO | null>(null);
 
   const filteredEntries = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase();
@@ -108,9 +110,6 @@ export function FinanceEntryTable({
 
   async function handleDelete(entry: FinanceEntryDTO) {
     if (!canManage) return;
-    if (!window.confirm(`Soll die Buchung "${entry.title}" wirklich gelöscht werden?`)) {
-      return;
-    }
     try {
       setDeletingId(entry.id);
       const response = await fetch(`/api/finance/${entry.id}`, { method: "DELETE" });
@@ -191,10 +190,10 @@ export function FinanceEntryTable({
           <div className="text-xs text-muted-foreground">
             {filteredEntries.length} von {entries.length} Buchungen · Ausgaben {formatCurrency(totalExpenses, dominantCurrency)} · Einnahmen {formatCurrency(totalIncome, dominantCurrency)}
           </div>
-          <Button type="button" variant="secondary" size="sm" onClick={onRefresh} disabled={refreshing} className="gap-2">
-            <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin")} aria-hidden />
-            {refreshing ? "Aktualisiere…" : "Aktualisieren"}
-          </Button>
+          <AsyncButton type="button" variant="secondary" size="sm" onClick={onRefresh} isLoading={refreshing} loadingText="Aktualisiere…" className="gap-2">
+            <RefreshIcon className={cn("h-4 w-4", refreshing && "animate-spin")} aria-hidden />
+            Aktualisieren
+          </AsyncButton>
         </div>
       </div>
 
@@ -308,16 +307,17 @@ export function FinanceEntryTable({
                   </td>
                   {canManage ? (
                     <td className="px-3 py-2 align-top text-right">
-                      <Button
+                      <AsyncButton
                         type="button"
                         variant="ghost"
                         size="sm"
-                        onClick={() => handleDelete(entry)}
-                        disabled={deletingId === entry.id}
+                        onClick={() => setEntryPendingDelete(entry)}
+                        isLoading={deletingId === entry.id}
+                        loadingText="Löschen…"
                       >
-                        <Trash2 className="h-4 w-4" aria-hidden />
+                        <TrashIcon className="h-4 w-4" aria-hidden />
                         Löschen
-                      </Button>
+                      </AsyncButton>
                     </td>
                   ) : null}
                 </tr>
@@ -333,6 +333,26 @@ export function FinanceEntryTable({
           </tbody>
         </table>
       </div>
+      <ConfirmDialog
+        open={entryPendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEntryPendingDelete(null);
+          }
+        }}
+        title="Buchung löschen"
+        description={entryPendingDelete ? `Soll die Buchung "${entryPendingDelete.title}" wirklich gelöscht werden?` : ""}
+        confirmLabel="Löschen"
+        cancelLabel="Abbrechen"
+        variant="destructive"
+        onConfirm={async () => {
+          if (entryPendingDelete) {
+            await handleDelete(entryPendingDelete);
+            setEntryPendingDelete(null);
+          }
+        }}
+        onCancel={() => setEntryPendingDelete(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Consolidate icon usage to the project-wide `@/components/ui/action-icons` and remove direct `lucide-react` imports for action icons.
- Replace native `confirm()` / `window.confirm` flows with the standardized `ConfirmDialog` component to provide consistent destructive-action UX and accessibility.
- Use `AsyncButton` for buttons with loading states to centralize loading UX and avoid manual text swapping.

### Description
- Swapped direct `lucide-react` imports to `EditIcon`, `TrashIcon`, `SettingsIcon`, `RefreshIcon`, and `PlusIcon` from `@/components/ui/action-icons` and updated all JSX usages accordingly in the targeted files.
- Replaced `confirm()` / `window.confirm` flows with `ConfirmDialog` and an open state (`useState`) so deletion only proceeds after dialog confirmation in `rehearsal-card-with-actions`, `finance-budget-table`, and `finance-entry-table`.
- Replaced manual/disabled submit/refresh/delete buttons with `AsyncButton`, setting `isLoading` and `loadingText` (e.g. `loadingText="Speichere …"`, `"Löschen…"`, `"Aktualisiere…"`) where requested.
- Updated the technik edit dialog trigger to use `EditIcon` and changed the error text color to the design-token `text-destructive`.
- Removed dead action buttons from the members UI icons table and switched the page heading to the design token class `text-h1`.

### Testing
- Ran `pnpm lint`; lint completed and returned only pre-existing unrelated warnings, no new errors from the changes.
- Ran `pnpm build`; the Next.js production build completed successfully and the modified files compiled cleanly (same unrelated warnings observed during lint/type checking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e0bd015c832db6464d4bf6c7bd9c)