### PR TITLE
Use semantic destructive token in Endproben‑Woche member pages

### DIFF
--- a/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx
@@ -12,7 +12,7 @@ export default async function EndprobenWocheDienstplanPage() {
   if (!allowed) {
     return (
       <div className="space-y-6">
-        <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-red-600">
+        <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-destructive">
           Kein Zugriff auf den Dienstplan der Endprobenwoche.
         </div>
       </div>

--- a/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx
@@ -12,7 +12,7 @@ export default async function EinkaufslistePage() {
   if (!allowed) {
     return (
       <div className="space-y-6">
-        <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-red-600">
+        <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-destructive">
           Kein Zugriff auf die Einkaufsliste.
         </div>
       </div>

--- a/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
+++ b/src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx
@@ -12,7 +12,7 @@ export default async function EssenplanungPage() {
   if (!allowed) {
     return (
       <div className="space-y-6">
-        <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-red-600">
+        <div className="rounded-md border border-border/60 bg-background/80 p-4 text-sm text-destructive">
           Kein Zugriff auf die Essensplanung.
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- Replace hardcoded Tailwind color utility with the design-system token to comply with the project's design-token rules in `AGENTS.md`.

### Description
- Replaced `text-red-600` with `text-destructive` in `src/app/(members)/mitglieder/endproben-woche/dienstplan/page.tsx`, `src/app/(members)/mitglieder/endproben-woche/einkaufsliste/page.tsx`, and `src/app/(members)/mitglieder/endproben-woche/essenplanung/page.tsx`.

### Testing
- Ran `pnpm lint` (passes; only pre-existing warnings unrelated to these files) and `pnpm build` (successful production build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f2f9158c832d8873da9e2ec12aeb)