### PR TITLE
Add responsive navigation patterns and make Tabs render a Select on small screens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,14 @@ Webauftritt läuft auf Next.js 15 (App Router) mit React 19, TypeScript und Tail
 - Barrierefreiheit hat Priorität: semantische HTML-Strukturen, `aria`-Attribute, sichtbare Fokuszustände.
 - Feedback-Komponenten laufen über `sonner`.
 
+## RESPONSIVE DESIGN PATTERNS
+
+- Die zentrale Dokumentation für responsive Navigationsmuster liegt in `src/config/responsive.ts`. Neue projektweite Breakpoint-Entscheidungen dort typisiert ergänzen.
+- Es gelten die Tailwind-Default-Breakpoints; es sind keine custom Breakpoints in `tailwind.config.js` definiert.
+- Tabs verwenden das gemeinsame TabsList-Pattern: unter `sm` (640px) shadcn `Select`, ab `sm` Pill-Tabs. Horizontal scrolling auf Tab-Listen ist ausdrücklich verboten.
+- Header-Navigation: unter `md` (768px) `Sheet`, ab `md` horizontale Navigation.
+- Sidebar: bis 1023px `Sheet`, ab 1024px feste Sidebar.
+
 ## Tests, Qualitätssicherung & Reviews
 
 - Vor jedem Commit `pnpm lint`, `pnpm test` und `pnpm build` ausführen.

--- a/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
+++ b/src/app/(members)/mitglieder/mitgliederverwaltung/[userId]/page.tsx
@@ -810,7 +810,7 @@ export default async function MemberProfileAdminPage({ params }: PageProps) {
         }
       />
       <Tabs defaultValue="overview" className="space-y-6">
-        <TabsList className="flex w-full justify-start overflow-x-auto rounded-full border border-border/70 bg-background/70 p-1 shadow-inner ring-1 ring-primary/10 backdrop-blur">
+        <TabsList className="w-full justify-start rounded-full border border-border/70 bg-background/70 p-1 shadow-inner ring-1 ring-primary/10 backdrop-blur">
           <TabsTrigger value="overview" className="gap-2 px-5 py-2 text-xs font-semibold uppercase tracking-wide sm:text-sm">
             <SparklesIcon className="h-4 w-4 text-muted-foreground/80" aria-hidden />
             <span>Profil</span>

