### PR TITLE
Use shared action-icons and AsyncButton for member actions; replace confirm with ConfirmDialog

### DIFF
--- a/src/components/members/file-library/file-library-manager.tsx
+++ b/src/components/members/file-library/file-library-manager.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { FileText, Loader2, Trash2, UploadCloud } from "lucide-react";
+import { UploadCloud } from "lucide-react";
 import { toast } from "sonner";
 
+import { FileIcon, TrashIcon } from "@/components/ui/action-icons";
+import { AsyncButton } from "@/components/ui/async-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -347,17 +349,13 @@ export function FileLibraryManager({ folderId, canUpload, canDownload, canManage
                     ))}
                   </div>
                   <div className="flex justify-end">
-                    <Button type="submit" disabled={uploading}>
-                      {uploading ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Upload läuft…
-                        </>
-                      ) : (
-                        <>
-                          <UploadCloud className="mr-2 h-4 w-4" aria-hidden /> Upload starten
-                        </>
-                      )}
-                    </Button>
+                    <AsyncButton
+                      type="submit"
+                      isLoading={uploading}
+                      loadingText="Upload läuft…"
+                    >
+                      Upload starten
+                    </AsyncButton>
                   </div>
                 </div>
               ) : null}
@@ -376,7 +374,7 @@ export function FileLibraryManager({ folderId, canUpload, canDownload, canManage
               {items.map((item) => (
                 <div key={item.id} className="flex flex-col gap-3 rounded-md border border-border/60 p-4 sm:flex-row sm:items-center sm:justify-between">
                   <div className="flex flex-1 items-start gap-3">
-                    <FileText className="mt-1 h-5 w-5 text-muted-foreground" aria-hidden />
+                    <FileIcon className="mt-1 h-5 w-5 text-muted-foreground" aria-hidden />
                     <div className="space-y-1">
                       <p className="font-medium text-foreground">{item.fileName}</p>
                       {item.description ? (
@@ -400,20 +398,17 @@ export function FileLibraryManager({ folderId, canUpload, canDownload, canManage
                       </Button>
                     )}
                     {(canManage || item.canDelete) && (
-                      <Button
+                      <AsyncButton
                         type="button"
                         size="icon"
                         variant="ghost"
                         onClick={() => handleDelete(item.id)}
-                        disabled={deletingId === item.id}
+                        isLoading={deletingId === item.id}
                         aria-label="Datei löschen"
                       >
-                        {deletingId === item.id ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <Trash2 className="h-4 w-4" />
-                        )}
-                      </Button>
+                        <TrashIcon className="h-4 w-4" aria-hidden />
+                        <span className="sr-only">Datei löschen</span>
+                      </AsyncButton>
                     )}
                   </div>
                 </div>

--- a/src/components/members/finance/finance-export-section.tsx
+++ b/src/components/members/finance/finance-export-section.tsx
@@ -9,12 +9,11 @@ import {
   FINANCE_ENTRY_STATUS_VALUES,
   FINANCE_TYPE_LABELS,
 } from "@/lib/finance";
-import { Button } from "@/components/ui/button";
+import { AsyncButton } from "@/components/ui/async-button";
 import { DateInput } from "@/components/ui/date-input";
-import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "sonner";
-import { FileDown, Loader2 } from "lucide-react";
+import { DownloadIcon } from "@/components/ui/action-icons";
 
 type FinanceExportSectionProps = {
   showId: string;
@@ -112,14 +111,15 @@ export function FinanceExportSection({ showId }: FinanceExportSectionProps) {
         <DateInput value={to} onChange={(event) => setTo(event.target.value)} placeholder="Bis" />
       </div>
       <div>
-        <Button type="button" onClick={handleDownload} disabled={downloading} className="gap-2">
-          {downloading ? (
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-          ) : (
-            <FileDown className="h-4 w-4" aria-hidden />
-          )}
-          {downloading ? "Export wird erstellt…" : "CSV-Export herunterladen"}
-        </Button>
+        <AsyncButton
+          type="button"
+          onClick={handleDownload}
+          isLoading={downloading}
+          loadingText="Export wird erstellt…"
+          className="gap-2"
+        >
+          <DownloadIcon className="h-4 w-4" aria-hidden /> CSV-Export herunterladen
+        </AsyncButton>
       </div>
     </div>
   );

--- a/src/components/members/gallery/member-gallery-manager.tsx
+++ b/src/components/members/gallery/member-gallery-manager.tsx
@@ -1,16 +1,11 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import {
-  AlertCircle,
-  Image as ImageIcon,
-  Loader2,
-  Trash2,
-  UploadCloud,
-  Video,
-} from "lucide-react";
+import { Image as ImageIcon, UploadCloud, Video } from "lucide-react";
 import { toast } from "sonner";
 
+import { TrashIcon, AlertIcon } from "@/components/ui/action-icons";
+import { AsyncButton } from "@/components/ui/async-button";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -428,7 +423,7 @@ export function MemberGalleryManager({ year, canUpload, canModerate, initialItem
                                 className="h-7 w-7 text-muted-foreground"
                                 onClick={() => handleRemoveCandidate(entry.key)}
                               >
-                                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                                <TrashIcon className="h-4 w-4" aria-hidden="true" />
                               </Button>
                             </div>
                             <div className="mt-3 space-y-1">
@@ -452,7 +447,7 @@ export function MemberGalleryManager({ year, canUpload, canModerate, initialItem
                     </div>
                   ) : (
                     <div className="flex items-center gap-2 rounded-md border border-dashed border-border/50 bg-muted/30 p-4 text-sm text-muted-foreground">
-                      <AlertCircle className="h-4 w-4" aria-hidden="true" />
+                      <AlertIcon className="h-4 w-4" aria-hidden="true" />
                       Noch keine Dateien ausgewählt.
                     </div>
                   )}
@@ -475,17 +470,14 @@ export function MemberGalleryManager({ year, canUpload, canModerate, initialItem
                       Auswahl leeren
                     </Button>
                   ) : null}
-                  <Button type="submit" disabled={uploading || selectedFiles.length === 0}>
-                    {uploading ? (
-                      <>
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Upload läuft
-                      </>
-                    ) : (
-                      <>
-                        <UploadCloud className="mr-2 h-4 w-4" aria-hidden /> Upload starten
-                      </>
-                    )}
-                  </Button>
+                  <AsyncButton
+                    type="submit"
+                    isLoading={uploading}
+                    loadingText="Upload läuft"
+                    disabled={selectedFiles.length === 0}
+                  >
+                    <UploadCloud className="h-4 w-4" aria-hidden /> Upload starten
+                  </AsyncButton>
                 </div>
               </div>
             </form>
@@ -545,20 +537,16 @@ export function MemberGalleryManager({ year, canUpload, canModerate, initialItem
                       </a>
                     </Button>
                     {item.canDelete || canModerate ? (
-                      <Button
+                      <AsyncButton
                         type="button"
                         variant="destructive"
                         size="sm"
                         onClick={() => handleDelete(item.id)}
-                        disabled={deletingId === item.id}
+                        isLoading={deletingId === item.id}
+                        loadingText="Entfernen"
                       >
-                        {deletingId === item.id ? (
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        ) : (
-                          <Trash2 className="mr-2 h-4 w-4" />
-                        )}
-                        Entfernen
-                      </Button>
+                        <TrashIcon className="h-4 w-4" aria-hidden /> Entfernen
+                      </AsyncButton>
                     ) : null}
                   </div>
                 </CardContent>

--- a/src/components/members/member-invite-manager.tsx
+++ b/src/components/members/member-invite-manager.tsx
@@ -4,11 +4,14 @@ import { useCallback, useEffect, useMemo, useState, useTransition } from "react"
 import type { FormEvent } from "react";
 import { toast } from "sonner";
 import type { Role } from "@prisma/client";
-import { ChevronDown, ChevronUp, Copy, ExternalLink, FileDown, MessageCircle, Pencil, Power, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, MessageCircle, Power } from "lucide-react";
 
+import { CopyIcon, DownloadIcon, EditIcon, ExternalLinkIcon, TrashIcon } from "@/components/ui/action-icons";
+import { AsyncButton } from "@/components/ui/async-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { DateInput } from "@/components/ui/date-input";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -215,6 +218,7 @@ export function MemberInviteManager() {
   const [downloadingPdfFor, setDownloadingPdfFor] = useState<string | null>(null);
   const [expandedInviteId, setExpandedInviteId] = useState<string | null>(null);
   const [editingInvite, setEditingInvite] = useState<EditableInviteFields | null>(null);
+  const [confirmDeleteInvite, setConfirmDeleteInvite] = useState<InviteSummary | null>(null);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [updatingInviteId, setUpdatingInviteId] = useState<string | null>(null);
   const [onboardingSettings, setOnboardingSettings] =
@@ -866,18 +870,19 @@ export function MemberInviteManager() {
     }
   };
 
-  const deleteInvite = async (invite: InviteSummary) => {
-    if (typeof window !== "undefined") {
-      const confirmed = window.confirm(
-        "Möchtest du diesen Onboarding-Link wirklich löschen? Dieser Schritt kann nicht rückgängig gemacht werden.",
-      );
-      if (!confirmed) return;
+  const deleteInvite = (invite: InviteSummary) => {
+    setConfirmDeleteInvite(invite);
+  };
+
+  const handleConfirmDeleteInvite = async () => {
+    if (!confirmDeleteInvite) {
+      return;
     }
 
-    setProcessingInviteId(invite.id);
+    setProcessingInviteId(confirmDeleteInvite.id);
     setError(null);
     try {
-      const response = await fetch(`/api/member-invites/${invite.id}`, {
+      const response = await fetch(`/api/member-invites/${confirmDeleteInvite.id}`, {
         method: "DELETE",
       });
       const data = await response.json().catch(() => null);
@@ -885,9 +890,10 @@ export function MemberInviteManager() {
         throw new Error(data?.error ?? "Einladung konnte nicht gelöscht werden");
       }
       toast.success("Einladung gelöscht");
-      if (freshInvite?.id === invite.id) {
+      if (freshInvite?.id === confirmDeleteInvite.id) {
         setFreshInvite(null);
       }
+      setConfirmDeleteInvite(null);
       await loadInvites();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Einladung konnte nicht gelöscht werden";
@@ -950,7 +956,7 @@ export function MemberInviteManager() {
                   onClick={copyFreshInvite}
                   disabled={!freshInviteLinkDetails.target}
                 >
-                  <Copy className="h-4 w-4" />
+                  <CopyIcon className="h-4 w-4" />
                   Link kopieren
                 </Button>
                 <Button
@@ -972,7 +978,7 @@ export function MemberInviteManager() {
                   }}
                   disabled={updatingInviteId === freshInvite.id}
                 >
-                  <Pencil className="h-4 w-4" />
+                  <EditIcon className="h-4 w-4" />
                   Details bearbeiten
                 </Button>
                 <Button
@@ -998,7 +1004,7 @@ export function MemberInviteManager() {
                     "PDF wird erstellt …"
                   ) : (
                     <>
-                      <FileDown className="h-4 w-4" />
+                      <DownloadIcon className="h-4 w-4" />
                       PDF generieren
                     </>
                   )}
@@ -1011,7 +1017,7 @@ export function MemberInviteManager() {
                     asChild
                   >
                     <a href={freshInviteLinkDetails.display || undefined} target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="h-4 w-4" />
+                      <ExternalLinkIcon className="h-4 w-4" />
                       Öffnen
                     </a>
                   </Button>
@@ -1072,7 +1078,7 @@ export function MemberInviteManager() {
                 const menuItems = [
                   {
                     label: "Details bearbeiten",
-                    icon: <Pencil className="h-4 w-4" />,
+                    icon: <EditIcon className="h-4 w-4" />,
                     onClick: () => {
                       if (updatingInviteId) return;
                       openEditModalWith(invite);
@@ -1082,14 +1088,14 @@ export function MemberInviteManager() {
                     ? [
                         {
                           label: "Link kopieren",
-                          icon: <Copy className="h-4 w-4" />,
+                          icon: <CopyIcon className="h-4 w-4" />,
                           onClick: () => {
                             void copyInviteLink(sharePath);
                           },
                         },
                         {
                           label: isDownloading ? "PDF wird erstellt …" : "PDF generieren",
-                          icon: <FileDown className="h-4 w-4" />,
+                          icon: <DownloadIcon className="h-4 w-4" />,
                           onClick: () => {
                             if (isDownloading) return;
                             void requestInvitePdf({
@@ -1105,7 +1111,7 @@ export function MemberInviteManager() {
                         },
                         {
                           label: "Im neuen Tab öffnen",
-                          icon: <ExternalLink className="h-4 w-4" />,
+                          icon: <ExternalLinkIcon className="h-4 w-4" />,
                           onClick: () => {
                             const absolute = buildAbsoluteUrl(sharePath);
                             if (absolute && typeof window !== "undefined") {
@@ -1127,7 +1133,7 @@ export function MemberInviteManager() {
                   },
                   {
                     label: "Einladung löschen",
-                    icon: <Trash2 className="h-4 w-4" />,
+                    icon: <TrashIcon className="h-4 w-4" />,
                     onClick: () => {
                       if (isProcessing) return;
                       void deleteInvite(invite);
@@ -1223,7 +1229,7 @@ export function MemberInviteManager() {
                                       target="_blank"
                                       rel="noopener noreferrer"
                                     >
-                                      <ExternalLink className="h-4 w-4" />
+                                      <ExternalLinkIcon className="h-4 w-4" />
                                       Öffnen
                                     </a>
                                   </Button>
@@ -1267,7 +1273,7 @@ export function MemberInviteManager() {
                                     className="h-8 gap-2 px-3 text-xs"
                                     onClick={() => copyInviteLink(sharePath)}
                                   >
-                                    <Copy className="h-4 w-4" />
+                                    <CopyIcon className="h-4 w-4" />
                                     Link kopieren
                                   </Button>
                                   <Button
@@ -1277,7 +1283,7 @@ export function MemberInviteManager() {
                                     onClick={() => openEditModalWith(invite)}
                                     disabled={updatingInviteId === invite.id}
                                   >
-                                    <Pencil className="h-4 w-4" />
+                                    <EditIcon className="h-4 w-4" />
                                     Details bearbeiten
                                   </Button>
                                   <Button
@@ -1302,7 +1308,7 @@ export function MemberInviteManager() {
                                       "PDF wird erstellt …"
                                     ) : (
                                       <>
-                                        <FileDown className="h-4 w-4" />
+                                        <DownloadIcon className="h-4 w-4" />
                                         PDF generieren
                                       </>
                                     )}
@@ -1314,7 +1320,7 @@ export function MemberInviteManager() {
                                     asChild
                                   >
                                     <a href={sharePath} target="_blank" rel="noopener noreferrer">
-                                      <ExternalLink className="h-4 w-4" />
+                                      <ExternalLinkIcon className="h-4 w-4" />
                                       Öffnen
                                     </a>
                                   </Button>
@@ -1546,9 +1552,9 @@ export function MemberInviteManager() {
             <Button type="button" variant="outline" onClick={closeEditModal} disabled={isUpdatingCurrentInvite}>
               Abbrechen
             </Button>
-            <Button onClick={handleUpdate} disabled={isUpdatingCurrentInvite || !editingInviteId}>
-              {isUpdatingCurrentInvite ? "Speichere …" : "Änderungen speichern"}
-            </Button>
+            <AsyncButton onClick={handleUpdate} isLoading={isUpdatingCurrentInvite} loadingText="Speichere …" disabled={!editingInviteId}>
+              Änderungen speichern
+            </AsyncButton>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -1690,9 +1696,9 @@ export function MemberInviteManager() {
             >
               Abbrechen
             </Button>
-            <Button onClick={handleCreate} disabled={creating}>
-              {creating ? "Erstelle …" : "Link erzeugen"}
-            </Button>
+            <AsyncButton onClick={handleCreate} isLoading={creating} loadingText="Erstelle …">
+              Link erzeugen
+            </AsyncButton>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -1778,6 +1784,22 @@ export function MemberInviteManager() {
           ) : null}
         </DialogContent>
       </Dialog>
+
+      <ConfirmDialog
+        open={confirmDeleteInvite !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            setConfirmDeleteInvite(null);
+          }
+        }}
+        variant="destructive"
+        title="Einladung löschen"
+        description="Möchtest du diesen Onboarding-Link wirklich löschen? Dieser Schritt kann nicht rückgängig gemacht werden."
+        confirmLabel="Löschen"
+        cancelLabel="Abbrechen"
+        onConfirm={handleConfirmDeleteInvite}
+        onCancel={() => setConfirmDeleteInvite(null)}
+      />
     </Card>
   );
 }

--- a/src/components/members/members-table.tsx
+++ b/src/components/members/members-table.tsx
@@ -1,9 +1,11 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Eye, Loader2, Pencil, Trash2, UserCheck, UserX } from "lucide-react";
+import { UserCheck, UserX } from "lucide-react";
 import { toast } from "sonner";
 
+import { EditIcon, EyeIcon, LoadingIcon, TrashIcon } from "@/components/ui/action-icons";
+import { AsyncButton } from "@/components/ui/async-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -416,7 +418,7 @@ function MemberActionButtons({
           aria-label={`Profil von ${actionTarget} öffnen`}
           title={`Profil von ${actionTarget} öffnen`}
         >
-          <Eye className="h-4 w-4" aria-hidden />
+          <EyeIcon className="h-4 w-4" aria-hidden />
           <span className="sr-only">Profil</span>
         </Link>
       </Button>
@@ -432,7 +434,7 @@ function MemberActionButtons({
         aria-label={`${actionTarget} bearbeiten`}
         title={`${actionTarget} bearbeiten`}
       >
-        <Pencil className="h-4 w-4" aria-hidden />
+        <EditIcon className="h-4 w-4" aria-hidden />
         <span className="sr-only">Bearbeiten</span>
       </Button>
       <Button
@@ -459,7 +461,7 @@ function MemberActionButtons({
         aria-label={`${actionTarget} löschen`}
         title={`${actionTarget} löschen`}
       >
-        <Trash2 className="h-4 w-4" aria-hidden />
+        <TrashIcon className="h-4 w-4" aria-hidden />
         <span className="sr-only">Löschen</span>
       </Button>
     </div>
@@ -537,12 +539,12 @@ function MemberStatusModal({ user, onClose, onStatusChange }: MemberStatusModalP
             <div className="text-xs text-muted-foreground">{user.email || "Keine E-Mail hinterlegt"}</div>
           </div>
           {targetWillDeactivate ? (
-            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-warning-foreground">
               Deaktivierte Profile bleiben in Listen sichtbar, verfügen jedoch über keinerlei Rechte mehr. Die
               Reaktivierung ist jederzeit möglich.
             </div>
           ) : (
-            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900">
+            <div className="rounded-md border border-success/30 bg-success/10 p-3 text-xs text-success-foreground">
               Das Mitglied kann nach der Reaktivierung sofort wieder alle zugewiesenen Funktionen nutzen.
             </div>
           )}
@@ -551,21 +553,15 @@ function MemberStatusModal({ user, onClose, onStatusChange }: MemberStatusModalP
           <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
             Abbrechen
           </Button>
-          <Button
+          <AsyncButton
             type="button"
             variant={targetWillDeactivate ? "destructive" : "default"}
             onClick={handleSubmit}
-            disabled={loading}
+            isLoading={loading}
+            loadingText={targetWillDeactivate ? "Deaktivieren" : "Aktivieren"}
           >
-            {loading ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                {targetWillDeactivate ? "Deaktivieren" : "Aktivieren"}
-              </span>
-            ) : (
-              targetWillDeactivate ? "Deaktivieren" : "Aktivieren"
-            )}
-          </Button>
+            {targetWillDeactivate ? "Deaktivieren" : "Aktivieren"}
+          </AsyncButton>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -698,7 +694,7 @@ function MemberDeleteModal({ user, onClose, onDeleted }: MemberDeleteModalProps)
 
           {loadingUsage ? (
             <div className="flex items-center justify-center gap-2 rounded-md border border-dashed p-4 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              <LoadingIcon className="h-4 w-4" aria-hidden />
               Lade Zuordnungen …
             </div>
           ) : usageError ? (
@@ -745,16 +741,15 @@ function MemberDeleteModal({ user, onClose, onDeleted }: MemberDeleteModalProps)
             <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
               Abbrechen
             </Button>
-            <Button type="button" variant="destructive" onClick={handleDelete} disabled={loading}>
-              {loading ? (
-                <span className="inline-flex items-center gap-2">
-                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                  Löschen
-                </span>
-              ) : (
-                "Endgültig löschen"
-              )}
-            </Button>
+            <AsyncButton
+              type="button"
+              variant="destructive"
+              onClick={handleDelete}
+              isLoading={loading}
+              loadingText="Löschen"
+            >
+              Endgültig löschen
+            </AsyncButton>
           </div>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
### Motivation
- Consolidate icon usage to the project's shared `action-icons` instead of importing the same icons directly from `lucide-react` to keep a single source of truth for project icons. 
- Standardize loading UX for interactive actions by using the `AsyncButton` component. 
- Replace ad-hoc `window.confirm` flows with the app `ConfirmDialog` to provide a consistent, accessible confirmation UI.

### Description
- Replaced direct `lucide-react` icons with the corresponding icons from `@/components/ui/action-icons` in `finance-export-section`, `member-gallery-manager`, `file-library-manager`, `members-table` and `member-invite-manager` and removed now-unused direct lucide imports. 
- Swapped regular `Button` usages for `AsyncButton` on all relevant loading actions: finance CSV download (`isLoading={downloading}`), gallery upload/delete (`isLoading={uploading}` / `isLoading={deletingId === item.id}`), file-library upload/delete, member status confirm and member delete modals (`isLoading={loading}`), and invite create/edit submit buttons; loading labels set as requested. 
- In `member-invite-manager` added `const [confirmDeleteInvite, setConfirmDeleteInvite] = useState<InviteSummary | null>(null)`, converted `deleteInvite` to open that confirm state, moved the actual delete logic into `handleConfirmDeleteInvite`, and added a `ConfirmDialog` wired to the new state. 
- Replaced hard-coded Tailwind amber/emerald utility classes in `members-table` with semantic design tokens `border-warning/30 bg-warning/10 text-warning-foreground` and `border-success/30 bg-success/10 text-success-foreground`. 
- Removed `window.confirm` usage and cleaned up unused imports / dead code introduced during refactor.

### Testing
- Ran `pnpm lint`; the command completed successfully (warnings reported are pre-existing in unrelated files). 
- Ran `pnpm build`; the project compiled and the production build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e83d98dc832d8ef776875ea87e94)