### PR TITLE
Export missing department types from permission workbench client

### DIFF
--- a/src/components/members/permissions/permission-workbench-client.tsx
+++ b/src/components/members/permissions/permission-workbench-client.tsx
@@ -15,7 +15,9 @@ import { toast } from "sonner";
 
 export type PermissionWorkbenchPermission = { id: string; key: string; label: string; description: string | null; categoryKey: string; categoryLabel: string; };
 export type PermissionWorkbenchRole = { id: string; name: string; isSystem: boolean; systemRole: string | null; sortIndex: number; };
+export type PermissionWorkbenchDepartment = { id: string; name: string; slug: string | null; requiresJoinApproval: boolean; };
 export type RoleGrantState = Record<string, Set<string>>;
+export type DepartmentGrantState = Record<string, Set<string>>;
 const CATEGORY_ORDER = ["base", "rehearsal", "department", "pages", "admin", "public", "communication", "analytics"] as const;
 const GROUPS = [
   { id: "group-base-access", category: "base", label: "Allgemeiner Zugang", description: "Steuert den grundlegenden Mitgliederzugang.", keys: ["PRIVATE.DASHBOARD.OVERVIEW.VIEW", "PRIVATE.PROFILE.OWN.VIEW"] },


### PR DESCRIPTION
### Motivation
- Restore the type exports that drawers expect so TypeScript imports in the permissions UI resolve (`DepartmentGrantState`, `PermissionWorkbenchDepartment`).

### Description
- Re-added and exported `PermissionWorkbenchDepartment` and `DepartmentGrantState` in `src/components/members/permissions/permission-workbench-client.tsx` so existing imports from `department-permission-drawer.tsx` and `permission-detail-drawer.tsx` compile without changing runtime logic.

### Testing
- Ran `corepack enable && pnpm lint && pnpm test && pnpm build`; `pnpm lint` and `pnpm build` fail due to pre-existing repository-wide issues (unrelated to this type-only change) and missing `@dnd-kit/*` modules, but the type import errors for the drawers are resolved by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f975e4f883208e591920cce6c799)