--- a/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
+++ b/src/app/dashboard/onboarding/[onboardingId]/_components/ranking-tab.tsx
@@ -533,7 +533,7 @@ export function RankingTab({ ranking, onboardingId, detailHrefTemplate }: Rankin
           </div>
           
           {/* Tabs + Context Info */}
-          <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
             <TabsList>
               <TabsTrigger value="acting">Acting</TabsTrigger>
               <TabsTrigger value="crew">Crew</TabsTrigger>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Children,
   createContext,
   isValidElement,
   useCallback,
@@ -14,6 +15,13 @@ import {
   type ButtonHTMLAttributes,
 } from "react";
 
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
 type TabsContextValue = {
@@ -118,12 +126,70 @@ interface TabsListProps {
   children: React.ReactNode;
 }
 
+type TabsListOption = {
+  value: string;
+  label: string;
+  disabled: boolean;
+};
+
+type TabsTriggerOptionProps = {
+  value?: unknown;
+  disabled?: unknown;
+  children?: React.ReactNode;
+};
+
+function readTextContent(node: React.ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(readTextContent).join(" ");
+  }
+
+  if (isValidElement<{ children?: React.ReactNode }>(node)) {
+    return readTextContent(node.props.children);
+  }
+
+  return "";
+}
+
+function getTabsListOptions(children: React.ReactNode): TabsListOption[] {
+  return Children.toArray(children).flatMap((child) => {
+    if (!isValidElement<TabsTriggerOptionProps>(child)) {
+      return [];
+    }
+
+    const { value, disabled, children: triggerChildren } = child.props;
+    if (typeof value !== "string" || value.length === 0) {
+      return [];
+    }
+
+    const label = readTextContent(triggerChildren).replace(/\s+/g, " ").trim();
+
+    return [
+      {
+        value,
+        label: label || value,
+        disabled: disabled === true,
+      },
+    ];
+  });
+}
+
+function usesCustomVisibility(className?: string) {
+  return className?.split(/\s+/).includes("hidden") ?? false;
+}
+
 export function TabsList({ className, children }: TabsListProps) {
-  const { value: activeValue } = useTabsContext("TabsList");
+  const { value: activeValue, setValue, idBase } = useTabsContext("TabsList");
   const listRef = useRef<HTMLDivElement>(null);
   const [pillState, setPillState] = useState<TabsPillState>({ left: 0, width: 0 });
+  const tabOptions = useMemo(() => getTabsListOptions(children), [children]);
+  const hasCustomVisibility = usesCustomVisibility(className);
+  const selectLabelId = `${idBase}-select-label`;
 
-  useLayoutEffect(() => {
+  const updatePillState = useCallback(() => {
     const activeTrigger = listRef.current?.querySelector<HTMLButtonElement>(
       '[aria-selected="true"]',
     );
@@ -137,25 +203,76 @@ export function TabsList({ className, children }: TabsListProps) {
       left: activeTrigger.offsetLeft,
       width: activeTrigger.offsetWidth,
     });
-  }, [activeValue]);
+  }, []);
+
+  useLayoutEffect(() => {
+    updatePillState();
+  }, [activeValue, children, updatePillState]);
+
+  useEffect(() => {
+    const listElement = listRef.current;
+    if (!listElement) {
+      return;
+    }
+
+    const handleResize = () => updatePillState();
+    window.addEventListener("resize", handleResize);
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => updatePillState())
+        : null;
+    resizeObserver?.observe(listElement);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      resizeObserver?.disconnect();
+    };
+  }, [updatePillState]);
 
   return (
-    <div
-      ref={listRef}
-      role="tablist"
-      aria-orientation="horizontal"
-      className={cn(
-        "relative inline-flex flex-wrap items-center gap-2 overflow-hidden rounded-full",
-        className,
-      )}
-    >
-      <span
-        aria-hidden
-        className="pointer-events-none absolute bottom-1 top-1 z-0 rounded-full border border-primary/60 bg-primary/15 transition-all duration-300 ease-in-out"
-        style={{ left: pillState.left, width: pillState.width }}
-      />
-      {children}
-    </div>
+    <>
+      {!hasCustomVisibility ? (
+        <div className={cn("w-full", className, "sm:hidden")}>
+          <span id={selectLabelId} className="sr-only">
+            Tab auswählen
+          </span>
+          <Select value={activeValue} onValueChange={setValue}>
+            <SelectTrigger aria-labelledby={selectLabelId} className="w-full">
+              <SelectValue placeholder="Ansicht auswählen" />
+            </SelectTrigger>
+            <SelectContent>
+              {tabOptions.map((option) => (
+                <SelectItem
+                  key={option.value}
+                  value={option.value}
+                  disabled={option.disabled}
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : null}
+      <div
+        ref={listRef}
+        role="tablist"
+        aria-orientation="horizontal"
+        className={cn(
+          "relative flex-wrap items-center gap-2 overflow-hidden rounded-full",
+          className,
+          !hasCustomVisibility && "hidden sm:inline-flex",
+        )}
+      >
+        <span
+          aria-hidden
+          className="pointer-events-none absolute bottom-1 top-1 z-0 rounded-full border border-primary/60 bg-primary/15 transition-all duration-300 ease-in-out"
+          style={{ left: pillState.left, width: pillState.width }}
+        />
+        {children}
+      </div>
+    </>
   );
 }
 

--- a/src/config/responsive.ts
+++ b/src/config/responsive.ts
@@ -1,0 +1,112 @@
+/**
+ * Project-wide responsive breakpoint patterns.
+ *
+ * Tailwind default breakpoints are used throughout the app. This file documents
+ * the shared responsive navigation decisions so UI components can reference a
+ * single typed source of truth instead of hard-coding intent in each feature.
+ */
+
+type TailwindBreakpointName = "sm" | "md" | "lg" | "xl" | "2xl";
+
+type BreakpointPattern = {
+  /** Tailwind breakpoint name when the switch maps directly to Tailwind. */
+  name: TailwindBreakpointName;
+  /** Pixel value where the desktop variant starts. */
+  minWidthPx: number;
+  /** Human-readable mobile behavior below the breakpoint. */
+  mobile: string;
+  /** Human-readable desktop behavior at and above the breakpoint. */
+  desktop: string;
+};
+
+type MediaQueryPattern = {
+  /** CSS media query used by the responsive component. */
+  mediaQuery: string;
+  /** Largest pixel width that still uses the mobile variant. */
+  maxMobileWidthPx: number;
+  /** Pixel value where the desktop variant starts. */
+  minDesktopWidthPx: number;
+  /** Human-readable mobile behavior below the desktop breakpoint. */
+  mobile: string;
+  /** Human-readable desktop behavior at and above the desktop breakpoint. */
+  desktop: string;
+};
+
+type ResponsiveNavPattern = {
+  /** UI component used below the breakpoint. */
+  mobileComponent: string;
+  /** Import path for the mobile component. */
+  mobileImportPath: string;
+  /** UI component used at and above the breakpoint. */
+  desktopComponent: string;
+  /** Import path for the desktop component. */
+  desktopImportPath: string;
+  /** Shared breakpoint pattern for this context. */
+  breakpoint: BreakpointPattern | MediaQueryPattern;
+};
+
+/**
+ * Tabs switch at Tailwind's default `sm` breakpoint.
+ * Below 640px, tab lists render as a full-width shadcn Select dropdown.
+ * At 640px and above, tab lists render as pill tabs.
+ */
+export const TAB_BREAKPOINT = {
+  name: "sm",
+  minWidthPx: 640,
+  mobile: "Select dropdown",
+  desktop: "pill tabs",
+} as const satisfies BreakpointPattern;
+
+/**
+ * Header navigation switches at Tailwind's default `md` breakpoint.
+ * Below 768px, the public header navigation renders in a Sheet.
+ * At 768px and above, the public header navigation renders horizontally.
+ */
+export const HEADER_BREAKPOINT = {
+  name: "md",
+  minWidthPx: 768,
+  mobile: "Sheet navigation",
+  desktop: "horizontal navigation",
+} as const satisfies BreakpointPattern;
+
+/**
+ * Members sidebar uses an explicit media query aligned with Tailwind's `lg`
+ * boundary. Up to 1023px, the sidebar renders in a Sheet. At 1024px and above,
+ * it renders as a fixed sidebar.
+ */
+export const SIDEBAR_BREAKPOINT = {
+  mediaQuery: "(max-width: 1023px)",
+  maxMobileWidthPx: 1023,
+  minDesktopWidthPx: 1024,
+  mobile: "Sheet sidebar",
+  desktop: "fixed sidebar",
+} as const satisfies MediaQueryPattern;
+
+/**
+ * Shared responsive navigation patterns for tab, header, and sidebar contexts.
+ * Use this object when documenting or implementing project-wide responsive
+ * navigation behavior.
+ */
+export const RESPONSIVE_NAV_PATTERN = {
+  tabs: {
+    mobileComponent: "Select",
+    mobileImportPath: "@/components/ui/select",
+    desktopComponent: "TabsList / TabsTrigger pill tabs",
+    desktopImportPath: "@/components/ui/tabs",
+    breakpoint: TAB_BREAKPOINT,
+  },
+  header: {
+    mobileComponent: "Sheet",
+    mobileImportPath: "@/components/ui/sheet",
+    desktopComponent: "horizontal Link navigation",
+    desktopImportPath: "next/link",
+    breakpoint: HEADER_BREAKPOINT,
+  },
+  sidebar: {
+    mobileComponent: "Sheet",
+    mobileImportPath: "@/components/ui/sheet",
+    desktopComponent: "Sidebar",
+    desktopImportPath: "@/components/ui/sidebar",
+    breakpoint: SIDEBAR_BREAKPOINT,
+  },
+} as const satisfies Record<string, ResponsiveNavPattern>;


### PR DESCRIPTION
### Motivation
- Centralize project-wide responsive navigation decisions and document them for consistent usage across components. 
- Prevent horizontal-scrolling tab lists on small screens by switching to a full-width `Select` control below the `sm` breakpoint. 
- Make the Tabs UI robust to layout changes by computing the pill indicator position reliably and reacting to resizes. 

### Description
- Added `src/config/responsive.ts` which defines typed breakpoint patterns and a `RESPONSIVE_NAV_PATTERN` object for tabs, header and sidebar behaviors. 
- Overhauled `src/components/ui/tabs.tsx` so `TabsList` derives options from `TabsTrigger` children, renders a shadcn `Select` for small screens, preserves desktop pill-tab UI for `sm+`, and uses a `ResizeObserver`/window `resize` handler to update the pill indicator. 
- Updated uses of the tabs UI to match the new responsive behavior: removed horizontal scrolling from `TabsList` wrapper in `page.tsx`, and made the ranking tab header stack/condense on small screens in `ranking-tab.tsx`. 
- Documented the responsive navigation patterns in `AGENTS.md` under `RESPONSIVE DESIGN PATTERNS`. 

### Testing
- Ran `pnpm lint` which completed successfully. 
- Ran `pnpm test` (Vitest + React Testing Library) and all tests passed. 
- Performed a production build with `pnpm build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2187826db483239650c95c38ddd063)