### PR TITLE
Support indeterminate state in Checkbox and forward checked prop

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -4,22 +4,41 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-type CheckboxProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type">;
+type CheckedState = boolean | "indeterminate";
 
-const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(({ className, ...props }, ref) => (
-  <input
-    ref={ref}
-    type="checkbox"
-    className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-input bg-background text-primary shadow-sm transition-colors",
-      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-      "checked:border-primary checked:bg-primary checked:text-primary-foreground",
-      "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
-      className
-    )}
-    {...props}
-  />
-));
+type CheckboxProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "checked" | "defaultChecked" | "onChange"> & {
+  checked?: CheckedState;
+  onCheckedChange?: (checked: CheckedState) => void;
+};
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(({ className, checked, onCheckedChange, ...props }, ref) => {
+  const internalRef = React.useRef<HTMLInputElement>(null);
+
+  React.useImperativeHandle(ref, () => internalRef.current as HTMLInputElement);
+
+  React.useEffect(() => {
+    if (!internalRef.current) return;
+    internalRef.current.indeterminate = checked === "indeterminate";
+  }, [checked]);
+
+  return (
+    <input
+      ref={internalRef}
+      type="checkbox"
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded-sm border border-input bg-background text-primary shadow-sm transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "checked:border-primary checked:bg-primary checked:text-primary-foreground",
+        "disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-destructive/60 aria-invalid:ring-destructive/30",
+        className
+      )}
+      checked={checked === true}
+      aria-checked={checked === "indeterminate" ? "mixed" : checked}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+      {...props}
+    />
+  );
+});
 
 Checkbox.displayName = "Checkbox";
 


### PR DESCRIPTION
### Motivation
- Enable group checkboxes to express an indeterminate state (`"indeterminate"`) so the UI can show mixed selection for permission groups. 
- Resolve the type error caused by `permission-workbench-client.tsx` passing `"indeterminate"` as a checked value to the Checkbox component.

### Description
- Updated `src/components/ui/checkbox.tsx` so the `checked` prop accepts `boolean | "indeterminate" | undefined` and added an `onCheckedChange` callback prop. 
- Implemented indeterminate handling by setting the native input's `indeterminate` flag when `checked === "indeterminate"` and exposing `aria-checked="mixed"` for accessibility. 
- The component now forwards an actual `checked={checked === true}` to the underlying `<input />` and bridges native `onChange` to `onCheckedChange`. 
- No logic changes were made to permission handling; `src/components/members/permissions/permission-workbench-client.tsx` already uses `checked={all ? true : some ? "indeterminate" : false}` so no edits were required there.

### Testing
- Ran `pnpm lint` which failed due to many pre-existing lint issues unrelated to this change. 
- Ran `pnpm test` which passed (`32 files, 106 tests`). 
- Ran `pnpm build` which still fails due to an unrelated TypeScript error in `permission-workbench-client.tsx` regarding a `ModalFormDialog` prop (`confirmLabel` not present on its props); the original checked/indeterminate typing issue is resolved by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168171e4988323b97d949b58ef205d)