### PR TITLE
refactor: use AsyncButton for pending submit states in rehearsal and mystery components

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/create-rehearsal-button.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/create-rehearsal-button.tsx
@@ -4,7 +4,7 @@ import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { Button } from "@/components/ui/button";
+import { AsyncButton } from "@/components/ui/async-button";
 
 import { createRehearsalDraftAction } from "./actions";
 
@@ -30,8 +30,8 @@ export function CreateRehearsalButton() {
   };
 
   return (
-    <Button type="button" onClick={handleClick} disabled={isPending}>
-      {isPending ? "Entwurf wird vorbereitet…" : "Neue Probe anlegen"}
-    </Button>
+    <AsyncButton type="button" onClick={handleClick} isLoading={isPending} loadingText="Entwurf wird vorbereitet…">
+      Neue Probe anlegen
+    </AsyncButton>
   );
 }

--- a/src/app/(site)/mystery/_components/mystery-guess-board.tsx
+++ b/src/app/(site)/mystery/_components/mystery-guess-board.tsx
@@ -3,6 +3,7 @@
 import { type FocusEvent, type FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { RefreshCw } from "lucide-react";
 
+import { AsyncButton } from "@/components/ui/async-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -255,9 +256,9 @@ export function MysteryGuessBoard({ initialTips = [], clueOptions, defaultClueId
                 </Text>
               )}
               <div className="flex flex-wrap items-center gap-2">
-                <Button type="submit" disabled={!canSubmit}>
-                  {isSubmitting ? "Wird gesendet…" : "Tipp abschicken"}
-                </Button>
+                <AsyncButton type="submit" isLoading={isSubmitting} loadingText="Wird gesendet…" disabled={!canSubmit}>
+                  Tipp abschicken
+                </AsyncButton>
                 <Button type="button" variant="ghost" onClick={refreshTips} disabled={isLoading} className="gap-2">
                   <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} aria-hidden />
                   Aktualisieren


### PR DESCRIPTION
### Motivation
- Standardize loading/pending button patterns to the shared UI system and avoid manual ternary label patterns.
- Keep visual/behavioral parity while preparing the codebase for broader UI-system enforcement per project standards.

### Description
- Replaced the manual pending-label `Button` with `AsyncButton` in `src/app/(members)/mitglieder/probenplanung/create-rehearsal-button.tsx` and updated imports accordingly.
- Replaced the manual submit-loading `Button` with `AsyncButton` in `src/app/(site)/mystery/_components/mystery-guess-board.tsx` and added the corresponding import.

### Testing
- Ran `pnpm lint`; the command executed but the repository has pre-existing lint errors unrelated to these two edits, so the lint run reported failures (not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a157f9064d883239789af36c9bed578)