### PR TITLE
Enhance Tabs with animated selection pill, fade transitions and usage fixes

### DIFF
--- a/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
+++ b/src/app/(members)/mitglieder/probenplanung/rehearsal-calendar.tsx
@@ -499,7 +499,7 @@ export function RehearsalCalendar({
         className="space-y-6"
       >
         <div className="flex flex-col items-start gap-3 sm:flex-row sm:justify-end">
-          <TabsList className="self-start">
+          <TabsList>
             <TabsTrigger value="calendar">Kalenderansicht</TabsTrigger>
             <TabsTrigger value="weekend">Wochenend-Fokus</TabsTrigger>
           </TabsList>

--- a/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
+++ b/src/app/(members)/mitglieder/sperrliste/sperrliste-tabs.tsx
@@ -4,8 +4,7 @@ import { useMemo, type ReactNode } from "react";
 import { addDays, format } from "date-fns";
 import { de } from "date-fns/locale/de";
 
-import { CalendarCheck2, UsersRound } from "lucide-react";
-
+import { CalendarCheckIcon, UsersRoundIcon } from "@/components/ui/action-icons";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BlockCalendar, type BlockedDay } from "./block-calendar";
 import { BlockOverview, type OverviewMember } from "./block-overview";
@@ -49,19 +48,19 @@ export function BlocklistTabs({
   return (
     <Tabs defaultValue="personal" className="space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <TabsList className="order-2 flex w-full gap-1.5 bg-muted/50 p-1 sm:order-1 sm:w-auto">
+        <TabsList className="order-2 flex w-full gap-1.5 sm:order-1 sm:w-auto">
           <TabsTrigger
             value="personal"
             className="flex-1 gap-2 px-3 py-1.5 text-sm sm:flex-none"
           >
-            <CalendarCheck2 className="h-4 w-4" aria-hidden />
+            <CalendarCheckIcon className="h-4 w-4" aria-hidden />
             <span>Meine Sperrtermine</span>
           </TabsTrigger>
           <TabsTrigger
             value="overview"
             className="flex-1 gap-2 px-3 py-1.5 text-sm sm:flex-none"
           >
-            <UsersRound className="h-4 w-4" aria-hidden />
+            <UsersRoundIcon className="h-4 w-4" aria-hidden />
             <span>Übersicht</span>
           </TabsTrigger>
         </TabsList>

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
@@ -440,15 +440,34 @@ export function RankingTab({ ranking, onboardingId, detailHrefTemplate }: Rankin
   }, [ranking.roles]);
 
   useEffect(() => {
-    if (domain === "acting" && actingRoleSummaries.length === 0 && crewRoleSummaries.length > 0) {
-      setDomain("crew");
-    } else if (domain === "crew" && crewRoleSummaries.length === 0 && actingRoleSummaries.length > 0) {
-      setDomain("acting");
+    const nextDomain =
+      domain === "acting" && actingRoleSummaries.length === 0 && crewRoleSummaries.length > 0
+        ? "crew"
+        : domain === "crew" && crewRoleSummaries.length === 0 && actingRoleSummaries.length > 0
+          ? "acting"
+          : null;
+
+    if (!nextDomain) {
+      return;
     }
+
+    const frameId = requestAnimationFrame(() => {
+      setDomain(nextDomain);
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
   }, [actingRoleSummaries.length, crewRoleSummaries.length, domain]);
 
   useEffect(() => {
-    setRoleFilter("all");
+    const frameId = requestAnimationFrame(() => {
+      setRoleFilter("all");
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
   }, [domain]);
 
   const activeFilterOptions = domain === "acting" ? roleFilterOptions.acting : roleFilterOptions.crew;
@@ -515,7 +534,7 @@ export function RankingTab({ ranking, onboardingId, detailHrefTemplate }: Rankin
           
           {/* Tabs + Context Info */}
           <div className="flex items-center justify-between gap-4">
-            <TabsList className="bg-muted/50 border border-border/40">
+            <TabsList>
               <TabsTrigger value="acting">Acting</TabsTrigger>
               <TabsTrigger value="crew">Crew</TabsTrigger>
             </TabsList>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -2,11 +2,14 @@
 
 import {
   createContext,
+  isValidElement,
   useCallback,
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
   type ButtonHTMLAttributes,
 } from "react";
@@ -19,6 +22,11 @@ type TabsContextValue = {
   idBase: string;
 };
 
+type TabsPillState = {
+  left: number;
+  width: number;
+};
+
 const TabsContext = createContext<TabsContextValue | null>(null);
 
 function useTabsContext(component: string): TabsContextValue {
@@ -27,6 +35,24 @@ function useTabsContext(component: string): TabsContextValue {
     throw new Error(`${component} muss innerhalb von <Tabs> verwendet werden.`);
   }
   return context;
+}
+
+function hasAnimatedChild(children: React.ReactNode): boolean {
+  if (!isValidElement<{
+    animate?: unknown;
+    exit?: unknown;
+    initial?: unknown;
+    transition?: unknown;
+  }>(children)) {
+    return false;
+  }
+
+  return (
+    children.props.initial !== undefined &&
+    children.props.animate !== undefined &&
+    children.props.exit !== undefined &&
+    children.props.transition !== undefined
+  );
 }
 
 interface TabsProps {
@@ -50,9 +76,17 @@ export function Tabs({
   const value = controlledValue ?? uncontrolledValue;
 
   useEffect(() => {
-    if (controlledValue === undefined && defaultValue !== undefined) {
-      setUncontrolledValue(defaultValue);
+    if (controlledValue !== undefined || defaultValue === undefined) {
+      return;
     }
+
+    const frameId = requestAnimationFrame(() => {
+      setUncontrolledValue(defaultValue);
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
   }, [controlledValue, defaultValue]);
 
   const setValue = useCallback(
@@ -85,15 +119,41 @@ interface TabsListProps {
 }
 
 export function TabsList({ className, children }: TabsListProps) {
+  const { value: activeValue } = useTabsContext("TabsList");
+  const listRef = useRef<HTMLDivElement>(null);
+  const [pillState, setPillState] = useState<TabsPillState>({ left: 0, width: 0 });
+
+  useLayoutEffect(() => {
+    const activeTrigger = listRef.current?.querySelector<HTMLButtonElement>(
+      '[aria-selected="true"]',
+    );
+
+    if (!activeTrigger) {
+      setPillState({ left: 0, width: 0 });
+      return;
+    }
+
+    setPillState({
+      left: activeTrigger.offsetLeft,
+      width: activeTrigger.offsetWidth,
+    });
+  }, [activeValue]);
+
   return (
     <div
+      ref={listRef}
       role="tablist"
       aria-orientation="horizontal"
       className={cn(
-        "inline-flex flex-wrap items-center gap-2 rounded-full bg-muted/40 p-1",
+        "relative inline-flex flex-wrap items-center gap-2 overflow-hidden rounded-full",
         className,
       )}
     >
+      <span
+        aria-hidden
+        className="pointer-events-none absolute bottom-1 top-1 z-0 rounded-full border border-primary/60 bg-primary/15 transition-all duration-300 ease-in-out"
+        style={{ left: pillState.left, width: pillState.width }}
+      />
       {children}
     </div>
   );
@@ -123,9 +183,9 @@ export function TabsTrigger({
       aria-controls={panelId}
       tabIndex={isActive ? 0 : -1}
       className={cn(
-        "inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition",
+        "relative z-10 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition",
         isActive
-          ? "border-primary/60 bg-primary/15 text-primary shadow-sm"
+          ? "border-transparent text-primary shadow-sm"
           : "border-transparent bg-transparent text-muted-foreground hover:border-primary/20 hover:bg-primary/10 hover:text-foreground",
         className,
       )}
@@ -150,9 +210,21 @@ interface TabsContentProps {
 
 export function TabsContent({ value, className, children }: TabsContentProps) {
   const { value: activeValue, idBase } = useTabsContext("TabsContent");
+  const [fadeIn, setFadeIn] = useState(false);
   const isActive = activeValue === value;
+  const shouldFade = !hasAnimatedChild(children);
   const panelId = `${idBase}-content-${value}`;
   const triggerId = `${idBase}-trigger-${value}`;
+
+  useEffect(() => {
+    const frameId = requestAnimationFrame(() => {
+      setFadeIn(isActive);
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, [isActive]);
 
   return (
     <div
@@ -160,7 +232,13 @@ export function TabsContent({ value, className, children }: TabsContentProps) {
       id={panelId}
       aria-labelledby={triggerId}
       hidden={!isActive}
-      className={cn("focus-visible:outline-none", !isActive && "hidden", className)}
+      className={cn(
+        "focus-visible:outline-none",
+        !isActive && "hidden",
+        isActive && shouldFade && "transition-opacity duration-200",
+        isActive && shouldFade && (fadeIn ? "opacity-100" : "opacity-0"),
+        className,
+      )}
     >
       {isActive ? children : null}
     </div>


### PR DESCRIPTION
### Motivation

- Improve the visual and interaction quality of the tab component by adding an animated selection pill and smoother content fades. 
- Avoid layout thrash and race conditions by deferring some state updates to the next animation frame. 
- Standardize icon usage in tab consumers and remove duplicated tablist styling so the new Tabs styling is applied consistently.

### Description

- Implemented an animated selection pill in `TabsList` by measuring the active trigger with `useLayoutEffect`, tracking a `pillState`, and rendering an absolutely positioned background span. 
- Added a fade-in transition for `TabsContent` that runs via `requestAnimationFrame`, and skipped the fade when a child already implements its own animations via `hasAnimatedChild`. 
- Changed `Tabs` uncontrolled initialization and several state updates in consumers to use `requestAnimationFrame` with cleanup via `cancelAnimationFrame` to avoid timing/layout issues. 
- Updated consumers to adopt the new Tabs styling and icons: replaced `CalendarCheck2`/`UsersRound` imports with `CalendarCheckIcon`/`UsersRoundIcon` from `@/components/ui/action-icons`, and removed explicit tablist classes in `rehearsal-calendar.tsx`, `sperrliste-tabs.tsx`, and `ranking-tab.tsx` so the Tabs component controls appearance.

### Testing

- Ran TypeScript type-check (`tsc --noEmit`) and the codebase type checks without errors. 
- Ran the unit test suite (`pnpm test`) and all tests passed. 
- Ran linter/formatter checks (`pnpm lint`) and results are clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216b3acbe4832e99bf80451f924566)