### PR TITLE
Add shadcn-style Collapsible UI wrapper

### DIFF
--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import * as React from "react"
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+import { cn } from "@/lib/utils"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <CollapsiblePrimitive.Trigger
+    ref={ref}
+    className={cn(className)}
+    {...props}
+  />
+))
+CollapsibleTrigger.displayName = CollapsiblePrimitive.Trigger.displayName
+
+const CollapsibleContent = React.forwardRef<
+  React.ElementRef<typeof CollapsiblePrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <CollapsiblePrimitive.Content
+    ref={ref}
+    className={cn(
+      "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+      className
+    )}
+    {...props}
+  />
+))
+CollapsibleContent.displayName = CollapsiblePrimitive.Content.displayName
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }


### PR DESCRIPTION
### Motivation
- Provide a small, reusable Radix `Collapsible` wrapper in shadcn/ui style so components can use a consistent `Collapsible`, `CollapsibleTrigger` and `CollapsibleContent` primitive across the project.

### Description
- Added `src/components/ui/collapsible.tsx` that starts with `"use client"`, imports `cn` from `@/lib/utils`, exports `Collapsible` as `CollapsiblePrimitive.Root`, and implements `CollapsibleTrigger` and `CollapsibleContent` with `React.forwardRef` and `displayName` set, where `CollapsibleContent` includes the animation classes `data-[state=closed]:animate-accordion-up` and `data-[state=open]:animate-accordion-down` and styling uses `cn` and semantic tokens only.

### Testing
- Ran `pnpm lint` which failed due to existing repository lint errors unrelated to this change, and ran `pnpm build` which failed due to a pre-existing TypeScript error elsewhere in the codebase; neither failure is caused by the new file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c6eaf718832d8ef555721ad6f8db)