### PR TITLE
Fix invalid icon references in member todos page

### DIFF
--- a/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
+++ b/src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx
@@ -1,9 +1,8 @@
 import { notFound } from "next/navigation";
-import { ClipboardCheck, ListTodo } from "lucide-react";
+import { CheckSquare, ClipboardCheck, Users, type LucideIcon } from "lucide-react";
 
 import { PageHeader } from "@/components/members/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { UsersIcon } from "@/components/ui/action-icons";
 import { hasPermission } from "@/lib/permissions";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/rbac";
@@ -12,7 +11,7 @@ type TodoStat = {
   label: string;
   value: string;
   hint: string;
-  icon: typeof ListTodo;
+  icon: LucideIcon;
 };
 
 export default async function DepartmentTodosPage() {
@@ -56,8 +55,8 @@ export default async function DepartmentTodosPage() {
   const openAssignedToMe = assignedToMe.filter((task) => task.status !== "done").length;
 
   const stats: TodoStat[] = [
-    { label: "Teams", value: memberships.length.toString(), hint: "Gewerke mit Aufgaben", icon: UsersIcon },
-    { label: "Offene Aufgaben", value: openTasks.toString(), hint: "Alle offenen Todos", icon: ListTodo },
+    { label: "Teams", value: memberships.length.toString(), hint: "Gewerke mit Aufgaben", icon: Users },
+    { label: "Offene Aufgaben", value: openTasks.toString(), hint: "Alle offenen Todos", icon: CheckSquare },
     { label: "Meine offenen Aufgaben", value: openAssignedToMe.toString(), hint: "Direkt zugewiesen", icon: ClipboardCheck },
   ];
 


### PR DESCRIPTION
### Motivation
- Fix three broken icon references in `src/app/(members)/mitglieder/meine-gewerke/todos/page.tsx` that caused TypeScript errors because the wrong symbols were imported/referenced for Lucide icons.

### Description
- Replace the project `UsersIcon` reference with the direct Lucide import `Users` and remove the `@/components/ui/action-icons` usage in this file.
- Replace the missing `ListTodo` reference with the direct Lucide icon `CheckSquare` and import it from `lucide-react`.
- Ensure `ClipboardCheck` is imported directly from `lucide-react` and use it for the third stat.
- Change the `TodoStat.icon` type from `typeof ListTodo` to `LucideIcon` so the icon field accepts the Lucide components without type errors.

### Testing
- Ran `pnpm build` to validate the changes and confirmed the edited `todos/page.tsx` file type-checks and the icon references resolve without TypeScript errors.
- The repository build fails overall due to an unrelated existing TypeScript error in `src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx` referencing a non-existent `ArrowLeftIconIcon` export, so the full `pnpm build` did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15cbec71b4832da470206a86b27973)