### PR TITLE
Add `toggle` variant and simplify outline/ghost styles in Button component

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,9 +18,11 @@ const buttonVariants = cva(
         accent:
           "bg-accent text-accent-foreground shadow-[var(--shadow-md)] hover:bg-accent/90",
         outline:
-          "border border-border bg-transparent text-foreground shadow-[var(--shadow-sm)] hover:border-primary/50 hover:text-primary",
+          "border border-border bg-transparent text-foreground hover:border-primary/50 hover:text-primary",
+        toggle:
+          "border border-transparent bg-transparent text-muted-foreground hover:bg-muted/40 data-[state=active]:border-transparent data-[state=active]:bg-accent data-[state=active]:text-accent-foreground",
         ghost:
-          "bg-transparent text-foreground shadow-[var(--shadow-sm)] hover:bg-muted/40 hover:text-foreground",
+          "bg-transparent text-foreground hover:bg-muted/40 hover:text-foreground",
         subtle:
           "bg-muted text-foreground/90 shadow-[var(--shadow-sm)] hover:bg-muted/70",
         link:


### PR DESCRIPTION
### Motivation

- Refine button visual variants to remove subtle shadows from non-primary styles and introduce a lightweight `toggle` variant for stateful icon-like buttons.

### Description

- Added a new `toggle` variant to `buttonVariants` with transparent borders and `data-[state=active]` styles for active state visuals in `src/components/ui/button.tsx`.
- Removed `shadow-[var(--shadow-sm)]` from the `outline` and `ghost` variants and simplified their class strings to avoid unintended drop-shadows on non-primary buttons.
- Kept defaults and sizing unchanged and preserved existing hover/focus behaviors while tightening visual consistency across variants.

### Testing

- Ran TypeScript type-check with `tsc --noEmit` and there were no type errors.  
- Executed the project test suite with `pnpm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a156d1bf7f88323b06fcae6c503d6fc)