### PR TITLE
Header: use white text for transparent home header links and mobile trigger

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -213,7 +213,7 @@ export function SiteHeader({
             className={`flex-1 min-w-0 truncate font-serif text-lg transition-all duration-300 sm:text-xl ${
               !isTransparentHomeHeader
                 ? "text-primary hover:opacity-90"
-                : "text-primary-foreground drop-shadow-lg hover:text-primary-foreground/90"
+                : "text-white drop-shadow-lg hover:text-white/90"
             }`}
             href="/"
             title={siteTitle}
@@ -245,7 +245,7 @@ export function SiteHeader({
                     "after:absolute after:-bottom-[var(--space-3xs)] after:left-0 after:h-[2px] after:w-full after:origin-left after:scale-x-0 after:rounded-full after:bg-[var(--primary)] after:opacity-95 after:transition-transform after:duration-300 after:content-[''] after:transform",
                     !isTransparentHomeHeader
                       ? "text-foreground/90 hover:text-[var(--primary)] hover:after:scale-x-100 focus-visible:outline-none focus-visible:text-[var(--primary)] focus-visible:after:scale-x-100 data-[active=true]:font-semibold data-[active=true]:text-[var(--primary)] data-[active=true]:after:scale-x-100"
-                      : "text-primary-foreground drop-shadow-lg hover:text-primary-foreground/90 hover:after:scale-x-100 focus-visible:outline-none focus-visible:text-primary-foreground focus-visible:after:scale-x-100 data-[active=true]:font-semibold data-[active=true]:text-primary-foreground data-[active=true]:after:scale-x-100",
+                      : "text-white drop-shadow-lg hover:text-white/90 hover:after:scale-x-100 focus-visible:outline-none focus-visible:text-white focus-visible:after:scale-x-100 data-[active=true]:font-semibold data-[active=true]:text-white data-[active=true]:after:scale-x-100",
                   )}
                   href={item.href}
                   aria-current={isActive ? "page" : undefined}
@@ -272,7 +272,7 @@ export function SiteHeader({
                 className={`inline-flex h-[var(--header-mobile-trigger-size)] w-[var(--header-mobile-trigger-size)] flex-shrink-0 items-center justify-center rounded-md transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-ring md:hidden ${
                   !isTransparentHomeHeader
                     ? "border border-border/60 text-foreground hover:bg-accent/30"
-                    : "border border-border/60 text-foreground drop-shadow-lg hover:bg-accent/20"
+                    : "border border-border/60 text-white drop-shadow-lg hover:bg-accent/20"
                 }`}
               >
                 <span className="sr-only">Menü</span>


### PR DESCRIPTION
### Motivation
- Ensure text and control colors remain readable over the transparent/hero header by using white text and matching hover/active states.

### Description
- Replace `text-primary-foreground` variants with `text-white` (and update hover/focus/active class variants) for the site title, navigation links, and mobile menu trigger when `isTransparentHomeHeader` is true.

### Testing
- Ran a Next.js production build with `next build`, TypeScript check with `tsc`, and lint via `npm run lint`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21494d737c832e8e9fae63941097c3)