### PR TITLE
Add member directory page with debounced search and sidebar link

### DIFF
--- a/src/app/(members)/mitglieder/verzeichnis/member-directory-client.tsx
+++ b/src/app/(members)/mitglieder/verzeichnis/member-directory-client.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+import { SearchIcon } from "@/components/ui/action-icons";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { ROLE_LABELS, type Role } from "@/lib/roles";
+
+type BadgeVariant = ComponentProps<typeof Badge>["variant"];
+
+export interface DirectoryMember {
+  id: string;
+  email: string;
+  name: string;
+  roles: Role[];
+}
+
+const ROLE_BADGE_VARIANTS: Record<Role, BadgeVariant> = {
+  member: "muted",
+  cast: "default",
+  tech: "info",
+  board: "success",
+  finance: "warning",
+  admin: "destructive",
+  owner: "secondary",
+};
+
+function getInitial(name: string) {
+  return name.trim().charAt(0).toLocaleUpperCase("de-DE") || "?";
+}
+
+export function MemberDirectoryClient({ members }: { members: DirectoryMember[] }) {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 300);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [search]);
+
+  const filteredMembers = useMemo(() => {
+    const normalizedSearch = debouncedSearch.trim().toLocaleLowerCase("de-DE");
+    if (!normalizedSearch) return members;
+
+    return members.filter((member) => {
+      const name = member.name.toLocaleLowerCase("de-DE");
+      const email = member.email.toLocaleLowerCase("de-DE");
+      return name.includes(normalizedSearch) || email.includes(normalizedSearch);
+    });
+  }, [debouncedSearch, members]);
+
+  return (
+    <div className="space-y-6">
+      <div className="relative">
+        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          aria-label="Mitglieder suchen"
+          className="pl-10"
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Mitglieder suchen..."
+          type="search"
+          value={search}
+        />
+      </div>
+
+      {filteredMembers.length > 0 ? (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+          {filteredMembers.map((member) => (
+            <Card key={member.id} className="flex min-w-0 flex-col items-center gap-3 text-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted text-lg font-semibold text-foreground">
+                {getInitial(member.name)}
+              </div>
+              <div className="min-w-0 space-y-2">
+                <h2 className="truncate text-sm font-semibold text-foreground">{member.name}</h2>
+                <div className="flex flex-wrap justify-center gap-1.5">
+                  {member.roles.map((role) => (
+                    <Badge key={role} variant={ROLE_BADGE_VARIANTS[role]} size="sm">
+                      {ROLE_LABELS[role] ?? role}
+                    </Badge>
+                  ))}
+                </div>
+                <p className="truncate text-xs text-muted-foreground">{member.email}</p>
+              </div>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <div className="py-12 text-center">
+          <SearchIcon className="mx-auto mb-3 size-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">Keine Mitglieder für diese Suche gefunden.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(members)/mitglieder/verzeichnis/page.tsx
+++ b/src/app/(members)/mitglieder/verzeichnis/page.tsx
@@ -1,0 +1,50 @@
+import { MemberDirectoryClient, type DirectoryMember } from "./member-directory-client";
+
+import { prisma } from "@/lib/prisma";
+import { hasPermission } from "@/lib/permissions";
+import { requireAuth } from "@/lib/rbac";
+import { combineNameParts } from "@/lib/names";
+import { sortRoles } from "@/lib/roles";
+
+export default async function MemberDirectoryPage() {
+  const session = await requireAuth();
+  const allowed = await hasPermission(session.user, "PRIVATE.ADMIN.MEMBERS.MANAGE");
+  if (!allowed) {
+    return <div className="text-sm text-destructive">Kein Zugriff auf das Mitgliederverzeichnis</div>;
+  }
+
+  const users = await prisma.user.findMany({
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }, { name: "asc" }, { email: "asc" }],
+    select: {
+      id: true,
+      email: true,
+      firstName: true,
+      lastName: true,
+      name: true,
+      role: true,
+      roles: { select: { role: true } },
+    },
+  });
+
+  const members: DirectoryMember[] = users.map((user) => {
+    const email = user.email ?? "Keine E-Mail hinterlegt";
+    const name = combineNameParts(user.firstName, user.lastName) ?? user.name ?? email;
+    return {
+      id: user.id,
+      email,
+      name,
+      roles: sortRoles([user.role, ...user.roles.map((entry) => entry.role)]),
+    };
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">Verzeichnis</h1>
+        <p className="text-sm text-muted-foreground">Durchsuche alle Mitglieder nach Namen und E-Mail-Adresse.</p>
+      </div>
+
+      <MemberDirectoryClient members={members} />
+    </div>
+  );
+}

--- a/src/config/members-navigation.tsx
+++ b/src/config/members-navigation.tsx
@@ -521,6 +521,12 @@ export const membersNavigation = [
     label: "Verwaltung",
     items: [
       {
+        href: "/mitglieder/verzeichnis",
+        label: "Verzeichnis",
+        permissionKey: "PRIVATE.ADMIN.MEMBERS.MANAGE",
+        icon: MembersAdminIcon,
+      },
+      {
         href: "/mitglieder/mitgliederverwaltung",
         label: "Mitgliederverwaltung",
         permissionKey: "PRIVATE.ADMIN.MEMBERS.MANAGE",


### PR DESCRIPTION
### Motivation
- Provide a searchable member directory in the members area so admins can quickly browse and find members by name or email. 
- Reuse the existing auth / Prisma pattern and UI primitives so the page integrates with the current members area and permission model (`PRIVATE.ADMIN.MEMBERS.MANAGE`).

### Description
- Add a server page `src/app/(members)/mitglieder/verzeichnis/page.tsx` that loads users via `requireAuth` / `hasPermission` and `prisma` and maps results to a simple `DirectoryMember` DTO with an email fallback.
- Add a client component `src/app/(members)/mitglieder/verzeichnis/member-directory-client.tsx` that renders members as responsive cards (`grid-cols-2` / `md:grid-cols-3` / `lg:grid-cols-4`) with an initials avatar, bold name, semantic `Badge` for roles and muted email text, and an empty-state view with `SearchIcon`.
- Implement a debounced search (300ms) using `useEffect` + `setTimeout` that filters members by name and email, and use the existing `Input` and `SearchIcon` UI components; no new dependencies were added.
- Add a navigation entry for the new page in `src/config/members-navigation.tsx` under the admin group and require the same `PRIVATE.ADMIN.MEMBERS.MANAGE` permission.

### Testing
- Ran targeted ESLint on the two new files with `pnpm exec eslint src/app/'(members)'/mitglieder/verzeichnis/page.tsx src/app/'(members)'/mitglieder/verzeichnis/member-directory-client.tsx` which passed without errors.
- Ran unit tests with `pnpm test` and all tests passed (`106` tests passed in the test run).
- Performed a production build with `pnpm build`, which completed successfully and the new route was included in the generated routes.
- Note: a full `pnpm lint` run fails due to pre-existing repository lint issues unrelated to these new files; the change itself does not introduce lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cd8fad2f8832e924fb561caddffee)