### PR TITLE
Replace permission matrix checkboxes with PermissionToggle & fix role header layout

### DIFF
--- a/src/components/members/permissions/permission-workbench-client.tsx
+++ b/src/components/members/permissions/permission-workbench-client.tsx
@@ -6,7 +6,7 @@ import { CSS } from "@dnd-kit/utilities";
 
 import { ChevronDownIcon, ChevronUpIcon, EditIcon, GripVerticalIcon, PlusIcon, SearchIcon } from "@/components/ui/action-icons";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
+import { PermissionToggle } from "@/components/ui/permission-toggle";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { ModalFormDialog } from "@/components/ui/modal-form-dialog";
@@ -16,6 +16,7 @@ import { toast } from "sonner";
 
 import type { PermissionWorkbenchPermission, PermissionWorkbenchRole, RoleGrantState } from "@/components/members/permissions/permission-workbench-types";
 const CATEGORY_ORDER = ["base", "rehearsal", "department", "pages", "admin", "public", "communication", "analytics"] as const;
+const ROLE_COLUMN_WIDTH_CLASS = "w-[7.5rem] min-w-[7.5rem] max-w-[7.5rem]";
 type PermissionGroup = { id: string; category: string; label: string; description: string; keys: string[] };
 const GROUPS: PermissionGroup[] = [
   { id: "group-base-access", category: "base", label: "Allgemeiner Zugang", description: "Steuert den grundlegenden Mitgliederzugang.", keys: ["PRIVATE.DASHBOARD.OVERVIEW.VIEW", "PRIVATE.PROFILE.OWN.VIEW"] },
@@ -109,7 +110,7 @@ export function PermissionWorkbenchClient({ permissions, roles: initialRoles, ro
                     <span className="text-sm font-medium text-foreground">{group.label}</span>
                     <span className="block text-xs text-muted-foreground">{group.description}</span>
                   </div>
-                  <Checkbox checked={allGranted ? true : someGranted ? "indeterminate" : false} onCheckedChange={(state) => { const grant = state === true; void Promise.all(group.keys.map((permissionKey) => togglePermission(mobileSelectedRoleId, permissionKey, grant))); }} />
+                  <PermissionToggle checked={allGranted ? true : someGranted ? "indeterminate" : false} onCheckedChange={(state) => { const grant = state === true; void Promise.all(group.keys.map((permissionKey) => togglePermission(mobileSelectedRoleId, permissionKey, grant))); }} />
                 </div>
                 {group.members.map((permission) => <div key={`mobile-member-${permission.key}`} className="border-b border-border/40 bg-card px-4 py-3 pl-8 last:border-b-0">
                   <span className="block text-sm font-medium text-foreground">{permission.label}</span>
@@ -124,7 +125,7 @@ export function PermissionWorkbenchClient({ permissions, roles: initialRoles, ro
                   <span className="block text-sm font-medium text-foreground">{permission.label}</span>
                   <span className="block text-xs text-muted-foreground">{permission.description ?? "Keine Beschreibung vorhanden."}</span>
                 </div>
-                <Checkbox checked={checked} onCheckedChange={(state) => void togglePermission(mobileSelectedRoleId, permission.key, state === true)} />
+                <PermissionToggle checked={checked} onCheckedChange={(state) => void togglePermission(mobileSelectedRoleId, permission.key, state === true)} />
               </div>;
             })}
           </div>
@@ -142,7 +143,7 @@ export function PermissionWorkbenchClient({ permissions, roles: initialRoles, ro
                 <th className="p-0" colSpan={orderedRoles.length}>
                   <SortableContext items={roleOrder} strategy={horizontalListSortingStrategy}>
                     <div className="flex">
-                      {orderedRoles.map((role) => <SortableItem key={role.id} id={role.id}>{({ attributes, listeners, setNodeRef, transform, transition }) => <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }} className="w-20 border-b border-l border-border/40 bg-card px-2 py-3 text-center text-sm font-medium text-foreground"><div className="space-y-1"><div className="truncate">{role.name}</div><div className="flex items-center justify-center gap-1"><button type="button" className="rounded p-1 hover:bg-muted" onClick={() => { setRoleName(role.name); setEditRole(role); }}><EditIcon className="size-4" /></button><button type="button" className="cursor-grab rounded p-1 hover:bg-muted" {...attributes} {...listeners}><GripVerticalIcon className="size-4" /></button></div></div></div>}</SortableItem>)}
+                      {orderedRoles.map((role) => <SortableItem key={role.id} id={role.id}>{({ attributes, listeners, setNodeRef, transform, transition }) => <div ref={setNodeRef} style={{ transform: CSS.Transform.toString(transform), transition }} className={`${ROLE_COLUMN_WIDTH_CLASS} border-b border-l border-border/40 bg-card px-2 py-3 text-center text-sm font-medium text-foreground`}><div className="flex min-w-0 flex-col items-center gap-1"><div className="w-full truncate">{role.name}</div><div className="flex flex-nowrap items-center justify-center gap-1 overflow-hidden"><button type="button" className="shrink-0 rounded p-1 hover:bg-muted" onClick={() => { setRoleName(role.name); setEditRole(role); }}><EditIcon className="size-4" /></button><button type="button" className="cursor-grab shrink-0 rounded p-1 hover:bg-muted" {...attributes} {...listeners}><GripVerticalIcon className="size-4" /></button></div></div></div>}</SortableItem>)}
                     </div>
                   </SortableContext>
                 </th>
@@ -160,12 +161,12 @@ export function PermissionWorkbenchClient({ permissions, roles: initialRoles, ro
                       return <Fragment key={group.id}>
                         <tr className="bg-muted/40 transition-colors hover:bg-muted/60">
                           <td className="border-b border-border/40 px-4 py-2.5"><button type="button" className="flex w-full items-start justify-between text-left" onClick={() => setOpenGroups((s) => ({ ...s, [group.id]: !groupOpen }))}><span><span className="text-sm font-medium text-foreground">{group.label}</span><span className="block text-xs text-muted-foreground">{group.description}</span></span>{groupOpen ? <ChevronUpIcon className="mt-0.5 size-4 text-muted-foreground" /> : <ChevronDownIcon className="mt-0.5 size-4 text-muted-foreground" />}</button></td>
-                          {orderedRoles.map((role) => { const granted = group.keys.filter((key) => roleGrants[role.id]?.has(key)).length; const all = granted === group.keys.length; const some = granted > 0 && !all; return <td key={`${group.id}-${role.id}`} className="w-20 border-b border-l border-border/40 px-2 py-2.5 text-center"><Checkbox checked={all ? true : some ? "indeterminate" : false} onCheckedChange={(state) => { const grant = state === true; void Promise.all(group.keys.map((permissionKey) => togglePermission(role.id, permissionKey, grant))); }} /></td>; })}
+                          {orderedRoles.map((role) => { const granted = group.keys.filter((key) => roleGrants[role.id]?.has(key)).length; const all = granted === group.keys.length; const some = granted > 0 && !all; return <td key={`${group.id}-${role.id}`} className={`${ROLE_COLUMN_WIDTH_CLASS} border-b border-l border-border/40 px-2 py-2.5 text-center`}><PermissionToggle checked={all ? true : some ? "indeterminate" : false} onCheckedChange={(state) => { const grant = state === true; void Promise.all(group.keys.map((permissionKey) => togglePermission(role.id, permissionKey, grant))); }} /></td>; })}
                         </tr>
-                        {groupOpen && group.members.map((permission, index) => <tr key={permission.key} className={index % 2 === 0 ? "bg-card transition-colors hover:bg-muted/10" : "bg-muted/20 transition-colors hover:bg-muted/30"}><td className="border-b border-border/40 px-4 py-2.5 pl-8"><span className="block text-sm font-medium text-foreground">{permission.label}</span><span className="mt-0.5 block text-xs text-muted-foreground">{permission.description ?? "Keine Beschreibung vorhanden."}</span></td>{orderedRoles.map((role) => <td key={`${permission.key}-${role.id}`} className="w-20 border-b border-l border-border/40 px-2 py-2.5 text-center"><Checkbox disabled checked={roleGrants[role.id]?.has(permission.key) ?? false} /></td>)}</tr>)}
+                        {groupOpen && group.members.map((permission, index) => <tr key={permission.key} className={index % 2 === 0 ? "bg-card transition-colors hover:bg-muted/10" : "bg-muted/10 transition-colors hover:bg-muted/20"}><td className="border-b border-border/40 px-4 py-2.5 pl-8"><span className="block text-sm font-medium text-foreground">{permission.label}</span><span className="mt-0.5 block text-xs text-muted-foreground">{permission.description ?? "Keine Beschreibung vorhanden."}</span></td>{orderedRoles.map((role) => <td key={`${permission.key}-${role.id}`} className={`${ROLE_COLUMN_WIDTH_CLASS} border-b border-l border-border/40 px-2 py-2.5 text-center`}><PermissionToggle disabled checked={roleGrants[role.id]?.has(permission.key) ?? false} /></td>)}</tr>)}
                       </Fragment>;
                     })}
-                    {category.singles.map((permission, idx) => <tr key={permission.key} className={idx % 2 === 0 ? "bg-card transition-colors hover:bg-muted/10" : "bg-muted/20 transition-colors hover:bg-muted/30"}><td className="border-b border-border/40 px-4 py-2.5"><span className="block text-sm font-medium text-foreground">{permission.label}</span><span className="mt-0.5 block text-xs text-muted-foreground">{permission.description ?? "Keine Beschreibung vorhanden."}</span></td>{orderedRoles.map((role) => <td key={role.id} className="w-20 border-b border-l border-border/40 px-2 py-2.5 text-center"><Checkbox checked={roleGrants[role.id]?.has(permission.key) ?? false} onCheckedChange={(checked) => void togglePermission(role.id, permission.key, checked === true)} /></td>)}</tr>)}
+                    {category.singles.map((permission, idx) => <tr key={permission.key} className={idx % 2 === 0 ? "bg-card transition-colors hover:bg-muted/10" : "bg-muted/10 transition-colors hover:bg-muted/20"}><td className="border-b border-border/40 px-4 py-2.5"><span className="block text-sm font-medium text-foreground">{permission.label}</span><span className="mt-0.5 block text-xs text-muted-foreground">{permission.description ?? "Keine Beschreibung vorhanden."}</span></td>{orderedRoles.map((role) => <td key={role.id} className={`${ROLE_COLUMN_WIDTH_CLASS} border-b border-l border-border/40 px-2 py-2.5 text-center`}><PermissionToggle checked={roleGrants[role.id]?.has(permission.key) ?? false} onCheckedChange={(checked) => void togglePermission(role.id, permission.key, checked === true)} /></td>)}</tr>)}
                   </></CollapsibleContent>
                 </></Collapsible>;
               })}

