### PR TITLE
fix: ensure Corepack is available in production Docker build

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -8,6 +8,7 @@ ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
     NEXT_TELEMETRY_DISABLED=1
 RUN apk add --no-cache openssl \
+    && npm install -g corepack@latest \
     && corepack enable
 WORKDIR /app
 


### PR DESCRIPTION
### Motivation
- Fix the production Docker build which failed with `/bin/sh: corepack: not found` when using the `node:26-alpine` base image by ensuring `corepack` is installed in the base stage.

### Description
- Install `corepack` globally in `Dockerfile.prod` base stage by adding `npm install -g corepack@latest` before calling `corepack enable`.

### Testing
- Ran `pnpm lint` (passes with existing warnings), `pnpm test` (all tests passed: 123 tests), and `pnpm build` (production build succeeds with existing lint warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fe4e3624832dbb7a96f4262c0b84)