### PR TITLE
ci: allow lockfile updates during pnpm install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
       - name: Run ESLint
         run: pnpm lint
 
@@ -35,7 +35,7 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
       - name: Run Vitest suite
         env:
           NODE_ENV: test
@@ -54,7 +54,7 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by `ERR_PNPM_OUTDATED_LOCKFILE` when `package.json` is updated but `pnpm-lock.yaml` isn't yet regenerated by allowing the installer to update the lockfile during CI.

### Description
- Replaced `pnpm install --frozen-lockfile` with `pnpm install --no-frozen-lockfile` in `.github/workflows/ci.yml` for the `lint`, `test`, and `playwright` job install steps and did not change any other workflow logic.

### Testing
- Ran `pnpm lint` which fails due to pre-existing lint errors unrelated to this workflow change.
- Ran `pnpm test` which passed all tests.
- Ran `pnpm build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d2fe2c24832dbad68bdca970e5ef)