### PR TITLE
chore: add @radix-ui/react-collapsible dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@prisma/adapter-pg": "7.8.0",
     "@prisma/client": "7.8.0",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.1.6",


### PR DESCRIPTION
### Motivation
- Add `@radix-ui/react-collapsible` so the project can use the Radix Collapsible primitive consistent with other Radix UI primitives already in the codebase.

### Description
- Inserted `@radix-ui/react-collapsible` with version `^1.1.12` into `dependencies` in `package.json` to align with the existing `1.x` Radix packages.

### Testing
- Ran `pnpm build`; installation via `pnpm add` failed in this environment with `ERR_PNPM_FETCH_403` (registry auth blocked), and the build subsequently fails type-checking with `Cannot find module '@radix-ui/react-collapsible'` because the package could not be installed. Please run `pnpm install` (or `pnpm add @radix-ui/react-collapsible@^1.1.12`) in an environment with registry access and re-run `pnpm build` to complete verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15cf8426ac832d847411acfe8f607f)