### PR TITLE
Add public back-to-top button

### DIFF
--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -3,6 +3,7 @@ import type { Session } from "next-auth";
 import { execSync } from "node:child_process";
 
 import { MysticBackground } from "@/components/mystic-background";
+import { BackToTop } from "@/components/ui/back-to-top";
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
 import { primaryNavigation } from "@/config/navigation";
@@ -120,6 +121,7 @@ export default async function SiteLayout({ children }: { children: React.ReactNo
           children
         )}
       </main>
+      {!showMaintenanceNotice ? <BackToTop /> : null}
       {!showMaintenanceNotice ? (
         <SiteFooter
           buildInfo={buildInfo}

--- a/src/components/ui/back-to-top.tsx
+++ b/src/components/ui/back-to-top.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+
+import { ChevronUpIcon } from "@/components/ui/action-icons";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const VISIBILITY_SCROLL_THRESHOLD = 300;
+
+export function BackToTop() {
+  const [isVisible, setIsVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > VISIBILITY_SCROLL_THRESHOLD);
+    };
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      aria-label="Nach oben"
+      onClick={handleClick}
+      className={cn(
+        "fixed bottom-6 right-6 z-50 min-h-11 min-w-11 bg-background/80 opacity-0 shadow-[var(--shadow-lg)] backdrop-blur transition-opacity duration-200 sm:bottom-8 sm:right-8",
+        isVisible ? "pointer-events-auto opacity-100" : "pointer-events-none"
+      )}
+    >
+      <ChevronUpIcon className="h-5 w-5" />
+    </Button>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide an easy way for visitors to return to the top of long public pages without adding new styling primitives or hardcoded colors.
- Reuse existing UI primitives and icons so the control matches project design tokens and accessibility patterns.

### Description
- Added a client component `src/components/ui/back-to-top.tsx` that becomes visible after the user scrolls more than `300px`, fades in/out via Tailwind `transition-opacity`, and smooth-scrolls to the top on click.
- The component uses the existing `Button` (`variant="outline"`, `size="icon"`) and `ChevronUpIcon` from `src/components/ui/action-icons.tsx` and relies only on semantic tokens (e.g. `bg-background`) and existing utility classes.
- The button is fixed to the bottom-right corner and uses `pointer-events` + opacity to toggle interactivity and visibility.
- Mounted the component in the public site layout (`src/app/(site)/layout.tsx`) so it appears on all public-facing pages when maintenance mode is not active.

### Testing
- `pnpm lint` was run and failed due to unrelated, pre-existing lint errors elsewhere in the repo (React hook warnings and other issues), not introduced by this change.
- `pnpm test` was run and reported 1 failing test (a timeout in `src/app/api/dashboard/overview/__tests__/route.test.ts`); other tests completed (31 test files; 1 failed, 31 passed at file level).
- `pnpm build` was run and completed successfully (site compiled and static pages generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c6c5a9a6c832ea855d10fa6458651)