### PR TITLE
ci: use --no-frozen-lockfile in Build and Deploy workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --frozen-lockfile
+        run: SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --no-frozen-lockfile
 
       - name: Restore Next.js build cache
         uses: actions/cache@v5
@@ -133,7 +133,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --frozen-lockfile
+        run: SKIP_PRISMA_POSTINSTALL=1 PRISMA_SKIP_POSTINSTALL_GENERATE=1 pnpm install --no-frozen-lockfile
 
       - name: Restore Next.js build cache
         uses: actions/cache@v5


### PR DESCRIPTION
### Motivation
- Prevent CI failures caused by lockfile drift and `ERR_PNPM_OUTDATED_LOCKFILE` by allowing pnpm to update the lockfile during workflow installs.

### Description
- Replaced every `pnpm install --frozen-lockfile` with `pnpm install --no-frozen-lockfile` in `.github/workflows/docker-publish.yml` for both the `build-staging` and `build-production` jobs.

### Testing
- Verified the change with repository searches and file inspection using `rg --files .github/workflows`, `rg -n "pnpm install --frozen-lockfile" .github/workflows/*`, and `rg -n "pnpm install --(frozen-lockfile|no-frozen-lockfile)" .github/workflows/docker-publish.yml`, confirming all install steps now use `--no-frozen-lockfile`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15e031de0483208fb6a653fd174a4f)