### PR TITLE
Centralize shared permission workbench types

### DIFF
--- a/src/components/members/permissions/department-permission-drawer.tsx
+++ b/src/components/members/permissions/department-permission-drawer.tsx
@@ -18,7 +18,7 @@ import type {
   DepartmentGrantState,
   PermissionWorkbenchDepartment,
   PermissionWorkbenchPermission,
-} from "@/components/members/permissions/permission-workbench-client";
+} from "@/components/members/permissions/permission-workbench-types";
 import { Filter, Layers, Power } from "lucide-react";
 
 type DepartmentPermissionDrawerProps = {

--- a/src/components/members/permissions/permission-detail-drawer.tsx
+++ b/src/components/members/permissions/permission-detail-drawer.tsx
@@ -18,7 +18,7 @@ import type {
   PermissionWorkbenchPermission,
   PermissionWorkbenchRole,
   RoleGrantState,
-} from "@/components/members/permissions/permission-workbench-client";
+} from "@/components/members/permissions/permission-workbench-types";
 import { ROLE_BADGE_VARIANTS, ROLE_LABELS } from "@/lib/roles";
 
 const ACTION_BUTTON_CLASS =

--- a/src/components/members/permissions/permission-workbench-client.tsx
+++ b/src/components/members/permissions/permission-workbench-client.tsx
@@ -14,9 +14,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { DndSortableProvider, horizontalListSortingStrategy, SortableContext, SortableItem } from "@/components/ui/sortable";
 import { toast } from "sonner";
 
-export type PermissionWorkbenchPermission = { id: string; key: string; label: string; description: string | null; categoryKey: string; categoryLabel: string };
-export type PermissionWorkbenchRole = { id: string; name: string; isSystem: boolean; systemRole: string | null; sortIndex: number };
-export type RoleGrantState = Record<string, Set<string>>;
+import type { PermissionWorkbenchPermission, PermissionWorkbenchRole, RoleGrantState } from "@/components/members/permissions/permission-workbench-types";
 const CATEGORY_ORDER = ["base", "rehearsal", "department", "pages", "admin", "public", "communication", "analytics"] as const;
 type PermissionGroup = { id: string; category: string; label: string; description: string; keys: string[] };
 const GROUPS: PermissionGroup[] = [

--- a/src/components/members/permissions/permission-workbench-types.ts
+++ b/src/components/members/permissions/permission-workbench-types.ts
@@ -1,0 +1,27 @@
+export type PermissionWorkbenchPermission = {
+  id: string;
+  key: string;
+  label: string;
+  description: string | null;
+  categoryKey: string;
+  categoryLabel: string;
+};
+
+export type PermissionWorkbenchRole = {
+  id: string;
+  name: string;
+  isSystem: boolean;
+  systemRole: string | null;
+  sortIndex: number;
+};
+
+export type PermissionWorkbenchDepartment = {
+  id: string;
+  name: string;
+  slug: string | null;
+  requiresJoinApproval: boolean;
+};
+
+export type RoleGrantState = Record<string, Set<string>>;
+
+export type DepartmentGrantState = Record<string, Set<string>>;


### PR DESCRIPTION
### Motivation
- Remove duplicated type definitions and fix broken imports by centralizing shared types used across the permission workbench components. 
- Ensure `department-permission-drawer.tsx` imports the correct type shapes so it compiles without type errors.

### Description
- Added `src/components/members/permissions/permission-workbench-types.ts` exporting `PermissionWorkbenchPermission`, `PermissionWorkbenchRole`, `PermissionWorkbenchDepartment`, `RoleGrantState`, and `DepartmentGrantState` with shapes based on usage in the workbench UI.
- Updated `department-permission-drawer.tsx` and `permission-detail-drawer.tsx` to import the shared types from `@/components/members/permissions/permission-workbench-types`.
- Updated `permission-workbench-client.tsx` to import the centralized types and removed the duplicate local type declarations.
- No runtime logic was changed and no barrel export file was present in the folder, so no additional export updates were required.

### Testing
- Ran `pnpm build`; `prisma generate` and build setup steps succeeded, but `next build` failed due to an unrelated missing dependency: `@radix-ui/react-checkbox` cannot be resolved from `src/components/ui/checkbox.tsx` (this is outside the scope of the refactor).
- Type-definition/import refactor was applied and the permission components now reference the centralized types; the original type-import errors motivating this change were addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16bd4774d88323ac67ef22d8b8f099)