--- a/src/components/ui/permission-toggle.tsx
+++ b/src/components/ui/permission-toggle.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { CheckIcon, MinusIcon } from "@/components/ui/action-icons";
+import { cn } from "@/lib/utils";
+
+export type PermissionToggleState = boolean | "indeterminate" | undefined;
+
+type PermissionToggleProps = {
+  checked?: PermissionToggleState;
+  disabled?: boolean;
+  className?: string;
+  onCheckedChange?: (checked: PermissionToggleState) => void;
+};
+
+export function PermissionToggle({ checked = false, disabled = false, className, onCheckedChange }: PermissionToggleProps) {
+  const isChecked = checked === true;
+  const isIndeterminate = checked === "indeterminate";
+
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={isIndeterminate ? "mixed" : isChecked}
+      disabled={disabled}
+      onClick={() => onCheckedChange?.(isChecked ? false : true)}
+      className={cn(
+        "inline-flex size-5 items-center justify-center rounded-full border border-border bg-transparent text-primary-foreground transition-colors",
+        "hover:border-primary/40 hover:bg-primary/10",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "data-[state=checked]:border-primary data-[state=checked]:bg-primary",
+        "data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary/60",
+        "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-border disabled:hover:bg-transparent",
+        className,
+      )}
+      data-state={isChecked ? "checked" : isIndeterminate ? "indeterminate" : "unchecked"}
+    >
+      {isChecked ? <CheckIcon className="size-3" /> : null}
+      {isIndeterminate ? <MinusIcon className="size-3" /> : null}
+    </button>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a compact circular permission toggle UI that matches the design tokens and improves scanability without changing existing permission logic. 
- Ensure role header icons (`EditIcon` and `GripVerticalIcon`) never stack and columns keep a consistent width across different role counts. 
- Make permission rows easier to follow by adding subtle zebra striping while excluding category header rows. 

### Description
- Replaced the matrix `Checkbox` cells with a new `PermissionToggle` component and preserved all existing toggle behavior, optimistic updates and indeterminate/group logic (changed usages in `src/components/members/permissions/permission-workbench-client.tsx`).
- Added `src/components/ui/permission-toggle.tsx`, a client component that renders a circular button with `role="checkbox"`, `aria-checked` states and visual variants for `checked`, `indeterminate` and `disabled`, using only semantic design-token classes/CSS variables (no hardcoded colors).
- Tightened the role header markup and introduced a fixed role column width class (`ROLE_COLUMN_WIDTH_CLASS`) so `EditIcon` and `GripVerticalIcon` are always in one horizontal row and do not overflow the column (changes in `permission-workbench-client.tsx`).
- Applied a subtler zebra-striping class to permission rows (group members and singles) while leaving category header rows unchanged.

### Testing
- Ran `pnpm lint` which reported pre-existing repository lint errors (multiple `react-hooks/set-state-in-effect` violations) that are unrelated to these changes and caused the lint step to fail. 
- Ran `pnpm build` which failed due to an existing type-check issue (missing `@radix-ui/react-checkbox` module referenced from `src/components/ui/checkbox.tsx`) and is unrelated to the new `PermissionToggle` component.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c89295788323bd18bf03234d796d)