### PR TITLE
Refine global tab styling

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -260,7 +260,7 @@ export function TabsList({ className, children }: TabsListProps) {
         role="tablist"
         aria-orientation="horizontal"
         className={cn(
-          "relative flex-wrap items-center gap-2 overflow-hidden rounded-full",
+          "relative flex-wrap items-center gap-2 overflow-hidden rounded-full bg-muted/40 p-1",
           className,
           !hasCustomVisibility && "hidden sm:inline-flex",
         )}
@@ -300,7 +300,7 @@ export function TabsTrigger({
       aria-controls={panelId}
       tabIndex={isActive ? 0 : -1}
       className={cn(
-        "relative z-10 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition",
+        "relative z-10 inline-flex items-center gap-2 rounded-full border px-4 py-2 text-base font-medium transition",
         isActive
           ? "border-transparent text-primary shadow-sm"
           : "border-transparent bg-transparent text-muted-foreground hover:border-primary/20 hover:bg-primary/10 hover:text-foreground",


### PR DESCRIPTION
### Motivation
- Restore the visible rounded pill container for desktop tab lists and give tab labels more breathing room so tabs read better across the site.

### Description
- Modify `src/components/ui/tabs.tsx` to add `bg-muted/40 p-1` to the desktop `TabsList` container and change the `TabsTrigger` base classes from `py-1.5 text-sm` to `py-2 text-base`, keeping the existing sliding pill animation intact.

### Testing
- Ran `pnpm test` (all tests passed) and `pnpm build` (succeeded); `pnpm lint` was run but failed due to unrelated existing lint errors elsewhere in the repo, and the `tabs.tsx` change itself is lint-clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21a1a72d38832cbe8ddff2b2a9be25)