### PR TITLE
Use shared ArrowLeft action icon in archive year page

### DIFF
--- a/src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx
+++ b/src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx
@@ -1,10 +1,10 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 
 import { PageHeader } from "@/components/members/page-header";
 import { MemberGalleryManager, type MemberGalleryItem } from "@/components/members/gallery/member-gallery-manager";
 import { Button } from "@/components/ui/button";
+import { ArrowLeftIcon } from "@/components/ui/action-icons";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
 import { hasPermission } from "@/lib/permissions";
@@ -46,7 +46,7 @@ export default async function ArchiveYearPage({
           actions={
             <Button asChild variant="outline">
               <Link href="/mitglieder/archiv-und-bilder">
-                <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+                <ArrowLeftIcon className="mr-2 h-4 w-4" /> Zur Übersicht
               </Link>
             </Button>
           }
@@ -91,7 +91,7 @@ export default async function ArchiveYearPage({
         actions={
           <Button asChild variant="outline">
             <Link href="/mitglieder/archiv-und-bilder">
-              <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+              <ArrowLeftIcon className="mr-2 h-4 w-4" /> Zur Übersicht
             </Link>
           </Button>
         }


### PR DESCRIPTION
### Motivation
- Replace a direct `lucide-react` icon import with the project-wide shared action icon to follow the icon import conventions and avoid duplicate `lucide-react` imports in `src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx`.

### Description
- Replaced the `ArrowLeft` import from `lucide-react` with `ArrowLeftIcon` from `@/components/ui/action-icons` and updated both back-button usages to `<ArrowLeftIcon />` in `src/app/(members)/mitglieder/archiv-und-bilder/[year]/page.tsx`.

### Testing
- Ran `pnpm lint`, which completed successfully (existing unrelated warnings remain); and ran `pnpm build`, which completed successfully with the same unrelated warnings during lint/type-check stage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ed1dd6bc832db1808ddda5fc1e98)