### PR TITLE
Use shared action-icons in department card (remove direct lucide-react imports)

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/department-card.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/department-card.tsx
@@ -2,12 +2,10 @@ import Link from "next/link";
 import type { CSSProperties } from "react";
 import { format, parse } from "date-fns";
 import { de } from "date-fns/locale/de";
-import { BellRing } from "lucide-react";
-
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CalendarIcon, ClockIcon } from "@/components/ui/action-icons";
+import { BellRingIcon, CalendarIcon, ClockIcon } from "@/components/ui/action-icons";
 import { compareMembersByLastName } from "@/lib/names";
 import { cn } from "@/lib/utils";
 import {
@@ -290,7 +288,7 @@ export function DepartmentCard({
                         >
                           <div className="flex items-center gap-3">
                             <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                              <CalendarDays aria-hidden className="h-5 w-5" />
+                              <CalendarIcon aria-hidden className="h-5 w-5" />
                             </span>
                             <div className="space-y-1">
                               <p className="text-sm font-medium text-foreground">{suggestion.label}</p>
@@ -331,7 +329,7 @@ export function DepartmentCard({
                     <div className="space-y-2 rounded-xl border border-dashed border-amber-400/40 bg-amber-500/5 p-3 text-xs">
                       <div className="flex items-center gap-2 text-foreground">
                         <span className="flex h-7 w-7 items-center justify-center rounded-full bg-amber-500/10 text-amber-600">
-                          <BellRing aria-hidden className="h-4 w-4" />
+                          <BellRingIcon aria-hidden className="h-4 w-4" />
                         </span>
                         <p className="text-sm font-semibold">Abmeldungen im Planungsfenster</p>
                       </div>
@@ -359,7 +357,7 @@ export function DepartmentCard({
                       href="/mitglieder/sperrliste"
                       className="inline-flex items-center gap-1 font-semibold text-primary transition hover:text-primary/80"
                     >
-                      <CalendarDays aria-hidden className="h-4 w-4" />
+                      <CalendarIcon aria-hidden className="h-4 w-4" />
                       Sperrliste öffnen
                     </Link>
                   </div>
@@ -495,7 +493,7 @@ export function DepartmentCard({
                                 dueMeta.isOverdue ? "border-destructive/60 text-destructive" : "text-muted-foreground",
                               )}
                             >
-                              <Clock aria-hidden className="h-3.5 w-3.5" />
+                              <ClockIcon aria-hidden className="h-3.5 w-3.5" />
                               {dueMeta.relative}
                             </span>
                           ) : null}

--- a/src/components/ui/action-icons.tsx
+++ b/src/components/ui/action-icons.tsx
@@ -6,6 +6,7 @@ import {
   ArrowRight,
   ArrowUpRight,
   ArrowLeft,
+  BellRing,
   CalendarCheck,
   CalendarCog,
   CalendarRange,
@@ -175,6 +176,10 @@ export function UsersIcon({ className = "w-4 h-4", ...props }: { className?: str
 
 export function CalendarIcon({ className = "w-4 h-4", ...props }: { className?: string } & React.SVGProps<SVGSVGElement>) {
   return <CalendarDays className={className} aria-hidden {...props} />;
+}
+
+export function BellRingIcon({ className = "w-4 h-4", ...props }: { className?: string } & React.SVGProps<SVGSVGElement>) {
+  return <BellRing className={className} aria-hidden {...props} />;
 }
 
 export function ClockIcon({ className = "w-4 h-4", ...props }: { className?: string } & React.SVGProps<SVGSVGElement>) {


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build error caused by `CalendarDays` being referenced without a direct import in `src/app/(members)/mitglieder/meine-gewerke/department-card.tsx` and align the file with the project rule to source icons from the shared action-icons module.
- Consolidate icon usage so components import only from `src/components/ui/action-icons.tsx` instead of directly from `lucide-react`.

### Description
- Removed the direct `lucide-react` import from `src/app/(members)/mitglieder/meine-gewerke/department-card.tsx` and replaced inline icon usages with shared wrappers from `@/components/ui/action-icons` (replaced `CalendarDays`/`Clock`/`BellRing` with `CalendarIcon`/`ClockIcon`/`BellRingIcon`).
- Added a `BellRingIcon` export in `src/components/ui/action-icons.tsx` backed by the `BellRing` lucide glyph so the department card can import it from the shared module.
- Updated the import list in `department-card.tsx` to import `BellRingIcon`, `CalendarIcon`, and `ClockIcon` from `@/components/ui/action-icons` and removed any direct `lucide-react` imports.

### Testing
- Ran `pnpm lint`; the command failed due to pre-existing, repo-wide lint errors unrelated to this change (multiple `react-hooks/set-state-in-effect` issues), so lint did not pass cleanly.
- Ran `pnpm build`; the build failed due to an unrelated TypeScript error in `src/app/(members)/mitglieder/meine-gewerke/page.tsx` (`Cannot find name 'ListTodo'`), therefore a full successful build could not be completed in this run.
- The changes ensure `department-card.tsx` no longer imports from `lucide-react` and its icon references are routed through `src/components/ui/action-icons.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c4555c20832d99688c40461a0b84)