### PR TITLE
Fix malformed action icon imports in member detail page

### DIFF
--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -20,7 +20,7 @@ import type {
 import { PageHeader } from "@/components/members/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ArrowLeftIconIcon, CalendarIcon, MailIconIcon, ShieldCheckIconIcon, SparklesIconIcon } from "@/components/ui/action-icons";
+import { ArrowLeftIcon, CalendarIcon, MailIcon, ShieldCheckIcon, SparklesIcon } from "@/components/ui/action-icons";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UserAvatar } from "@/components/user-avatar";


### PR DESCRIPTION
### Motivation

- The member detail page had malformed icon imports with duplicated `Icon` suffixes which caused unresolved exports and needed correction to match the actual exports in `src/components/ui/action-icons.tsx`.

### Description

- Fixed the import list in `src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx` by replacing `ArrowLeftIconIcon`, `MailIconIcon`, `ShieldCheckIconIcon`, `SparklesIconIcon` with the correct `ArrowLeftIcon`, `MailIcon`, `ShieldCheckIcon`, and `SparklesIcon` respectively, without changing any logic or layout.

### Testing

- Ran `pnpm build`; the change was committed and the app compilation reached the Next.js build step, but the process failed TypeScript checks due to an unrelated missing dependency `@radix-ui/react-collapsible` referenced from `src/components/ui/collapsible.tsx` (failure unrelated to the icon import fixes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15cdb11144832d905fdab88d0eb68e)