### PR TITLE
Align member UI controls with shared components

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/discard-draft-button.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/discard-draft-button.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+
+import { AsyncButton } from "@/components/ui/async-button";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 
 import { discardRehearsalDraftAction } from "./actions";
 
@@ -14,17 +17,14 @@ type DiscardDraftButtonProps = {
 export function DiscardDraftButton({ id, title }: DiscardDraftButtonProps) {
   const router = useRouter();
   const [isDiscarding, startDiscard] = useTransition();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const normalizedTitle = title?.trim();
+  const confirmationMessage = normalizedTitle
+    ? `Möchtest du den Entwurf "${normalizedTitle}" wirklich verwerfen? Diese Aktion kann nicht rückgängig gemacht werden.`
+    : "Möchtest du diesen Entwurf wirklich verwerfen? Diese Aktion kann nicht rückgängig gemacht werden.";
 
   const handleDiscard = () => {
-    const normalizedTitle = title?.trim();
-    const confirmationMessage = normalizedTitle
-      ? `Möchtest du den Entwurf "${normalizedTitle}" wirklich verwerfen? Diese Aktion kann nicht rückgängig gemacht werden.`
-      : "Möchtest du diesen Entwurf wirklich verwerfen? Diese Aktion kann nicht rückgängig gemacht werden.";
-
-    if (!confirm(confirmationMessage)) {
-      return;
-    }
-
     startDiscard(() => {
       discardRehearsalDraftAction({ id })
         .then((result) => {
@@ -37,18 +37,35 @@ export function DiscardDraftButton({ id, title }: DiscardDraftButtonProps) {
         })
         .catch(() => {
           toast.error("Der Entwurf konnte nicht verworfen werden.");
+        })
+        .finally(() => {
+          setConfirmOpen(false);
         });
     });
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleDiscard}
-      disabled={isDiscarding}
-      className="rounded text-xs font-medium text-destructive underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
-    >
-      {isDiscarding ? "Verwerfe Entwurf…" : "Entwurf verwerfen"}
-    </button>
+    <>
+      <AsyncButton
+        type="button"
+        variant="destructive"
+        onClick={() => setConfirmOpen(true)}
+        isLoading={isDiscarding}
+        loadingText="Verwerfe Entwurf…"
+      >
+        Entwurf verwerfen
+      </AsyncButton>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={handleDiscard}
+        title="Entwurf verwerfen?"
+        description={confirmationMessage}
+        confirmLabel="Verwerfen"
+        cancelLabel="Abbrechen"
+        variant="destructive"
+      />
+    </>
   );
 }

--- a/src/components/members/photo-consent-admin-panel.tsx
+++ b/src/components/members/photo-consent-admin-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Image from "next/image";
-import { Loader2, RefreshCw, Search } from "lucide-react";
+import { LoadingIcon, RefreshIcon, SearchIcon } from "@/components/ui/action-icons";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -116,7 +116,7 @@ function DocumentPreview({ previewUrl, documentName, signatureVersion, signature
             alt={documentName ? `Dokumentvorschau: ${documentName}` : "Digitale Unterschrift"}
             fill
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 60vw, 420px"
-            className="object-contain bg-white"
+            className="object-contain bg-card"
             unoptimized
           />
         );
@@ -142,7 +142,7 @@ function DocumentPreview({ previewUrl, documentName, signatureVersion, signature
           alt={documentName ? `Dokumentvorschau: ${documentName}` : "Digitale Unterschrift"}
           fill
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 60vw, 420px"
-          className="object-contain bg-white"
+          className="object-contain bg-card"
           unoptimized
         />
       );
@@ -353,7 +353,7 @@ export function PhotoConsentAdminPanel() {
         <div className="space-y-3">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <div className="relative w-full lg:max-w-md">
-              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={searchTerm}
                 onChange={(event) => setSearchTerm(event.target.value)}
@@ -457,9 +457,9 @@ export function PhotoConsentAdminPanel() {
             className="min-w-[10rem]"
           >
             {loading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <LoadingIcon className="mr-2 h-4 w-4 animate-spin" />
             ) : (
-              <RefreshCw className="mr-2 h-4 w-4" />
+              <RefreshIcon className="mr-2 h-4 w-4" />
             )}
             {loading ? "Aktualisiere …" : "Aktualisieren"}
           </Button>

--- a/src/components/members/photo-consent-card.tsx
+++ b/src/components/members/photo-consent-card.tsx
@@ -5,7 +5,8 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ChangeEvent, FormEvent } from "react";
 import { toast } from "sonner";
-import { Camera, ChevronDown, RefreshCw, Upload } from "lucide-react";
+import { Camera } from "lucide-react";
+import { ChevronDownIcon, RefreshIcon, UploadIcon } from "@/components/ui/action-icons";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -117,7 +118,7 @@ function ConsentDocumentPreview({ previewUrl, documentName, signatureVersion, si
             alt={documentName ? `Digitale Unterschrift: ${documentName}` : "Digitale Unterschrift"}
             fill
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 60vw, 420px"
-            className="object-contain bg-white"
+            className="object-contain bg-card"
             unoptimized
           />
         );
@@ -138,7 +139,7 @@ function ConsentDocumentPreview({ previewUrl, documentName, signatureVersion, si
           alt={documentName ? `Digitale Unterschrift: ${documentName}` : "Digitale Unterschrift"}
           fill
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 60vw, 420px"
-          className="object-contain bg-white"
+          className="object-contain bg-card"
           unoptimized
         />
       );
@@ -520,21 +521,20 @@ export function PhotoConsentCard({
             {statusBadge}
           </div>
           {isCollapsible && (
-            <button
+            <Button
               type="button"
+              variant="toggle"
+              data-state={expanded ? "active" : "inactive"}
               onClick={() => setExpanded((prev) => !prev)}
               aria-expanded={expanded}
-              className={cn(
-                "group inline-flex items-center justify-center gap-2 self-start rounded-full border border-primary/35 bg-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary transition hover:bg-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:self-end",
-                expanded ? "bg-primary/15" : ""
-              )}
+              className="group self-start rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] sm:self-end"
             >
               <span>{expanded ? "Details ausblenden" : "Details anzeigen"}</span>
-              <ChevronDown
+              <ChevronDownIcon
                 className={cn("h-4 w-4 transition-transform", expanded ? "rotate-180" : "rotate-0")}
                 aria-hidden="true"
               />
-            </button>
+            </Button>
           )}
         </div>
       </CardHeader>
@@ -726,7 +726,7 @@ export function PhotoConsentCard({
                         onClick={handleSelectUploadMode}
                         disabled={submitting}
                       >
-                        <Upload className="h-4 w-4" aria-hidden />
+                        <UploadIcon className="h-4 w-4" aria-hidden />
                         Datei hochladen
                       </Button>
                       <Button
@@ -813,7 +813,7 @@ export function PhotoConsentCard({
                     {submitting ? "Speichere …" : "Jetzt zustimmen"}
                   </Button>
                   <Button type="button" variant="outline" size="sm" onClick={() => void load()} disabled={submitting}>
-                    <RefreshCw className="h-4 w-4" aria-hidden />
+                    <RefreshIcon className="h-4 w-4" aria-hidden />
                     Status aktualisieren
                   </Button>
                   {status === "approved" && (


### PR DESCRIPTION
### Motivation
- Standardize member-facing UI patterns by using central components for controls, icons, toggles and semantic tokens.
- Remove native `confirm()` and ad-hoc toggle styling to ensure consistent UX and easier theming across the app.

### Description
- Replaced native discard control and `confirm()` flow with `AsyncButton` + `ConfirmDialog` in `src/app/(members)/mitglieder/probenplanung/discard-draft-button.tsx` to use the shared async/confirm patterns.
- Migrated several direct `lucide-react` icon usages to the project icon wrappers in `@/components/ui/action-icons` and swapped component usage to `ChevronDownIcon`, `RefreshIcon`, `UploadIcon`, `LoadingIcon`, and `SearchIcon` in `src/components/members/photo-consent-card.tsx` and `src/components/members/photo-consent-admin-panel.tsx`.
- Replaced a manually styled collapsible control with `Button variant="toggle"` and `data-state={expanded ? "active" : "inactive"}` in `src/components/members/photo-consent-card.tsx` to centralize toggle visuals and state handling.
- Swapped hardcoded preview surface classes from `bg-white` to the semantic token `bg-card` in photo consent preview components to follow the design-token rules.

### Testing
- Ran `pnpm lint`; the command completed but returned repository-wide failures unrelated to the scoped changes (pre-existing `react-hooks/set-state-in-effect` and other lint issues), so lint did not fully pass for the repo.
- No automated unit tests were added or modified for this patch and `pnpm test` was not executed as part of this change.
- The updated components were built and inspected locally during development and render changes are limited to the modified files only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a157aabf28483239bc143b7b0616d5f)