### PR TITLE
Fix ESLint config crash with ESLint 10

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,17 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+function stripReactRules(config) {
+  if (!config?.rules) return config;
+  const filteredRules = Object.fromEntries(
+    Object.entries(config.rules).filter(([name]) => !name.startsWith("react/")),
+  );
+  return { ...config, rules: filteredRules };
+}
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...nextVitals.map(stripReactRules),
+  ...nextTypescript.map(stripReactRules),
   {
     ignores: [
       "node_modules/**",
@@ -19,6 +20,8 @@ const eslintConfig = [
       "build/**",
       "next-env.d.ts",
       "public/workbox/**",
+      "deploy-service/**",
+      "eslint.config.mjs",
     ],
   },
 ];


### PR DESCRIPTION
### Motivation
- ESLint 10 failed during config loading with a circular-JSON/config validation error and runtime errors coming from `eslint-plugin-react`, which prevented `pnpm lint` from running at all.
- The intent of the change is to make the project's ESLint configuration compatible with ESLint 10 so linting can execute and surface actual code issues.

### Description
- Replaced the `FlatCompat`/`@eslint/eslintrc` approach with direct flat-config imports from `eslint-config-next/core-web-vitals` and `eslint-config-next/typescript` in `eslint.config.mjs`.
- Added a `stripReactRules` helper that removes imported `react/*` rules to avoid runtime incompatibilities with `eslint-plugin-react` under ESLint 10.
- Restored and extended ignore patterns in `eslint.config.mjs` to include `deploy-service/**` and `eslint.config.mjs` so ESLint does not attempt to lint unrelated build/deploy files.

### Testing
- Ran `pnpm lint` and verified the previous TypeError during config loading no longer occurs and ESLint completes its configuration phase successfully.
- `pnpm lint` now runs and reports real code-level lint findings (the run exited non-zero due to existing lint errors such as many `react-hooks/set-state-in-effect` violations), confirming linting is functional again.
- No additional automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a152ed82e548326b1c1345b615f9b68)