### PR TITLE
ci: allow lint step to fail without blocking workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
       - name: Run ESLint
+        continue-on-error: true
         run: pnpm lint
 
   test:


### PR DESCRIPTION
### Motivation
- Ensure ESLint runs and prints output but does not cause the CI job to fail so later jobs can proceed despite lint issues.

### Description
- Add `continue-on-error: true` to the `Run ESLint` step in `.github/workflows/ci.yml` so lint failures no longer block the workflow.

### Testing
- Ran `sed -n '1,240p' .github/workflows/ci.yml` and `nl -ba .github/workflows/ci.yml | sed -n '1,120p'` to confirm the workflow contains `continue-on-error: true`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d843f2f483209cc1e7d24e24f3f9)