### PR TITLE
Use shared ArrowLeftIcon in members file-library folder page

### DIFF
--- a/src/app/(members)/mitglieder/dateisystem/[folderId]/page.tsx
+++ b/src/app/(members)/mitglieder/dateisystem/[folderId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeftIcon } from "@/components/ui/action-icons";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -107,7 +107,7 @@ export default async function FileLibraryFolderPage({
           actions={
             <Button asChild variant="outline">
               <Link href="/mitglieder/dateisystem">
-                <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+                <ArrowLeftIcon className="mr-2 h-4 w-4" /> Zur Übersicht
               </Link>
             </Button>
           }
@@ -159,7 +159,7 @@ export default async function FileLibraryFolderPage({
           actions={
             <Button asChild variant="outline">
               <Link href="/mitglieder/dateisystem">
-                <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+                <ArrowLeftIcon className="mr-2 h-4 w-4" /> Zur Übersicht
               </Link>
             </Button>
           }
@@ -286,7 +286,7 @@ export default async function FileLibraryFolderPage({
           <div className="flex items-center gap-2">
             <Button asChild variant="outline">
               <Link href="/mitglieder/dateisystem">
-                <ArrowLeft className="mr-2 h-4 w-4" /> Zur Übersicht
+                <ArrowLeftIcon className="mr-2 h-4 w-4" /> Zur Übersicht
               </Link>
             </Button>
             {canManage ? (


### PR DESCRIPTION
### Motivation
- Replace direct `lucide-react` icon usage with the project's shared icon to follow the icon-import guideline and centralize icons.

### Description
- Replaced `import { ArrowLeft } from "lucide-react"` with `import { ArrowLeftIcon } from "@/components/ui/action-icons"` and updated all three back-navigation usages in `src/app/(members)/mitglieder/dateisystem/[folderId]/page.tsx` to use `<ArrowLeftIcon />`, removing the `lucide-react` import from the file.

### Testing
- Ran `pnpm lint` and `pnpm build`, and both completed successfully (lint reported unrelated warnings outside the modified file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f09b3c8c832d956313dba92e366c)