### PR TITLE
refactor: use shared PlusIcon in inventory stickers page

### DIFF
--- a/src/app/(members)/mitglieder/inventar-aufkleber/inventory-stickers-page-client.tsx
+++ b/src/app/(members)/mitglieder/inventar-aufkleber/inventory-stickers-page-client.tsx
@@ -3,14 +3,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { KeyboardEvent } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Plus } from "lucide-react";
 import QRCode from "qrcode";
 import { toast } from "sonner";
 import { useForm, type Resolver } from "react-hook-form";
 import { z } from "zod";
 
 import { PageHeader } from "@/components/members/page-header";
-import { CirclePlusIcon, MinusIcon, PrinterIcon, SearchIcon, TrashIcon } from "@/components/ui/action-icons";
+import { CirclePlusIcon, MinusIcon, PlusIcon, PrinterIcon, SearchIcon, TrashIcon } from "@/components/ui/action-icons";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -858,7 +857,7 @@ export default function InventoryStickersPageClient({
                             disabled={entry.copies >= MAX_TOTAL_STICKERS}
                             title="Plus 1 (Shift: +5)"
                           >
-                            <Plus className="h-4 w-4" />
+                            <PlusIcon className="h-4 w-4" />
                           </Button>
                           <Button
                             type="button"


### PR DESCRIPTION
### Motivation
- Ensure the inventory stickers members page follows the project icon rule to import standard action icons from `src/components/ui/action-icons.tsx` instead of directly from `lucide-react`. 
- Remove a direct third-party icon import to keep icon usage consistent and centralized.

### Description
- Removed the direct `Plus` import from `lucide-react` in `src/app/(members)/mitglieder/inventar-aufkleber/inventory-stickers-page-client.tsx`.
- Added `PlusIcon` to the existing import from `@/components/ui/action-icons` in the same file.
- Replaced the JSX usage of `<Plus className="h-4 w-4" />` with `<PlusIcon className="h-4 w-4" />`.

### Testing
- Ran `pnpm lint`, which completed successfully and reported existing unrelated warnings in other files.
- Ran `pnpm build`, which completed successfully; Next.js build emitted the same existing lint/type-check warnings but the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f9e843d8832d8cb092ca34edeb37)