### PR TITLE
Fix missing icon references in meine-gewerke stats

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { Building2, FolderOpen, Wrench } from "lucide-react";
+import { Building2, CalendarDays, FolderOpen, Wrench } from "lucide-react";
 
 import { PageHeader } from "@/components/members/page-header";
 import { Button } from "@/components/ui/button";
@@ -68,8 +68,8 @@ export default async function MeineGewerkePage() {
 
   const stats: StatItem[] = [
     { label: "Gewerke", value: teamCount.toString(), hint: "Teams mit Zugriff", icon: Wrench },
-    { label: "Offene Aufgaben", value: openTasks.toString(), hint: "Todos in deinen Gewerken", icon: ListTodo },
-    { label: "Termine", value: eventCount.toString(), hint: "Ereignisse in den Teams", icon: CalendarIcon },
+    { label: "Offene Aufgaben", value: openTasks.toString(), hint: "Todos in deinen Gewerken", icon: Wrench },
+    { label: "Termine", value: eventCount.toString(), hint: "Ereignisse in den Teams", icon: CalendarDays },
     { label: "Dokumente", value: documentCount.toString(), hint: "Dateien aus den Gewerken", icon: FolderOpen },
   ];
 


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build error caused by undefined icon references used in `src/app/(members)/mitglieder/meine-gewerke/page.tsx` (`ListTodo` and `CalendarIcon`).

### Description
- Replace the undefined `ListTodo` icon with the existing `Wrench` icon and replace `CalendarIcon` with `CalendarDays`, and update the `lucide-react` import line accordingly, without changing any logic or layout in the file.

### Testing
- Ran `pnpm build`; the edited file compiles, but the full project type-check fails due to an unrelated pre-existing type error in `src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx` (icon component typing mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15c942d3a0832d9670e2cf4592467f)