### PR TITLE
Fix SummaryStat icon typing for Gewerke detail build

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { addDays, format, startOfToday } from "date-fns";
 import { de } from "date-fns/locale/de";
-import type { LucideIcon } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
 import { ListTodo, Ruler } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -24,7 +24,8 @@ import {
 import { DepartmentCard, type DepartmentMeasurementsByUser } from "../department-card";
 import { DepartmentEventPlanner, type DepartmentEventLite } from "../department-event-planner";
 
-type SummaryStat = { label: string; value: number; hint?: string; icon: LucideIcon };
+type SummaryStatIcon = ComponentType<SVGProps<SVGSVGElement>>;
+type SummaryStat = { label: string; value: number; hint?: string; icon: SummaryStatIcon };
 
 type PageProps = { params: Promise<{ slug: string }> };
 


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript build error in the Gewerke detail page caused by incompatible icon types so both lucide forward-ref icons and local icon wrappers can be used in the `summaryStats` array.

### Description
- Replace `import type { LucideIcon } from "lucide-react"` with `import type { ComponentType, SVGProps } from "react"` in `src/app/(members)/mitglieder/meine-gewerke/[slug]/page.tsx`.
- Introduce `type SummaryStatIcon = ComponentType<SVGProps<SVGSVGElement>>;` and update `SummaryStat` to use that icon type so wrappers from `src/components/ui/action-icons` and lucide components are compatible.

### Testing
- Ran `pnpm test`, all tests passed (`106` tests, `32` files).
- Ran `pnpm lint`, which failed due to pre-existing unrelated ESLint `react-hooks/set-state-in-effect` and other warnings in other files.
- Ran `pnpm build`, the original icon typing error is resolved but the build still fails on a separate pre-existing issue (`Cannot find name 'CalendarDays'` in `department-card.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15bffec734832db2797151e815eace)