### PR TITLE
Fix permission group keys typing in permission workbench

### DIFF
--- a/src/components/members/permissions/permission-workbench-client.tsx
+++ b/src/components/members/permissions/permission-workbench-client.tsx
@@ -19,11 +19,12 @@ export type PermissionWorkbenchDepartment = { id: string; name: string; slug: st
 export type RoleGrantState = Record<string, Set<string>>;
 export type DepartmentGrantState = Record<string, Set<string>>;
 const CATEGORY_ORDER = ["base", "rehearsal", "department", "pages", "admin", "public", "communication", "analytics"] as const;
-const GROUPS = [
+type PermissionGroup = { id: string; category: string; label: string; description: string; keys: string[] };
+const GROUPS: PermissionGroup[] = [
   { id: "group-base-access", category: "base", label: "Allgemeiner Zugang", description: "Steuert den grundlegenden Mitgliederzugang.", keys: ["PRIVATE.DASHBOARD.OVERVIEW.VIEW", "PRIVATE.PROFILE.OWN.VIEW"] },
   { id: "group-department-costume", category: "department", label: "Kostüm & Verpflegung", description: "Bündelt Freigaben für Maße, Größen und Ernährung.", keys: ["PRIVATE.PROFILE.MEASUREMENTS.MANAGE", "PRIVATE.PROFILE.SIZES.MANAGE", "PRIVATE.PROFILE.DIETARY.MANAGE"] },
   { id: "group-public-content", category: "public", label: "Öffentliche Inhalte", description: "Regelt zentrale Inhalte der öffentlichen Website.", keys: ["PUBLIC.HOME.COUNTDOWN.EDIT", "PUBLIC.CONTENT.MANAGE"] },
-] as const;
+];
 
 function toGrantState(record: Record<string, string[]>) { const n: RoleGrantState = {}; for (const [k, v] of Object.entries(record)) n[k] = new Set(v); return n; }
 


### PR DESCRIPTION
### Motivation
- The `GROUPS` constant was inferred too narrowly so `keys` had the wrong type, causing `group.keys.includes(p.key)` to type-error when `p.key` is a `string`.

### Description
- Add an explicit `PermissionGroup` type with `keys: string[]` and annotate `GROUPS` as `PermissionGroup[]`, removing the `as const` inference so `keys` is correctly typed without changing any runtime logic.

### Testing
- Ran `pnpm build`; the original `group.keys.includes(p.key)` type error is resolved, but the build now fails TypeScript checking due to an unrelated prop type error in `src/components/members/permissions/permission-workbench-client.tsx` where `Checkbox`'s `checked` prop receives the string `"indeterminate"` (type error at line 79).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a167eb6603c8323804b5a52ac542655)