### PR TITLE
chore(prisma): move datasource URL into Prisma config

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "@prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  datasource: {
+    url: process.env.DATABASE_URL,
+  },
+});

--- a/prisma/config.ts
+++ b/prisma/config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "@prisma/config";
+
+export default defineConfig({
+  datasource: {
+    url: process.env.DATABASE_URL,
+  },
+});


### PR DESCRIPTION
### Motivation
- Ensure the Prisma schema is compatible with Prisma 7 validation by removing the hard-coded `url` from the datasource block and reading the connection URL from environment instead. 
- Centralize datasource configuration in a Prisma config file so the database URL is provided via `process.env.DATABASE_URL` and not stored in `prisma/schema.prisma`.

### Description
- Removed the `url` property from the `datasource db` block in `prisma/schema.prisma`, leaving only `provider = "postgresql"` in the datasource. 
- Added a root-level `prisma.config.ts` that exports a default config via `defineConfig` from `@prisma/config` and sets the schema plus `datasource.url = process.env.DATABASE_URL`.
- Added `prisma/config.ts` that also exports a `defineConfig` with `datasource.url = process.env.DATABASE_URL` to satisfy Prisma config resolution.

### Testing
- Ran `pnpm prisma:generate` which initially failed with Prisma schema validation error `P1012` complaining the datasource `url` was missing. 
- After adding the config files, attempted `pnpm prisma:generate` again but the command failed because the `prisma` binary was unavailable in this environment due to dependency installation failing. 
- Ran `corepack enable && pnpm install --frozen-lockfile` which failed with `ERR_PNPM_FETCH_403` when fetching registry packages, so dependency installation could not be completed and `prisma generate` could not be verified to succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130ae0c244832d92b0e6d1352dc1f6)