### PR TITLE
fix(prisma): support Prisma 7 datasource config during generate/build

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,12 @@
+import "dotenv/config";
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrate: {
+    path: "prisma/migrations",
+  },
+  datasource: {
+    url: process.env.DATABASE_URL,
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 enum Role {


### PR DESCRIPTION
### Motivation
- Docker builds failed at `pnpm prisma:generate` with Prisma 7 error `P1012` because Prisma 7 no longer allows a `url` field inside `schema.prisma` datasources.
- The project needs a Prisma-7-compatible configuration so `prisma generate` and the build can run in environments using Prisma 7.

### Description
- Added `prisma.config.ts` that uses `defineConfig` and places the datasource URL in the config via `process.env.DATABASE_URL`.
- Removed the deprecated `url = env("DATABASE_URL")` line from the `datasource db` block in `prisma/schema.prisma` so the schema is Prisma-7-compatible.
- Kept `schema` and `migrate.path` set in `prisma.config.ts` so `prisma generate` can locate schema and migrations.

### Testing
- Ran `pnpm lint`; lint completed successfully with existing repo warnings.
- Ran `pnpm test`; all tests passed (`123/123` tests succeeded).
- Ran `pnpm build`/`pnpm prisma:generate` in this environment which still fails due to a local Prisma CLI mismatch (installed CLI `6.16.2` vs repo target `7.x`), but the change addresses the `P1012` error and will allow builds to succeed when the environment uses Prisma 7.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1301ccaa88832d879cb0ac02cd96c8)